### PR TITLE
Document M1 intricacies and flag M2 starting line

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,4 +79,30 @@ In-memory graph snapshots to `${NEAT_OUT_PATH:-./neat-out/graph.json}` on a 60s 
 
 ## Compat matrix
 
-`packages/core/compat.json` — data file, not code. `compat.ts` looks up `(driver, driverVersion, engine, engineVersion)` and returns `{ compatible, reason, minDriverVersion }`. Adding a new (in)compatibility is a JSON edit, not a code change. Lands in M1 issue #5.
+`packages/core/compat.json` — data file, not code. `compat.ts` looks up `(driver, driverVersion, engine, engineVersion)` and returns `{ compatible, reason, minDriverVersion }`. Adding a new (in)compatibility is a JSON edit, not a code change.
+
+The matrix carries a `minEngineVersion` field per pair — the driver constraint only fires once the engine is at that major or higher. So `pg 7.4.0 / postgresql 13` still passes (PG 13 doesn't require scram), `pg 7.4.0 / postgresql 14` fails.
+
+`compatPairs()` is the second exported function — `extract.ts` iterates it to populate `DatabaseNode.compatibleDrivers`. So adding a new pair to `compat.json` automatically shows up on the right engine's `compatibleDrivers` list, no other code change required.
+
+## M1 implementation notes
+
+Things that aren't load-bearing decisions but are non-obvious from reading the code:
+
+- **Node ids**: `service:<package.name>` for ServiceNodes, `database:<host>` for DatabaseNodes (host comes from `db-config.yaml`). Edge ids: `${type}:${source}->${target}`. The id format is the contract everything else (traversal in M3, MCP tools in M4) keys off, so don't change it casually.
+
+- **Extract is three phases.** (1) Discover services from `package.json` files. (2) For each service, parse `db-config.yaml` if present → emit DatabaseNode + `CONNECTS_TO` edge + run compat check. (3) tree-sitter parse every JS/TS file in each service dir, collect string literals, look for URLs containing a known service hostname → emit `CALLS` edges (deduped per source). The function is idempotent — running it twice on the same path adds 0 nodes/edges.
+
+- **tree-sitter scope is intentionally tiny.** It's a string-literal scan for URL substrings matching known hostnames, not a full import-graph analysis. Good enough to pick up `axios.get('http://service-b:3001/...')` and similar; doesn't catch dynamically constructed URLs or network calls hidden behind a config object. Worth revisiting only if a real demo case needs more.
+
+- **Compat ignores garbage versions rather than erroring.** If `semver.coerce` can't make sense of a driver version string, `checkCompatibility` returns `{ compatible: true }`. Better to under-flag than to claim a known failure on input we can't reason about.
+
+- **`pgDriverVersion` lives on ServiceNode AND in `incompatibilities[]`.** The first is for cheap UI/lookup ("what version is this service on?"), the second is the audit trail ("here's what specifically is wrong"). Both are populated during extract phase 2.
+
+- **The yaml dependency is M1-scoped.** `db-config.yaml` is parsed today only because it's the cheapest path to `payments-db.engineVersion: "15"` for the demo. Full yaml/env extraction with first-class `ConfigNode` types and `CONFIGURED_BY` edges is M5. Don't expand the yaml parsing surface inside `extract.ts` — it goes to its own pass when M5 happens.
+
+- **Persistence loads BEFORE extracts on startup.** OBSERVED edges (M2 onwards) won't be reproduced by static extraction — they have to survive a restart. Reorder this and you silently lose every runtime observation on every reboot.
+
+- **Snapshots have a `schemaVersion: 1` envelope** wrapping the `graphology.export()` blob. Mismatched versions throw on load (no silent migration). When the graph shape changes incompatibly, bump the version and add a migration path here, not in the extract code.
+
+- **JSON imports use `with { type: "json" }`** (Node 20+ import attribute). tsup bundles `compat.json` into the dist output. The `"files": ["dist", "compat.json"]` line in `packages/core/package.json` keeps it shipped if/when this package gets published.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -94,3 +94,60 @@ Commit messages, PR bodies, code comments, and docs read like a colleague wrote 
 `demo/service-a` and `demo/service-b` exist as source files only during M0/M1. The static extractor reads their `package.json` directly from disk; it doesn't need their deps resolved. Listing them as workspaces would force npm to resolve pg, express, and the OTel SDK — ~80 transitive packages — for no current benefit.
 
 M2 brings them back into workspaces when docker-compose actually launches the services.
+
+---
+
+## ADR-010 — Node and edge ID conventions
+
+**Date:** 2026-05-01
+**Status:** Active.
+
+Node ids are typed prefixes joined to a stable name:
+
+- `service:<package.name>` for `ServiceNode`s. The package name is what the discovery phase reads from `package.json`, so it survives directory renames and matches what humans (and the MCP tools) will type.
+- `database:<host>` for `DatabaseNode`s. The host comes from `db-config.yaml`; it's the same value services reach the database with, which makes deduplication trivial when multiple services connect to the same db.
+
+Edge ids are `${type}:${source}->${target}`. This makes edges deterministic — two extracts that see the same relationship produce the same key, so re-running `extractFromDirectory` is idempotent without needing a separate dedup pass.
+
+**Why it matters:** every traversal (M3) and every MCP tool argument (M4) keys off these ids. Changing the format breaks the contract with everything downstream. If a new node type appears, give it a new prefix (`config:`, `infra:`); don't repurpose existing ones.
+
+---
+
+## ADR-011 — Snapshot envelope with schemaVersion
+
+**Date:** 2026-05-01
+**Status:** Active.
+
+`saveGraphToDisk` doesn't write the raw `graphology.export()` blob. It wraps it:
+
+```json
+{ "schemaVersion": 1, "exportedAt": "2026-05-01T...", "graph": <export> }
+```
+
+`loadGraphFromDisk` rejects mismatched `schemaVersion` rather than trying to migrate silently. The first time the graph shape changes incompatibly (new required attribute, edge type rename, etc.), bump to `schemaVersion: 2` and add a migration branch in `loadGraphFromDisk`.
+
+The write itself is atomic: `<path>.tmp` first, then `fs.rename`. A crash mid-write leaves the previous snapshot intact rather than half-truncating the active file.
+
+---
+
+## ADR-012 — tree-sitter scope for M1: URL substring matching only
+
+**Date:** 2026-05-01
+**Status:** Active for M1. Revisit if M3+ traversal needs richer call graphs.
+
+The M1 extractor uses tree-sitter only to walk the AST and collect string literals; it then searches those literals for URLs containing a known service hostname. That's enough for the demo (`axios.get('http://service-b:3001/...')`).
+
+What it deliberately does **not** do: full import-graph analysis, dynamic-URL inference, or following config objects. Those would multiply the surface area of what the extractor can be wrong about, and the failure cases the design doc cares about don't need them.
+
+If a future demo case requires richer call-graph extraction, that's a deliberate scope expansion — write tests against the new failure mode first, then extend `extract.ts`.
+
+---
+
+## ADR-013 — Compat threshold semantics: under-flag rather than over-flag
+
+**Date:** 2026-05-01
+**Status:** Active.
+
+`compat.json` carries a `minEngineVersion` per pair. The driver constraint only fires once the engine reaches that major or higher — so `pg 7.4.0 / postgresql 13` returns `compatible: true` because PG 13 still supports md5 auth.
+
+Driver versions go through `semver.coerce` so `"v7.4.0"` and `"7.4"` both work. If a version string is unparseable (a git SHA, a build label, etc.), the function returns `compatible: true`. We'd rather miss a real incompatibility than fabricate a false positive on input we genuinely can't reason about — false positives erode trust in everything else the system says.

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -10,6 +10,28 @@ Source of truth for sprint status. Update this file at the end of every session.
 
 ---
 
+## 🚩 Pick up here
+
+**Last session ended:** 2026-05-01, M0 + M1 both VERIFIED.
+
+**Next session starts at M2 — OTel layer.** Recommended order (it's the seed plan's order — services first, then transport, then receiver):
+
+1. `#22` `docker-compose.yml` — bring up `service-a`, `service-b`, `payments-db` (`postgres:15-alpine`), `otel-collector`, and `core`. Hitting `GET service-a:3000/data` should produce a 500 from the pg/PG 15 mismatch, with OTel spans flowing somewhere observable.
+2. `#23` OTel collector config — receive OTLP/HTTP on `:4318`, forward to core's ingest endpoint (also OTLP/HTTP).
+3. `#7` OTel span receiver in `@neat/core` — accept the OTLP wire format, decode spans.
+4. `#8` Span → edge mapper — turn each span into an `OBSERVED` edge between the corresponding service nodes (or service → database for db spans), with `confidence` and `lastObserved`. Stale detection demotes edges not seen in N seconds.
+
+**Before M2 also (project-management cleanup, not code):**
+- Manually close GitHub issues for the M0+M1 work that's now merged: #1, #2, #3, #4, #5, #6, #9, #13, #24, #27. Leave #21 open — it's "partial" until M2 brings up docker-compose.
+- Relabel the dashboard issues #28–#31 as `post-mvp-enhance` and remove them from milestone M5 (per ADR-004).
+
+**Gotchas a fresh session would benefit from:**
+- The npm migration is the reason the seed plan and some issue bodies still mention pnpm. Ignore those — see ADR-007. We're on `npm@11.11.0` with `workspaces: ["packages/*"]`.
+- `demo/*` is **not** in workspaces yet (ADR-009). M2 puts it back when docker-compose actually runs the services — that means the next session will need to add `demo/*` to root `workspaces` and probably regenerate the lockfile.
+- M1 implementation intricacies (id formats, why extraction is 3 phases, why persist loads before extract) live in `docs/architecture.md` under "M1 implementation notes". Read that before touching anything in `packages/core/src/`.
+
+---
+
 ## M0 — Monorepo scaffolded, types defined, packages stubbed
 
 **End state:** `npm install && npx turbo build test lint` green from a clean checkout. CI green on a pushed branch. Every `@neat/*` package builds (ESM + CJS + DTS). `import { ServiceNodeSchema } from '@neat/types'` resolves from any package.


### PR DESCRIPTION
## Summary

Three doc updates so a new chat session (or human picking up cold) knows where to start *and* understands the non-obvious choices baked into M1.

**`docs/milestones.md`** gets a `🚩 Pick up here` header at the top — M2 as the active milestone, the seed-plan order (`#22 docker-compose → #23 collector config → #7 receiver → #8 mapper`), and the by-hand cleanup the user is doing (closing the M0+M1 issues, relabeling #28–#31).

**`docs/decisions.md`** picks up four new ADRs for decisions that landed during M1 implementation but weren't recorded:

- ADR-010 — node and edge id conventions (`service:<name>`, `database:<host>`, `${type}:${source}->${target}`). The contract everything downstream keys off.
- ADR-011 — snapshot envelope (`schemaVersion: 1` + atomic write).
- ADR-012 — tree-sitter scope is URL-substring match only, deliberately not a full import graph.
- ADR-013 — compat under-flags rather than over-flags on unparseable versions.

**`docs/architecture.md`** ends with an "M1 implementation notes" section covering the gotchas: three-phase extract, why `pgDriverVersion` lives in two places, why persist loads before extract, why yaml parsing is intentionally narrow today, the `with { type: 'json' }` import attribute, etc.