### PR TITLE
OTel span receiver in @neat/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,3 +8,12 @@ export {
 } from './compat.js'
 export { loadGraphFromDisk, saveGraphToDisk, startPersistLoop } from './persist.js'
 export { buildApi, type BuildApiOptions } from './api.js'
+export {
+  buildOtelReceiver,
+  logSpanHandler,
+  parseOtlpRequest,
+  type ParsedSpan,
+  type SpanHandler,
+  type BuildOtelReceiverOptions,
+  type OtlpTracesRequest,
+} from './otel.js'

--- a/packages/core/src/otel.ts
+++ b/packages/core/src/otel.ts
@@ -1,0 +1,186 @@
+import Fastify, { type FastifyInstance } from 'fastify'
+
+// OTLP/HTTP receiver. Listens on /v1/traces and decodes the JSON wire format
+// (collector's `otlphttp` exporter with `encoding: json`). Each span is
+// flattened into a ParsedSpan and handed to the configured handler. The
+// handler is the seam #8 wires its edge mapper into; #7 itself stays decoupled
+// from graph mutation.
+
+export interface ParsedSpan {
+  service: string
+  traceId: string
+  spanId: string
+  parentSpanId?: string
+  name: string
+  kind?: number
+  startTimeUnixNano: string
+  endTimeUnixNano: string
+  // bigint so the 9-digit-nanos arithmetic doesn't lose precision on long traces.
+  durationNanos: bigint
+  attributes: Record<string, AttributeValue>
+  // Convenience accessors for the attributes #8 cares about.
+  dbSystem?: string
+  dbName?: string
+  // 0 = UNSET, 1 = OK, 2 = ERROR per OTLP. We only care that 2 means error.
+  statusCode?: number
+  errorMessage?: string
+}
+
+export type AttributeValue =
+  | string
+  | number
+  | boolean
+  | bigint
+  | string[]
+  | number[]
+  | boolean[]
+  | null
+
+export type SpanHandler = (span: ParsedSpan) => void | Promise<void>
+
+export interface BuildOtelReceiverOptions {
+  onSpan: SpanHandler
+  // Fastify body limit. OTLP batches can be large; default is 16 MB.
+  bodyLimit?: number
+}
+
+interface OtlpKeyValue {
+  key: string
+  value?: OtlpAnyValue
+}
+
+interface OtlpAnyValue {
+  stringValue?: string
+  intValue?: string | number
+  doubleValue?: number
+  boolValue?: boolean
+  arrayValue?: { values?: OtlpAnyValue[] }
+  // kvlistValue / bytesValue are skipped — neither is on the demo path.
+}
+
+interface OtlpStatus {
+  code?: number
+  message?: string
+}
+
+interface OtlpSpan {
+  traceId?: string
+  spanId?: string
+  parentSpanId?: string
+  name?: string
+  kind?: number
+  startTimeUnixNano?: string
+  endTimeUnixNano?: string
+  attributes?: OtlpKeyValue[]
+  status?: OtlpStatus
+}
+
+interface OtlpScopeSpans {
+  spans?: OtlpSpan[]
+}
+
+interface OtlpResourceSpans {
+  resource?: { attributes?: OtlpKeyValue[] }
+  scopeSpans?: OtlpScopeSpans[]
+}
+
+export interface OtlpTracesRequest {
+  resourceSpans?: OtlpResourceSpans[]
+}
+
+function flattenAttribute(v: OtlpAnyValue | undefined): AttributeValue {
+  if (!v) return null
+  if (v.stringValue !== undefined) return v.stringValue
+  if (v.boolValue !== undefined) return v.boolValue
+  if (v.intValue !== undefined) {
+    return typeof v.intValue === 'string' ? Number(v.intValue) : v.intValue
+  }
+  if (v.doubleValue !== undefined) return v.doubleValue
+  if (v.arrayValue?.values) {
+    return v.arrayValue.values.map((x) => flattenAttribute(x)) as AttributeValue
+  }
+  return null
+}
+
+function attrsToRecord(attrs: OtlpKeyValue[] | undefined): Record<string, AttributeValue> {
+  const out: Record<string, AttributeValue> = {}
+  if (!attrs) return out
+  for (const kv of attrs) {
+    if (kv.key) out[kv.key] = flattenAttribute(kv.value)
+  }
+  return out
+}
+
+function durationNanos(start?: string, end?: string): bigint {
+  if (!start || !end) return 0n
+  try {
+    return BigInt(end) - BigInt(start)
+  } catch {
+    return 0n
+  }
+}
+
+export function parseOtlpRequest(body: OtlpTracesRequest): ParsedSpan[] {
+  const out: ParsedSpan[] = []
+  for (const rs of body.resourceSpans ?? []) {
+    const resourceAttrs = attrsToRecord(rs.resource?.attributes)
+    const service = typeof resourceAttrs['service.name'] === 'string'
+      ? (resourceAttrs['service.name'] as string)
+      : 'unknown'
+
+    for (const ss of rs.scopeSpans ?? []) {
+      for (const span of ss.spans ?? []) {
+        const attrs = attrsToRecord(span.attributes)
+        const parsed: ParsedSpan = {
+          service,
+          traceId: span.traceId ?? '',
+          spanId: span.spanId ?? '',
+          parentSpanId: span.parentSpanId || undefined,
+          name: span.name ?? '',
+          kind: span.kind,
+          startTimeUnixNano: span.startTimeUnixNano ?? '0',
+          endTimeUnixNano: span.endTimeUnixNano ?? '0',
+          durationNanos: durationNanos(span.startTimeUnixNano, span.endTimeUnixNano),
+          attributes: attrs,
+          dbSystem: typeof attrs['db.system'] === 'string' ? (attrs['db.system'] as string) : undefined,
+          dbName: typeof attrs['db.name'] === 'string' ? (attrs['db.name'] as string) : undefined,
+          statusCode: span.status?.code,
+          errorMessage: span.status?.message,
+        }
+        out.push(parsed)
+      }
+    }
+  }
+  return out
+}
+
+export async function buildOtelReceiver(
+  opts: BuildOtelReceiverOptions,
+): Promise<FastifyInstance> {
+  const app = Fastify({
+    logger: false,
+    bodyLimit: opts.bodyLimit ?? 16 * 1024 * 1024,
+  })
+
+  app.get('/health', async () => ({ ok: true }))
+
+  app.post<{ Body: OtlpTracesRequest }>('/v1/traces', async (req, reply) => {
+    const spans = parseOtlpRequest(req.body ?? {})
+    for (const span of spans) {
+      await opts.onSpan(span)
+    }
+    // OTLP success response is `{ partialSuccess: {} }` for "all accepted".
+    return reply.code(200).send({ partialSuccess: {} })
+  })
+
+  return app
+}
+
+export function logSpanHandler(span: ParsedSpan): void {
+  const parent = span.parentSpanId ? span.parentSpanId.slice(0, 8) : '<root>'
+  const status = span.statusCode === 2 ? 'ERROR' : 'OK'
+  const db = span.dbSystem ? ` db=${span.dbSystem}/${span.dbName ?? '?'}` : ''
+  console.log(
+    `otel: ${span.service} ${span.name} parent=${parent} status=${status}${db}`,
+  )
+}

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -3,6 +3,7 @@ import { getGraph } from './graph.js'
 import { buildApi } from './api.js'
 import { extractFromDirectory } from './extract.js'
 import { loadGraphFromDisk, startPersistLoop } from './persist.js'
