### PR TITLE
Traverse routes on core REST API

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -1,9 +1,10 @@
 import Fastify, { type FastifyInstance } from 'fastify'
 import cors from '@fastify/cors'
-import type { GraphEdge, GraphNode } from '@neat/types'
+import type { ErrorEvent, GraphEdge, GraphNode } from '@neat/types'
 import type { NeatGraph } from './graph.js'
 import { extractFromDirectory } from './extract.js'
 import { readErrorEvents } from './ingest.js'
+import { getBlastRadius, getRootCause } from './traverse.js'
 
 export interface BuildApiOptions {
   graph: NeatGraph
@@ -78,6 +79,42 @@ export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> 
     const events = await readErrorEvents(opts.errorsPath)
     return events.filter((e) => e.affectedNode === nodeId || e.service === nodeId.replace(/^service:/, ''))
   })
+
+  app.get<{ Params: { nodeId: string }; Querystring: { errorId?: string } }>(
+    '/traverse/root-cause/:nodeId',
+    async (req, reply) => {
+      const { nodeId } = req.params
+      if (!graph.hasNode(nodeId)) {
+        return reply.code(404).send({ error: 'node not found', id: nodeId })
+      }
+      let errorEvent: ErrorEvent | undefined
+      if (req.query.errorId && opts.errorsPath) {
+        const events = await readErrorEvents(opts.errorsPath)
+        errorEvent = events.find((e) => e.id === req.query.errorId)
+        if (!errorEvent) {
+          return reply.code(404).send({ error: 'error event not found', id: req.query.errorId })
+        }
+      }
+      const result = getRootCause(graph, nodeId, errorEvent)
+      if (!result) return reply.code(404).send({ error: 'no root cause found', id: nodeId })
+      return result
+    },
+  )
+
+  app.get<{ Params: { nodeId: string }; Querystring: { depth?: string } }>(
+    '/traverse/blast-radius/:nodeId',
+    async (req, reply) => {
+      const { nodeId } = req.params
+      if (!graph.hasNode(nodeId)) {
+        return reply.code(404).send({ error: 'node not found', id: nodeId })
+      }
+      const depth = req.query.depth ? Number(req.query.depth) : undefined
+      if (depth !== undefined && (!Number.isFinite(depth) || depth < 0)) {
+        return reply.code(400).send({ error: 'depth must be a non-negative number' })
+      }
+      return getBlastRadius(graph, nodeId, depth)
+    },
+  )
 
   app.get<{ Querystring: { q?: string } }>('/search', async (req, reply) => {
     const q = (req.query.q ?? '').trim().toLowerCase()

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -117,4 +117,88 @@ describe('REST API (fastify.inject)', () => {
     const res = await app.inject({ method: 'POST', url: '/graph/scan' })
     expect(res.statusCode).toBe(409)
   })
+
+  it('GET /traverse/root-cause/:nodeId returns the demo pg incompatibility', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/traverse/root-cause/database:payments-db',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.rootCauseNode).toBe('service:service-b')
+    expect(body.traversalPath).toEqual([
+      'database:payments-db',
+      'service:service-b',
+      'service:service-a',
+    ])
+    expect(body.confidence).toBe(0.5)
+    expect(body.fixRecommendation).toMatch(/8\.0\.0/)
+  })
+
+  it('GET /traverse/root-cause/:nodeId returns 404 for an unknown node', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/traverse/root-cause/database:nope',
+    })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('GET /traverse/root-cause/:nodeId returns 404 when no root cause is found', async () => {
+    // service:service-a is a service node, not a database — getRootCause bails out.
+    const res = await app.inject({
+      method: 'GET',
+      url: '/traverse/root-cause/service:service-a',
+    })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('GET /traverse/blast-radius/:nodeId returns downstream nodes with distances', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/traverse/blast-radius/service:service-a',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.origin).toBe('service:service-a')
+    expect(body.totalAffected).toBe(2)
+    expect(body.affectedNodes).toEqual([
+      {
+        nodeId: 'service:service-b',
+        distance: 1,
+        edgeProvenance: 'EXTRACTED',
+      },
+      {
+        nodeId: 'database:payments-db',
+        distance: 2,
+        edgeProvenance: 'EXTRACTED',
+      },
+    ])
+  })
+
+  it('GET /traverse/blast-radius/:nodeId returns 404 for an unknown node', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/traverse/blast-radius/service:nope',
+    })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('GET /traverse/blast-radius/:nodeId rejects a negative depth', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/traverse/blast-radius/service:service-a?depth=-1',
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('GET /traverse/blast-radius/:nodeId honours a custom depth', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/traverse/blast-radius/service:service-a?depth=1',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.totalAffected).toBe(1)
+    expect(body.affectedNodes[0].nodeId).toBe('service:service-b')
+  })
 })


### PR DESCRIPTION
Stacked on #58 (which is stacked on #57). Wires the two new traversal functions into Fastify.

\`\`\`
GET /traverse/root-cause/:nodeId           → RootCauseResult
GET /traverse/root-cause/:nodeId?errorId=  → RootCauseResult coloured by an ErrorEvent
GET /traverse/blast-radius/:nodeId         → BlastRadiusResult
GET /traverse/blast-radius/:nodeId?depth=N → BlastRadiusResult with custom depth
\`\`\`

Routing follows the path-param shape from \`docs/milestones.md\` rather than the original issue's query-param sketch — the milestones doc is the active source of truth and the path form reads better when MCP tools start interpolating node ids.

404s on missing nodes; \`/traverse/root-cause\` also 404s when nothing in the path matches a known incompatibility, so callers can distinguish "I don't see a problem" from "the system is broken." \`?depth=\` validation rejects negatives with a 400.

Together these cover the M3 verification path; #14/#15 in M4 are the MCP tools that call these.

Refs #12