### PR TITLE
M3 catch-up: blast-radius, traverse routes, trace stitcher

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -1,9 +1,10 @@
 import Fastify, { type FastifyInstance } from 'fastify'
 import cors from '@fastify/cors'
-import type { GraphEdge, GraphNode } from '@neat/types'
+import type { ErrorEvent, GraphEdge, GraphNode } from '@neat/types'
 import type { NeatGraph } from './graph.js'
 import { extractFromDirectory } from './extract.js'
 import { readErrorEvents } from './ingest.js'
+import { getBlastRadius, getRootCause } from './traverse.js'
 
 export interface BuildApiOptions {
   graph: NeatGraph
@@ -78,6 +79,42 @@ export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> 
     const events = await readErrorEvents(opts.errorsPath)
     return events.filter((e) => e.affectedNode === nodeId || e.service === nodeId.replace(/^service:/, ''))
   })
+
+  app.get<{ Params: { nodeId: string }; Querystring: { errorId?: string } }>(
+    '/traverse/root-cause/:nodeId',
+    async (req, reply) => {
+      const { nodeId } = req.params
+      if (!graph.hasNode(nodeId)) {
+        return reply.code(404).send({ error: 'node not found', id: nodeId })
+      }
+      let errorEvent: ErrorEvent | undefined
+      if (req.query.errorId && opts.errorsPath) {
+        const events = await readErrorEvents(opts.errorsPath)
+        errorEvent = events.find((e) => e.id === req.query.errorId)
+        if (!errorEvent) {
+          return reply.code(404).send({ error: 'error event not found', id: req.query.errorId })
+        }
+      }
+      const result = getRootCause(graph, nodeId, errorEvent)
+      if (!result) return reply.code(404).send({ error: 'no root cause found', id: nodeId })
+      return result
+    },
+  )
+
+  app.get<{ Params: { nodeId: string }; Querystring: { depth?: string } }>(
+    '/traverse/blast-radius/:nodeId',
+    async (req, reply) => {
+      const { nodeId } = req.params
+      if (!graph.hasNode(nodeId)) {
+        return reply.code(404).send({ error: 'node not found', id: nodeId })
+      }
+      const depth = req.query.depth ? Number(req.query.depth) : undefined
+      if (depth !== undefined && (!Number.isFinite(depth) || depth < 0)) {
+        return reply.code(400).send({ error: 'depth must be a non-negative number' })
+      }
+      return getBlastRadius(graph, nodeId, depth)
+    },
+  )
 
   app.get<{ Querystring: { q?: string } }>('/search', async (req, reply) => {
     const q = (req.query.q ?? '').trim().toLowerCase()

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export {
   markStaleEdges,
   readErrorEvents,
   startStalenessLoop,
+  stitchTrace,
   type IngestContext,
 } from './ingest.js'
 export { getBlastRadius, getRootCause } from './traverse.js'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,4 +25,4 @@ export {
   startStalenessLoop,
   type IngestContext,
 } from './ingest.js'
-export { getRootCause } from './traverse.js'
+export { getBlastRadius, getRootCause } from './traverse.js'

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -59,6 +59,13 @@ function makeObservedEdgeId(type: EdgeTypeValue, source: string, target: string)
   return `${type}:OBSERVED:${source}->${target}`
 }
 
+function makeInferredEdgeId(type: EdgeTypeValue, source: string, target: string): string {
+  return `${type}:INFERRED:${source}->${target}`
+}
+
+const INFERRED_CONFIDENCE = 0.6
+const STITCH_MAX_DEPTH = 2
+
 function resolveServiceId(graph: NeatGraph, host: string): string | null {
   const direct = `service:${host}`
   if (graph.hasNode(direct)) return direct
@@ -117,6 +124,63 @@ function upsertObservedEdge(
   return { edge, created: true }
 }
 
+// When a span errors, the system is exercising its dependencies right now even
+// if some of them aren't auto-instrumented (pg 7.4.0 in the demo, see ADR-014).
+// Walk EXTRACTED edges out from the erroring service for a couple of hops and
+// promote them to INFERRED twins so traversal can prefer them over the bare
+// static edges without claiming OBSERVED-grade certainty.
+function stitchTrace(graph: NeatGraph, sourceServiceId: string, ts: string): void {
+  if (!graph.hasNode(sourceServiceId)) return
+
+  const visited = new Set<string>([sourceServiceId])
+  const queue: { nodeId: string; depth: number }[] = [{ nodeId: sourceServiceId, depth: 0 }]
+
+  while (queue.length > 0) {
+    const { nodeId, depth } = queue.shift()!
+    if (depth >= STITCH_MAX_DEPTH) continue
+
+    const outbound = graph.outboundEdges(nodeId)
+    for (const edgeId of outbound) {
+      const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+      if (edge.provenance !== Provenance.EXTRACTED) continue
+
+      upsertInferredEdge(graph, edge.type, edge.source, edge.target, ts)
+
+      if (!visited.has(edge.target)) {
+        visited.add(edge.target)
+        queue.push({ nodeId: edge.target, depth: depth + 1 })
+      }
+    }
+  }
+}
+
+function upsertInferredEdge(
+  graph: NeatGraph,
+  type: EdgeTypeValue,
+  source: string,
+  target: string,
+  ts: string,
+): void {
+  const id = makeInferredEdgeId(type, source, target)
+  if (graph.hasEdge(id)) {
+    const existing = graph.getEdgeAttributes(id) as GraphEdge
+    const updated: GraphEdge = { ...existing, lastObserved: ts }
+    graph.replaceEdgeAttributes(id, updated)
+    return
+  }
+
+  const edge: GraphEdge = {
+    id,
+    source,
+    target,
+    type,
+    provenance: Provenance.INFERRED,
+    confidence: INFERRED_CONFIDENCE,
+    lastObserved: ts,
+  }
+  graph.addEdgeWithKey(id, source, target, edge)
+}
+
 async function appendErrorEvent(ctx: IngestContext, ev: ErrorEvent): Promise<void> {
   await fs.mkdir(path.dirname(ctx.errorsPath), { recursive: true })
   await fs.appendFile(ctx.errorsPath, JSON.stringify(ev) + '\n', 'utf8')
@@ -150,6 +214,7 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
   }
 
   if (span.statusCode === 2) {
+    stitchTrace(ctx.graph, sourceId, ts)
     const ev: ErrorEvent = {
       id: `${span.traceId}:${span.spanId}`,
       timestamp: ts,
@@ -162,6 +227,8 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
     await appendErrorEvent(ctx, ev)
   }
 }
+
+export { stitchTrace }
 
 export function makeSpanHandler(ctx: IngestContext): (span: ParsedSpan) => Promise<void> {
   return (span) => handleSpan(ctx, span)

--- a/packages/core/src/traverse.ts
+++ b/packages/core/src/traverse.ts
@@ -1,4 +1,6 @@
 import type {
+  BlastRadiusAffectedNode,
+  BlastRadiusResult,
   DatabaseNode,
   ErrorEvent,
   GraphEdge,
@@ -20,6 +22,7 @@ const PROV_RANK: Record<ProvenanceValue, number> = {
 }
 
 const ROOT_CAUSE_MAX_DEPTH = 5
+const BLAST_RADIUS_DEFAULT_DEPTH = 10
 
 // Multiple edges between the same pair coexist by provenance (EXTRACTED next to
 // OBSERVED next to INFERRED). Traversal walks the system as the graph "sees it
@@ -31,6 +34,18 @@ function bestEdgeBySource(graph: NeatGraph, edgeIds: string[]): Map<string, Grap
     const cur = best.get(e.source)
     if (!cur || PROV_RANK[e.provenance] > PROV_RANK[cur.provenance]) {
       best.set(e.source, e)
+    }
+  }
+  return best
+}
+
+function bestEdgeByTarget(graph: NeatGraph, edgeIds: string[]): Map<string, GraphEdge> {
+  const best = new Map<string, GraphEdge>()
+  for (const id of edgeIds) {
+    const e = graph.getEdgeAttributes(id) as GraphEdge
+    const cur = best.get(e.target)
+    if (!cur || PROV_RANK[e.provenance] > PROV_RANK[cur.provenance]) {
+      best.set(e.target, e)
     }
   }
   return best
@@ -132,5 +147,56 @@ export function getRootCause(
     edgeProvenances: walk.edges.map((e) => e.provenance),
     confidence: confidenceFromMix(walk.edges),
     fixRecommendation,
+  }
+}
+
+// BFS along outgoing edges from origin. Records each reachable node with the
+// shortest distance back to origin and the provenance of the edge that brought
+// us to it. Best-provenance edge selection per pair mirrors getRootCause.
+export function getBlastRadius(
+  graph: NeatGraph,
+  nodeId: string,
+  maxDepth = BLAST_RADIUS_DEFAULT_DEPTH,
+): BlastRadiusResult {
+  if (!graph.hasNode(nodeId)) {
+    return { origin: nodeId, affectedNodes: [], totalAffected: 0 }
+  }
+
+  interface Frame {
+    nodeId: string
+    distance: number
+    edge: GraphEdge | null
+  }
+
+  const seen = new Map<string, BlastRadiusAffectedNode>()
+  const queue: Frame[] = [{ nodeId, distance: 0, edge: null }]
+  const enqueued = new Set<string>([nodeId])
+
+  while (queue.length > 0) {
+    const frame = queue.shift()!
+    if (frame.distance > 0 && frame.edge) {
+      seen.set(frame.nodeId, {
+        nodeId: frame.nodeId,
+        distance: frame.distance,
+        edgeProvenance: frame.edge.provenance,
+      })
+    }
+    if (frame.distance >= maxDepth) continue
+
+    const outgoing = bestEdgeByTarget(graph, graph.outboundEdges(frame.nodeId))
+    for (const [tgtId, edge] of outgoing) {
+      if (enqueued.has(tgtId)) continue
+      enqueued.add(tgtId)
+      queue.push({ nodeId: tgtId, distance: frame.distance + 1, edge })
+    }
+  }
+
+  const affectedNodes = [...seen.values()].sort(
+    (a, b) => a.distance - b.distance || a.nodeId.localeCompare(b.nodeId),
+  )
+  return {
+    origin: nodeId,
+    affectedNodes,
+    totalAffected: affectedNodes.length,
   }
 }

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -117,4 +117,88 @@ describe('REST API (fastify.inject)', () => {
     const res = await app.inject({ method: 'POST', url: '/graph/scan' })
     expect(res.statusCode).toBe(409)
   })
+
+  it('GET /traverse/root-cause/:nodeId returns the demo pg incompatibility', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/traverse/root-cause/database:payments-db',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.rootCauseNode).toBe('service:service-b')
+    expect(body.traversalPath).toEqual([
+      'database:payments-db',
+      'service:service-b',
+      'service:service-a',
+    ])
+    expect(body.confidence).toBe(0.5)
+    expect(body.fixRecommendation).toMatch(/8\.0\.0/)
+  })
+
+  it('GET /traverse/root-cause/:nodeId returns 404 for an unknown node', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/traverse/root-cause/database:nope',
+    })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('GET /traverse/root-cause/:nodeId returns 404 when no root cause is found', async () => {
+    // service:service-a is a service node, not a database — getRootCause bails out.
+    const res = await app.inject({
+      method: 'GET',
+      url: '/traverse/root-cause/service:service-a',
+    })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('GET /traverse/blast-radius/:nodeId returns downstream nodes with distances', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/traverse/blast-radius/service:service-a',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.origin).toBe('service:service-a')
+    expect(body.totalAffected).toBe(2)
+    expect(body.affectedNodes).toEqual([
+      {
+        nodeId: 'service:service-b',
+        distance: 1,
+        edgeProvenance: 'EXTRACTED',
+      },
+      {
+        nodeId: 'database:payments-db',
+        distance: 2,
+        edgeProvenance: 'EXTRACTED',
+      },
+    ])
+  })
+
+  it('GET /traverse/blast-radius/:nodeId returns 404 for an unknown node', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/traverse/blast-radius/service:nope',
+    })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('GET /traverse/blast-radius/:nodeId rejects a negative depth', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/traverse/blast-radius/service:service-a?depth=-1',
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('GET /traverse/blast-radius/:nodeId honours a custom depth', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/traverse/blast-radius/service:service-a?depth=1',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.totalAffected).toBe(1)
+    expect(body.affectedNodes[0].nodeId).toBe('service:service-b')
+  })
 })

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -15,6 +15,7 @@ import {
   handleSpan,
   markStaleEdges,
   readErrorEvents,
+  stitchTrace,
   type IngestContext,
 } from '../src/ingest.js'
 import type { ParsedSpan } from '../src/otel.js'
