### PR TITLE
Implement graph persistence (#6)

### DIFF
--- a/packages/core/src/persist.ts
+++ b/packages/core/src/persist.ts
@@ -1,14 +1,93 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
 import type { NeatGraph } from './graph.js'
 
-// Stub. SIGTERM/SIGINT save, periodic save, and load-on-startup land in #6.
-export async function loadGraphFromDisk(_graph: NeatGraph, _outPath: string): Promise<void> {
-  return
+const SCHEMA_VERSION = 1
+
+interface PersistedGraph {
+  schemaVersion: number
+  exportedAt: string
+  graph: ReturnType<NeatGraph['export']>
 }
 
-export async function saveGraphToDisk(_graph: NeatGraph, _outPath: string): Promise<void> {
-  return
+async function ensureDir(filePath: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
 }
 
-export function startPersistLoop(_graph: NeatGraph, _outPath: string, _intervalMs = 60_000): () => void {
-  return () => {}
+export async function saveGraphToDisk(graph: NeatGraph, outPath: string): Promise<void> {
+  await ensureDir(outPath)
+  const payload: PersistedGraph = {
+    schemaVersion: SCHEMA_VERSION,
+    exportedAt: new Date().toISOString(),
+    graph: graph.export(),
+  }
+  // Atomic write: drop into <name>.tmp first, then rename. A crash mid-write
+  // leaves the previous snapshot intact instead of a half-truncated file.
+  const tmp = `${outPath}.tmp`
+  await fs.writeFile(tmp, JSON.stringify(payload), 'utf8')
+  await fs.rename(tmp, outPath)
+}
+
+export async function loadGraphFromDisk(graph: NeatGraph, outPath: string): Promise<void> {
+  let raw: string
+  try {
+    raw = await fs.readFile(outPath, 'utf8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return
+    throw err
+  }
+  const payload = JSON.parse(raw) as PersistedGraph
+  if (payload.schemaVersion !== SCHEMA_VERSION) {
+    throw new Error(
+      `persist: unsupported snapshot schemaVersion ${payload.schemaVersion} (expected ${SCHEMA_VERSION})`,
+    )
+  }
+  graph.clear()
+  graph.import(payload.graph)
+}
+
+// Periodic save + best-effort save on SIGTERM/SIGINT. Returns a cleanup that
+// clears the interval and unhooks the signal handlers — important for tests so
+// they don't keep the process alive.
+export function startPersistLoop(
+  graph: NeatGraph,
+  outPath: string,
+  intervalMs = 60_000,
+): () => void {
+  let stopped = false
+
+  const tick = async (): Promise<void> => {
+    if (stopped) return
+    try {
+      await saveGraphToDisk(graph, outPath)
+    } catch (err) {
+      console.error('persist: periodic save failed', err)
+    }
+  }
+
+  const interval = setInterval(() => {
+    void tick()
+  }, intervalMs)
+
+  const onSignal = (signal: NodeJS.Signals): void => {
+    void (async () => {
+      try {
+        await saveGraphToDisk(graph, outPath)
+      } catch (err) {
+        console.error(`persist: ${signal} save failed`, err)
+      } finally {
+        process.exit(0)
+      }
+    })()
+  }
+
+  process.on('SIGTERM', onSignal)
+  process.on('SIGINT', onSignal)
+
+  return () => {
+    stopped = true
+    clearInterval(interval)
+    process.off('SIGTERM', onSignal)
+    process.off('SIGINT', onSignal)
+  }
 }

--- a/packages/core/test/persist.test.ts
+++ b/packages/core/test/persist.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { tmpdir } from 'node:os'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import { saveGraphToDisk, loadGraphFromDisk, startPersistLoop } from '../src/persist.js'
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const DEMO_PATH = path.resolve(__dirname, '../../../demo')
+
+describe('persistence', () => {
+  let outPath: string
+
+  beforeEach(async () => {
+    resetGraph()
+    outPath = path.join(
+      await fs.mkdtemp(path.join(tmpdir(), 'neat-persist-')),
+      'graph.json',
+    )
+  })
+
+  afterEach(async () => {
+    await fs.rm(path.dirname(outPath), { recursive: true, force: true })
+  })
+
+  it('saveGraphToDisk writes a valid JSON snapshot', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+    await saveGraphToDisk(graph, outPath)
+
+    const raw = await fs.readFile(outPath, 'utf8')
+    const parsed = JSON.parse(raw)
+    expect(parsed.schemaVersion).toBe(1)
+    expect(parsed.exportedAt).toBeTypeOf('string')
+    expect(parsed.graph.nodes.length).toBeGreaterThanOrEqual(3)
+    expect(parsed.graph.edges.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('round-trips a graph: save → load reproduces the same node and edge counts', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+    const orderBefore = graph.order
+    const sizeBefore = graph.size
+
+    await saveGraphToDisk(graph, outPath)
+    resetGraph()
+    const restored = getGraph()
+    await loadGraphFromDisk(restored, outPath)
+
+    expect(restored.order).toBe(orderBefore)
+    expect(restored.size).toBe(sizeBefore)
+    expect(restored.hasNode('service:service-b')).toBe(true)
+    expect(restored.hasNode('database:payments-db')).toBe(true)
+  })
+
+  it('round-trips node attributes (pgDriverVersion preserved)', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+    await saveGraphToDisk(graph, outPath)
+
+    resetGraph()
+    const restored = getGraph()
+    await loadGraphFromDisk(restored, outPath)
+
+    const serviceB = restored.getNodeAttributes('service:service-b') as {
+      pgDriverVersion?: string
+    }
+    expect(serviceB.pgDriverVersion).toBe('7.4.0')
+  })
+
+  it('writes atomically — only the final file lands, no .tmp leftover', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+    await saveGraphToDisk(graph, outPath)
+
+    const dir = path.dirname(outPath)
+    const entries = await fs.readdir(dir)
+    expect(entries).toContain('graph.json')
+    expect(entries.find((e) => e.endsWith('.tmp'))).toBeUndefined()
+  })
+
+  it('loadGraphFromDisk on a non-existent file is a no-op (no throw)', async () => {
+    const graph = getGraph()
+    await expect(loadGraphFromDisk(graph, outPath)).resolves.toBeUndefined()
+    expect(graph.order).toBe(0)
+  })
+
+  it('loadGraphFromDisk rejects an unsupported schemaVersion', async () => {
+    await fs.mkdir(path.dirname(outPath), { recursive: true })
+    await fs.writeFile(
+      outPath,
+      JSON.stringify({ schemaVersion: 999, exportedAt: '', graph: { nodes: [], edges: [] } }),
+    )
+    await expect(loadGraphFromDisk(getGraph(), outPath)).rejects.toThrow(/schemaVersion/)
+  })
+
+  it('saveGraphToDisk creates the parent directory if missing', async () => {
+    const nested = path.join(path.dirname(outPath), 'a', 'b', 'graph.json')
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+    await expect(saveGraphToDisk(graph, nested)).resolves.toBeUndefined()
+    await expect(fs.access(nested)).resolves.toBeUndefined()
+  })
+
+  it('startPersistLoop saves on its interval and the cleanup unhooks signals', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+
+    const sigtermBefore = process.listenerCount('SIGTERM')
+    const sigintBefore = process.listenerCount('SIGINT')
+
+    const stop = startPersistLoop(graph, outPath, 50)
+    try {
+      expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore + 1)
+      expect(process.listenerCount('SIGINT')).toBe(sigintBefore + 1)
+
+      await new Promise((r) => setTimeout(r, 120))
+      const raw = await fs.readFile(outPath, 'utf8')
+      expect(JSON.parse(raw).graph.nodes.length).toBeGreaterThan(0)
+    } finally {
+      stop()
+    }
+
+    expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore)
+    expect(process.listenerCount('SIGINT')).toBe(sigintBefore)
+  })
+})


### PR DESCRIPTION
## Summary

Replaces the no-op stubs in `persist.ts`.

- **`saveGraphToDisk`** — `graph.export()` into a small wrapper carrying `schemaVersion: 1` and `exportedAt`. Atomic write (`<path>.tmp` → `fs.rename`) so a crash mid-write keeps the previous snapshot intact.
- **`loadGraphFromDisk`** — swallows `ENOENT` (first run, no snapshot yet), rejects unsupported `schemaVersion`. `graph.clear()` before `import()` so calling it twice is safe.
- **`startPersistLoop`** — `setInterval` on the requested cadence (default 60s) + `SIGTERM`/`SIGINT` handlers that each do a final save then `process.exit(0)`. The returned cleanup `clearInterval`'s and `process.off`'s both signals so tests don't leak handlers.

Refs #6

## Test plan

- [x] `npm run test --workspace @neat/core` — 35/35 (3 graph + 16 compat + 8 extract + 8 persist)
- [x] Round-trip: extract → save → reset → load reproduces node/edge counts and preserves `pgDriverVersion: "7.4.0"`
- [x] Atomicity: only `graph.json` lands, no `.tmp` leftover
- [x] `loadGraphFromDisk` on a missing file is a no-op; on a v999 file throws with `/schemaVersion/`
- [x] `saveGraphToDisk` creates parent directories
- [x] `startPersistLoop` saves on interval; cleanup unhooks SIGTERM and SIGINT (listener counts back to baseline)