### PR TITLE
span -> graph edge mapper

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -3,12 +3,15 @@ import cors from '@fastify/cors'
 import type { GraphEdge, GraphNode } from '@neat/types'
 import type { NeatGraph } from './graph.js'
 import { extractFromDirectory } from './extract.js'
+import { readErrorEvents } from './ingest.js'
 
 export interface BuildApiOptions {
   graph: NeatGraph
   startedAt?: number
   // Path the POST /graph/scan endpoint should re-extract from. Optional for tests.
   scanPath?: string
+  // ndjson path the /incidents endpoints read from. Optional for tests.
+  errorsPath?: string
 }
 
 interface SerializedGraph {
@@ -62,15 +65,18 @@ export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> 
     return { inbound, outbound }
   })
 
-  // Incidents come online with M2 (OTel ingest). Stub the routes so clients can
-  // wire against the final URL shape today.
-  app.get('/incidents', async () => [])
+  app.get('/incidents', async () => {
+    if (!opts.errorsPath) return []
+    return readErrorEvents(opts.errorsPath)
+  })
   app.get<{ Params: { nodeId: string } }>('/incidents/:nodeId', async (req, reply) => {
     const { nodeId } = req.params
     if (!graph.hasNode(nodeId)) {
       return reply.code(404).send({ error: 'node not found', id: nodeId })
     }
-    return []
+    if (!opts.errorsPath) return []
+    const events = await readErrorEvents(opts.errorsPath)
+    return events.filter((e) => e.affectedNode === nodeId || e.service === nodeId.replace(/^service:/, ''))
   })
 
   app.get<{ Querystring: { q?: string } }>('/search', async (req, reply) => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,3 +17,11 @@ export {
   type BuildOtelReceiverOptions,
   type OtlpTracesRequest,
 } from './otel.js'
+export {
+  handleSpan,
+  makeSpanHandler,
+  markStaleEdges,
+  readErrorEvents,
+  startStalenessLoop,
+  type IngestContext,
+} from './ingest.js'

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -1,0 +1,226 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import type { ErrorEvent, GraphEdge } from '@neat/types'
+import { EdgeType, NodeType, Provenance, type EdgeTypeValue } from '@neat/types'
+import type { NeatGraph } from './graph.js'
+import type { ParsedSpan } from './otel.js'
+
+// Maps OTel spans to graph signal:
+//   * Cross-service span → upsert CALLS edge.
+//   * Database span (db.system attr present) → upsert CONNECTS_TO edge to a
+//     DatabaseNode resolved by host.
+//   * Span with status.code === 2 → ErrorEvent appended to errors.ndjson.
+//
+// Observed edges live alongside extracted ones with a distinct id pattern
+// (`${type}:OBSERVED:...`) so static and runtime signal coexist instead of
+// stomping each other. Provenance, lastObserved, callCount, and confidence
+// are set on the OBSERVED edge; the static edge is untouched.
+
+export interface IngestContext {
+  graph: NeatGraph
+  errorsPath: string
+  now?: () => number
+}
+
+const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000
+
+function nowIso(ctx: IngestContext): string {
+  return new Date(ctx.now ? ctx.now() : Date.now()).toISOString()
+}
+
+function pickAttr(span: ParsedSpan, ...keys: string[]): string | undefined {
+  for (const k of keys) {
+    const v = span.attributes[k]
+    if (typeof v === 'string' && v.length > 0) return v
+  }
+  return undefined
+}
+
+function hostFromUrl(u: string | undefined): string | undefined {
+  if (!u) return undefined
+  try {
+    return new URL(u).hostname
+  } catch {
+    return undefined
+  }
+}
+
+// OTel HTTP/db semconv has gone through several names for "the host on the
+// other end of this call." Try the modern ones first, fall back to the legacy
+// ones, then last resort parse out of a full URL.
+function pickAddress(span: ParsedSpan): string | undefined {
+  return (
+    pickAttr(span, 'server.address', 'net.peer.name', 'net.host.name') ??
+    hostFromUrl(pickAttr(span, 'url.full', 'http.url'))
+  )
+}
+
+function makeObservedEdgeId(type: EdgeTypeValue, source: string, target: string): string {
+  return `${type}:OBSERVED:${source}->${target}`
+}
+
+function resolveServiceId(graph: NeatGraph, host: string): string | null {
+  const direct = `service:${host}`
+  if (graph.hasNode(direct)) return direct
+
+  // Service hostnames in the demo can match either the package name (which the
+  // node id is built from) or the directory basename. We've already tried the
+  // direct id; fall back to scanning service nodes for a matching name.
+  let found: string | null = null
+  graph.forEachNode((id, attrs) => {
+    if (found) return
+    const a = attrs as { type?: string; name?: string }
+    if (a.type === NodeType.ServiceNode && a.name === host) found = id
+  })
+  return found
+}
+
+interface UpsertResult {
+  edge: GraphEdge
+  created: boolean
+}
+
+function upsertObservedEdge(
+  graph: NeatGraph,
+  type: EdgeTypeValue,
+  source: string,
+  target: string,
+  ts: string,
+): UpsertResult | null {
+  if (!graph.hasNode(source) || !graph.hasNode(target)) return null
+
+  const id = makeObservedEdgeId(type, source, target)
+  if (graph.hasEdge(id)) {
+    const existing = graph.getEdgeAttributes(id) as GraphEdge
+    const updated: GraphEdge = {
+      ...existing,
+      provenance: Provenance.OBSERVED,
+      lastObserved: ts,
+      callCount: (existing.callCount ?? 0) + 1,
+      confidence: 1.0,
+    }
+    graph.replaceEdgeAttributes(id, updated)
+    return { edge: updated, created: false }
+  }
+
+  const edge: GraphEdge = {
+    id,
+    source,
+    target,
+    type,
+    provenance: Provenance.OBSERVED,
+    confidence: 1.0,
+    lastObserved: ts,
+    callCount: 1,
+  }
+  graph.addEdgeWithKey(id, source, target, edge)
+  return { edge, created: true }
+}
+
+async function appendErrorEvent(ctx: IngestContext, ev: ErrorEvent): Promise<void> {
+  await fs.mkdir(path.dirname(ctx.errorsPath), { recursive: true })
+  await fs.appendFile(ctx.errorsPath, JSON.stringify(ev) + '\n', 'utf8')
+}
+
+export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<void> {
+  const ts = nowIso(ctx)
+  const sourceId = `service:${span.service}`
+
+  let affectedNode = sourceId
+
+  if (span.dbSystem) {
+    // Database span — try to resolve the DatabaseNode by host.
+    const host = pickAddress(span)
+    if (host) {
+      const targetId = `database:${host}`
+      const result = upsertObservedEdge(ctx.graph, EdgeType.CONNECTS_TO, sourceId, targetId, ts)
+      if (result) affectedNode = targetId
+    }
+  } else {
+    // Possibly a cross-service call — only if the address resolves to a known
+    // service node, and isn't ourselves.
+    const host = pickAddress(span)
+    if (host && host !== span.service) {
+      const targetId = resolveServiceId(ctx.graph, host)
+      if (targetId && targetId !== sourceId) {
+        upsertObservedEdge(ctx.graph, EdgeType.CALLS, sourceId, targetId, ts)
+        affectedNode = targetId
+      }
+    }
+  }
+
+  if (span.statusCode === 2) {
+    const ev: ErrorEvent = {
+      id: `${span.traceId}:${span.spanId}`,
+      timestamp: ts,
+      service: span.service,
+      traceId: span.traceId,
+      spanId: span.spanId,
+      errorMessage: span.errorMessage ?? span.name ?? 'unknown error',
+      affectedNode,
+    }
+    await appendErrorEvent(ctx, ev)
+  }
+}
+
+export function makeSpanHandler(ctx: IngestContext): (span: ParsedSpan) => Promise<void> {
+  return (span) => handleSpan(ctx, span)
+}
+
+// Demote OBSERVED edges that haven't been seen in a while. Returns the count
+// of demotions for visibility in tests + logs.
+export function markStaleEdges(
+  graph: NeatGraph,
+  thresholdMs = STALE_THRESHOLD_MS,
+  now = Date.now(),
+): number {
+  let count = 0
+  graph.forEachEdge((id, attrs) => {
+    const e = attrs as GraphEdge
+    if (e.provenance !== Provenance.OBSERVED) return
+    if (!e.lastObserved) return
+    const age = now - new Date(e.lastObserved).getTime()
+    if (age > thresholdMs) {
+      const updated: GraphEdge = { ...e, provenance: Provenance.STALE, confidence: 0.3 }
+      graph.replaceEdgeAttributes(id, updated)
+      count++
+    }
+  })
+  return count
+}
+
+export function startStalenessLoop(
+  graph: NeatGraph,
+  thresholdMs = STALE_THRESHOLD_MS,
+  intervalMs = 60_000,
+): () => void {
+  let stopped = false
+  const tick = (): void => {
+    if (stopped) return
+    try {
+      markStaleEdges(graph, thresholdMs)
+    } catch (err) {
+      console.error('staleness tick failed', err)
+    }
+  }
+  const interval = setInterval(tick, intervalMs)
+  // Don't keep the process alive just for this.
+  if (typeof interval.unref === 'function') interval.unref()
+  return () => {
+    stopped = true
+    clearInterval(interval)
+  }
+}
+
+export async function readErrorEvents(errorsPath: string): Promise<ErrorEvent[]> {
+  try {
+    const raw = await fs.readFile(errorsPath, 'utf8')
+    return raw
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line) as ErrorEvent)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw err
+  }
+}

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -3,12 +3,16 @@ import { getGraph } from './graph.js'
 import { buildApi } from './api.js'
 import { extractFromDirectory } from './extract.js'
 import { loadGraphFromDisk, startPersistLoop } from './persist.js'