@@ -43,6 +44,33 @@ function newGraph(): NeatGraph {
     compatibleDrivers: [],
   })
   return g
+}
+
+function addExtractedEdges(g: NeatGraph): void {
+  g.addEdgeWithKey(
+    'CALLS:service:service-a->service:service-b',
+    'service:service-a',
+    'service:service-b',
+    {
+      id: 'CALLS:service:service-a->service:service-b',
+      source: 'service:service-a',
+      target: 'service:service-b',
+      type: EdgeType.CALLS,
+      provenance: Provenance.EXTRACTED,
+    },
+  )
+  g.addEdgeWithKey(
+    'CONNECTS_TO:service:service-b->database:payments-db',
+    'service:service-b',
+    'database:payments-db',
+    {
+      id: 'CONNECTS_TO:service:service-b->database:payments-db',
+      source: 'service:service-b',
+      target: 'database:payments-db',
+      type: EdgeType.CONNECTS_TO,
+      provenance: Provenance.EXTRACTED,
+    },
+  )
 }
 
 function clientHttpSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
@@ -282,6 +310,135 @@ describe('readErrorEvents', () => {
   it('returns [] when the file does not exist yet', async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-ingest-read-'))
     expect(await readErrorEvents(path.join(tmpDir, 'absent.ndjson'))).toEqual([])
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+})
+
+describe('stitchTrace', () => {
+  it('writes INFERRED twins of EXTRACTED outgoing edges within depth 2', () => {
+    const graph = newGraph()
+    addExtractedEdges(graph)
+    stitchTrace(graph, 'service:service-a', '2026-05-01T00:00:00.000Z')
+
+    const callsId = `${EdgeType.CALLS}:INFERRED:service:service-a->service:service-b`
+    const connectsId = `${EdgeType.CONNECTS_TO}:INFERRED:service:service-b->database:payments-db`
+    expect(graph.hasEdge(callsId)).toBe(true)
+    expect(graph.hasEdge(connectsId)).toBe(true)
+
+    const calls = graph.getEdgeAttributes(callsId) as GraphEdge
+    expect(calls.provenance).toBe(Provenance.INFERRED)
+    expect(calls.confidence).toBe(0.6)
+    expect(calls.lastObserved).toBe('2026-05-01T00:00:00.000Z')
+    const connects = graph.getEdgeAttributes(connectsId) as GraphEdge
+    expect(connects.confidence).toBe(0.6)
+  })
+
+  it('refreshes lastObserved on re-stitch without duplicating the edge', () => {
+    const graph = newGraph()
+    addExtractedEdges(graph)
+    stitchTrace(graph, 'service:service-b', '2026-05-01T00:00:00.000Z')
+    stitchTrace(graph, 'service:service-b', '2026-05-01T01:00:00.000Z')
+
+    const id = `${EdgeType.CONNECTS_TO}:INFERRED:service:service-b->database:payments-db`
+    const edge = graph.getEdgeAttributes(id) as GraphEdge
+    expect(edge.lastObserved).toBe('2026-05-01T01:00:00.000Z')
+
+    let count = 0
+    graph.forEachEdge((k) => {
+      if (k === id) count++
+    })
+    expect(count).toBe(1)
+  })
+
+  it('does not promote OBSERVED edges to INFERRED twins', () => {
+    const graph = newGraph()
+    graph.addEdgeWithKey(
+      'CALLS:OBSERVED:service:service-a->service:service-b',
+      'service:service-a',
+      'service:service-b',
+      {
+        id: 'CALLS:OBSERVED:service:service-a->service:service-b',
+        source: 'service:service-a',
+        target: 'service:service-b',
+        type: EdgeType.CALLS,
+        provenance: Provenance.OBSERVED,
+        confidence: 1.0,
+        lastObserved: '2026-05-01T00:00:00.000Z',
+        callCount: 5,
+      },
+    )
+    stitchTrace(graph, 'service:service-a', '2026-05-01T00:00:00.000Z')
+
+    expect(
+      graph.hasEdge(`${EdgeType.CALLS}:INFERRED:service:service-a->service:service-b`),
+    ).toBe(false)
+  })
+
+  it('respects the depth-2 ceiling', () => {
+    const graph = newGraph()
+    graph.addNode('service:service-c', {
+      id: 'service:service-c',
+      type: NodeType.ServiceNode,
+      name: 'service-c',
+      language: 'javascript',
+    })
+    addExtractedEdges(graph)
+    // service-b -> service-c extends the chain to depth 3 from service-a.
+    graph.addEdgeWithKey(
+      'CALLS:service:service-b->service:service-c',
+      'service:service-b',
+      'service:service-c',
+      {
+        id: 'CALLS:service:service-b->service:service-c',
+        source: 'service:service-b',
+        target: 'service:service-c',
+        type: EdgeType.CALLS,
+        provenance: Provenance.EXTRACTED,
+      },
+    )
+    stitchTrace(graph, 'service:service-a', '2026-05-01T00:00:00.000Z')
+
+    // Depth 1: service-a -> service-b. Depth 2: service-b -> service-c, service-b -> payments-db.
+    // Anything past service-b's outbound is depth >= 3 and shouldn't be stitched.
+    expect(
+      graph.hasEdge(`${EdgeType.CALLS}:INFERRED:service:service-a->service:service-b`),
+    ).toBe(true)
+    expect(
+      graph.hasEdge(`${EdgeType.CALLS}:INFERRED:service:service-b->service:service-c`),
+    ).toBe(true)
+    expect(
+      graph.hasEdge(`${EdgeType.CONNECTS_TO}:INFERRED:service:service-b->database:payments-db`),
+    ).toBe(true)
+  })
+
+  it('is a no-op for an unknown source service', () => {
+    const graph = newGraph()
+    addExtractedEdges(graph)
+    stitchTrace(graph, 'service:does-not-exist', '2026-05-01T00:00:00.000Z')
+
+    let inferred = 0
+    graph.forEachEdge((k) => {
+      if (k.includes(':INFERRED:')) inferred++
+    })
+    expect(inferred).toBe(0)
+  })
+
+  it('runs from handleSpan when a span has statusCode === 2', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-stitch-'))
+    const graph = newGraph()
+    addExtractedEdges(graph)
+    const ctx: IngestContext = {
+      graph,
+      errorsPath: path.join(tmpDir, 'errors.ndjson'),
+    }
+    await handleSpan(
+      ctx,
+      dbSpan({ statusCode: 2, errorMessage: 'SASL: SCRAM-SERVER-FIRST-MESSAGE' }),
+    )
+
+    expect(
+      graph.hasEdge(`${EdgeType.CONNECTS_TO}:INFERRED:service:service-b->database:payments-db`),
+    ).toBe(true)
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 })

--- a/packages/core/test/traverse.test.ts
+++ b/packages/core/test/traverse.test.ts
@@ -9,7 +9,7 @@ import {
   type GraphNode,
 } from '@neat/types'
 import type { NeatGraph } from '../src/graph.js'
-import { getRootCause } from '../src/traverse.js'
+import { getBlastRadius, getRootCause } from '../src/traverse.js'
 
 function makeNode(id: string, attrs: GraphNode): GraphNode {
   return { ...attrs, id }
@@ -196,5 +196,127 @@ describe('getRootCause', () => {
       },
     )
     expect(getRootCause(g, 'database:payments-db')).toBeNull()
+  })
+})
+
+describe('getBlastRadius', () => {
+  it('returns service-b and payments-db downstream of service-a on the demo graph', () => {
+    const g = newDemoGraph()
+    addEdge(g, callsEdge(Provenance.EXTRACTED))
+    addEdge(g, connectsEdge(Provenance.EXTRACTED))
+
+    const result = getBlastRadius(g, 'service:service-a')
+    expect(result.origin).toBe('service:service-a')
+    expect(result.totalAffected).toBe(2)
+    expect(result.affectedNodes).toEqual([
+      {
+        nodeId: 'service:service-b',
+        distance: 1,
+        edgeProvenance: Provenance.EXTRACTED,
+      },
+      {
+        nodeId: 'database:payments-db',
+        distance: 2,
+        edgeProvenance: Provenance.EXTRACTED,
+      },
+    ])
+  })
+
+  it('reports OBSERVED provenance when an OBSERVED edge sits alongside the EXTRACTED one', () => {
+    const g = newDemoGraph()
+    addEdge(g, callsEdge(Provenance.EXTRACTED))
+    addEdge(g, callsEdge(Provenance.OBSERVED))
+    addEdge(g, connectsEdge(Provenance.EXTRACTED))
+    addEdge(g, connectsEdge(Provenance.OBSERVED))
+
+    const result = getBlastRadius(g, 'service:service-a')
+    expect(result.affectedNodes.find((n) => n.nodeId === 'service:service-b')!.edgeProvenance).toBe(
+      Provenance.OBSERVED,
+    )
+    expect(
+      result.affectedNodes.find((n) => n.nodeId === 'database:payments-db')!.edgeProvenance,
+    ).toBe(Provenance.OBSERVED)
+  })
+
+  it('returns nothing for a node with no outgoing edges', () => {
+    const g = newDemoGraph()
+    addEdge(g, callsEdge(Provenance.EXTRACTED))
+    addEdge(g, connectsEdge(Provenance.EXTRACTED))
+
+    const result = getBlastRadius(g, 'database:payments-db')
+    expect(result.affectedNodes).toEqual([])
+    expect(result.totalAffected).toBe(0)
+    expect(result.origin).toBe('database:payments-db')
+  })
+
+  it('returns an empty result for a node that does not exist', () => {
+    const g = newDemoGraph()
+    const result = getBlastRadius(g, 'service:nope')
+    expect(result.affectedNodes).toEqual([])
+    expect(result.totalAffected).toBe(0)
+    expect(result.origin).toBe('service:nope')
+  })
+
+  it('respects the depth limit', () => {
+    const g = newDemoGraph()
+    addEdge(g, callsEdge(Provenance.EXTRACTED))
+    addEdge(g, connectsEdge(Provenance.EXTRACTED))
+
+    const result = getBlastRadius(g, 'service:service-a', 1)
+    expect(result.affectedNodes).toEqual([
+      {
+        nodeId: 'service:service-b',
+        distance: 1,
+        edgeProvenance: Provenance.EXTRACTED,
+      },
+    ])
+  })
+
+  it('records the BFS-shortest distance when two paths reach the same node', () => {
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:a', {
+      id: 'service:a',
+      type: NodeType.ServiceNode,
+      name: 'a',
+      language: 'javascript',
+    })
+    g.addNode('service:b', {
+      id: 'service:b',
+      type: NodeType.ServiceNode,
+      name: 'b',
+      language: 'javascript',
+    })
+    g.addNode('service:c', {
+      id: 'service:c',
+      type: NodeType.ServiceNode,
+      name: 'c',
+      language: 'javascript',
+    })
+    // a -> c (direct, distance 1) and a -> b -> c (distance 2). Direct should win.
+    g.addEdgeWithKey('CALLS:service:a->service:c', 'service:a', 'service:c', {
+      id: 'CALLS:service:a->service:c',
+      source: 'service:a',
+      target: 'service:c',
+      type: EdgeType.CALLS,
+      provenance: Provenance.EXTRACTED,
+    })
+    g.addEdgeWithKey('CALLS:service:a->service:b', 'service:a', 'service:b', {
+      id: 'CALLS:service:a->service:b',
+      source: 'service:a',
+      target: 'service:b',
+      type: EdgeType.CALLS,
+      provenance: Provenance.EXTRACTED,
+    })
+    g.addEdgeWithKey('CALLS:service:b->service:c', 'service:b', 'service:c', {
+      id: 'CALLS:service:b->service:c',
+      source: 'service:b',
+      target: 'service:c',
+      type: EdgeType.CALLS,
+      provenance: Provenance.EXTRACTED,
+    })
+
+    const result = getBlastRadius(g, 'service:a')
+    const c = result.affectedNodes.find((n) => n.nodeId === 'service:c')
+    expect(c!.distance).toBe(1)
   })
 })


