### PR TITLE
Root-cause traversal

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,3 +25,4 @@ export {
   startStalenessLoop,
   type IngestContext,
 } from './ingest.js'
+export { getRootCause } from './traverse.js'

--- a/packages/core/src/traverse.ts
+++ b/packages/core/src/traverse.ts
@@ -1,0 +1,136 @@
+import type {
+  DatabaseNode,
+  ErrorEvent,
+  GraphEdge,
+  GraphNode,
+  ProvenanceValue,
+  RootCauseResult,
+  ServiceNode,
+} from '@neat/types'
+import { NodeType, Provenance } from '@neat/types'
+import type { NeatGraph } from './graph.js'
+import { checkCompatibility } from './compat.js'
+
+const PROV_RANK: Record<ProvenanceValue, number> = {
+  OBSERVED: 3,
+  INFERRED: 2,
+  EXTRACTED: 1,
+  STALE: 0,
+  FRONTIER: 0,
+}
+
+const ROOT_CAUSE_MAX_DEPTH = 5
+
+// Multiple edges between the same pair coexist by provenance (EXTRACTED next to
+// OBSERVED next to INFERRED). Traversal walks the system as the graph "sees it
+// best", so for any neighbour pair we pick the highest-provenance edge.
+function bestEdgeBySource(graph: NeatGraph, edgeIds: string[]): Map<string, GraphEdge> {
+  const best = new Map<string, GraphEdge>()
+  for (const id of edgeIds) {
+    const e = graph.getEdgeAttributes(id) as GraphEdge
+    const cur = best.get(e.source)
+    if (!cur || PROV_RANK[e.provenance] > PROV_RANK[cur.provenance]) {
+      best.set(e.source, e)
+    }
+  }
+  return best
+}
+
+function confidenceFromMix(edges: GraphEdge[]): number {
+  if (edges.length === 0) return 1.0
+  if (edges.every((e) => e.provenance === Provenance.OBSERVED)) return 1.0
+  if (edges.some((e) => e.provenance === Provenance.INFERRED)) return 0.7
+  return 0.5
+}
+
+interface Walk {
+  path: string[]
+  edges: GraphEdge[]
+}
+
+// DFS along incoming edges from start, depth-bounded. Returns the longest path
+// reachable, picking best-provenance edges per neighbour pair so the walk
+// reflects the system as the graph knows it most reliably.
+function longestIncomingWalk(graph: NeatGraph, start: string, maxDepth: number): Walk {
+  let best: Walk = { path: [start], edges: [] }
+  const visited = new Set<string>([start])
+
+  function step(node: string, path: string[], edges: GraphEdge[]): void {
+    if (path.length > best.path.length) {
+      best = { path: [...path], edges: [...edges] }
+    }
+    if (path.length - 1 >= maxDepth) return
+
+    const incoming = bestEdgeBySource(graph, graph.inboundEdges(node))
+    for (const [srcId, edge] of incoming) {
+      if (visited.has(srcId)) continue
+      visited.add(srcId)
+      path.push(srcId)
+      edges.push(edge)
+      step(srcId, path, edges)
+      path.pop()
+      edges.pop()
+      visited.delete(srcId)
+    }
+  }
+
+  step(start, [start], [])
+  return best
+}
+
+export function getRootCause(
+  graph: NeatGraph,
+  errorNodeId: string,
+  errorEvent?: ErrorEvent,
+): RootCauseResult | null {
+  if (!graph.hasNode(errorNodeId)) return null
+
+  const startAttrs = graph.getNodeAttributes(errorNodeId) as GraphNode
+  // Today the only failure mode the compat matrix catches is driver/engine, so
+  // we only walk in if the error surfaced at a database. Other root-cause
+  // shapes (config drift, version skew between services) come with M5.
+  if (startAttrs.type !== NodeType.DatabaseNode) return null
+  const targetDb = startAttrs as DatabaseNode
+
+  const walk = longestIncomingWalk(graph, errorNodeId, ROOT_CAUSE_MAX_DEPTH)
+
+  let rootCauseNode: string | null = null
+  let rootCauseReason: string | null = null
+  let fixRecommendation: string | undefined
+
+  for (const id of walk.path) {
+    const attrs = graph.getNodeAttributes(id) as GraphNode
+    if (attrs.type !== NodeType.ServiceNode) continue
+    const svc = attrs as ServiceNode
+    if (!svc.pgDriverVersion) continue
+    const result = checkCompatibility(
+      'pg',
+      svc.pgDriverVersion,
+      targetDb.engine,
+      targetDb.engineVersion,
+    )
+    if (!result.compatible) {
+      rootCauseNode = id
+      rootCauseReason = result.reason ?? 'incompatible driver'
+      if (result.minDriverVersion) {
+        fixRecommendation = `Upgrade ${svc.name} pg driver to >= ${result.minDriverVersion}`
+      }
+      break
+    }
+  }
+
+  if (!rootCauseNode || !rootCauseReason) return null
+
+  const reason = errorEvent
+    ? `${rootCauseReason} (observed error: ${errorEvent.errorMessage})`
+    : rootCauseReason
+
+  return {
+    rootCauseNode,
+    rootCauseReason: reason,
+    traversalPath: walk.path,
+    edgeProvenances: walk.edges.map((e) => e.provenance),
+    confidence: confidenceFromMix(walk.edges),
+    fixRecommendation,
+  }
+}

