### PR TITLE
OTel collector config for the M2 demo

### DIFF
--- a/demo/collector/config.yaml
+++ b/demo/collector/config.yaml
@@ -15,8 +15,12 @@ processors:
     timeout: 1s
 
 exporters:
-  otlp/neat:
+  # Forward to neat-core's receiver as JSON over HTTP. Protobuf is the OTLP
+  # default, but JSON keeps core's receiver (#7) free of a proto decoder while
+  # the wire shape is still settling.
+  otlphttp/neat:
     endpoint: http://neat-core:4318
+    encoding: json
     tls:
       insecure: true
   logging:
@@ -27,4 +31,4 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/neat, logging]
+      exporters: [otlphttp/neat, logging]

--- a/demo/collector/config.yaml
+++ b/demo/collector/config.yaml
@@ -1,0 +1,30 @@
+# OTel collector config for the M2 demo. Sits between the instrumented demo
+# services and neat-core: receives OTLP/HTTP on :4318, batches, then fans out
+# to neat-core's own OTLP receiver and to a verbose stdout exporter so spans
+# are observable from `docker compose logs otel-collector` without needing the
+# core ingest path to be working yet.
+
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 1s
+
+exporters:
+  otlp/neat:
+    endpoint: http://neat-core:4318
+    tls:
+      insecure: true
+  logging:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/neat, logging]


### PR DESCRIPTION
## Summary

Adds `demo/collector/config.yaml` — the OTel collector config the docker-compose stack mounts into the `otel-collector` service. OTLP/HTTP receiver on :4318, a 1s batch processor, and two exporters: `otlp/neat` forwarding to `http://neat-core:4318` and a `logging` exporter at detailed verbosity.

The logging exporter is deliberate: it lets us verify spans are flowing from the demo services well before `#7` (core's OTLP receiver) is ready. `docker compose logs otel-collector` will show every span hitting the collector.

## Depends on

The compose file in #50 mounts this path. Until #50 lands the file just sits there.

## Test plan

- [ ] After #50 merges, `docker compose up` starts `otel-collector` cleanly with this config
- [ ] Hitting `service-a:/data` produces span output in `docker compose logs otel-collector`

Refs #23.