### PR TITLE
Implement REST API M1 routes (#9)

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -1,25 +1,102 @@
 import Fastify, { type FastifyInstance } from 'fastify'
 import cors from '@fastify/cors'
+import type { GraphEdge, GraphNode } from '@neat/types'
 import type { NeatGraph } from './graph.js'
+import { extractFromDirectory } from './extract.js'
 
 export interface BuildApiOptions {
   graph: NeatGraph
   startedAt?: number
+  // Path the POST /graph/scan endpoint should re-extract from. Optional for tests.
+  scanPath?: string
 }
 
-// Skeleton API. Real routes (graph, incidents, search, scan) land in #9; traversal in #12.
+interface SerializedGraph {
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+}
+
+function serializeGraph(graph: NeatGraph): SerializedGraph {
+  const nodes: GraphNode[] = []
+  graph.forEachNode((_id, attrs) => {
+    nodes.push(attrs)
+  })
+  const edges: GraphEdge[] = []
+  graph.forEachEdge((_id, attrs) => {
+    edges.push(attrs)
+  })
+  return { nodes, edges }
+}
+
 export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> {
   const app = Fastify({ logger: false })
   await app.register(cors, { origin: true })
 
   const startedAt = opts.startedAt ?? Date.now()
+  const { graph } = opts
 
-  app.get('/health', async () => {
+  app.get('/health', async () => ({
+    uptime: Math.floor((Date.now() - startedAt) / 1000),
+    nodeCount: graph.order,
+    edgeCount: graph.size,
+    lastUpdated: new Date().toISOString(),
+  }))
+
+  app.get('/graph', async () => serializeGraph(graph))
+
+  app.get<{ Params: { id: string } }>('/graph/node/:id', async (req, reply) => {
+    const { id } = req.params
+    if (!graph.hasNode(id)) {
+      return reply.code(404).send({ error: 'node not found', id })
+    }
+    return graph.getNodeAttributes(id) as GraphNode
+  })
+
+  app.get<{ Params: { id: string } }>('/graph/edges/:id', async (req, reply) => {
+    const { id } = req.params
+    if (!graph.hasNode(id)) {
+      return reply.code(404).send({ error: 'node not found', id })
+    }
+    const inbound = graph.inboundEdges(id).map((e) => graph.getEdgeAttributes(e) as GraphEdge)
+    const outbound = graph.outboundEdges(id).map((e) => graph.getEdgeAttributes(e) as GraphEdge)
+    return { inbound, outbound }
+  })
+
+  // Incidents come online with M2 (OTel ingest). Stub the routes so clients can
+  // wire against the final URL shape today.
+  app.get('/incidents', async () => [])
+  app.get<{ Params: { nodeId: string } }>('/incidents/:nodeId', async (req, reply) => {
+    const { nodeId } = req.params
+    if (!graph.hasNode(nodeId)) {
+      return reply.code(404).send({ error: 'node not found', id: nodeId })
+    }
+    return []
+  })
+
+  app.get<{ Querystring: { q?: string } }>('/search', async (req, reply) => {
+    const q = (req.query.q ?? '').trim().toLowerCase()
+    if (!q) return reply.code(400).send({ error: 'query parameter `q` is required' })
+    const matches: GraphNode[] = []
+    graph.forEachNode((id, attrs) => {
+      const name = (attrs as { name?: string }).name ?? ''
+      if (id.toLowerCase().includes(q) || name.toLowerCase().includes(q)) {
+        matches.push(attrs)
+      }
+    })
+    return { query: q, matches }
+  })
+
+  app.post('/graph/scan', async (_req, reply) => {
+    if (!opts.scanPath) {
+      return reply.code(409).send({ error: 'NEAT_SCAN_PATH not configured on this server' })
+    }
+    const result = await extractFromDirectory(graph, opts.scanPath)
     return {
-      uptime: Math.floor((Date.now() - startedAt) / 1000),
-      nodeCount: opts.graph.order,
-      edgeCount: opts.graph.size,
-      lastUpdated: new Date().toISOString(),
+      scanned: opts.scanPath,
+      nodesAdded: result.nodesAdded,
+      edgesAdded: result.edgesAdded,
+      nodeCount: graph.order,
+      edgeCount: graph.size,
     }
   })
 

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -1,17 +1,34 @@
+import path from 'node:path'
 import { getGraph } from './graph.js'
 import { buildApi } from './api.js'
+import { extractFromDirectory } from './extract.js'
+import { loadGraphFromDisk, startPersistLoop } from './persist.js'
 
-// Wires the pieces together. Extraction, persistence, and the rest of the routes
-// get plugged in over the next few branches.
 async function main(): Promise<void> {
   const graph = getGraph()
-  const app = await buildApi({ graph })
+  const scanPath = path.resolve(process.env.NEAT_SCAN_PATH ?? './demo')
+  const outPath = path.resolve(process.env.NEAT_OUT_PATH ?? './neat-out/graph.json')
 
+  // Load any existing snapshot first so a restart doesn't lose runtime
+  // (M2 OBSERVED) edges that won't be reproduced by a fresh extract.
+  await loadGraphFromDisk(graph, outPath)
+
+  // Then re-run extraction over the source. Existing nodes/edges are dedup'd
+  // by id, so this is a refresh, not a wipe.
+  const extractResult = await extractFromDirectory(graph, scanPath)
+  console.log(
+    `extract: ${extractResult.nodesAdded} new nodes, ${extractResult.edgesAdded} new edges (graph total ${graph.order}/${graph.size})`,
+  )
+
+  startPersistLoop(graph, outPath)
+
+  const app = await buildApi({ graph, scanPath })
   const port = Number(process.env.PORT ?? 8080)
   const host = process.env.HOST ?? '0.0.0.0'
-
   await app.listen({ port, host })
   console.log(`neat-core listening on http://${host}:${port}`)
+  console.log(`  scan path:     ${scanPath}`)
+  console.log(`  snapshot path: ${outPath}`)
 }
 
 main().catch((err) => {

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import path from 'node:path'
+import type { FastifyInstance } from 'fastify'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { buildApi } from '../src/api.js'
+import { extractFromDirectory } from '../src/extract.js'
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const DEMO_PATH = path.resolve(__dirname, '../../../demo')
+
+describe('REST API (fastify.inject)', () => {
+  let app: FastifyInstance
+
+  beforeEach(async () => {
+    resetGraph()
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+    app = await buildApi({ graph, scanPath: DEMO_PATH })
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('GET /health returns the expected shape', async () => {
+    const res = await app.inject({ method: 'GET', url: '/health' })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body).toMatchObject({
+      uptime: expect.any(Number),
+      nodeCount: expect.any(Number),
+      edgeCount: expect.any(Number),
+      lastUpdated: expect.any(String),
+    })
+    expect(body.nodeCount).toBeGreaterThanOrEqual(3)
+  })
+
+  it('GET /graph returns nodes and edges arrays', async () => {
+    const res = await app.inject({ method: 'GET', url: '/graph' })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.nodes.length).toBeGreaterThanOrEqual(3)
+    expect(body.edges.length).toBeGreaterThanOrEqual(2)
+
+    const serviceB = body.nodes.find((n: { id: string }) => n.id === 'service:service-b')
+    expect(serviceB.pgDriverVersion).toBe('7.4.0')
+
+    const db = body.nodes.find((n: { id: string }) => n.id === 'database:payments-db')
+    expect(db.engineVersion).toBe('15')
+    expect(db.compatibleDrivers.find((d: { name: string }) => d.name === 'pg').minVersion).toBe(
+      '8.0.0',
+    )
+  })
+
+  it('GET /graph/node/:id returns a single node', async () => {
+    const res = await app.inject({ method: 'GET', url: '/graph/node/service:service-b' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().pgDriverVersion).toBe('7.4.0')
+  })
+
+  it('GET /graph/node/:id returns 404 for an unknown node', async () => {
+    const res = await app.inject({ method: 'GET', url: '/graph/node/nope' })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('GET /graph/edges/:id returns inbound and outbound', async () => {
+    const res = await app.inject({ method: 'GET', url: '/graph/edges/service:service-b' })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.inbound.length).toBeGreaterThanOrEqual(1)
+    expect(body.outbound.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('GET /incidents returns an empty array (M2 fills this in)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/incidents' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual([])
+  })
+
+  it('GET /incidents/:nodeId returns [] for a known node', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/incidents/service:service-b',
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual([])
+  })
+
+  it('GET /search?q=service-b finds the matching node', async () => {
+    const res = await app.inject({ method: 'GET', url: '/search?q=service-b' })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.query).toBe('service-b')
+    expect(body.matches.length).toBeGreaterThanOrEqual(1)
+    expect(body.matches.some((n: { id: string }) => n.id === 'service:service-b')).toBe(true)
+  })
+
+  it('GET /search with no q returns 400', async () => {
+    const res = await app.inject({ method: 'GET', url: '/search' })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('POST /graph/scan re-runs extraction (idempotent — adds nothing the second time)', async () => {
+    const res = await app.inject({ method: 'POST', url: '/graph/scan' })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.scanned).toMatch(/demo$/)
+    expect(body.nodesAdded).toBe(0)
+    expect(body.edgesAdded).toBe(0)
+    expect(body.nodeCount).toBeGreaterThanOrEqual(3)
+  })
+
+  it('POST /graph/scan returns 409 when scanPath was not configured', async () => {
+    await app.close()
+    const graph = getGraph()
+    app = await buildApi({ graph })
+    const res = await app.inject({ method: 'POST', url: '/graph/scan' })
+    expect(res.statusCode).toBe(409)
+  })
+})


### PR DESCRIPTION
## Summary

`api.ts` grows from `/health`-only to the full M1 surface:

| Method | Route                | Behavior                                                                      |
|--------|----------------------|-------------------------------------------------------------------------------|
| GET    | `/health`            | uptime + node/edge counts + lastUpdated                                       |
| GET    | `/graph`             | full dump (`{ nodes, edges }`)                                                |
| GET    | `/graph/node/:id`    | one node, 404 if not found                                                    |
| GET    | `/graph/edges/:id`   | `{ inbound, outbound }` for a node                                            |
| GET    | `/incidents`         | `[]` for now (M2 wires real OTel events)                                      |
| GET    | `/incidents/:nodeId` | `[]` per node (404 if node unknown)                                           |
| GET    | `/search?q=`         | substring match against id + name; 400 if `q` missing                         |
| POST   | `/graph/scan`        | re-runs `extractFromDirectory` against the configured scan path; 409 if none  |

Traversal routes (`/traverse/*`) stay deferred to #12 in M3.

`server.ts` now actually wires the pieces together: load any existing snapshot from `NEAT_OUT_PATH`, run `extractFromDirectory` against `NEAT_SCAN_PATH`, kick off the persist loop, then start Fastify. **Loading before extracting matters** because OBSERVED edges (M2 onwards) won't be reproduced by static extraction — they have to survive a restart.

Refs #9

## Test plan

- [x] `npm run test --workspace @neat/core` — 46/46 (3 graph + 16 compat + 8 extract + 8 persist + 11 api)
- [x] `/graph` over `fastify.inject()`: ≥ 3 nodes, ≥ 2 edges, `service-b.pgDriverVersion: "7.4.0"`, `payments-db.engineVersion: "15"`, compat list
- [x] `POST /graph/scan` idempotent — 0 nodes / 0 edges added on a second call
- [x] 404 paths for unknown nodes; 400 for missing `q`; 409 for unconfigured scan path
- [x] Local boot: `NEAT_SCAN_PATH=./demo npm run dev --workspace @neat/core` (manual smoke)

## M1 verification gate

After this lands, the M0+M1 gates in `docs/milestones.md` should both flip to VERIFIED. Tests assert every gate item.