--- a/packages/core/test/traverse.test.ts
+++ b/packages/core/test/traverse.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest'
+import { MultiDirectedGraph } from 'graphology'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  type ErrorEvent,
+  type GraphEdge,
+  type GraphNode,
+} from '@neat/types'
+import type { NeatGraph } from '../src/graph.js'
+import { getRootCause } from '../src/traverse.js'
+
+function makeNode(id: string, attrs: GraphNode): GraphNode {
+  return { ...attrs, id }
+}
+
+function newDemoGraph(): NeatGraph {
+  const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+  g.addNode(
+    'service:service-a',
+    makeNode('service:service-a', {
+      id: 'service:service-a',
+      type: NodeType.ServiceNode,
+      name: 'service-a',
+      language: 'javascript',
+    }),
+  )
+  g.addNode(
+    'service:service-b',
+    makeNode('service:service-b', {
+      id: 'service:service-b',
+      type: NodeType.ServiceNode,
+      name: 'service-b',
+      language: 'javascript',
+      pgDriverVersion: '7.4.0',
+    }),
+  )
+  g.addNode(
+    'database:payments-db',
+    makeNode('database:payments-db', {
+      id: 'database:payments-db',
+      type: NodeType.DatabaseNode,
+      name: 'payments',
+      engine: 'postgresql',
+      engineVersion: '15',
+      compatibleDrivers: [{ name: 'pg', minVersion: '8.0.0' }],
+    }),
+  )
+  return g
+}
+
+function addEdge(g: NeatGraph, e: GraphEdge): void {
+  g.addEdgeWithKey(e.id, e.source, e.target, e)
+}
+
+function callsEdge(provenance: GraphEdge['provenance'], suffix = ''): GraphEdge {
+  const id =
+    provenance === Provenance.EXTRACTED
+      ? `${EdgeType.CALLS}:service:service-a->service:service-b`
+      : `${EdgeType.CALLS}:${provenance}${suffix}:service:service-a->service:service-b`
+  return {
+    id,
+    source: 'service:service-a',
+    target: 'service:service-b',
+    type: EdgeType.CALLS,
+    provenance,
+  }
+}
+
+function connectsEdge(provenance: GraphEdge['provenance'], suffix = ''): GraphEdge {
+  const id =
+    provenance === Provenance.EXTRACTED
+      ? `${EdgeType.CONNECTS_TO}:service:service-b->database:payments-db`
+      : `${EdgeType.CONNECTS_TO}:${provenance}${suffix}:service:service-b->database:payments-db`
+  return {
+    id,
+    source: 'service:service-b',
+    target: 'database:payments-db',
+    type: EdgeType.CONNECTS_TO,
+    provenance,
+  }
+}
+
+describe('getRootCause', () => {
+  it('returns the pg-driver mismatch with the full incoming path on the demo graph', () => {
+    const g = newDemoGraph()
+    addEdge(g, callsEdge(Provenance.EXTRACTED))
+    addEdge(g, connectsEdge(Provenance.EXTRACTED))
+
+    const result = getRootCause(g, 'database:payments-db')
+    expect(result).not.toBeNull()
+    expect(result!.rootCauseNode).toBe('service:service-b')
+    expect(result!.traversalPath).toEqual([
+      'database:payments-db',
+      'service:service-b',
+      'service:service-a',
+    ])
+    expect(result!.rootCauseReason).toMatch(/pg|scram|postgres/i)
+    expect(result!.fixRecommendation).toMatch(/8\.0\.0/)
+  })
+
+  it('reports confidence 0.5 when every edge along the path is EXTRACTED only', () => {
+    const g = newDemoGraph()
+    addEdge(g, callsEdge(Provenance.EXTRACTED))
+    addEdge(g, connectsEdge(Provenance.EXTRACTED))
+
+    const result = getRootCause(g, 'database:payments-db')
+    expect(result!.confidence).toBe(0.5)
+    expect(result!.edgeProvenances).toEqual([Provenance.EXTRACTED, Provenance.EXTRACTED])
+  })
+
+  it('reports confidence 1.0 when both edges along the path are OBSERVED', () => {
+    const g = newDemoGraph()
+    addEdge(g, callsEdge(Provenance.EXTRACTED))
+    addEdge(g, connectsEdge(Provenance.EXTRACTED))
+    addEdge(g, callsEdge(Provenance.OBSERVED))
+    addEdge(g, connectsEdge(Provenance.OBSERVED))
+
+    const result = getRootCause(g, 'database:payments-db')
+    expect(result!.confidence).toBe(1.0)
+    expect(result!.edgeProvenances).toEqual([Provenance.OBSERVED, Provenance.OBSERVED])
+  })
+
+  it('reports confidence 0.7 when any edge along the path is INFERRED', () => {
+    const g = newDemoGraph()
+    addEdge(g, callsEdge(Provenance.EXTRACTED))
+    addEdge(g, callsEdge(Provenance.OBSERVED))
+    // Only an INFERRED CONNECTS_TO exists for service-b -> db (the pg < 8 case).
+    addEdge(g, connectsEdge(Provenance.INFERRED))
+
+    const result = getRootCause(g, 'database:payments-db')
+    expect(result!.confidence).toBe(0.7)
+    // OBSERVED CALLS beats EXTRACTED CALLS; INFERRED is the only CONNECTS_TO option.
+    expect(result!.edgeProvenances).toEqual([Provenance.INFERRED, Provenance.OBSERVED])
+  })
+
+  it('colours rootCauseReason with the observed error message when one is supplied', () => {
+    const g = newDemoGraph()
+    addEdge(g, callsEdge(Provenance.EXTRACTED))
+    addEdge(g, connectsEdge(Provenance.EXTRACTED))
+
+    const ev: ErrorEvent = {
+      id: 'trace-1:span-b',
+      timestamp: new Date().toISOString(),
+      service: 'service-b',
+      traceId: 'trace-1',
+      spanId: 'span-b',
+      errorMessage: 'SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string',
+      affectedNode: 'database:payments-db',
+    }
+    const result = getRootCause(g, 'database:payments-db', ev)
+    expect(result!.rootCauseReason).toContain('SCRAM')
+  })
+
+  it('returns null when the error node does not exist in the graph', () => {
+    const g = newDemoGraph()
+    addEdge(g, connectsEdge(Provenance.EXTRACTED))
+    expect(getRootCause(g, 'database:does-not-exist')).toBeNull()
+  })
+
+  it('returns null when the error node is not a database', () => {
+    const g = newDemoGraph()
+    addEdge(g, callsEdge(Provenance.EXTRACTED))
+    addEdge(g, connectsEdge(Provenance.EXTRACTED))
+    expect(getRootCause(g, 'service:service-a')).toBeNull()
+  })
+
+  it('returns null when no service in the path has a known incompatibility', () => {
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:happy', {
+      id: 'service:happy',
+      type: NodeType.ServiceNode,
+      name: 'happy',
+      language: 'javascript',
+      pgDriverVersion: '8.11.0',
+    })
+    g.addNode('database:payments-db', {
+      id: 'database:payments-db',
+      type: NodeType.DatabaseNode,
+      name: 'payments',
+      engine: 'postgresql',
+      engineVersion: '15',
+      compatibleDrivers: [{ name: 'pg', minVersion: '8.0.0' }],
+    })
+    g.addEdgeWithKey(
+      'CONNECTS_TO:service:happy->database:payments-db',
+      'service:happy',
+      'database:payments-db',
+      {
+        id: 'CONNECTS_TO:service:happy->database:payments-db',
+        source: 'service:happy',
+        target: 'database:payments-db',
+        type: EdgeType.CONNECTS_TO,
+        provenance: Provenance.EXTRACTED,
+      },
+    )
+    expect(getRootCause(g, 'database:payments-db')).toBeNull()
+  })
+})