-import { buildOtelReceiver, logSpanHandler } from './otel.js'
+import { buildOtelReceiver } from './otel.js'
+import { makeSpanHandler, startStalenessLoop } from './ingest.js'
 
 async function main(): Promise<void> {
   const graph = getGraph()
   const scanPath = path.resolve(process.env.NEAT_SCAN_PATH ?? './demo')
   const outPath = path.resolve(process.env.NEAT_OUT_PATH ?? './neat-out/graph.json')
+  const errorsPath = path.resolve(
+    process.env.NEAT_ERRORS_PATH ?? path.join(path.dirname(outPath), 'errors.ndjson'),
+  )
 
   // Load any existing snapshot first so a restart doesn't lose runtime
   // (M2 OBSERVED) edges that won't be reproduced by a fresh extract.
@@ -22,20 +26,21 @@ async function main(): Promise<void> {
   )
 
   startPersistLoop(graph, outPath)
+  startStalenessLoop(graph)
 
   const host = process.env.HOST ?? '0.0.0.0'
   const port = Number(process.env.PORT ?? 8080)
   const otelPort = Number(process.env.OTEL_PORT ?? 4318)
 
-  const app = await buildApi({ graph, scanPath })
+  const app = await buildApi({ graph, scanPath, errorsPath })
   await app.listen({ port, host })
   console.log(`neat-core listening on http://${host}:${port}`)
   console.log(`  scan path:     ${scanPath}`)
   console.log(`  snapshot path: ${outPath}`)
+  console.log(`  errors log:    ${errorsPath}`)
 
-  // Span handler defaults to a one-line log — DoD for #7. The graph mutation
-  // handler comes online with #8.
-  const otelApp = await buildOtelReceiver({ onSpan: logSpanHandler })
+  const onSpan = makeSpanHandler({ graph, errorsPath })
+  const otelApp = await buildOtelReceiver({ onSpan })
   await otelApp.listen({ port: otelPort, host })
   console.log(`neat-core OTLP receiver on http://${host}:${otelPort}/v1/traces`)
 }

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import { MultiDirectedGraph } from 'graphology'
+import {
+  EdgeType,
+  type ErrorEvent,
+  type GraphEdge,
+  type GraphNode,
+  NodeType,
+  Provenance,
+} from '@neat/types'
+import {
+  handleSpan,
+  markStaleEdges,
+  readErrorEvents,
+  type IngestContext,
+} from '../src/ingest.js'
+import type { ParsedSpan } from '../src/otel.js'
+import type { NeatGraph } from '../src/graph.js'
+
+function newGraph(): NeatGraph {
+  const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+  g.addNode('service:service-a', {
+    id: 'service:service-a',
+    type: NodeType.ServiceNode,
+    name: 'service-a',
+    language: 'javascript',
+  })
+  g.addNode('service:service-b', {
+    id: 'service:service-b',
+    type: NodeType.ServiceNode,
+    name: 'service-b',
+    language: 'javascript',
+  })
+  g.addNode('database:payments-db', {
+    id: 'database:payments-db',
+    type: NodeType.DatabaseNode,
+    name: 'neatdemo',
+    engine: 'postgresql',
+    engineVersion: '15',
+    compatibleDrivers: [],
+  })
+  return g
+}
+
+function clientHttpSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
+  return {
+    service: 'service-a',
+    traceId: 'trace-1',
+    spanId: 'span-a',
+    name: 'GET /query',
+    kind: 3,
+    startTimeUnixNano: '0',
+    endTimeUnixNano: '0',
+    durationNanos: 0n,
+    attributes: {
+      'http.method': 'GET',
+      'server.address': 'service-b',
+      'server.port': 3001,
+    },
+    statusCode: 0,
+    ...overrides,
+  }
+}
+
+function dbSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
+  return {
+    service: 'service-b',
+    traceId: 'trace-1',
+    spanId: 'span-b',
+    parentSpanId: 'span-a',
+    name: 'pg.query',
+    kind: 3,
+    startTimeUnixNano: '0',
+    endTimeUnixNano: '0',
+    durationNanos: 0n,
+    attributes: {
+      'db.system': 'postgresql',
+      'db.name': 'neatdemo',
+      'server.address': 'payments-db',
+    },
+    dbSystem: 'postgresql',
+    dbName: 'neatdemo',
+    statusCode: 0,
+    ...overrides,
+  }
+}
+
+describe('handleSpan', () => {
+  let tmpDir: string
+  let ctx: IngestContext
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-ingest-'))
+    ctx = {
+      graph: newGraph(),
+      errorsPath: path.join(tmpDir, 'errors.ndjson'),
+    }
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('upserts an OBSERVED CALLS edge for a cross-service HTTP client span', async () => {
+    await handleSpan(ctx, clientHttpSpan())
+    const id = `${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`
+    expect(ctx.graph.hasEdge(id)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(id) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.callCount).toBe(1)
+    expect(edge.confidence).toBe(1)
+    expect(edge.lastObserved).toBeTruthy()
+  })
+
+  it('increments callCount on repeat observations without duplicating the edge', async () => {
+    await handleSpan(ctx, clientHttpSpan())
+    await handleSpan(ctx, clientHttpSpan({ spanId: 'span-a2' }))
+    await handleSpan(ctx, clientHttpSpan({ spanId: 'span-a3' }))
+    const id = `${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`
+    expect(ctx.graph.hasEdge(id)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(id) as GraphEdge
+    expect(edge.callCount).toBe(3)
+    // No duplicate edges.
+    const keys: string[] = []
+    ctx.graph.forEachEdge((k) => keys.push(k))
+    expect(keys.filter((k) => k.startsWith(`${EdgeType.CALLS}:OBSERVED:`))).toHaveLength(1)
+  })
+
+  it('upserts an OBSERVED CONNECTS_TO edge for a database span', async () => {
+    await handleSpan(ctx, dbSpan())
+    const id = `${EdgeType.CONNECTS_TO}:OBSERVED:service:service-b->database:payments-db`
+    expect(ctx.graph.hasEdge(id)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(id) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.callCount).toBe(1)
+  })
+
+  it('falls back to net.peer.name when server.address is missing', async () => {
+    const span = dbSpan({
+      attributes: {
+        'db.system': 'postgresql',
+        'db.name': 'neatdemo',
+        'net.peer.name': 'payments-db',
+      },
+    })
+    await handleSpan(ctx, span)
+    expect(
+      ctx.graph.hasEdge(`${EdgeType.CONNECTS_TO}:OBSERVED:service:service-b->database:payments-db`),
+    ).toBe(true)
+  })
+
+  it('parses host out of url.full when peer attrs are absent', async () => {
+    const span = clientHttpSpan({
+      attributes: {
+        'http.method': 'GET',
+        'url.full': 'http://service-b:3001/query',
+      },
+    })
+    await handleSpan(ctx, span)
+    expect(
+      ctx.graph.hasEdge(`${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`),
+    ).toBe(true)
+  })
+
+  it('skips spans whose target service node does not exist in the graph', async () => {
+    await handleSpan(ctx, clientHttpSpan({ attributes: { 'server.address': 'unknown-service' } }))
+    let calls = 0
+    ctx.graph.forEachEdge((k) => {
+      if (k.startsWith(`${EdgeType.CALLS}:OBSERVED:`)) calls++
+    })
+    expect(calls).toBe(0)
+  })
+
+  it('does not touch a pre-existing EXTRACTED edge between the same services', async () => {
+    const staticId = `${EdgeType.CALLS}:service:service-a->service:service-b`
+    ctx.graph.addEdgeWithKey(staticId, 'service:service-a', 'service:service-b', {
+      id: staticId,
+      source: 'service:service-a',
+      target: 'service:service-b',
+      type: EdgeType.CALLS,
+      provenance: Provenance.EXTRACTED,
+    })
+    await handleSpan(ctx, clientHttpSpan())
+    const staticEdge = ctx.graph.getEdgeAttributes(staticId) as GraphEdge
+    expect(staticEdge.provenance).toBe(Provenance.EXTRACTED)
+    expect(staticEdge.callCount).toBeUndefined()
+    expect(
+      ctx.graph.hasEdge(`${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`),
+    ).toBe(true)
+  })
+
+  it('writes an ErrorEvent line to the ndjson file when status.code === 2', async () => {
+    await handleSpan(
+      ctx,
+      dbSpan({ statusCode: 2, errorMessage: 'SASL: SCRAM-SERVER-FIRST-MESSAGE' }),
+    )
+    const events = await readErrorEvents(ctx.errorsPath)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      service: 'service-b',
+      traceId: 'trace-1',
+      spanId: 'span-b',
+      affectedNode: 'database:payments-db',
+      errorMessage: expect.stringContaining('SCRAM'),
+    } as ErrorEvent)
+  })
+
+  it('does not log an ErrorEvent for a successful span', async () => {
+    await handleSpan(ctx, clientHttpSpan())
+    expect(await readErrorEvents(ctx.errorsPath)).toEqual([])
+  })
+})
+
+describe('markStaleEdges', () => {
+  it('demotes OBSERVED edges whose lastObserved is older than the threshold to STALE', async () => {
+    const graph = newGraph()
+    const fresh = new Date()
+    const old = new Date(fresh.getTime() - 25 * 60 * 60 * 1000)
+    graph.addEdgeWithKey(
+      'CALLS:OBSERVED:service:service-a->service:service-b',
+      'service:service-a',
+      'service:service-b',
+      {
+        id: 'CALLS:OBSERVED:service:service-a->service:service-b',
+        source: 'service:service-a',
+        target: 'service:service-b',
+        type: EdgeType.CALLS,
+        provenance: Provenance.OBSERVED,
+        lastObserved: old.toISOString(),
+        callCount: 7,
+        confidence: 1,
+      },
+    )
+    graph.addEdgeWithKey(
+      'CONNECTS_TO:OBSERVED:service:service-b->database:payments-db',
+      'service:service-b',
+      'database:payments-db',
+      {
+        id: 'CONNECTS_TO:OBSERVED:service:service-b->database:payments-db',
+        source: 'service:service-b',
+        target: 'database:payments-db',
+        type: EdgeType.CONNECTS_TO,
+        provenance: Provenance.OBSERVED,
+        lastObserved: fresh.toISOString(),
+        callCount: 3,
+        confidence: 1,
+      },
+    )
+    const demoted = markStaleEdges(graph, 24 * 60 * 60 * 1000, fresh.getTime())
+    expect(demoted).toBe(1)
+    const stale = graph.getEdgeAttributes('CALLS:OBSERVED:service:service-a->service:service-b') as GraphEdge
+    expect(stale.provenance).toBe(Provenance.STALE)
+    expect(stale.confidence).toBe(0.3)
+    const still = graph.getEdgeAttributes(
+      'CONNECTS_TO:OBSERVED:service:service-b->database:payments-db',
+    ) as GraphEdge
+    expect(still.provenance).toBe(Provenance.OBSERVED)
+  })
+
+  it('leaves EXTRACTED edges alone', () => {
+    const graph = newGraph()
+    graph.addEdgeWithKey(
+      'CALLS:service:service-a->service:service-b',
+      'service:service-a',
+      'service:service-b',
+      {
+        id: 'CALLS:service:service-a->service:service-b',
+        source: 'service:service-a',
+        target: 'service:service-b',
+        type: EdgeType.CALLS,
+        provenance: Provenance.EXTRACTED,
+      },
+    )
+    expect(markStaleEdges(graph, 0, Date.now())).toBe(0)
+  })
+})
+
+describe('readErrorEvents', () => {
+  it('returns [] when the file does not exist yet', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-ingest-read-'))
+    expect(await readErrorEvents(path.join(tmpDir, 'absent.ndjson'))).toEqual([])
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+})


### PR DESCRIPTION
## Summary

Closes the M2 loop: spans coming in through #7's receiver now turn into graph signal. Cross-service calls become OBSERVED CALLS edges, database calls become OBSERVED CONNECTS_TO edges, errored spans drop a structured event into the ndjson incident log, and a 60s loop demotes anything that hasn't been observed in 24h to STALE.

## Stacked

This PR targets `7-otel-receiver` because it imports the `ParsedSpan` shape from #7. Once #52 merges to main I'll rebase this onto main and the `7-otel-receiver` commits drop out of the diff.

## Shape

`packages/core/src/ingest.ts`:

- `handleSpan(ctx, span)` — the SpanHandler that #7's receiver now calls. Branches on `db.system` (database span) vs an address that resolves to a known service node (cross-service span). Self-calls, unknown hosts, and spans whose target isn't in the graph are dropped silently.
- `upsertObservedEdge` — single edge per `(type, source, target)` triple, keyed by `${type}:OBSERVED:${source}->${target}`. First observation creates it; later observations bump `callCount` and `lastObserved`. Static EXTRACTED edges aren't touched, so the two provenances coexist.
- Address resolution tolerates the OTel semconv churn — tries `server.address`, `net.peer.name`, `net.host.name`, and falls back to `URL(url.full || http.url).hostname`.
- `markStaleEdges(graph, thresholdMs, now)` walks OBSERVED edges and demotes the ones past `thresholdMs` to STALE with `confidence: 0.3`. `startStalenessLoop` runs it every 60s with `interval.unref()` so it doesn't keep the process alive in tests.
- `readErrorEvents(path)` reads the ndjson back and returns parsed `ErrorEvent[]` for `/incidents`.

`server.ts` swaps `logSpanHandler` (the #7 placeholder) for `makeSpanHandler({ graph, errorsPath })` and starts the staleness loop. New env var `NEAT_ERRORS_PATH` overrides the default `<NEAT_OUT_PATH dir>/errors.ndjson`.

`api.ts` `/incidents` and `/incidents/:nodeId` now read the ndjson back. Tests in `api.test.ts` keep passing because they don't pass `errorsPath` and fall through to the empty-array path.

## Tests

12 new in `test/ingest.test.ts`:

- HTTP client span → OBSERVED CALLS edge with provenance, callCount=1, confidence=1, lastObserved.
- Repeat observation → callCount increments, no duplicate edge created.
- Database span → OBSERVED CONNECTS_TO edge.
- `net.peer.name` and `url.full` fallback resolution.
- Unknown target → no edge.
- Pre-existing EXTRACTED edge survives untouched while a sibling OBSERVED edge is created.
- ERROR span → ndjson line with the right shape; success span → no line.
- `markStaleEdges` demotes only the over-threshold OBSERVED edges; EXTRACTED edges stay put.
- `readErrorEvents` returns `[]` for a missing file.

## Test plan

- [ ] `npx turbo build test lint` green (full workspace)
- [ ] After this lands and `docker compose up`, hitting `service-a:/data` for ~60s leaves the graph with `CALLS:OBSERVED:service:service-a->service:service-b` (callCount > 0) and `CONNECTS_TO:OBSERVED:service:service-b->database:payments-db` (callCount > 0)
- [ ] `curl localhost:8080/incidents` returns the SCRAM auth failures from service-b

Refs #8.