### PR TITLE
M2 runtime fixes: collector compression, manual pg span, pg timeout

### DIFF
--- a/demo/collector/config.yaml
+++ b/demo/collector/config.yaml
@@ -21,6 +21,10 @@ exporters:
   otlphttp/neat:
     endpoint: http://neat-core:4318
     encoding: json
+    # otlphttp gzip-compresses by default; core's Fastify receiver only does
+    # plain JSON, so spell out "no compression" here. Cheaper to keep the
+    # receiver simple than to plumb gzip handling through it.
+    compression: none
     tls:
       insecure: true
   logging:

--- a/demo/service-b/index.js
+++ b/demo/service-b/index.js
@@ -1,16 +1,70 @@
 const express = require('express')
 const { Pool } = require('pg')
+const { trace, SpanStatusCode, SpanKind } = require('@opentelemetry/api')
 
 const app = express()
 const port = Number(process.env.PORT ?? 3001)
 
 // Connection params come from the standard PG* env vars (PGHOST, PGUSER,
 // PGPASSWORD, PGDATABASE, PGPORT) which pg reads automatically.
-const pool = new Pool()
+//
+// connectionTimeoutMillis: pg 7.4.0 has no SCRAM-SHA-256 path, so against
+// PG 15 the auth handshake never completes — pool.query would hang
+// indefinitely instead of throwing. The 4s ceiling forces a real error
+// up to the catch block so the span can close and export.
+const pool = new Pool({ connectionTimeoutMillis: 4000 })
+
+// !!! TEMPORARY — REMOVE WHEN M3 TRACE STITCHING LANDS !!!
+//
+// @opentelemetry/instrumentation-pg only supports pg >= 8.x. pg 7.4.0 (the
+// version that breaks against PG 15 — the whole point of the demo) is too old
+// for the auto-instrumenter to hook into, so no span gets emitted with
+// `db.system: postgresql`. Without that span, neat-core's ingest can't draw
+// the OBSERVED CONNECTS_TO edge service-b → payments-db, which M2's
+// verification gate expects.
+//
+// The systems-level fix is M3's planned trace stitcher: when an upstream span
+// errors, walk the static graph from that service along EXTRACTED edges and
+// write INFERRED edges. Once that lands, this manual span is debt — pull
+// `tracedQuery` and the `@opentelemetry/api` import, drop the call site back
+// to plain `pool.query(...)`, and verify the demo still works.
+//
+// Tracking: docs/decisions.md ADR-014, docs/milestones.md M3 notes.
+const tracer = trace.getTracer('service-b')
+
+async function tracedQuery(sql) {
+  return tracer.startActiveSpan(
+    'pg.query',
+    {
+      kind: SpanKind.CLIENT,
+      attributes: {
+        'db.system': 'postgresql',
+        'db.name': process.env.PGDATABASE ?? 'neatdemo',
+        'db.user': process.env.PGUSER ?? 'neat',
+        'db.statement': sql,
+        'server.address': process.env.PGHOST ?? 'payments-db',
+        'server.port': Number(process.env.PGPORT ?? 5432),
+      },
+    },
+    async (span) => {
+      try {
+        const result = await pool.query(sql)
+        span.setStatus({ code: SpanStatusCode.OK })
+        return result
+      } catch (err) {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: err.message })
+        span.recordException(err)
+        throw err
+      } finally {
+        span.end()
+      }
+    },
+  )
+}
 
 app.get('/query', async (_req, res) => {
   try {
-    const r = await pool.query('SELECT now() as now')
+    const r = await tracedQuery('SELECT now() as now')
     res.json({ now: r.rows[0].now })
   } catch (err) {
     // pg 7.4.0 + Postgres 15 → scram-sha-256 auth failure surfaces here.

--- a/demo/service-b/package.json
+++ b/demo/service-b/package.json
@@ -8,6 +8,7 @@
     "start": "node -r ./otel.js index.js"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.49.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.52.0",
     "@opentelemetry/sdk-node": "^0.52.0",

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -151,3 +151,21 @@ If a future demo case requires richer call-graph extraction, that's a deliberate
 `compat.json` carries a `minEngineVersion` per pair. The driver constraint only fires once the engine reaches that major or higher — so `pg 7.4.0 / postgresql 13` returns `compatible: true` because PG 13 still supports md5 auth.
 
 Driver versions go through `semver.coerce` so `"v7.4.0"` and `"7.4"` both work. If a version string is unparseable (a git SHA, a build label, etc.), the function returns `compatible: true`. We'd rather miss a real incompatibility than fabricate a false positive on input we genuinely can't reason about — false positives erode trust in everything else the system says.
+
+---
+
+## ADR-014 — Manual pg span in service-b is M2-only debt
+
+**Date:** 2026-05-01
+**Status:** Active until M3 trace stitching lands. Then: delete the workaround.
+
+`@opentelemetry/instrumentation-pg` only hooks pg >= 8.x. service-b is pinned to pg 7.4.0 because that's the version that fails the SCRAM handshake against PG 15 — without the failure there is no demo. The auto-instrumenter therefore never wraps `pool.query`, no span carries `db.system: postgresql`, and ingest has nothing to turn into an OBSERVED `CONNECTS_TO` edge. M2's verification gate explicitly expects that edge.
+
+Today we paper over this by hand-rolling the span in `demo/service-b/index.js` (`tracedQuery` wrapping `pool.query` with `@opentelemetry/api`). It's a fixture, not architecture: a real NEAT user with a modern instrumented driver gets the OBSERVED edge for free.
+
+The systems-level fix is M3's planned trace stitcher (see #10 + the INFERRED row of the provenance table in `architecture.md`): when an upstream span errors, walk the static graph from that service along EXTRACTED edges and write INFERRED edges with `confidence: 0.6`. Root-cause traversal already prefers OBSERVED → INFERRED → EXTRACTED, so the missing CONNECTS_TO becomes invisible to the system, not a special case to patch.
+
+When M3 ships:
+- Remove `tracedQuery`, the `@opentelemetry/api` import, and the `@opentelemetry/api` dep in `demo/service-b/package.json`. Drop the call site back to `pool.query('SELECT now() …')`.
+- Re-run M2's verification gate. The OBSERVED CALLS edge should still appear; the OBSERVED CONNECTS_TO disappears, but an INFERRED CONNECTS_TO with confidence 0.6 should take its place.
+- Update M2's gate text in `milestones.md` to reflect that CONNECTS_TO is INFERRED, not OBSERVED, in the live demo.

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -108,6 +108,11 @@ Source of truth for sprint status. Update this file at the end of every session.
 
 **Issues:** #10 (root-cause traversal), #11 (blast-radius traversal), #12 (traverse routes).
 
+**Bring along when M3 lands:**
+
+- Implement the trace stitcher (see ADR-014). When an upstream span errors, walk the static graph from that service along EXTRACTED edges and write INFERRED edges with `confidence: 0.6`. This closes the gap the manual span in `demo/service-b/index.js` is currently filling.
+- Once the stitcher is producing INFERRED `CONNECTS_TO` edges, **delete `tracedQuery` and the `@opentelemetry/api` import in `demo/service-b/index.js`**, drop the `@opentelemetry/api` dep in `demo/service-b/package.json`, and re-run M2's verification gate. CONNECTS_TO will be INFERRED rather than OBSERVED in the live demo; update the gate wording to match.
+
 ---
 
 ## M4 — MCP tools working against live graph

--- a/package-lock.json
+++ b/package-lock.json
@@ -339,6 +339,7 @@
     "demo/service-b": {
       "version": "1.0.0",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.49.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.52.0",
         "@opentelemetry/sdk-node": "^0.52.0",


### PR DESCRIPTION
## Summary

Three small fixes to unblock M2's verification gate. After #50–#52 + #54 landed and the live demo came up, spans weren't producing OBSERVED edges. Each layer of the pipeline turned up something:

1. **Collector → core was 400ing.** `otlphttp` exporter gzip-compresses by default; core's Fastify receiver only does plain JSON. `demo/collector/config.yaml` gets `compression: none` on the `otlphttp/neat` exporter. Cheaper than plumbing gzip handling through the receiver.

2. **No pg spans were ever emitted.** `@opentelemetry/instrumentation-pg` only supports pg >= 8.x. service-b is pinned to pg 7.4.0 because that's the version that breaks against PG 15 — the whole demo. Without an auto-emitted span there's no `db.system` attribute, and ingest can't draw the OBSERVED `CONNECTS_TO` edge the gate expects. `demo/service-b/index.js` now hand-rolls the span via `@opentelemetry/api`, with a loud comment block flagging this as M2-only debt.

3. **The handshake hung instead of throwing.** pg 7.4.0 has no SCRAM-SHA-256 path, so against PG 15 the auth never completes — `pool.query` would hang forever instead of erroring. `connectionTimeoutMillis: 4000` on the Pool forces a real error so the span can close and export. service-a's 5s axios timeout was masking this as a generic upstream timeout; now it's a proper pg connection-timeout event.

## Why fix #2 is debt, not architecture

Spelled out in `docs/decisions.md` ADR-014 and bring-along noted in `docs/milestones.md` under M3:

The systems-level answer is M3's planned trace stitcher (issue #10 already prefers OBSERVED → INFERRED → EXTRACTED in traversal, and the architecture doc defines INFERRED as "computed from other edges"). When an upstream span errors, walk the static graph along EXTRACTED edges from that service and write INFERRED edges with `confidence: 0.6`. Once that lands, the manual span comes back out — root-cause traversal will reconstruct the missing `CONNECTS_TO` from the static topology + the trace error, and pg's instrumentation gap becomes invisible to the system instead of a special case to patch.

The M3 milestone doc and the in-code comment both reference ADR-014 and call out the exact files/lines to delete when M3 ships.

## Live verification

After this branch is up + a fresh `docker compose up --build`:

```
$ for i in $(seq 1 10); do curl -s localhost:3000/data > /dev/null; done
$ curl -s localhost:8080/graph | jq '.edges'
```

Returns four edges including:
- `CALLS:OBSERVED:service:service-a->service:service-b` (callCount > 0, confidence 1)
- `CONNECTS_TO:OBSERVED:service:service-b->database:payments-db` (callCount > 0, confidence 1)

```
$ curl -s localhost:8080/incidents
```

Returns the pg connection-timeout events attributed to `database:payments-db` plus service-a's upstream timeouts.

## Test plan

- [ ] `npx turbo build test lint` green
- [ ] `docker compose up --build`, hit `localhost:3000/data` ~10 times
- [ ] `/graph` shows both OBSERVED edges with `callCount > 0`
- [ ] `/incidents` includes pg events attributed to `database:payments-db`

Refs #7 #8 #22 #23.