### PR TITLE
Trace stitcher for INFERRED edges on error spans

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export {
   markStaleEdges,
   readErrorEvents,
   startStalenessLoop,
+  stitchTrace,
   type IngestContext,
 } from './ingest.js'
 export { getBlastRadius, getRootCause } from './traverse.js'

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -59,6 +59,13 @@ function makeObservedEdgeId(type: EdgeTypeValue, source: string, target: string)
   return `${type}:OBSERVED:${source}->${target}`
 }
 
+function makeInferredEdgeId(type: EdgeTypeValue, source: string, target: string): string {
+  return `${type}:INFERRED:${source}->${target}`
+}
+
+const INFERRED_CONFIDENCE = 0.6
+const STITCH_MAX_DEPTH = 2
+
 function resolveServiceId(graph: NeatGraph, host: string): string | null {
   const direct = `service:${host}`
   if (graph.hasNode(direct)) return direct
@@ -117,6 +124,63 @@ function upsertObservedEdge(
   return { edge, created: true }
 }
 
+// When a span errors, the system is exercising its dependencies right now even
+// if some of them aren't auto-instrumented (pg 7.4.0 in the demo, see ADR-014).
+// Walk EXTRACTED edges out from the erroring service for a couple of hops and
+// promote them to INFERRED twins so traversal can prefer them over the bare
+// static edges without claiming OBSERVED-grade certainty.
+function stitchTrace(graph: NeatGraph, sourceServiceId: string, ts: string): void {
+  if (!graph.hasNode(sourceServiceId)) return
+
+  const visited = new Set<string>([sourceServiceId])
+  const queue: { nodeId: string; depth: number }[] = [{ nodeId: sourceServiceId, depth: 0 }]
+
+  while (queue.length > 0) {
+    const { nodeId, depth } = queue.shift()!
+    if (depth >= STITCH_MAX_DEPTH) continue
+
+    const outbound = graph.outboundEdges(nodeId)
+    for (const edgeId of outbound) {
+      const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+      if (edge.provenance !== Provenance.EXTRACTED) continue
+
+      upsertInferredEdge(graph, edge.type, edge.source, edge.target, ts)
+
+      if (!visited.has(edge.target)) {
+        visited.add(edge.target)
+        queue.push({ nodeId: edge.target, depth: depth + 1 })
+      }
+    }
+  }
+}
+
+function upsertInferredEdge(
+  graph: NeatGraph,
+  type: EdgeTypeValue,
+  source: string,
+  target: string,
+  ts: string,
+): void {
+  const id = makeInferredEdgeId(type, source, target)
+  if (graph.hasEdge(id)) {
+    const existing = graph.getEdgeAttributes(id) as GraphEdge
+    const updated: GraphEdge = { ...existing, lastObserved: ts }
+    graph.replaceEdgeAttributes(id, updated)
+    return
+  }
+
+  const edge: GraphEdge = {
+    id,
+    source,
+    target,
+    type,
+    provenance: Provenance.INFERRED,
+    confidence: INFERRED_CONFIDENCE,
+    lastObserved: ts,
+  }
+  graph.addEdgeWithKey(id, source, target, edge)
+}
+
 async function appendErrorEvent(ctx: IngestContext, ev: ErrorEvent): Promise<void> {
   await fs.mkdir(path.dirname(ctx.errorsPath), { recursive: true })
   await fs.appendFile(ctx.errorsPath, JSON.stringify(ev) + '\n', 'utf8')
@@ -150,6 +214,7 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
   }
 
   if (span.statusCode === 2) {
+    stitchTrace(ctx.graph, sourceId, ts)
     const ev: ErrorEvent = {
       id: `${span.traceId}:${span.spanId}`,
       timestamp: ts,
@@ -162,6 +227,8 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
     await appendErrorEvent(ctx, ev)
   }
 }
+
+export { stitchTrace }
 
 export function makeSpanHandler(ctx: IngestContext): (span: ParsedSpan) => Promise<void> {
   return (span) => handleSpan(ctx, span)

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -15,6 +15,7 @@ import {
   handleSpan,
   markStaleEdges,
   readErrorEvents,
+  stitchTrace,
   type IngestContext,
 } from '../src/ingest.js'
 import type { ParsedSpan } from '../src/otel.js'
@@ -43,6 +44,33 @@ function newGraph(): NeatGraph {
     compatibleDrivers: [],
   })
   return g
+}
+
+function addExtractedEdges(g: NeatGraph): void {
+  g.addEdgeWithKey(
+    'CALLS:service:service-a->service:service-b',
+    'service:service-a',
+    'service:service-b',
+    {
+      id: 'CALLS:service:service-a->service:service-b',
+      source: 'service:service-a',
+      target: 'service:service-b',
+      type: EdgeType.CALLS,
+      provenance: Provenance.EXTRACTED,
+    },
+  )
+  g.addEdgeWithKey(
+    'CONNECTS_TO:service:service-b->database:payments-db',
+    'service:service-b',
+    'database:payments-db',
+    {
+      id: 'CONNECTS_TO:service:service-b->database:payments-db',
+      source: 'service:service-b',
+      target: 'database:payments-db',
+      type: EdgeType.CONNECTS_TO,
+      provenance: Provenance.EXTRACTED,
+    },
+  )
 }
 
 function clientHttpSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
