### PR TITLE
Define shared types in packages/types (#2)

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@neat/types",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared Zod schemas, types, and runtime constants for NEAT",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "lint": "eslint src",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -1,0 +1,27 @@
+export const Provenance = {
+  EXTRACTED: 'EXTRACTED',
+  INFERRED: 'INFERRED',
+  OBSERVED: 'OBSERVED',
+  STALE: 'STALE',
+  FRONTIER: 'FRONTIER',
+} as const
+
+export type ProvenanceValue = (typeof Provenance)[keyof typeof Provenance]
+
+export const EdgeType = {
+  CALLS: 'CALLS',
+  DEPENDS_ON: 'DEPENDS_ON',
+  CONNECTS_TO: 'CONNECTS_TO',
+  CONFIGURED_BY: 'CONFIGURED_BY',
+} as const
+
+export type EdgeTypeValue = (typeof EdgeType)[keyof typeof EdgeType]
+
+export const NodeType = {
+  ServiceNode: 'ServiceNode',
+  DatabaseNode: 'DatabaseNode',
+  ConfigNode: 'ConfigNode',
+  InfraNode: 'InfraNode',
+} as const
+
+export type NodeTypeValue = (typeof NodeType)[keyof typeof NodeType]

--- a/packages/types/src/edges.ts
+++ b/packages/types/src/edges.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod'
+import { EdgeType, Provenance } from './constants.js'
+
+export const ProvenanceSchema = z.enum([
+  Provenance.EXTRACTED,
+  Provenance.INFERRED,
+  Provenance.OBSERVED,
+  Provenance.STALE,
+  Provenance.FRONTIER,
+])
+
+export const EdgeTypeSchema = z.enum([
+  EdgeType.CALLS,
+  EdgeType.DEPENDS_ON,
+  EdgeType.CONNECTS_TO,
+  EdgeType.CONFIGURED_BY,
+])
+
+export const GraphEdgeSchema = z.object({
+  id: z.string(),
+  source: z.string(),
+  target: z.string(),
+  type: EdgeTypeSchema,
+  provenance: ProvenanceSchema,
+  confidence: z.number().min(0).max(1).optional(),
+  lastObserved: z.string().datetime().optional(),
+  callCount: z.number().int().nonnegative().optional(),
+})
+export type GraphEdge = z.infer<typeof GraphEdgeSchema>

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+export const ErrorEventSchema = z.object({
+  id: z.string(),
+  timestamp: z.string().datetime(),
+  service: z.string(),
+  traceId: z.string(),
+  spanId: z.string(),
+  errorType: z.string().optional(),
+  errorMessage: z.string(),
+  affectedNode: z.string(),
+})
+export type ErrorEvent = z.infer<typeof ErrorEventSchema>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,5 @@
+export * from './constants.js'
+export * from './nodes.js'
+export * from './edges.js'
+export * from './events.js'
+export * from './results.js'

--- a/packages/types/src/nodes.ts
+++ b/packages/types/src/nodes.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod'
+import { NodeType } from './constants.js'
+
+export const CompatibleDriverSchema = z.object({
+  name: z.string(),
+  minVersion: z.string(),
+})
+export type CompatibleDriver = z.infer<typeof CompatibleDriverSchema>
+
+export const ServiceNodeSchema = z.object({
+  id: z.string(),
+  type: z.literal(NodeType.ServiceNode),
+  name: z.string(),
+  language: z.string(),
+  version: z.string().optional(),
+  pgDriverVersion: z.string().optional(),
+  dbConnectionTarget: z.string().optional(),
+  repoPath: z.string().optional(),
+  dependencies: z.record(z.string(), z.string()).optional(),
+  incompatibilities: z
+    .array(
+      z.object({
+        driver: z.string(),
+        driverVersion: z.string(),
+        engine: z.string(),
+        engineVersion: z.string(),
+        reason: z.string(),
+      }),
+    )
+    .optional(),
+})
+export type ServiceNode = z.infer<typeof ServiceNodeSchema>
+
+export const DatabaseNodeSchema = z.object({
+  id: z.string(),
+  type: z.literal(NodeType.DatabaseNode),
+  name: z.string(),
+  engine: z.string(),
+  engineVersion: z.string(),
+  compatibleDrivers: z.array(CompatibleDriverSchema),
+  host: z.string().optional(),
+  port: z.number().optional(),
+})
+export type DatabaseNode = z.infer<typeof DatabaseNodeSchema>
+
+export const ConfigNodeSchema = z.object({
+  id: z.string(),
+  type: z.literal(NodeType.ConfigNode),
+  name: z.string(),
+  path: z.string(),
+  fileType: z.string(),
+})
+export type ConfigNode = z.infer<typeof ConfigNodeSchema>
+
+export const InfraNodeSchema = z.object({
+  id: z.string(),
+  type: z.literal(NodeType.InfraNode),
+  name: z.string(),
+  provider: z.string(),
+  region: z.string().optional(),
+})
+export type InfraNode = z.infer<typeof InfraNodeSchema>
+
+export const GraphNodeSchema = z.discriminatedUnion('type', [
+  ServiceNodeSchema,
+  DatabaseNodeSchema,
+  ConfigNodeSchema,
+  InfraNodeSchema,
+])
+export type GraphNode = z.infer<typeof GraphNodeSchema>

--- a/packages/types/src/results.ts
+++ b/packages/types/src/results.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod'
+import { ProvenanceSchema } from './edges.js'
+
+export const RootCauseResultSchema = z.object({
+  rootCauseNode: z.string(),
+  rootCauseReason: z.string(),
+  traversalPath: z.array(z.string()),
+  edgeProvenances: z.array(ProvenanceSchema),
+  confidence: z.number().min(0).max(1),
+  fixRecommendation: z.string().optional(),
+})
+export type RootCauseResult = z.infer<typeof RootCauseResultSchema>
+
+export const BlastRadiusAffectedNodeSchema = z.object({
+  nodeId: z.string(),
+  distance: z.number().int().nonnegative(),
+  edgeProvenance: ProvenanceSchema,
+})
+export type BlastRadiusAffectedNode = z.infer<typeof BlastRadiusAffectedNodeSchema>
+
+export const BlastRadiusResultSchema = z.object({
+  origin: z.string(),
+  affectedNodes: z.array(BlastRadiusAffectedNodeSchema),
+  totalAffected: z.number().int().nonnegative(),
+})
+export type BlastRadiusResult = z.infer<typeof BlastRadiusResultSchema>

--- a/packages/types/test/schemas.test.ts
+++ b/packages/types/test/schemas.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ServiceNodeSchema,
+  DatabaseNodeSchema,
+  ConfigNodeSchema,
+  InfraNodeSchema,
+  GraphEdgeSchema,
+  ProvenanceSchema,
+  EdgeTypeSchema,
+  ErrorEventSchema,
+  RootCauseResultSchema,
+  BlastRadiusResultSchema,
+  Provenance,
+  EdgeType,
+  NodeType,
+} from '../src/index.js'
+
+describe('runtime constants', () => {
+  it('Provenance has 5 values', () => {
+    expect(Object.values(Provenance)).toHaveLength(5)
+  })
+  it('EdgeType has 4 values', () => {
+    expect(Object.values(EdgeType)).toHaveLength(4)
+  })
+  it('NodeType has 4 values', () => {
+    expect(Object.values(NodeType)).toHaveLength(4)
+  })
+})
+
+describe('ServiceNodeSchema', () => {
+  it('accepts a valid ServiceNode', () => {
+    const node = {
+      id: 'service-b',
+      type: 'ServiceNode' as const,
+      name: 'service-b',
+      language: 'javascript',
+      pgDriverVersion: '7.4.0',
+    }
+    expect(ServiceNodeSchema.parse(node)).toEqual(node)
+  })
+  it('rejects wrong type literal', () => {
+    expect(() =>
+      ServiceNodeSchema.parse({ id: 'x', type: 'DatabaseNode', name: 'x', language: 'js' }),
+    ).toThrow()
+  })
+  it('rejects missing required fields', () => {
+    expect(() => ServiceNodeSchema.parse({ id: 'x', type: 'ServiceNode' })).toThrow()
+  })
+})
+
+describe('DatabaseNodeSchema', () => {
+  it('accepts a valid DatabaseNode with compatibleDrivers', () => {
+    const node = {
+      id: 'payments-db',
+      type: 'DatabaseNode' as const,
+      name: 'payments-db',
+      engine: 'postgresql',
+      engineVersion: '15',
+      compatibleDrivers: [{ name: 'pg', minVersion: '8.0.0' }],
+    }
+    expect(DatabaseNodeSchema.parse(node)).toEqual(node)
+  })
+  it('rejects an empty compatibleDrivers array? actually empty is fine', () => {
+    const node = {
+      id: 'db',
+      type: 'DatabaseNode' as const,
+      name: 'db',
+      engine: 'mysql',
+      engineVersion: '8',
+      compatibleDrivers: [],
+    }
+    expect(() => DatabaseNodeSchema.parse(node)).not.toThrow()
+  })
+})
+
+describe('ConfigNodeSchema', () => {
+  it('accepts a valid ConfigNode', () => {
+    const node = {
+      id: 'cfg',
+      type: 'ConfigNode' as const,
+      name: 'app.yaml',
+      path: '/srv/app.yaml',
+      fileType: 'yaml',
+    }
+    expect(ConfigNodeSchema.parse(node)).toEqual(node)
+  })
+})
+
+describe('InfraNodeSchema', () => {
+  it('accepts a valid InfraNode', () => {
+    const node = {
+      id: 'infra',
+      type: 'InfraNode' as const,
+      name: 'us-east-1',
+      provider: 'aws',
+      region: 'us-east-1',
+    }
+    expect(InfraNodeSchema.parse(node)).toEqual(node)
+  })
+})
+
+describe('GraphEdgeSchema', () => {
+  it('accepts a valid OBSERVED CALLS edge', () => {
+    const edge = {
+      id: 'e1',
+      source: 'service-a',
+      target: 'service-b',
+      type: 'CALLS' as const,
+      provenance: 'OBSERVED' as const,
+      confidence: 0.95,
+      lastObserved: new Date().toISOString(),
+      callCount: 42,
+    }
+    expect(GraphEdgeSchema.parse(edge)).toEqual(edge)
+  })
+  it('rejects an invalid provenance', () => {
+    expect(() =>
+      GraphEdgeSchema.parse({
+        id: 'e',
+        source: 'a',
+        target: 'b',
+        type: 'CALLS',
+        provenance: 'BOGUS',
+      }),
+    ).toThrow()
+  })
+  it('rejects confidence out of range', () => {
+    expect(() =>
+      GraphEdgeSchema.parse({
+        id: 'e',
+        source: 'a',
+        target: 'b',
+        type: 'CALLS',
+        provenance: 'OBSERVED',
+        confidence: 1.5,
+      }),
+    ).toThrow()
+  })
+})
+
+describe('ProvenanceSchema and EdgeTypeSchema', () => {
+  it.each(Object.values(Provenance))('accepts provenance %s', (p) => {
+    expect(ProvenanceSchema.parse(p)).toBe(p)
+  })
+  it.each(Object.values(EdgeType))('accepts edge type %s', (t) => {
+    expect(EdgeTypeSchema.parse(t)).toBe(t)
+  })
+})
+
+describe('ErrorEventSchema', () => {
+  it('accepts a valid error event', () => {
+    const e = {
+      id: 'err1',
+      timestamp: new Date().toISOString(),
+      service: 'service-b',
+      traceId: 't1',
+      spanId: 's1',
+      errorMessage: 'connection refused',
+      affectedNode: 'payments-db',
+    }
+    expect(ErrorEventSchema.parse(e)).toEqual(e)
+  })
+})
+
+describe('RootCauseResultSchema', () => {
+  it('accepts a valid result', () => {
+    const r = {
+      rootCauseNode: 'service-b',
+      rootCauseReason: 'pg 7.4.0 incompatible with PostgreSQL 15',
+      traversalPath: ['payments-db', 'service-b'],
+      edgeProvenances: ['OBSERVED' as const, 'OBSERVED' as const],
+      confidence: 1.0,
+    }
+    expect(RootCauseResultSchema.parse(r)).toEqual(r)
+  })
+})
+
+describe('BlastRadiusResultSchema', () => {
+  it('accepts a valid blast radius', () => {
+    const b = {
+      origin: 'service-a',
+      affectedNodes: [
+        { nodeId: 'service-b', distance: 1, edgeProvenance: 'OBSERVED' as const },
+        { nodeId: 'payments-db', distance: 2, edgeProvenance: 'OBSERVED' as const },
+      ],
+      totalAffected: 2,
+    }
+    expect(BlastRadiusResultSchema.parse(b)).toEqual(b)
+  })
+})

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/packages/types/tsup.config.ts
+++ b/packages/types/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  target: 'node20',
+})

