### PR TITLE
Implement the compat matrix (#5)

### DIFF
--- a/packages/core/compat.json
+++ b/packages/core/compat.json
@@ -1,0 +1,25 @@
+{
+  "pairs": [
+    {
+      "driver": "pg",
+      "engine": "postgresql",
+      "minDriverVersion": "8.0.0",
+      "minEngineVersion": "14",
+      "reason": "PostgreSQL 14+ requires scram-sha-256 auth by default; pg < 8.0.0 only speaks md5."
+    },
+    {
+      "driver": "mysql2",
+      "engine": "mysql",
+      "minDriverVersion": "3.0.0",
+      "minEngineVersion": "8",
+      "reason": "MySQL 8 defaults to caching_sha2_password; mysql2 < 3.0.0 doesn't negotiate it."
+    },
+    {
+      "driver": "mongoose",
+      "engine": "mongodb",
+      "minDriverVersion": "7.0.0",
+      "minEngineVersion": "7",
+      "reason": "MongoDB 7 drops legacy wire-protocol opcodes that mongoose < 7.0.0 still emits."
+    }
+  ]
+}

--- a/packages/core/src/compat.ts
+++ b/packages/core/src/compat.ts
@@ -1,15 +1,75 @@
+import semver from 'semver'
+import compatData from '../compat.json' with { type: 'json' }
+
 export interface CompatibilityResult {
   compatible: boolean
   reason?: string
   minDriverVersion?: string
 }
 
-// Stub. The real compat matrix and compat.json land in #5.
+interface CompatPair {
+  driver: string
+  engine: string
+  minDriverVersion: string
+  // The driver constraint only kicks in once the engine is at this major or higher.
+  // Older engines (e.g. PostgreSQL 13) accept the older driver fine.
+  minEngineVersion?: string
+  reason: string
+}
+
+interface CompatMatrix {
+  pairs: CompatPair[]
+}
+
+const matrix = compatData as CompatMatrix
+
+// Engines like Postgres/MySQL only carry a major in the version field, so semver
+// won't always parse them cleanly. Compare as integers when both sides look like
+// majors; otherwise fall back to semver.coerce.
+function engineMeetsThreshold(engineVersion: string, threshold: string): boolean {
+  const e = parseInt(engineVersion, 10)
+  const t = parseInt(threshold, 10)
+  if (Number.isFinite(e) && Number.isFinite(t)) return e >= t
+
+  const ec = semver.coerce(engineVersion)
+  const tc = semver.coerce(threshold)
+  if (ec && tc) return semver.gte(ec, tc)
+
+  // Can't reason → don't claim incompatibility.
+  return false
+}
+
 export function checkCompatibility(
-  _driver: string,
-  _driverVersion: string,
-  _engine: string,
-  _engineVersion: string,
+  driver: string,
+  driverVersion: string,
+  engine: string,
+  engineVersion: string,
 ): CompatibilityResult {
+  const pair = matrix.pairs.find((p) => p.driver === driver && p.engine === engine)
+  if (!pair) return { compatible: true }
+
+  if (pair.minEngineVersion && !engineMeetsThreshold(engineVersion, pair.minEngineVersion)) {
+    return { compatible: true }
+  }
+
+  const driverCoerced = semver.coerce(driverVersion)
+  if (!driverCoerced) return { compatible: true }
+
+  if (semver.lt(driverCoerced, pair.minDriverVersion)) {
+    return {
+      compatible: false,
+      reason: pair.reason,
+      minDriverVersion: pair.minDriverVersion,
+    }
+  }
+
   return { compatible: true }
 }
+
+// Exported so #4 (extract) can iterate the configured pairs to build
+// `compatibleDrivers` lists on DatabaseNodes.
+export function compatPairs(): readonly CompatPair[] {
+  return matrix.pairs
+}
+
+export type { CompatPair }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,10 @@
 export { getGraph, resetGraph, type NeatGraph } from './graph.js'
 export { extractFromDirectory, type ExtractResult } from './extract.js'
-export { checkCompatibility, type CompatibilityResult } from './compat.js'
+export {
+  checkCompatibility,
+  compatPairs,
+  type CompatibilityResult,
+  type CompatPair,
+} from './compat.js'
 export { loadGraphFromDisk, saveGraphToDisk, startPersistLoop } from './persist.js'
 export { buildApi, type BuildApiOptions } from './api.js'

--- a/packages/core/test/compat.test.ts
+++ b/packages/core/test/compat.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { checkCompatibility, compatPairs } from '../src/compat.js'
+
+describe('checkCompatibility', () => {
+  describe('pg / postgresql', () => {
+    it('flags pg 7.4.0 against PostgreSQL 15 as incompatible (the demo case)', () => {
+      const r = checkCompatibility('pg', '7.4.0', 'postgresql', '15')
+      expect(r.compatible).toBe(false)
+      expect(r.minDriverVersion).toBe('8.0.0')
+      expect(r.reason).toMatch(/scram/i)
+    })
+
+    it('flags pg 7.4.0 against PostgreSQL 14 as incompatible', () => {
+      expect(checkCompatibility('pg', '7.4.0', 'postgresql', '14').compatible).toBe(false)
+    })
+
+    it('lets pg 7.4.0 against PostgreSQL 13 pass — engine threshold not reached', () => {
+      expect(checkCompatibility('pg', '7.4.0', 'postgresql', '13').compatible).toBe(true)
+    })
+
+    it('lets pg 8.0.0 against PostgreSQL 15 pass', () => {
+      expect(checkCompatibility('pg', '8.0.0', 'postgresql', '15').compatible).toBe(true)
+    })
+
+    it('lets pg 8.11.3 against PostgreSQL 16 pass', () => {
+      expect(checkCompatibility('pg', '8.11.3', 'postgresql', '16').compatible).toBe(true)
+    })
+  })
+
+  describe('mysql2 / mysql', () => {
+    it('flags mysql2 2.3.0 against MySQL 8 as incompatible', () => {
+      const r = checkCompatibility('mysql2', '2.3.0', 'mysql', '8')
+      expect(r.compatible).toBe(false)
+      expect(r.minDriverVersion).toBe('3.0.0')
+      expect(r.reason).toMatch(/caching_sha2/i)
+    })
+
+    it('lets mysql2 2.3.0 against MySQL 5 pass', () => {
+      expect(checkCompatibility('mysql2', '2.3.0', 'mysql', '5').compatible).toBe(true)
+    })
+
+    it('lets mysql2 3.6.0 against MySQL 8 pass', () => {
+      expect(checkCompatibility('mysql2', '3.6.0', 'mysql', '8').compatible).toBe(true)
+    })
+  })
+
+  describe('mongoose / mongodb', () => {
+    it('flags mongoose 6.10.0 against MongoDB 7 as incompatible', () => {
+      const r = checkCompatibility('mongoose', '6.10.0', 'mongodb', '7')
+      expect(r.compatible).toBe(false)
+      expect(r.minDriverVersion).toBe('7.0.0')
+    })
+
+    it('lets mongoose 6.10.0 against MongoDB 6 pass', () => {
+      expect(checkCompatibility('mongoose', '6.10.0', 'mongodb', '6').compatible).toBe(true)
+    })
+
+    it('lets mongoose 7.5.0 against MongoDB 7 pass', () => {
+      expect(checkCompatibility('mongoose', '7.5.0', 'mongodb', '7').compatible).toBe(true)
+    })
+  })
+
+  describe('unknown pairs', () => {
+    it('returns compatible for an unknown driver/engine combination', () => {
+      expect(checkCompatibility('bun:sqlite', '1.0.0', 'sqlite', '3').compatible).toBe(true)
+    })
+
+    it('returns compatible when only the driver matches but engine is different', () => {
+      expect(checkCompatibility('pg', '7.4.0', 'cockroachdb', '23').compatible).toBe(true)
+    })
+  })
+
+  describe('version coercion edge cases', () => {
+    it('handles a "v"-prefixed driver version', () => {
+      expect(checkCompatibility('pg', 'v7.4.0', 'postgresql', '15').compatible).toBe(false)
+    })
+
+    it('returns compatible when driver version is unparseable', () => {
+      // Refuse to claim incompatibility on garbage input.
+      expect(checkCompatibility('pg', 'nightly-build', 'postgresql', '15').compatible).toBe(true)
+    })
+  })
+
+  describe('compatPairs() export', () => {
+    it('exposes the configured matrix for #4 to read', () => {
+      const pairs = compatPairs()
+      expect(pairs.length).toBe(3)
+      expect(pairs.map((p) => `${p.driver}/${p.engine}`).sort()).toEqual([
+        'mongoose/mongodb',
+        'mysql2/mysql',
+        'pg/postgresql',
+      ])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Replaces the always-`true` stub in `packages/core/src/compat.ts`. `compat.json` carries the rules; `compat.ts` reads it.

Three pairs to start:

| driver     | engine       | min driver | engine threshold | reason                             |
|------------|--------------|------------|------------------|------------------------------------|
| `pg`       | `postgresql` | `8.0.0`    | `14`             | scram-sha-256 default in PG 14+    |
| `mysql2`   | `mysql`      | `3.0.0`    | `8`              | caching_sha2_password in MySQL 8   |
| `mongoose` | `mongodb`    | `7.0.0`    | `7`              | legacy wire protocol dropped       |

The driver constraint only fires once the engine is at the threshold major or higher, so `pg 7.4.0 / postgresql 13` still passes — which matches reality.

`semver.coerce` handles `v`-prefixed and minor-only versions on the driver side. The engine stays string-major because Postgres/MySQL only publish a major in the version field. Garbage driver versions return `compatible: true` — under-flag rather than claim a known failure on input we can't reason about.

`compatPairs()` is exported so #4 (extract) can iterate the matrix when building `DatabaseNode.compatibleDrivers` lists.

Refs #5

## Test plan

- [x] `npm run test --workspace @neat/core` — 19/19 (3 graph + 16 compat)
- [x] Demo case verified: `checkCompatibility('pg', '7.4.0', 'postgresql', '15')` → `{ compatible: false, minDriverVersion: '8.0.0', reason: /scram/ }`
- [x] `npm run build --workspace @neat/core` — JSON import resolves; ESM/CJS/DTS clean
- [x] `npm run lint --workspace @neat/core` — clean