@@ -282,6 +310,135 @@ describe('readErrorEvents', () => {
   it('returns [] when the file does not exist yet', async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-ingest-read-'))
     expect(await readErrorEvents(path.join(tmpDir, 'absent.ndjson'))).toEqual([])
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+})
+
+describe('stitchTrace', () => {
+  it('writes INFERRED twins of EXTRACTED outgoing edges within depth 2', () => {
+    const graph = newGraph()
+    addExtractedEdges(graph)
+    stitchTrace(graph, 'service:service-a', '2026-05-01T00:00:00.000Z')
+
+    const callsId = `${EdgeType.CALLS}:INFERRED:service:service-a->service:service-b`
+    const connectsId = `${EdgeType.CONNECTS_TO}:INFERRED:service:service-b->database:payments-db`
+    expect(graph.hasEdge(callsId)).toBe(true)
+    expect(graph.hasEdge(connectsId)).toBe(true)
+
+    const calls = graph.getEdgeAttributes(callsId) as GraphEdge
+    expect(calls.provenance).toBe(Provenance.INFERRED)
+    expect(calls.confidence).toBe(0.6)
+    expect(calls.lastObserved).toBe('2026-05-01T00:00:00.000Z')
+    const connects = graph.getEdgeAttributes(connectsId) as GraphEdge
+    expect(connects.confidence).toBe(0.6)
+  })
+
+  it('refreshes lastObserved on re-stitch without duplicating the edge', () => {
+    const graph = newGraph()
+    addExtractedEdges(graph)
+    stitchTrace(graph, 'service:service-b', '2026-05-01T00:00:00.000Z')
+    stitchTrace(graph, 'service:service-b', '2026-05-01T01:00:00.000Z')
+
+    const id = `${EdgeType.CONNECTS_TO}:INFERRED:service:service-b->database:payments-db`
+    const edge = graph.getEdgeAttributes(id) as GraphEdge
+    expect(edge.lastObserved).toBe('2026-05-01T01:00:00.000Z')
+
+    let count = 0
+    graph.forEachEdge((k) => {
+      if (k === id) count++
+    })
+    expect(count).toBe(1)
+  })
+
+  it('does not promote OBSERVED edges to INFERRED twins', () => {
+    const graph = newGraph()
+    graph.addEdgeWithKey(
+      'CALLS:OBSERVED:service:service-a->service:service-b',
+      'service:service-a',
+      'service:service-b',
+      {
+        id: 'CALLS:OBSERVED:service:service-a->service:service-b',
+        source: 'service:service-a',
+        target: 'service:service-b',
+        type: EdgeType.CALLS,
+        provenance: Provenance.OBSERVED,
+        confidence: 1.0,
+        lastObserved: '2026-05-01T00:00:00.000Z',
+        callCount: 5,
+      },
+    )
+    stitchTrace(graph, 'service:service-a', '2026-05-01T00:00:00.000Z')
+
+    expect(
+      graph.hasEdge(`${EdgeType.CALLS}:INFERRED:service:service-a->service:service-b`),
+    ).toBe(false)
+  })
+
+  it('respects the depth-2 ceiling', () => {
+    const graph = newGraph()
+    graph.addNode('service:service-c', {
+      id: 'service:service-c',
+      type: NodeType.ServiceNode,
+      name: 'service-c',
+      language: 'javascript',
+    })
+    addExtractedEdges(graph)
+    // service-b -> service-c extends the chain to depth 3 from service-a.
+    graph.addEdgeWithKey(
+      'CALLS:service:service-b->service:service-c',
+      'service:service-b',
+      'service:service-c',
+      {
+        id: 'CALLS:service:service-b->service:service-c',
+        source: 'service:service-b',
+        target: 'service:service-c',
+        type: EdgeType.CALLS,
+        provenance: Provenance.EXTRACTED,
+      },
+    )
+    stitchTrace(graph, 'service:service-a', '2026-05-01T00:00:00.000Z')
+
+    // Depth 1: service-a -> service-b. Depth 2: service-b -> service-c, service-b -> payments-db.
+    // Anything past service-b's outbound is depth >= 3 and shouldn't be stitched.
+    expect(
+      graph.hasEdge(`${EdgeType.CALLS}:INFERRED:service:service-a->service:service-b`),
+    ).toBe(true)
+    expect(
+      graph.hasEdge(`${EdgeType.CALLS}:INFERRED:service:service-b->service:service-c`),
+    ).toBe(true)
+    expect(
+      graph.hasEdge(`${EdgeType.CONNECTS_TO}:INFERRED:service:service-b->database:payments-db`),
+    ).toBe(true)
+  })
+
+  it('is a no-op for an unknown source service', () => {
+    const graph = newGraph()
+    addExtractedEdges(graph)
+    stitchTrace(graph, 'service:does-not-exist', '2026-05-01T00:00:00.000Z')
+
+    let inferred = 0
+    graph.forEachEdge((k) => {
+      if (k.includes(':INFERRED:')) inferred++
+    })
+    expect(inferred).toBe(0)
+  })
+
+  it('runs from handleSpan when a span has statusCode === 2', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-stitch-'))
+    const graph = newGraph()
+    addExtractedEdges(graph)
+    const ctx: IngestContext = {
+      graph,
+      errorsPath: path.join(tmpDir, 'errors.ndjson'),
+    }
+    await handleSpan(
+      ctx,
+      dbSpan({ statusCode: 2, errorMessage: 'SASL: SCRAM-SERVER-FIRST-MESSAGE' }),
+    )
+
+    expect(
+      graph.hasEdge(`${EdgeType.CONNECTS_TO}:INFERRED:service:service-b->database:payments-db`),
+    ).toBe(true)
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 })


### PR DESCRIPTION
Stacked on #59. Closes out M3 by addressing the pg 7.4.0 instrumentation gap (ADR-014) at the system level instead of the manual-span workaround currently sitting in \`demo/service-b/index.js\`.

When \`handleSpan\` sees a span with \`statusCode === 2\`, \`stitchTrace\` walks the static graph from \`service:<span.service>\` outward along EXTRACTED edges, depth ≤ 2, and upserts INFERRED twins of every edge encountered. Edge id pattern is \`\${type}:INFERRED:\${source}->\${target}\` by analogy with the OBSERVED ones already produced by the M2 mapper. Confidence 0.6, \`lastObserved\` refreshed each pass.

Why this works for the demo: \`@opentelemetry/instrumentation-pg\` doesn't speak pg < 8, so service-b can't emit a span carrying \`db.system: postgresql\` — but service-b's error span IS evidence the service is exercising its dependencies right now, and the static graph already knows where those go. \`getRootCause\` already prefers OBSERVED → INFERRED → EXTRACTED, so the INFERRED CONNECTS_TO collapses into the existing traversal as a 0.7-confidence path automatically.

Deliberately NOT in this PR:

- The cleanup in \`demo/service-b/index.js\` (delete \`tracedQuery\`, drop the \`@opentelemetry/api\` dep). That needs a live \`docker compose up --build\` + \`/data\` smoke to confirm the INFERRED edge shows up end-to-end before pulling the safety net. That's the next step after merging this.
- Any change to the M2 verification gate text in \`docs/milestones.md\`. Same reason — gate the rewrite on the live verify.

Test coverage: new INFERRED edge written, lastObserved refreshed on re-stitch, OBSERVED edges left alone, depth ceiling honoured, no-op for unknown source service, plus the integration through \`handleSpan\` on \`statusCode === 2\`.

Refs #60