### PR TITLE
M4: MCP tools wired to neat-core

### DIFF
--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -1,7 +1,43 @@
 # @neat/mcp
 
-Placeholder. The full agent-facing guide (when to call which tool, how to interpret results, the skill.md companion) lands with issue #20 in M4.
+The NEAT MCP server. Stdio JSON-RPC, six tools, talks to a running `@neat/core` instance over HTTP.
 
-For now: this package is the MCP stdio server. Six tool stubs are registered (`get_root_cause`, `get_blast_radius`, `get_dependencies`, `get_observed_dependencies`, `get_incident_history`, `semantic_search`) — each returns a "not yet implemented" placeholder pointing at its tracking issue.
+## When to use these tools
 
-To smoke-test the handshake: `npm run build --workspace @neat/mcp && node packages/mcp/dist/index.cjs` then send a JSON-RPC `initialize` over stdin.
+Reach for NEAT before grepping or reading source for **architecture-level questions** about a running system: dependencies, runtime traffic, recent failures, what would break if X changed. The graph already knows the answer; reading code reconstructs the answer from scratch each time.
+
+Rule of thumb: if the question would take more than two file reads to answer from source, try a NEAT tool first.
+
+| Question shape                                       | Tool                       |
+|------------------------------------------------------|----------------------------|
+| "Why is X failing?" / "What's the root cause of …"   | `get_root_cause`           |
+| "What breaks if I redeploy X?" / blast assessment    | `get_blast_radius`         |
+| "What does X depend on?" / dependency tree           | `get_dependencies`         |
+| "What does X actually call at runtime?"              | `get_observed_dependencies`|
+| "Show me recent errors on X"                         | `get_incident_history`     |
+| "Find nodes matching …"                              | `semantic_search`          |
+
+If a tool returns "not found" or empty, check that core is running (`curl $NEAT_CORE_URL/health`) before falling back to source reads.
+
+## Configuration
+
+`NEAT_CORE_URL` — base URL for the core REST API. Default `http://localhost:8080`.
+
+## Smoke-test the handshake
+
+```bash
+npm run build --workspace @neat/mcp
+node packages/mcp/dist/index.cjs
+# then send `{"jsonrpc":"2.0","id":1,"method":"initialize",…}` over stdin
+```
+
+## Provenance, briefly
+
+Every edge and result carries a provenance:
+
+- **OBSERVED** — seen in production via OTel. Trustworthy.
+- **INFERRED** — computed from other edges (e.g. on error spans where the static graph fills in for missing instrumentation). Confidence ≈ 0.6.
+- **EXTRACTED** — derived from source code or config. Always available, lowest authority.
+- **STALE** — was OBSERVED, hasn't been seen recently. Treat with suspicion.
+
+Tools surface this in their output so a result reading "INFERRED CONNECTS_TO" gets the right amount of trust from the consumer.

