### PR TITLE
Blast-radius traversal

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,4 +25,4 @@ export {
   startStalenessLoop,
   type IngestContext,
 } from './ingest.js'
-export { getRootCause } from './traverse.js'
+export { getBlastRadius, getRootCause } from './traverse.js'

--- a/packages/core/src/traverse.ts
+++ b/packages/core/src/traverse.ts
@@ -1,4 +1,6 @@
 import type {
+  BlastRadiusAffectedNode,
+  BlastRadiusResult,
   DatabaseNode,
   ErrorEvent,
   GraphEdge,
@@ -20,6 +22,7 @@ const PROV_RANK: Record<ProvenanceValue, number> = {
 }
 
 const ROOT_CAUSE_MAX_DEPTH = 5
+const BLAST_RADIUS_DEFAULT_DEPTH = 10
 
 // Multiple edges between the same pair coexist by provenance (EXTRACTED next to
 // OBSERVED next to INFERRED). Traversal walks the system as the graph "sees it
@@ -31,6 +34,18 @@ function bestEdgeBySource(graph: NeatGraph, edgeIds: string[]): Map<string, Grap
     const cur = best.get(e.source)
     if (!cur || PROV_RANK[e.provenance] > PROV_RANK[cur.provenance]) {
       best.set(e.source, e)
+    }
+  }
+  return best
+}
+
+function bestEdgeByTarget(graph: NeatGraph, edgeIds: string[]): Map<string, GraphEdge> {
+  const best = new Map<string, GraphEdge>()
+  for (const id of edgeIds) {
+    const e = graph.getEdgeAttributes(id) as GraphEdge
+    const cur = best.get(e.target)
+    if (!cur || PROV_RANK[e.provenance] > PROV_RANK[cur.provenance]) {
+      best.set(e.target, e)
     }
   }
   return best
@@ -132,5 +147,56 @@ export function getRootCause(
     edgeProvenances: walk.edges.map((e) => e.provenance),
     confidence: confidenceFromMix(walk.edges),
     fixRecommendation,
+  }
+}
+
+// BFS along outgoing edges from origin. Records each reachable node with the
+// shortest distance back to origin and the provenance of the edge that brought
+// us to it. Best-provenance edge selection per pair mirrors getRootCause.
+export function getBlastRadius(
+  graph: NeatGraph,
+  nodeId: string,
+  maxDepth = BLAST_RADIUS_DEFAULT_DEPTH,
+): BlastRadiusResult {
+  if (!graph.hasNode(nodeId)) {
+    return { origin: nodeId, affectedNodes: [], totalAffected: 0 }
+  }
+
+  interface Frame {
+    nodeId: string
+    distance: number
+    edge: GraphEdge | null
+  }
+
+  const seen = new Map<string, BlastRadiusAffectedNode>()
+  const queue: Frame[] = [{ nodeId, distance: 0, edge: null }]
+  const enqueued = new Set<string>([nodeId])
+
+  while (queue.length > 0) {
+    const frame = queue.shift()!
+    if (frame.distance > 0 && frame.edge) {
+      seen.set(frame.nodeId, {
+        nodeId: frame.nodeId,
+        distance: frame.distance,
+        edgeProvenance: frame.edge.provenance,
+      })
+    }
+    if (frame.distance >= maxDepth) continue
+
+    const outgoing = bestEdgeByTarget(graph, graph.outboundEdges(frame.nodeId))
+    for (const [tgtId, edge] of outgoing) {
+      if (enqueued.has(tgtId)) continue
+      enqueued.add(tgtId)
+      queue.push({ nodeId: tgtId, distance: frame.distance + 1, edge })
+    }
+  }
+
+  const affectedNodes = [...seen.values()].sort(
+    (a, b) => a.distance - b.distance || a.nodeId.localeCompare(b.nodeId),
+  )
+  return {
+    origin: nodeId,
+    affectedNodes,
+    totalAffected: affectedNodes.length,
   }
 }

--- a/packages/core/test/traverse.test.ts
+++ b/packages/core/test/traverse.test.ts
@@ -9,7 +9,7 @@ import {
   type GraphNode,
 } from '@neat/types'
 import type { NeatGraph } from '../src/graph.js'