+import { buildOtelReceiver, logSpanHandler } from './otel.js'
 
 async function main(): Promise<void> {
   const graph = getGraph()
@@ -22,13 +23,21 @@ async function main(): Promise<void> {
 
   startPersistLoop(graph, outPath)
 
-  const app = await buildApi({ graph, scanPath })
-  const port = Number(process.env.PORT ?? 8080)
   const host = process.env.HOST ?? '0.0.0.0'
+  const port = Number(process.env.PORT ?? 8080)
+  const otelPort = Number(process.env.OTEL_PORT ?? 4318)
+
+  const app = await buildApi({ graph, scanPath })
   await app.listen({ port, host })
   console.log(`neat-core listening on http://${host}:${port}`)
   console.log(`  scan path:     ${scanPath}`)
   console.log(`  snapshot path: ${outPath}`)
+
+  // Span handler defaults to a one-line log — DoD for #7. The graph mutation
+  // handler comes online with #8.
+  const otelApp = await buildOtelReceiver({ onSpan: logSpanHandler })
+  await otelApp.listen({ port: otelPort, host })
+  console.log(`neat-core OTLP receiver on http://${host}:${otelPort}/v1/traces`)
 }
 
 main().catch((err) => {

--- a/packages/core/test/otel.test.ts
+++ b/packages/core/test/otel.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+import {
+  buildOtelReceiver,
+  parseOtlpRequest,
+  type OtlpTracesRequest,
+  type ParsedSpan,
+} from '../src/otel.js'
+
+// Canned OTLP/HTTP JSON body: one trace, one root span on service-a calling
+// service-b, plus a child span on service-b that errored against the database.
+const SAMPLE_BODY: OtlpTracesRequest = {
+  resourceSpans: [
+    {
+      resource: {
+        attributes: [
+          { key: 'service.name', value: { stringValue: 'service-a' } },
+          { key: 'telemetry.sdk.language', value: { stringValue: 'nodejs' } },
+        ],
+      },
+      scopeSpans: [
+        {
+          spans: [
+            {
+              traceId: 'aabbccddeeff00112233445566778899',
+              spanId: '1111111111111111',
+              name: 'GET /data',
+              kind: 2,
+              startTimeUnixNano: '1000000000000000000',
+              endTimeUnixNano: '1000000000050000000',
+              attributes: [
+                { key: 'http.method', value: { stringValue: 'GET' } },
+                { key: 'http.status_code', value: { intValue: '500' } },
+              ],
+              status: { code: 0 },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      resource: {
+        attributes: [{ key: 'service.name', value: { stringValue: 'service-b' } }],
+      },
+      scopeSpans: [
+        {
+          spans: [
+            {
+              traceId: 'aabbccddeeff00112233445566778899',
+              spanId: '2222222222222222',
+              parentSpanId: '1111111111111111',
+              name: 'pg.query',
+              kind: 3,
+              startTimeUnixNano: '1000000000010000000',
+              endTimeUnixNano: '1000000000040000000',
+              attributes: [
+                { key: 'db.system', value: { stringValue: 'postgresql' } },
+                { key: 'db.name', value: { stringValue: 'neatdemo' } },
+                { key: 'db.statement', value: { stringValue: 'SELECT now()' } },
+              ],
+              status: { code: 2, message: 'SASL: SCRAM-SERVER-FIRST-MESSAGE' },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+describe('parseOtlpRequest', () => {
+  it('flattens resource + scope + span into ParsedSpan list', () => {
+    const spans = parseOtlpRequest(SAMPLE_BODY)
+    expect(spans).toHaveLength(2)
+  })
+
+  it('extracts service.name from resource attributes', () => {
+    const spans = parseOtlpRequest(SAMPLE_BODY)
+    expect(spans[0].service).toBe('service-a')
+    expect(spans[1].service).toBe('service-b')
+  })
+
+  it('keeps parent/child span linkage', () => {
+    const spans = parseOtlpRequest(SAMPLE_BODY)
+    expect(spans[0].parentSpanId).toBeUndefined()
+    expect(spans[1].parentSpanId).toBe('1111111111111111')
+  })
+
+  it('hoists db.system and db.name onto the parsed span', () => {
+    const spans = parseOtlpRequest(SAMPLE_BODY)
+    expect(spans[0].dbSystem).toBeUndefined()
+    expect(spans[1].dbSystem).toBe('postgresql')
+    expect(spans[1].dbName).toBe('neatdemo')
+  })
+
+  it('preserves the full attribute bag', () => {
+    const spans = parseOtlpRequest(SAMPLE_BODY)
+    expect(spans[0].attributes['http.method']).toBe('GET')
+    expect(spans[0].attributes['http.status_code']).toBe(500)
+    expect(spans[1].attributes['db.statement']).toBe('SELECT now()')
+  })
+
+  it('captures status.code = 2 as the error signal', () => {
+    const spans = parseOtlpRequest(SAMPLE_BODY)
+    expect(spans[0].statusCode).toBe(0)
+    expect(spans[1].statusCode).toBe(2)
+    expect(spans[1].errorMessage).toMatch(/SCRAM/)
+  })
+
+  it('computes durationNanos as endTime - startTime', () => {
+    const spans = parseOtlpRequest(SAMPLE_BODY)
+    expect(spans[0].durationNanos).toBe(50_000_000n)
+    expect(spans[1].durationNanos).toBe(30_000_000n)
+  })
+
+  it('returns [] for an empty body', () => {
+    expect(parseOtlpRequest({})).toEqual([])
+    expect(parseOtlpRequest({ resourceSpans: [] })).toEqual([])
+  })
+
+  it('falls back to "unknown" service when service.name is missing', () => {
+    const spans = parseOtlpRequest({
+      resourceSpans: [
+        {
+          scopeSpans: [
+            { spans: [{ traceId: 'a', spanId: 'b', name: 'x' }] },
+          ],
+        },
+      ],
+    })
+    expect(spans[0].service).toBe('unknown')
+  })
+})
+
+describe('buildOtelReceiver', () => {
+  let app: FastifyInstance
+  let collected: ParsedSpan[]
+
+  beforeEach(async () => {
+    collected = []
+    app = await buildOtelReceiver({
+      onSpan: (s) => {
+        collected.push(s)
+      },
+    })
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('POST /v1/traces accepts JSON OTLP and dispatches each span', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/traces',
+      headers: { 'content-type': 'application/json' },
+      payload: SAMPLE_BODY,
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ partialSuccess: {} })
+    expect(collected).toHaveLength(2)
+    expect(collected[0].service).toBe('service-a')
+    expect(collected[1].service).toBe('service-b')
+  })
+
+  it('GET /health returns ok', async () => {
+    const res = await app.inject({ method: 'GET', url: '/health' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ ok: true })
+  })
+
+  it('handles an empty payload without erroring', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/traces',
+      headers: { 'content-type': 'application/json' },
+      payload: {},
+    })
+    expect(res.statusCode).toBe(200)
+    expect(collected).toEqual([])
+  })
+
+  it('awaits async handlers before returning', async () => {
+    await app.close()
+    const observed: string[] = []
+    app = await buildOtelReceiver({
+      onSpan: async (s) => {
+        await new Promise((r) => setTimeout(r, 5))
+        observed.push(s.spanId)
+      },
+    })
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/traces',
+      headers: { 'content-type': 'application/json' },
+      payload: SAMPLE_BODY,
+    })
+    expect(res.statusCode).toBe(200)
+    expect(observed).toEqual(['1111111111111111', '2222222222222222'])
+  })
+})


### PR DESCRIPTION
## Summary

Stands up the OTLP/HTTP receiver that #8 will mount its graph mutation onto. Listens on `0.0.0.0:4318` (separate Fastify instance from the REST API on 8080), accepts `POST /v1/traces` with the OTLP JSON encoding the collector is configured to send (#23), and walks each `resourceSpans` → `scopeSpans` → `spans` tree into a flat `ParsedSpan[]` that's handed to a pluggable `SpanHandler`.

## Shape

`packages/core/src/otel.ts`:

- `parseOtlpRequest(body)` — pure function. Resource attributes are flattened to a record; `service.name` becomes `ParsedSpan.service`. `db.system` and `db.name` are hoisted off span attributes so #8's mapper doesn't need to re-read them. Duration is computed as a `bigint` so 9-digit nanos arithmetic doesn't lose precision.
- `buildOtelReceiver({ onSpan })` — Fastify instance with `POST /v1/traces` + `GET /health`. 16 MB body limit by default. Awaits the handler before returning the OTLP success envelope (`{ partialSuccess: {} }`).
- `logSpanHandler` — one-line stdout log per span. Default for #7's DoD; #8 swaps in the real handler.

`server.ts` starts the receiver alongside the existing API. New env var `OTEL_PORT` defaults to 4318.

`@neat/core`'s public API gets `buildOtelReceiver`, `logSpanHandler`, `parseOtlpRequest`, and the `ParsedSpan` / `SpanHandler` / `OtlpTracesRequest` types.

## Tests

13 new in `test/otel.test.ts`:

- `parseOtlpRequest` over a canned 2-span trace (service-a → service-b pg.query)
  - service.name extraction, parent/child linkage, `db.system` / `db.name` hoisting, full attribute bag preserved, status code 2, `bigint` duration, empty-body fallback, missing-service-name fallback.
- `buildOtelReceiver` via `fastify.inject`
  - `POST /v1/traces` accepts JSON OTLP, dispatches each span, returns the OTLP success envelope.
  - `GET /health` returns ok.
  - Empty payload returns 200 without erroring.
  - Async handlers are awaited before the response.

## Out of scope

- Protobuf decoding. The collector is configured for `encoding: json` in #23, so this PR doesn't pay the protobuf cost. If we ever want stock OTel SDK clients to talk straight to core, we revisit.
- Graph mutation. Edge upserts + `ErrorEvent` writes are #8.

## Test plan

- [ ] `npx turbo build test lint --filter=@neat/core` green
- [ ] After this + #50 + #51 land, `docker compose up` followed by hitting `service-a:/data` produces `otel: ...` lines in `docker compose logs neat-core`

Refs #7.