### PR TITLE
Implement tree-sitter extraction (#4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6918,6 +6918,21 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -6963,6 +6978,7 @@
         "tree-sitter": "^0.21.1",
         "tree-sitter-javascript": "^0.21.4",
         "tree-sitter-typescript": "^0.21.2",
+        "yaml": "^2.5.0",
         "zod": "^3.23.8"
       },
       "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "tree-sitter": "^0.21.1",
     "tree-sitter-javascript": "^0.21.4",
     "tree-sitter-typescript": "^0.21.2",
+    "yaml": "^2.5.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/core/src/extract.ts
+++ b/packages/core/src/extract.ts
@@ -1,14 +1,292 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import Parser from 'tree-sitter'
+import JavaScript from 'tree-sitter-javascript'
+import { parse as parseYaml } from 'yaml'
+import type {
+  DatabaseNode,
+  GraphEdge,
+  GraphNode,
+  ServiceNode,
+  CompatibleDriver,
+} from '@neat/types'
+import { EdgeType, NodeType, Provenance } from '@neat/types'
 import type { NeatGraph } from './graph.js'
+import { checkCompatibility, compatPairs } from './compat.js'
 
 export interface ExtractResult {
   nodesAdded: number
   edgesAdded: number
 }
 
-// Just a stub for now. Real tree-sitter extraction lands in #4.
+interface PackageJson {
+  name: string
+  version?: string
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+interface DbConfig {
+  host: string
+  port?: number
+  database: string
+  engine: string
+  engineVersion: string
+}
+
+interface DiscoveredService {
+  pkg: PackageJson
+  dir: string
+  node: ServiceNode
+}
+
+const SERVICE_FILE_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.ts', '.tsx'])
+const IGNORED_DIRS = new Set(['node_modules', '.git', '.turbo', 'dist', 'build', '.next'])
+
+// Strip semver range prefixes (^, ~, >=, etc.) and bare "v" so the extracted
+// version is usable for compat checks. We don't try to resolve ranges to actual
+// installed versions — that's a published-lockfile concern, not extraction's job.
+function cleanVersion(raw: string | undefined): string | undefined {
+  if (!raw) return undefined
+  return raw.replace(/^[\^~><=v\s]+/, '').trim() || undefined
+}
+
+async function readJson<T>(filePath: string): Promise<T> {
+  const raw = await fs.readFile(filePath, 'utf8')
+  return JSON.parse(raw) as T
+}
+
+async function readYaml<T>(filePath: string): Promise<T> {
+  const raw = await fs.readFile(filePath, 'utf8')
+  return parseYaml(raw) as T
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function discoverServices(scanPath: string): Promise<DiscoveredService[]> {
+  const out: DiscoveredService[] = []
+  const entries = await fs.readdir(scanPath, { withFileTypes: true })
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || IGNORED_DIRS.has(entry.name)) continue
+    const dir = path.join(scanPath, entry.name)
+    const pkgPath = path.join(dir, 'package.json')
+    if (!(await exists(pkgPath))) continue
+
+    const pkg = await readJson<PackageJson>(pkgPath)
+    const deps = pkg.dependencies ?? {}
+    const node: ServiceNode = {
+      id: `service:${pkg.name}`,
+      type: NodeType.ServiceNode,
+      name: pkg.name,
+      language: 'javascript',
+      version: pkg.version,
+      dependencies: deps,
+      repoPath: path.relative(scanPath, dir),
+    }
+    if (deps.pg) {
+      node.pgDriverVersion = cleanVersion(deps.pg)
+    }
+    out.push({ pkg, dir, node })
+  }
+  return out
+}
+
+function compatibleDriversFor(engine: string): CompatibleDriver[] {
+  return compatPairs()
+    .filter((p) => p.engine === engine)
+    .map((p) => ({ name: p.driver, minVersion: p.minDriverVersion }))
+}
+
+async function extractDatabaseFromConfig(
+  service: DiscoveredService,
+): Promise<{ node: DatabaseNode; config: DbConfig } | null> {
+  const yamlPath = path.join(service.dir, 'db-config.yaml')
+  if (!(await exists(yamlPath))) return null
+
+  const config = await readYaml<DbConfig>(yamlPath)
+  const node: DatabaseNode = {
+    id: `database:${config.host}`,
+    type: NodeType.DatabaseNode,
+    name: config.database,
+    engine: config.engine,
+    engineVersion: config.engineVersion,
+    compatibleDrivers: compatibleDriversFor(config.engine),
+    host: config.host,
+    port: config.port,
+  }
+  return { node, config }
+}
+
+function attachIncompatibilities(service: DiscoveredService, dbConfig: DbConfig): void {
+  const deps = service.pkg.dependencies ?? {}
+  const incompatibilities: NonNullable<ServiceNode['incompatibilities']> = []
+
+  for (const pair of compatPairs()) {
+    if (pair.engine !== dbConfig.engine) continue
+    const declaredVersion = cleanVersion(deps[pair.driver])
+    if (!declaredVersion) continue
+    const result = checkCompatibility(
+      pair.driver,
+      declaredVersion,
+      dbConfig.engine,
+      dbConfig.engineVersion,
+    )
+    if (!result.compatible && result.reason) {
+      incompatibilities.push({
+        driver: pair.driver,
+        driverVersion: declaredVersion,
+        engine: dbConfig.engine,
+        engineVersion: dbConfig.engineVersion,
+        reason: result.reason,
+      })
+    }
+  }
+
+  if (incompatibilities.length > 0) {
+    service.node.incompatibilities = incompatibilities
+  }
+}
+
+async function walkSourceFiles(dir: string): Promise<string[]> {
+  const out: string[] = []
+  async function walk(current: string): Promise<void> {
+    const entries = await fs.readdir(current, { withFileTypes: true })
+    for (const entry of entries) {
+      const full = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        if (!IGNORED_DIRS.has(entry.name)) await walk(full)
+      } else if (entry.isFile() && SERVICE_FILE_EXTENSIONS.has(path.extname(entry.name))) {
+        out.push(full)
+      }
+    }
+  }
+  await walk(dir)
+  return out
+}
+
+function collectStringLiterals(node: Parser.SyntaxNode, out: string[]): void {
+  if (node.type === 'string_fragment') out.push(node.text)
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i)
+    if (child) collectStringLiterals(child, out)
+  }
+}
+
+// Find URL-like literals in the AST that point at one of the known service
+// hostnames (the directory name OR the package.json name). Each match implies a
+// CALLS edge from the file's owning service to the target.
+function callsFromSource(source: string, parser: Parser, knownHosts: Set<string>): Set<string> {
+  const tree = parser.parse(source)
+  const literals: string[] = []
+  collectStringLiterals(tree.rootNode, literals)
+  const targets = new Set<string>()
+  for (const lit of literals) {
+    for (const host of knownHosts) {
+      if (lit.includes(`//${host}`) || lit.includes(`//${host}:`)) {
+        targets.add(host)
+      }
+    }
+  }
+  return targets
+}
+
+function makeEdgeId(source: string, target: string, type: string): string {
+  return `${type}:${source}->${target}`
+}
+
 export async function extractFromDirectory(
-  _graph: NeatGraph,
-  _path: string,
+  graph: NeatGraph,
+  scanPath: string,
 ): Promise<ExtractResult> {
-  return { nodesAdded: 0, edgesAdded: 0 }
+  const result: ExtractResult = { nodesAdded: 0, edgesAdded: 0 }
+  const services = await discoverServices(scanPath)
+
+  // Phase 1 — service nodes (also: collect db configs for the next phases).
+  for (const service of services) {
+    if (!graph.hasNode(service.node.id)) {
+      graph.addNode(service.node.id, service.node)
+      result.nodesAdded++
+    }
+  }
+
+  // Phase 2 — database nodes from db-config.yaml + CONNECTS_TO edges + compat
+  // checks. Each service can have at most one db-config.yaml in this MVP scope.
+  for (const service of services) {
+    const db = await extractDatabaseFromConfig(service)
+    if (!db) continue
+
+    if (!graph.hasNode(db.node.id)) {
+      graph.addNode(db.node.id, db.node)
+      result.nodesAdded++
+    }
+
+    const edge: GraphEdge = {
+      id: makeEdgeId(service.node.id, db.node.id, EdgeType.CONNECTS_TO),
+      source: service.node.id,
+      target: db.node.id,
+      type: EdgeType.CONNECTS_TO,
+      provenance: Provenance.EXTRACTED,
+    }
+    if (!graph.hasEdge(edge.id)) {
+      graph.addEdgeWithKey(edge.id, edge.source, edge.target, edge)
+      result.edgesAdded++
+    }
+
+    attachIncompatibilities(service, db.config)
+    // Re-set the node attributes after mutating incompatibilities.
+    graph.replaceNodeAttributes(service.node.id, service.node as unknown as GraphNode)
+  }
+
+  // Phase 3 — service-to-service CALLS via tree-sitter scan of every source
+  // file in each service directory.
+  const parser = new Parser()
+  parser.setLanguage(JavaScript)
+  const knownHosts = new Set<string>()
+  for (const service of services) {
+    knownHosts.add(path.basename(service.dir))
+    knownHosts.add(service.pkg.name)
+  }
+  // Map host → service node id so we can resolve URL → target.
+  const hostToNodeId = new Map<string, string>()
+  for (const service of services) {
+    hostToNodeId.set(path.basename(service.dir), service.node.id)
+    hostToNodeId.set(service.pkg.name, service.node.id)
+  }
+
+  for (const service of services) {
+    const files = await walkSourceFiles(service.dir)
+    const seenTargets = new Set<string>()
+    for (const file of files) {
+      const source = await fs.readFile(file, 'utf8')
+      const targets = callsFromSource(source, parser, knownHosts)
+      for (const t of targets) {
+        const targetId = hostToNodeId.get(t)
+        if (!targetId || targetId === service.node.id) continue
+        seenTargets.add(targetId)
+      }
+    }
+    for (const targetId of seenTargets) {
+      const edge: GraphEdge = {
+        id: makeEdgeId(service.node.id, targetId, EdgeType.CALLS),
+        source: service.node.id,
+        target: targetId,
+        type: EdgeType.CALLS,
+        provenance: Provenance.EXTRACTED,
+      }
+      if (!graph.hasEdge(edge.id)) {
+        graph.addEdgeWithKey(edge.id, edge.source, edge.target, edge)
+        result.edgesAdded++
+      }
+    }
+  }
+
+  return result
 }