--- a/packages/mcp/skill.md
+++ b/packages/mcp/skill.md
@@ -1,0 +1,72 @@
+---
+name: neat
+description: Query a live semantic graph of a running software system — dependencies, runtime traffic, root-cause analysis, blast radius, and incident history. Use this for architecture-level questions before reading source code.
+---
+
+# NEAT skill
+
+NEAT keeps a continuously updated graph of a software system from static analysis + OpenTelemetry. This skill exposes it over six MCP tools.
+
+## When to invoke
+
+Reach for these tools when a question would take multiple file reads to answer from source. The graph already has the answer.
+
+| Prompt                                                  | Tool                       |
+|---------------------------------------------------------|----------------------------|
+| "Why is payments-db failing?"                           | `get_root_cause`           |
+| "What breaks if I redeploy service-a?"                  | `get_blast_radius`         |
+| "What does service-a depend on?"                        | `get_dependencies`         |
+| "What does service-b actually call at runtime?"         | `get_observed_dependencies`|
+| "Show me recent errors on database:payments-db"         | `get_incident_history`     |
+| "Find nodes matching pg"                                | `semantic_search`          |
+
+## Tool reference
+
+### `get_root_cause`
+
+Trace upstream from a failing node to find the actual cause. Walks incoming dependency edges, prefers OBSERVED → INFERRED → EXTRACTED, runs the compatibility matrix at each ServiceNode against the originating DatabaseNode.
+
+Inputs: `errorNode` (graph node id, e.g. `database:payments-db`), optional `errorId` (a specific incident id from `get_incident_history`).
+
+### `get_blast_radius`
+
+Walk outgoing dependencies from a node and list every downstream component with distance + the provenance of the edge that brought us to it.
+
+Inputs: `nodeId`, optional `depth` (default 10, max 20).
+
+### `get_dependencies`
+
+Outgoing dependency tree, deduped to the most trustworthy provenance per (target, edge type) pair.
+
+Inputs: `nodeId`.
+
+### `get_observed_dependencies`
+
+OBSERVED-only outgoing edges — services and databases the node actually contacted in production. Useful for spotting drift between code and reality.
+
+Inputs: `nodeId`.
+
+### `get_incident_history`
+
+Recent OTel error events recorded against a node, newest first.
+
+Inputs: `nodeId`, optional `limit` (default 20, max 100).
+
+### `semantic_search`
+
+Free-text match across node ids and names. Keyword-only for the MVP; vector search is a post-MVP enhancement.
+
+Inputs: `query`.
+
+## Configuration
+
+Set `NEAT_CORE_URL` if `@neat/core` is not running on `http://localhost:8080`.
+
+## Install
+
+```bash
+npm install -g @neat/mcp
+neat install
+```
+
+This registers the server with Claude Code and the six tools become available in any session.

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -1,0 +1,31 @@
+// Thin HTTP client for the neat-core REST surface. Tools call out via this
+// instead of fetch() directly so tests can swap in a stub implementation
+// without monkey-patching globals.
+
+export interface HttpClient {
+  get<T>(path: string): Promise<T>
+}
+
+export function createHttpClient(baseUrl: string): HttpClient {
+  const root = baseUrl.replace(/\/$/, '')
+  return {
+    async get<T>(path: string): Promise<T> {
+      const res = await fetch(`${root}${path}`)
+      if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        throw new HttpError(res.status, `${res.status} ${res.statusText} on GET ${path}: ${body}`)
+      }
+      return (await res.json()) as T
+    },
+  }
+}
+
+export class HttpError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'HttpError'
+  }
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -3,68 +3,84 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
+import { createHttpClient } from './client.js'
+import {
+  getBlastRadius,
+  getDependencies,
+  getIncidentHistory,
+  getObservedDependencies,
+  getRootCause,
+  semanticSearch,
+} from './tools.js'
 
-// Stub server. The six tools below match issues #14–#19 — each one returns
-// a placeholder string for now so Claude Code can connect, list_tools, and
-// see all six surfaces wired up. Real implementations land per-issue.
+const baseUrl = process.env.NEAT_CORE_URL ?? 'http://localhost:8080'
+const client = createHttpClient(baseUrl)
 
 const server = new McpServer({
   name: 'neat',
   version: '0.1.0',
 })
 