--- a/packages/types/vitest.config.ts
+++ b/packages/types/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,22 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@20.19.39)
 
+  packages/types:
+    dependencies:
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@20.19.39)
+
 packages:
 
   '@esbuild/aix-ppc64@0.21.5':
@@ -1298,6 +1314,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@esbuild/aix-ppc64@0.21.5':
@@ -2398,3 +2417,5 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,6 @@
     "declarationMap": true,
     "sourceMap": true,
     "isolatedModules": true,
-    "verbatimModuleSyntax": false,
-    "incremental": true
+    "verbatimModuleSyntax": false
   }
 }


### PR DESCRIPTION
## Summary
- Zod schemas for all node kinds (Service / Database / Config / Infra), edges, error events, and traversal results.
- Runtime constants `Provenance`, `EdgeType`, `NodeType` for autocomplete-safe enum-like usage.
- Dual ESM/CJS build via tsup; only `zod` as a runtime dep per the design doc.

Drop `incremental` from `tsconfig.base.json` since tsup's DTS step rejects it without an explicit `tsBuildInfoFile`.

Refs #2

## Test plan
- [x] \`pnpm --filter @neat/types build\` green (ESM + CJS + DTS)
- [x] \`pnpm --filter @neat/types test\` — 25/25 passing
- [x] \`pnpm turbo build\` and \`pnpm turbo test\` green at workspace level