--- a/packages/core/test/extract.test.ts
+++ b/packages/core/test/extract.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import type { DatabaseNode, ServiceNode } from '@neat/types'
+
+// repoRoot/demo
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const DEMO_PATH = path.resolve(__dirname, '../../../demo')
+
+describe('extractFromDirectory against demo/', () => {
+  beforeEach(() => resetGraph())
+
+  it('produces the M1 graph shape', async () => {
+    const graph = getGraph()
+    const result = await extractFromDirectory(graph, DEMO_PATH)
+
+    expect(result.nodesAdded).toBeGreaterThanOrEqual(3)
+    expect(result.edgesAdded).toBeGreaterThanOrEqual(2)
+    expect(graph.order).toBeGreaterThanOrEqual(3)
+    expect(graph.size).toBeGreaterThanOrEqual(2)
+  })
+
+  it('emits a service-b ServiceNode with pgDriverVersion = "7.4.0"', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+
+    expect(graph.hasNode('service:service-b')).toBe(true)
+    const serviceB = graph.getNodeAttributes('service:service-b') as ServiceNode
+    expect(serviceB.pgDriverVersion).toBe('7.4.0')
+  })
+
+  it('emits a payments-db DatabaseNode with engineVersion = "15"', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+
+    expect(graph.hasNode('database:payments-db')).toBe(true)
+    const db = graph.getNodeAttributes('database:payments-db') as DatabaseNode
+    expect(db.engine).toBe('postgresql')
+    expect(db.engineVersion).toBe('15')
+    expect(db.compatibleDrivers.find((d) => d.name === 'pg')?.minVersion).toBe('8.0.0')
+  })
+
+  it('flags pg 7.4.0 as incompatible on service-b', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+    const serviceB = graph.getNodeAttributes('service:service-b') as ServiceNode
+    expect(serviceB.incompatibilities).toBeDefined()
+    expect(serviceB.incompatibilities?.[0]).toMatchObject({
+      driver: 'pg',
+      driverVersion: '7.4.0',
+      engine: 'postgresql',
+      engineVersion: '15',
+    })
+  })
+
+  it('emits a CONNECTS_TO edge from service-b to payments-db', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+
+    const edges = graph.outboundEdges('service:service-b')
+    const connectEdges = edges.filter(
+      (e) => graph.getEdgeAttribute(e, 'type') === 'CONNECTS_TO',
+    )
+    expect(connectEdges).toHaveLength(1)
+    expect(graph.target(connectEdges[0]!)).toBe('database:payments-db')
+  })
+
+  it('emits a CALLS edge from service-a to service-b (tree-sitter URL match)', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+
+    const edges = graph.outboundEdges('service:service-a')
+    const callEdges = edges.filter(
+      (e) => graph.getEdgeAttribute(e, 'type') === 'CALLS',
+    )
+    expect(callEdges.length).toBeGreaterThanOrEqual(1)
+    expect(callEdges.map((e) => graph.target(e))).toContain('service:service-b')
+  })
+
+  it('all extracted edges have provenance EXTRACTED', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+    graph.forEachEdge((_id, attrs) => {
+      expect(attrs.provenance).toBe('EXTRACTED')
+    })
+  })
+
+  it('is idempotent — running twice does not add duplicate nodes/edges', async () => {
+    const graph = getGraph()
+    const first = await extractFromDirectory(graph, DEMO_PATH)
+    const orderBefore = graph.order
+    const sizeBefore = graph.size
+    const second = await extractFromDirectory(graph, DEMO_PATH)
+    expect(second.nodesAdded).toBe(0)
+    expect(second.edgesAdded).toBe(0)
+    expect(graph.order).toBe(orderBefore)
+    expect(graph.size).toBe(sizeBefore)
+    expect(first.nodesAdded).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

Replaces the `0/0` stub in `extract.ts`. `extractFromDirectory` walks a scan path, builds the graph, and runs the compat check on the way out.

Three phases:

1. **Discover services.** Anything under the scan path with a `package.json` becomes a `ServiceNode`. Pull `pgDriverVersion` from `dependencies.pg` if present.
2. **Database nodes from `db-config.yaml`.** If a service has one, parse it into a `DatabaseNode` (one per host), wire a `CONNECTS_TO` edge, and compute `compatibleDrivers` from the compat matrix. Run `checkCompatibility` for every driver the service declares against that engine; incompatibilities attach to the service's `incompatibilities` array.
3. **`CALLS` edges via tree-sitter.** Parse every JS/TS file in each service dir, collect string literals, look for URLs pointing at known service hostnames. Each match becomes a `CALLS` edge (deduped per source).

All extracted edges carry `provenance: EXTRACTED`. The function is **idempotent** — re-running against the same path doesn't add duplicates.

Adds `yaml@^2.5.0` for `db-config.yaml`. Full yaml/env extraction (`ConfigNode` types, `CONFIGURED_BY` edges) is M5 (#28-equivalent post-mvp); this is the minimum needed for the `payments-db` node M1 requires.

Refs #4

## Test plan

- [x] `npm run test --workspace @neat/core` — 27/27 (3 graph + 16 compat + 8 extract)
- [x] M1 verification gate (graph contents):
  - [x] ≥ 3 nodes, ≥ 2 edges
  - [x] `service:service-b` ServiceNode with `pgDriverVersion: "7.4.0"`
  - [x] `database:payments-db` DatabaseNode with `engine: postgresql`, `engineVersion: "15"`, `compatibleDrivers` containing `pg ≥ 8.0.0`
  - [x] `service-b.incompatibilities[0]` flags pg 7.4.0 vs PG 15 with the scram-sha-256 reason
  - [x] `CONNECTS_TO` edge `service-b → payments-db`
  - [x] `CALLS` edge `service-a → service-b` (tree-sitter URL match)
  - [x] All edges `provenance: "EXTRACTED"`
- [x] Idempotency — re-running on an already-extracted graph adds 0 nodes / 0 edges
- [x] `npm run build / lint --workspace @neat/core` — clean