-import { getRootCause } from '../src/traverse.js'
+import { getBlastRadius, getRootCause } from '../src/traverse.js'
 
 function makeNode(id: string, attrs: GraphNode): GraphNode {
   return { ...attrs, id }
@@ -196,5 +196,127 @@ describe('getRootCause', () => {
       },
     )
     expect(getRootCause(g, 'database:payments-db')).toBeNull()
+  })
+})
+
+describe('getBlastRadius', () => {
+  it('returns service-b and payments-db downstream of service-a on the demo graph', () => {
+    const g = newDemoGraph()
+    addEdge(g, callsEdge(Provenance.EXTRACTED))
+    addEdge(g, connectsEdge(Provenance.EXTRACTED))
+
+    const result = getBlastRadius(g, 'service:service-a')
+    expect(result.origin).toBe('service:service-a')
+    expect(result.totalAffected).toBe(2)
+    expect(result.affectedNodes).toEqual([
+      {
+        nodeId: 'service:service-b',
+        distance: 1,
+        edgeProvenance: Provenance.EXTRACTED,
+      },
+      {
+        nodeId: 'database:payments-db',
+        distance: 2,
+        edgeProvenance: Provenance.EXTRACTED,
+      },
+    ])
+  })
+
+  it('reports OBSERVED provenance when an OBSERVED edge sits alongside the EXTRACTED one', () => {
+    const g = newDemoGraph()
+    addEdge(g, callsEdge(Provenance.EXTRACTED))
+    addEdge(g, callsEdge(Provenance.OBSERVED))
+    addEdge(g, connectsEdge(Provenance.EXTRACTED))
+    addEdge(g, connectsEdge(Provenance.OBSERVED))
+
+    const result = getBlastRadius(g, 'service:service-a')
+    expect(result.affectedNodes.find((n) => n.nodeId === 'service:service-b')!.edgeProvenance).toBe(
+      Provenance.OBSERVED,
+    )
+    expect(
+      result.affectedNodes.find((n) => n.nodeId === 'database:payments-db')!.edgeProvenance,
+    ).toBe(Provenance.OBSERVED)
+  })
+
+  it('returns nothing for a node with no outgoing edges', () => {
+    const g = newDemoGraph()
+    addEdge(g, callsEdge(Provenance.EXTRACTED))
+    addEdge(g, connectsEdge(Provenance.EXTRACTED))
+
+    const result = getBlastRadius(g, 'database:payments-db')
+    expect(result.affectedNodes).toEqual([])
+    expect(result.totalAffected).toBe(0)
+    expect(result.origin).toBe('database:payments-db')
+  })
+
+  it('returns an empty result for a node that does not exist', () => {
+    const g = newDemoGraph()
+    const result = getBlastRadius(g, 'service:nope')
+    expect(result.affectedNodes).toEqual([])
+    expect(result.totalAffected).toBe(0)
+    expect(result.origin).toBe('service:nope')
+  })
+
+  it('respects the depth limit', () => {
+    const g = newDemoGraph()
+    addEdge(g, callsEdge(Provenance.EXTRACTED))
+    addEdge(g, connectsEdge(Provenance.EXTRACTED))
+
+    const result = getBlastRadius(g, 'service:service-a', 1)
+    expect(result.affectedNodes).toEqual([
+      {
+        nodeId: 'service:service-b',
+        distance: 1,
+        edgeProvenance: Provenance.EXTRACTED,
+      },
+    ])
+  })
+
+  it('records the BFS-shortest distance when two paths reach the same node', () => {
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:a', {
+      id: 'service:a',
+      type: NodeType.ServiceNode,
+      name: 'a',
+      language: 'javascript',
+    })
+    g.addNode('service:b', {
+      id: 'service:b',
+      type: NodeType.ServiceNode,
+      name: 'b',
+      language: 'javascript',
+    })
+    g.addNode('service:c', {
+      id: 'service:c',
+      type: NodeType.ServiceNode,
+      name: 'c',
+      language: 'javascript',
+    })
+    // a -> c (direct, distance 1) and a -> b -> c (distance 2). Direct should win.
+    g.addEdgeWithKey('CALLS:service:a->service:c', 'service:a', 'service:c', {
+      id: 'CALLS:service:a->service:c',
+      source: 'service:a',
+      target: 'service:c',
+      type: EdgeType.CALLS,
+      provenance: Provenance.EXTRACTED,
+    })
+    g.addEdgeWithKey('CALLS:service:a->service:b', 'service:a', 'service:b', {
+      id: 'CALLS:service:a->service:b',
+      source: 'service:a',
+      target: 'service:b',
+      type: EdgeType.CALLS,
+      provenance: Provenance.EXTRACTED,
+    })
+    g.addEdgeWithKey('CALLS:service:b->service:c', 'service:b', 'service:c', {
+      id: 'CALLS:service:b->service:c',
+      source: 'service:b',
+      target: 'service:c',
+      type: EdgeType.CALLS,
+      provenance: Provenance.EXTRACTED,
+    })
+
+    const result = getBlastRadius(g, 'service:a')
+    const c = result.affectedNodes.find((n) => n.nodeId === 'service:c')
+    expect(c!.distance).toBe(1)
   })
 })


### PR DESCRIPTION
Stacked on #57. Adds \`getBlastRadius\` to \`packages/core/src/traverse.ts\`.

BFS along outgoing edges from origin up to depth 10 (configurable). Every reachable node lands in the result with its shortest distance from the origin and the provenance of the edge that brought us there — same best-provenance selection as \`getRootCause\` so the two functions answer the same view of the graph.

\`graphology-shortest-path\` is in the dep set per the original issue, but BFS gets the answer in one pass with the per-pair provenance pick built in, where the library helpers would have us either run a second pass for distances or paper over the multigraph's parallel edges. Worth a sentence in the PR; happy to revisit if review prefers the library route.

On the demo graph:
\`\`\`ts
getBlastRadius(graph, 'service:service-a')
// → {
//     origin: 'service:service-a',
//     totalAffected: 2,
//     affectedNodes: [
//       { nodeId: 'service:service-b',     distance: 1, edgeProvenance: 'EXTRACTED' },
//       { nodeId: 'database:payments-db',  distance: 2, edgeProvenance: 'EXTRACTED' },
//     ],
//   }
\`\`\`

Which matches the DOD on the original issue. Routes (#12) follow next.

Refs #11