### PR DESCRIPTION
First M3 piece. Adds `getRootCause` in a new `packages/core/src/traverse.ts`.

The function walks incoming edges from the error node depth-first up to depth 5, picking the highest-provenance edge between any neighbour pair so EXTRACTED, INFERRED, and OBSERVED siblings (which the graph carries side-by-side per ADR-010) collapse into one walk that prefers what the system knows most reliably. At each ServiceNode along the path it runs the existing compat check against the originating DatabaseNode — the first incompatibility wins.

Confidence on the result cascades by edge mix along the path: 1.0 if every edge is OBSERVED, 0.7 if any is INFERRED, 0.5 when only EXTRACTED is on offer. An optional `ErrorEvent` gets folded into `rootCauseReason` so callers (incident pages, the upcoming MCP tool) can show the SCRAM-flavoured message users will actually see in logs.

On the demo graph this returns:

- `rootCauseNode`: `service:service-b`
- `traversalPath`: `["database:payments-db", "service:service-b", "service:service-a"]`
- `confidence`: 0.5 (EXTRACTED-only), 1.0 once OBSERVED CALLS + CONNECTS_TO are present
- `fixRecommendation`: `Upgrade service-b pg driver to >= 8.0.0`

Which matches the M3 verification target in `docs/milestones.md`.

Scope is deliberately narrow: only fires when the error node is a database, since the only failure mode the compat matrix catches today is driver/engine. Other root-cause shapes (config drift, version skew between services) come with M5.

`getBlastRadius` lands in the next PR (#11) so each issue gets its own review surface per ADR-005. Routes (#12) follow once both functions are in.

Refs #10