-const stub = (issue: number) => async () => ({
-  content: [
-    {
-      type: 'text' as const,
-      text: `not yet implemented — see issue #${issue}`,
-    },
-  ],
-})
-
 server.tool(
   'get_root_cause',
-  'Trace a failing node up its dependency graph to find the underlying cause.',
-  { nodeId: z.string().describe('Graph node id to start tracing from') },
-  stub(14),
+  'Trace a failing node up its dependency graph to find the underlying cause. Use this when something is breaking and you want to know which upstream component is the actual culprit.',
+  {
+    errorNode: z
+      .string()
+      .describe('Graph node id where the error surfaced, e.g. "database:payments-db"'),
+    errorId: z
+      .string()
+      .optional()
+      .describe('Specific error event id from incident history; if set, the result is coloured with that error message'),
+  },
+  async (input) => getRootCause(client, input),
 )
 
 server.tool(
   'get_blast_radius',
-  'List every node downstream of the given node — what would break if it failed.',
-  { nodeId: z.string().describe('Graph node id to compute blast radius from') },
-  stub(15),
+  'List every node downstream of the given node — what would break if this node failed or was redeployed.',
+  {
+    nodeId: z.string().describe('Graph node id to compute blast radius from'),
+    depth: z
+      .number()
+      .int()
+      .nonnegative()
+      .max(20)
+      .optional()
+      .describe('Max BFS depth (default 10)'),
+  },
+  async (input) => getBlastRadius(client, input),
 )
 
 server.tool(
   'get_dependencies',
-  'List the static (extracted from source) dependencies of a node.',
+  'List the outgoing dependencies of a node — both static (EXTRACTED from source) and runtime (OBSERVED via OTel), de-duplicated to the most trustworthy provenance per pair.',
   { nodeId: z.string().describe('Graph node id to inspect') },
-  stub(16),
+  async (input) => getDependencies(client, input),
 )
 
 server.tool(
   'get_observed_dependencies',
-  'List the runtime (observed via OTel) dependencies of a node.',
+  'List only the runtime (OBSERVED via OTel) outgoing dependencies of a node. Use this to compare what code SAYS the service depends on vs what production actually does.',
   { nodeId: z.string().describe('Graph node id to inspect') },
-  stub(17),
+  async (input) => getObservedDependencies(client, input),
 )
 
 server.tool(
   'get_incident_history',
-  'Return recent OTel error events recorded against a node.',
+  'Return recent OTel error events recorded against a node, most recent first.',
   {
     nodeId: z.string().describe('Graph node id to query'),
-    limit: z.number().int().positive().max(100).optional().describe('Max events to return'),
+    limit: z.number().int().positive().max(100).optional().describe('Max events to return (default 20)'),
   },
-  stub(18),
+  async (input) => getIncidentHistory(client, input),
 )
 
 server.tool(
   'semantic_search',
-  'Search nodes and edges by free-text query (keyword stub for MVP).',
+  'Search nodes by free-text query. Currently a keyword match over node ids and names; vector search lands post-MVP.',
   { query: z.string().describe('Search text') },
-  stub(19),
+  async (input) => semanticSearch(client, input),
 )
 
 async function main(): Promise<void> {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,0 +1,251 @@
+// Tool implementations. Each one takes an HttpClient + the validated input and
+// returns an MCP CallToolResult (always shape `{ content: [{ type, text }] }`).
+// Keeping these as pure functions of (client, input) means tests don't need a
+// running server — just a stub client that returns canned JSON.
+
+import type {
+  BlastRadiusAffectedNode,
+  BlastRadiusResult,
+  ErrorEvent,
+  GraphEdge,
+  GraphNode,
+  RootCauseResult,
+} from '@neat/types'
+import { Provenance } from '@neat/types'
+import { HttpError, type HttpClient } from './client.js'
+
+export interface ToolResponse {
+  [x: string]: unknown
+  content: { type: 'text'; text: string }[]
+  isError?: boolean
+}
+
+function text(s: string): ToolResponse {
+  return { content: [{ type: 'text', text: s }] }
+}
+
+function errorText(s: string): ToolResponse {
+  return { content: [{ type: 'text', text: s }], isError: true }
+}
+
+// Most tools want "node missing → friendly message, anything else → real error".
+async function withMissingNodeFallback(
+  fn: () => Promise<ToolResponse>,
+  notFoundMessage: string,
+): Promise<ToolResponse> {
+  try {
+    return await fn()
+  } catch (err) {
+    if (err instanceof HttpError && err.status === 404) {
+      return text(notFoundMessage)
+    }
+    return errorText(`Error talking to neat-core: ${(err as Error).message}`)
+  }
+}
+
+export interface RootCauseInput {
+  errorNode: string
+  errorId?: string
+}
+
+export async function getRootCause(client: HttpClient, input: RootCauseInput): Promise<ToolResponse> {
+  const qs = input.errorId ? `?errorId=${encodeURIComponent(input.errorId)}` : ''
+  const path = `/traverse/root-cause/${encodeURIComponent(input.errorNode)}${qs}`
+
+  return withMissingNodeFallback(async () => {
+    const result = await client.get<RootCauseResult>(path)
+    const arrowPath = result.traversalPath.join(' ← ')
+    const provenances = result.edgeProvenances.length
+      ? result.edgeProvenances.join(', ')
+      : '(direct, no edges traversed)'
+    const lines = [
+      `Root cause identified: ${result.rootCauseNode}.`,
+      result.rootCauseReason,
+      '',
+      `Traversal path: ${arrowPath}`,
+      `Edge provenances: ${provenances}`,
+      `Confidence: ${result.confidence.toFixed(2)}`,
+    ]
+    if (result.fixRecommendation) {
+      lines.push('', `Recommended fix: ${result.fixRecommendation}`)
+    }
+    return text(lines.join('\n'))
+  }, `No root cause found for ${input.errorNode}. The node may be healthy, or it may not exist in the graph.`)
+}
+
+export interface BlastRadiusInput {
+  nodeId: string
+  depth?: number
+}
+
+export async function getBlastRadius(
+  client: HttpClient,
+  input: BlastRadiusInput,
+): Promise<ToolResponse> {
+  const qs = input.depth !== undefined ? `?depth=${input.depth}` : ''
+  const path = `/traverse/blast-radius/${encodeURIComponent(input.nodeId)}${qs}`
+
+  return withMissingNodeFallback(async () => {
+    const result = await client.get<BlastRadiusResult>(path)
+    if (result.totalAffected === 0) {
+      return text(
+        `${result.origin} has no downstream dependencies. Nothing else would break if it failed.`,
+      )
+    }
+    const sorted = [...result.affectedNodes].sort(
+      (a, b) => a.distance - b.distance || a.nodeId.localeCompare(b.nodeId),
+    )
+    const lines = [`Blast radius for ${result.origin} (${result.totalAffected} affected):`, '']
+    for (const n of sorted) {
+      lines.push(formatBlastEntry(n))
+    }
+    return text(lines.join('\n'))
+  }, `Node ${input.nodeId} not found in the graph.`)
+}
+
+function formatBlastEntry(n: BlastRadiusAffectedNode): string {
+  const tag = n.edgeProvenance === Provenance.STALE ? ' [STALE — last seen too long ago]' : ''
+  return `  • ${n.nodeId} (distance ${n.distance}, ${n.edgeProvenance})${tag}`
+}
+
+interface EdgesResponse {
+  inbound: GraphEdge[]
+  outbound: GraphEdge[]
+}
+
+export interface DependenciesInput {
+  nodeId: string
+}
+
+export async function getDependencies(
+  client: HttpClient,
+  input: DependenciesInput,
+): Promise<ToolResponse> {
+  return withMissingNodeFallback(async () => {
+    const edges = await client.get<EdgesResponse>(
+      `/graph/edges/${encodeURIComponent(input.nodeId)}`,
+    )
+    const outbound = edges.outbound
+    if (outbound.length === 0) {
+      return text(`${input.nodeId} has no outgoing dependencies in the graph.`)
+    }
+    const lines = [`Dependencies of ${input.nodeId}:`, '']
+    for (const e of dedupeBestProvenance(outbound)) {
+      lines.push(`  • ${e.target} — ${e.type} (${e.provenance})${edgeMeta(e)}`)
+    }
+    return text(lines.join('\n'))
+  }, `Node ${input.nodeId} not found in the graph.`)
+}
+
+export async function getObservedDependencies(
+  client: HttpClient,
+  input: DependenciesInput,
+): Promise<ToolResponse> {
+  return withMissingNodeFallback(async () => {
+    const edges = await client.get<EdgesResponse>(
+      `/graph/edges/${encodeURIComponent(input.nodeId)}`,
+    )
+    const observed = edges.outbound.filter((e) => e.provenance === Provenance.OBSERVED)
+    if (observed.length === 0) {
+      const hasExtracted = edges.outbound.some((e) => e.provenance === Provenance.EXTRACTED)
+      const note = hasExtracted
+        ? ' Static (EXTRACTED) dependencies exist but no runtime traffic has been seen — is OTel running?'
+        : ''
+      return text(`No OBSERVED dependencies for ${input.nodeId}.${note}`)
+    }
+    const lines = [`Runtime dependencies of ${input.nodeId} (OBSERVED):`, '']
+    for (const e of observed) {
+      lines.push(`  • ${e.target} — ${e.type}${edgeMeta(e)}`)
+    }
+    return text(lines.join('\n'))
+  }, `Node ${input.nodeId} not found in the graph.`)
+}
+
+function edgeMeta(e: GraphEdge): string {
+  const bits: string[] = []
+  if (e.callCount !== undefined) bits.push(`callCount=${e.callCount}`)
+  if (e.lastObserved) bits.push(`lastObserved=${e.lastObserved}`)
+  if (e.confidence !== undefined) bits.push(`confidence=${e.confidence}`)
+  return bits.length ? ` [${bits.join(', ')}]` : ''
+}
+
+// Two services can have an EXTRACTED edge AND an OBSERVED edge AND an INFERRED
+// edge between the same pair. For "dependencies" output we want one line per
+// (target, type), preferring the most-trustworthy provenance.
+function dedupeBestProvenance(edges: GraphEdge[]): GraphEdge[] {
+  const rank: Record<string, number> = {
+    OBSERVED: 3,
+    INFERRED: 2,
+    EXTRACTED: 1,
+    STALE: 0,
+    FRONTIER: 0,
+  }
+  const best = new Map<string, GraphEdge>()
+  for (const e of edges) {
+    const key = `${e.target}|${e.type}`
+    const cur = best.get(key)
+    if (!cur || rank[e.provenance] > rank[cur.provenance]) best.set(key, e)
+  }
+  return [...best.values()]
+}
+
+export interface IncidentHistoryInput {
+  nodeId: string
+  limit?: number
+}
+
+export async function getIncidentHistory(
+  client: HttpClient,
+  input: IncidentHistoryInput,
+): Promise<ToolResponse> {
+  return withMissingNodeFallback(async () => {
+    const events = await client.get<ErrorEvent[]>(
+      `/incidents/${encodeURIComponent(input.nodeId)}`,
+    )
+    if (events.length === 0) {
+      return text(`No incidents recorded against ${input.nodeId}.`)
+    }
+    // ndjson order is append-time = oldest first. Reverse so the most recent
+    // event leads, then trim to the requested limit.
+    const ordered = [...events].reverse().slice(0, input.limit ?? 20)
+    const lines = [
+      `Recent incidents on ${input.nodeId} (${ordered.length} of ${events.length}):`,
+      '',
+    ]
+    for (const ev of ordered) {
+      lines.push(`  ${ev.timestamp} — ${ev.service}: ${ev.errorMessage}`)
+      lines.push(`    trace=${ev.traceId} span=${ev.spanId}`)
+    }
+    return text(lines.join('\n'))
+  }, `Node ${input.nodeId} not found in the graph.`)
+}
+
+export interface SemanticSearchInput {
+  query: string
+}
+
+interface SearchResponse {
+  query: string
+  matches: GraphNode[]
+}
+
+export async function semanticSearch(
+  client: HttpClient,
+  input: SemanticSearchInput,
+): Promise<ToolResponse> {
+  try {
+    const result = await client.get<SearchResponse>(
+      `/search?q=${encodeURIComponent(input.query)}`,
+    )
+    if (result.matches.length === 0) {
+      return text(`No matches for "${input.query}".`)
+    }
+    const lines = [`Search results for "${input.query}":`, '']
+    for (const n of result.matches) {
+      lines.push(`  • ${n.id} (${n.type}) — ${n.name}`)
+    }
+    return text(lines.join('\n'))
+  } catch (err) {
+    return errorText(`Error talking to neat-core: ${(err as Error).message}`)
+  }
+}

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -1,0 +1,359 @@
+import { describe, expect, it } from 'vitest'
+import { EdgeType, NodeType, Provenance } from '@neat/types'
+import { HttpError, type HttpClient } from '../src/client.js'
+import {
+  getBlastRadius,
+  getDependencies,
+  getIncidentHistory,
+  getObservedDependencies,
+  getRootCause,
+  semanticSearch,
+} from '../src/tools.js'
+
+interface Capture {
+  paths: string[]
+}
+
+// Decoded lookup so test keys can read like '/incidents/database:payments-db'
+// instead of '/incidents/database%3Apayments-db'. Capture records the raw,
+// pre-decode path so tests can assert on actual encoding.
+function decodePath(p: string): string {
+  const [base, ...rest] = p.split('?')
+  return decodeURIComponent(base) + (rest.length ? '?' + rest.join('?') : '')
+}
+
+function clientFor(map: Record<string, unknown>, capture: Capture = { paths: [] }): {
+  client: HttpClient
+  capture: Capture
+} {
+  return {
+    capture,
+    client: {
+      async get<T>(path: string): Promise<T> {
+        capture.paths.push(path)
+        const decoded = decodePath(path)
+        if (decoded in map) return map[decoded] as T
+        if (path in map) return map[path] as T
+        throw new HttpError(404, `404 on ${path}`)
+      },
+    },
+  }
+}
+
+function errorClient(err: Error): HttpClient {
+  return {
+    async get<T>(): Promise<T> {
+      throw err
+    },
+  }
+}
+
+describe('getRootCause', () => {
+  it('formats RootCauseResult as natural language with arrow path', async () => {
+    const { client, capture } = clientFor({
+      '/traverse/root-cause/database:payments-db': {
+        rootCauseNode: 'service:service-b',
+        rootCauseReason:
+          'PostgreSQL 14+ requires scram-sha-256; pg < 8.0.0 only speaks md5.',
+        traversalPath: ['database:payments-db', 'service:service-b', 'service:service-a'],
+        edgeProvenances: [Provenance.OBSERVED, Provenance.OBSERVED],
+        confidence: 1,
+        fixRecommendation: 'Upgrade service-b pg driver to >= 8.0.0',
+      },
+    })
+    const res = await getRootCause(client, { errorNode: 'database:payments-db' })
+    expect(res.isError).toBeFalsy()
+    const text = res.content[0].text
+    expect(text).toContain('Root cause identified: service:service-b')
+    expect(text).toContain('database:payments-db ← service:service-b ← service:service-a')
+    expect(text).toContain('Confidence: 1.00')
+    expect(text).toContain('OBSERVED, OBSERVED')
+    expect(text).toContain('Recommended fix: Upgrade service-b pg driver to >= 8.0.0')
+    expect(capture.paths).toEqual(['/traverse/root-cause/database%3Apayments-db'])
+  })
+
+  it('threads errorId through as a query parameter', async () => {
+    const { client, capture } = clientFor({
+      '/traverse/root-cause/database:payments-db?errorId=trace-1%3Aspan-b': {
+        rootCauseNode: 'service:service-b',
+        rootCauseReason: 'reason',
+        traversalPath: ['database:payments-db', 'service:service-b'],
+        edgeProvenances: [Provenance.EXTRACTED],
+        confidence: 0.5,
+      },
+    })
+    await getRootCause(client, { errorNode: 'database:payments-db', errorId: 'trace-1:span-b' })
+    expect(capture.paths[0]).toBe(
+      '/traverse/root-cause/database%3Apayments-db?errorId=trace-1%3Aspan-b',
+    )
+  })
+
+  it('returns a friendly message on 404', async () => {
+    const { client } = clientFor({})
+    const res = await getRootCause(client, { errorNode: 'database:nope' })
+    expect(res.isError).toBeFalsy()
+    expect(res.content[0].text).toContain('No root cause found')
+  })
+
+  it('reports a non-404 error as isError', async () => {
+    const res = await getRootCause(errorClient(new Error('connect ECONNREFUSED')), {
+      errorNode: 'database:payments-db',
+    })
+    expect(res.isError).toBe(true)
+    expect(res.content[0].text).toContain('ECONNREFUSED')
+  })
+})
+
+describe('getBlastRadius', () => {
+  it('lists affected nodes sorted by distance with provenance tags', async () => {
+    const { client } = clientFor({
+      '/traverse/blast-radius/service:service-a': {
+        origin: 'service:service-a',
+        totalAffected: 2,
+        affectedNodes: [
+          {
+            nodeId: 'database:payments-db',
+            distance: 2,
+            edgeProvenance: Provenance.OBSERVED,
+          },
+          {
+            nodeId: 'service:service-b',
+            distance: 1,
+            edgeProvenance: Provenance.OBSERVED,
+          },
+        ],
+      },
+    })
+    const res = await getBlastRadius(client, { nodeId: 'service:service-a' })
+    const lines = res.content[0].text.split('\n')
+    expect(lines[0]).toContain('Blast radius for service:service-a (2 affected)')
+    // service-b at distance 1 should appear before payments-db at distance 2
+    const bIdx = lines.findIndex((l) => l.includes('service:service-b'))
+    const dbIdx = lines.findIndex((l) => l.includes('database:payments-db'))
+    expect(bIdx).toBeGreaterThan(0)
+    expect(dbIdx).toBeGreaterThan(bIdx)
+  })
+
+  it('flags STALE edges explicitly', async () => {
+    const { client } = clientFor({
+      '/traverse/blast-radius/service:service-a': {
+        origin: 'service:service-a',
+        totalAffected: 1,
+        affectedNodes: [
+          {
+            nodeId: 'service:service-b',
+            distance: 1,
+            edgeProvenance: Provenance.STALE,
+          },
+        ],
+      },
+    })
+    const res = await getBlastRadius(client, { nodeId: 'service:service-a' })
+    expect(res.content[0].text).toContain('[STALE')
+  })
+
+  it('handles a node with no downstream nodes', async () => {
+    const { client } = clientFor({
+      '/traverse/blast-radius/database:payments-db': {
+        origin: 'database:payments-db',
+        totalAffected: 0,
+        affectedNodes: [],
+      },
+    })
+    const res = await getBlastRadius(client, { nodeId: 'database:payments-db' })
+    expect(res.content[0].text).toContain('no downstream dependencies')
+  })
+
+  it('passes depth as a query parameter', async () => {
+    const { client, capture } = clientFor({
+      '/traverse/blast-radius/service:service-a?depth=1': {
+        origin: 'service:service-a',
+        totalAffected: 0,
+        affectedNodes: [],
+      },
+    })
+    await getBlastRadius(client, { nodeId: 'service:service-a', depth: 1 })
+    expect(capture.paths[0]).toBe('/traverse/blast-radius/service%3Aservice-a?depth=1')
+  })
+})
+
+describe('getDependencies', () => {
+  it('returns outgoing edges with the best provenance per pair', async () => {
+    const { client } = clientFor({
+      '/graph/edges/service:service-a': {
+        inbound: [],
+        outbound: [
+          {
+            id: 'CALLS:service:service-a->service:service-b',
+            source: 'service:service-a',
+            target: 'service:service-b',
+            type: EdgeType.CALLS,
+            provenance: Provenance.EXTRACTED,
+          },
+          {
+            id: 'CALLS:OBSERVED:service:service-a->service:service-b',
+            source: 'service:service-a',
+            target: 'service:service-b',
+            type: EdgeType.CALLS,
+            provenance: Provenance.OBSERVED,
+            confidence: 1,
+            callCount: 11,
+            lastObserved: '2026-05-01T15:51:11.967Z',
+          },
+        ],
+      },
+    })
+    const res = await getDependencies(client, { nodeId: 'service:service-a' })
+    const text = res.content[0].text
+    expect(text).toContain('Dependencies of service:service-a')
+    expect(text).toContain('service:service-b — CALLS (OBSERVED)')
+    expect(text).toContain('callCount=11')
+    // The EXTRACTED twin should be deduped out.
+    expect(text.split('\n').filter((l) => l.includes('service:service-b'))).toHaveLength(1)
+  })
+
+  it('returns a friendly message when there are no outgoing edges', async () => {
+    const { client } = clientFor({
+      '/graph/edges/database:payments-db': { inbound: [], outbound: [] },
+    })
+    const res = await getDependencies(client, { nodeId: 'database:payments-db' })
+    expect(res.content[0].text).toContain('no outgoing dependencies')
+  })
+})
+
+describe('getObservedDependencies', () => {
+  it('filters to OBSERVED only and includes lastObserved + callCount', async () => {
+    const { client } = clientFor({
+      '/graph/edges/service:service-a': {
+        inbound: [],
+        outbound: [
+          {
+            id: 'CALLS:service:service-a->service:service-b',
+            source: 'service:service-a',
+            target: 'service:service-b',
+            type: EdgeType.CALLS,
+            provenance: Provenance.EXTRACTED,
+          },
+          {
+            id: 'CALLS:OBSERVED:service:service-a->service:service-b',
+            source: 'service:service-a',
+            target: 'service:service-b',
+            type: EdgeType.CALLS,
+            provenance: Provenance.OBSERVED,
+            confidence: 1,
+            callCount: 11,
+            lastObserved: '2026-05-01T15:51:11.967Z',
+          },
+        ],
+      },
+    })
+    const res = await getObservedDependencies(client, { nodeId: 'service:service-a' })
+    const text = res.content[0].text
+    expect(text).toContain('Runtime dependencies of service:service-a')
+    expect(text).toContain('service:service-b')
+    expect(text).toContain('lastObserved=2026-05-01T15:51:11.967Z')
+  })
+
+  it('explains the OTel-down case when only EXTRACTED edges exist', async () => {
+    const { client } = clientFor({
+      '/graph/edges/service:service-a': {
+        inbound: [],
+        outbound: [
+          {
+            id: 'CALLS:service:service-a->service:service-b',
+            source: 'service:service-a',
+            target: 'service:service-b',
+            type: EdgeType.CALLS,
+            provenance: Provenance.EXTRACTED,
+          },
+        ],
+      },
+    })
+    const res = await getObservedDependencies(client, { nodeId: 'service:service-a' })
+    expect(res.content[0].text).toContain('OTel running')
+  })
+})
+
+describe('getIncidentHistory', () => {
+  it('returns events newest first with trace and span ids', async () => {
+    const { client } = clientFor({
+      '/incidents/database:payments-db': [
+        {
+          id: 'trace-1:span-1',
+          timestamp: '2026-05-01T15:00:00.000Z',
+          service: 'service-b',
+          traceId: 'trace-1',
+          spanId: 'span-1',
+          errorMessage: 'older',
+          affectedNode: 'database:payments-db',
+        },
+        {
+          id: 'trace-2:span-2',
+          timestamp: '2026-05-01T15:30:00.000Z',
+          service: 'service-b',
+          traceId: 'trace-2',
+          spanId: 'span-2',
+          errorMessage: 'SCRAM-SERVER-FIRST-MESSAGE',
+          affectedNode: 'database:payments-db',
+        },
+      ],
+    })
+    const res = await getIncidentHistory(client, { nodeId: 'database:payments-db' })
+    const text = res.content[0].text
+    expect(text).toContain('Recent incidents on database:payments-db (2 of 2)')
+    const newerIdx = text.indexOf('SCRAM')
+    const olderIdx = text.indexOf('older')
+    expect(newerIdx).toBeGreaterThan(0)
+    expect(newerIdx).toBeLessThan(olderIdx)
+    expect(text).toContain('trace=trace-2 span=span-2')
+  })
+
+  it('honours limit', async () => {
+    const events = Array.from({ length: 5 }, (_, i) => ({
+      id: `t:${i}`,
+      timestamp: `2026-05-01T15:0${i}:00.000Z`,
+      service: 's',
+      traceId: `trace-${i}`,
+      spanId: `span-${i}`,
+      errorMessage: `e${i}`,
+      affectedNode: 'database:payments-db',
+    }))
+    const { client } = clientFor({ '/incidents/database:payments-db': events })
+    const res = await getIncidentHistory(client, { nodeId: 'database:payments-db', limit: 2 })
+    expect(res.content[0].text).toContain('(2 of 5)')
+  })
+
+  it('returns a friendly message for an empty list', async () => {
+    const { client } = clientFor({ '/incidents/service:service-a': [] })
+    const res = await getIncidentHistory(client, { nodeId: 'service:service-a' })
+    expect(res.content[0].text).toContain('No incidents recorded')
+  })
+})
+
+describe('semanticSearch', () => {
+  it('formats matches with id, type, and name', async () => {
+    const { client } = clientFor({
+      '/search?q=service-b': {
+        query: 'service-b',
+        matches: [
+          {
+            id: 'service:service-b',
+            type: NodeType.ServiceNode,
+            name: 'service-b',
+            language: 'javascript',
+          },
+        ],
+      },
+    })
+    const res = await semanticSearch(client, { query: 'service-b' })
+    expect(res.content[0].text).toContain('service:service-b (ServiceNode) — service-b')
+  })
+
+  it('returns a friendly message when there are no matches', async () => {
+    const { client } = clientFor({
+      '/search?q=nothing': { query: 'nothing', matches: [] },
+    })
+    const res = await semanticSearch(client, { query: 'nothing' })
+    expect(res.content[0].text).toContain('No matches')
+  })
+})


### PR DESCRIPTION
Reopened off main after #63 auto-closed when its stacked base branch was deleted by the #62 merge. Same diff, just re-rooted.

Replaces the six stubs in \`@neat/mcp\` with real HTTP-calling implementations and ships the agent-facing docs.

## Tools

| Tool | Endpoint | Refs |
|------|----------|------|
| \`get_root_cause\` | \`/traverse/root-cause/:nodeId[?errorId=]\` | #14 |
| \`get_blast_radius\` | \`/traverse/blast-radius/:nodeId[?depth=]\` | #15 |
| \`get_dependencies\` | \`/graph/edges/:nodeId\` (best-provenance dedup per pair) | #16 |
| \`get_observed_dependencies\` | \`/graph/edges/:nodeId\` (OBSERVED only) | #17 |
| \`get_incident_history\` | \`/incidents/:nodeId\` (newest first, default limit 20) | #18 |
| \`semantic_search\` | \`/search?q=\` | #19 |

Each tool is a pure \`(HttpClient, input) → ToolResponse\` function in \`tools.ts\` and registered against the MCP server in \`index.ts\`. The split means tests inject a stub client and assert on request paths + natural-language output, no server spin-up.

Output is rendered for humans:

\`\`\`
Root cause identified: service:service-b.
PostgreSQL 14+ requires scram-sha-256 auth by default; pg < 8.0.0 only speaks md5.

Traversal path: database:payments-db ← service:service-b ← service:service-a
Edge provenances: OBSERVED, OBSERVED
Confidence: 1.00

Recommended fix: Upgrade service-b pg driver to >= 8.0.0
\`\`\`

## Docs (#20)

- **CLAUDE.md** — tells Claude Code to reach for NEAT tools before grepping for architecture-level questions, with a prompt-to-tool mapping and a quick provenance primer.
- **skill.md** — skill registration file with frontmatter + per-tool reference + install instructions.

## Tests

17 new tests in \`packages/mcp/test/tools.test.ts\` covering happy paths, errorId thread-through, 404 → friendly message, non-404 → \`isError: true\`, STALE flagging in blast radius, OTel-down explanation in observed deps, limit honoured in incidents, dedupe in get_dependencies. \`turbo build test lint\` clean across the workspace (115 tests).

Refs #14 #15 #16 #17 #18 #19 #20