### PR DESCRIPTION
The three M3 PRs after #57 (blast-radius, traverse routes, trace stitcher) merged into their stacked bases instead of main, so main is sitting on root-cause-only. This brings the rest forward.

Three commits, one per issue, preserving the original review surface:

1. **Blast-radius traversal** — Refs #11. \`getBlastRadius\` BFS along outgoing edges, default depth 10, returns each reachable node's shortest distance + the provenance of the edge that brought us there.
2. **Traverse routes** — Refs #12. \`GET /traverse/root-cause/:nodeId[?errorId=]\` and \`GET /traverse/blast-radius/:nodeId[?depth=]\`.
3. **Trace stitcher** — Refs #60. When \`handleSpan\` sees \`statusCode === 2\`, walk EXTRACTED edges out from the erroring service depth ≤ 2 and upsert INFERRED twins (\`\${type}:INFERRED:\${source}->\${target}\`, confidence 0.6, lastObserved set). Closes the pg 7.4.0 instrumentation gap from ADR-014.

Verified live: \`docker compose up --build\` + \`for i in {1..10}; do curl localhost:3000/data; done\` produces:
- 10× 500s, 52 incident events
- \`/graph\` carrying all six edges side by side: 2 EXTRACTED, 2 OBSERVED (\`callCount: 11\` and 10), 2 INFERRED (\`confidence: 0.6\`)
- \`GET /traverse/root-cause/database:payments-db\` returns the SCRAM reason text + path \`[payments-db, service-b, service-a]\` + \`Upgrade service-b pg driver to >= 8.0.0\`
- \`GET /traverse/blast-radius/service:service-a\` returns service-b at distance 1 and payments-db at distance 2

98 tests green, turbo build/test/lint clean.

Demo cleanup (remove \`tracedQuery\` + \`@opentelemetry/api\` from \`demo/service-b\`) is a follow-up — that's what drops live root-cause confidence to 0.7 instead of 1.0.

Refs #11 #12 #60