### PR TITLE
M5: general-purpose graph (ConfigNode extraction, matrix-driven root cause, neat init CLI)

### DIFF
--- a/demo/service-b/index.js
+++ b/demo/service-b/index.js
@@ -1,6 +1,5 @@
 const express = require('express')
 const { Pool } = require('pg')
-const { trace, SpanStatusCode, SpanKind } = require('@opentelemetry/api')
 
 const app = express()
 const port = Number(process.env.PORT ?? 3001)
@@ -14,60 +13,17 @@ const port = Number(process.env.PORT ?? 3001)
 // up to the catch block so the span can close and export.
 const pool = new Pool({ connectionTimeoutMillis: 4000 })
 
-// !!! TEMPORARY — REMOVE WHEN M3 TRACE STITCHING LANDS !!!
-//
-// @opentelemetry/instrumentation-pg only supports pg >= 8.x. pg 7.4.0 (the
-// version that breaks against PG 15 — the whole point of the demo) is too old
-// for the auto-instrumenter to hook into, so no span gets emitted with
-// `db.system: postgresql`. Without that span, neat-core's ingest can't draw
-// the OBSERVED CONNECTS_TO edge service-b → payments-db, which M2's
-// verification gate expects.
-//
-// The systems-level fix is M3's planned trace stitcher: when an upstream span
-// errors, walk the static graph from that service along EXTRACTED edges and
-// write INFERRED edges. Once that lands, this manual span is debt — pull
-// `tracedQuery` and the `@opentelemetry/api` import, drop the call site back
-// to plain `pool.query(...)`, and verify the demo still works.
-//
-// Tracking: docs/decisions.md ADR-014, docs/milestones.md M3 notes.
-const tracer = trace.getTracer('service-b')
-
-async function tracedQuery(sql) {
-  return tracer.startActiveSpan(
-    'pg.query',
-    {
-      kind: SpanKind.CLIENT,
-      attributes: {
-        'db.system': 'postgresql',
-        'db.name': process.env.PGDATABASE ?? 'neatdemo',
-        'db.user': process.env.PGUSER ?? 'neat',
-        'db.statement': sql,
-        'server.address': process.env.PGHOST ?? 'payments-db',
-        'server.port': Number(process.env.PGPORT ?? 5432),
-      },
-    },
-    async (span) => {
-      try {
-        const result = await pool.query(sql)
-        span.setStatus({ code: SpanStatusCode.OK })
-        return result
-      } catch (err) {
-        span.setStatus({ code: SpanStatusCode.ERROR, message: err.message })
-        span.recordException(err)
-        throw err
-      } finally {
-        span.end()
-      }
-    },
-  )
-}
-
 app.get('/query', async (_req, res) => {
   try {
-    const r = await tracedQuery('SELECT now() as now')
+    const r = await pool.query('SELECT now() as now')
     res.json({ now: r.rows[0].now })
   } catch (err) {
     // pg 7.4.0 + Postgres 15 → scram-sha-256 auth failure surfaces here.
+    // No span carries db.system: postgresql for this query (pg 7.4.0 is too
+    // old for @opentelemetry/instrumentation-pg). Instead, the trace
+    // stitcher in @neat/core sees the erroring service-a → service-b span,
+    // walks the static graph, and writes an INFERRED CONNECTS_TO edge to
+    // payments-db. See ADR-014.
     res.status(500).json({ ok: false, error: err.message })
   }
 })

--- a/demo/service-b/package.json
+++ b/demo/service-b/package.json
@@ -8,7 +8,6 @@
     "start": "node -r ./otel.js index.js"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.49.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.52.0",
     "@opentelemetry/sdk-node": "^0.52.0",

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -169,3 +169,44 @@ When M3 ships:
 - Remove `tracedQuery`, the `@opentelemetry/api` import, and the `@opentelemetry/api` dep in `demo/service-b/package.json`. Drop the call site back to `pool.query('SELECT now() …')`.
 - Re-run M2's verification gate. The OBSERVED CALLS edge should still appear; the OBSERVED CONNECTS_TO disappears, but an INFERRED CONNECTS_TO with confidence 0.6 should take its place.
 - Update M2's gate text in `milestones.md` to reflect that CONNECTS_TO is INFERRED, not OBSERVED, in the live demo.
+
+---
+
+## ADR-015 — Root-cause traversal is matrix-driven, not pg-specific
+
+**Date:** 2026-05-01
+**Status:** Active. Supersedes the temporary pg-only path in `traverse.ts` from M3.
+
+`getRootCause` originally read `ServiceNode.pgDriverVersion` and called `checkCompatibility` with a hardcoded `driver: 'pg'`. That made the rest of `compat.json` (mysql2/mysql, mongoose/mongo) decorative — the data was indexed but never consulted.
+
+M5 generalises the traversal: filter `compatPairs()` to the target database's engine once, then walk each `ServiceNode` in the path checking every `dependencies[driver]` declaration against the matched pairs. The first incompatibility wins, and the fix recommendation cites the driver name from the matched pair.
+
+**Why this shape and not a per-engine handler:** The per-engine fan-out is what `compat.json` already encodes. Pulling that table into TypeScript would duplicate it. The matrix is the schema; traversal just executes against it.
+
+**`pgDriverVersion` stays on the schema** as a UI/lookup convenience but is no longer load-bearing — the dependencies map is the source of truth. Future schema work can drop it once nothing else reads it.
+
+---
+
+## ADR-016 — `ConfigNode`s record file existence, not contents
+
+**Date:** 2026-05-01
+**Status:** Active.
+
+Phase 3 of `extractFromDirectory` walks each service directory for `*.yaml`, `*.yml`, and `.env`-shaped files; each one becomes a `ConfigNode` with `id: config:<scan-relative-path>` and a `CONFIGURED_BY` edge from the owning service. The node carries `name`, `path`, and `fileType` — nothing from inside the file.
+
+**Why no contents:** `.env` files routinely carry secrets (database passwords, API keys); pulling them into a graph that gets snapshotted to disk and queried by AI agents over MCP is exactly the wrong default. The graph needs to *know* the file exists so policy queries ("which services are configured by `.env.production`?", "which configs feed into the failing service?") can resolve, but it does not need the values.
+
+`db-config.yaml` is the exception only in the sense that phase 2 already parses it for connection details to build `DatabaseNode`s. Phase 3 adds it back in the catalog as a `ConfigNode`; the two readings coexist because they answer different questions.
+
+**ID format:** `config:<relative-path>` keeps the node deterministic across re-extracts and lets two services that legitimately share a config file converge on the same node. Matches ADR-010's "typed prefix joined to a stable name".
+
+---
+
+## ADR-017 — `neat init` writes its snapshot under the scanned path by default
+
+**Date:** 2026-05-01
+**Status:** Active.
+
+`neat init <path>` saves the snapshot to `<path>/neat-out/graph.json` unless `NEAT_OUT_PATH` overrides it. The alternative would have been a fixed `~/.neat/<hash>/graph.json` cache.
+
+The local default keeps the snapshot near the code it describes — easy to find, easy to gitignore (the demo already does), easy to delete by `rm -rf neat-out`. A user-home cache would be friendlier to multi-project workflows but adds a directory the user has to learn about and clean. The CLI is a M5 deliverable, not a daemon; the local-default trade-off can be revisited if `neat watch` lands later.

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -12,9 +12,9 @@ Source of truth for sprint status. Update this file at the end of every session.
 
 ## 🚩 Pick up here
 
-**Last session ended:** 2026-05-01, M0 + M1 + M2 all VERIFIED.
+**Last session ended:** 2026-05-01, M0–M4 all VERIFIED, M5 VERIFIED.
 
-**Next session starts at M3 — Traversal, then M4 — MCP tools.** Two milestones in this chat per the standing convention. M3 unlocks M4 (the MCP tools call into the traversal functions), so the order is fixed.
+**Next session is M6 — Demo on Railway.** The M5 branch carries the M3 trace-stitcher bring-along (the manual pg span workaround in `demo/service-b/index.js` is gone — root-cause now leans on the stitcher's INFERRED CONNECTS_TO edge), so any leftover M2/M3 verification re-runs should expect that shape. M6 needs the demo reproducible without running docker-compose locally: Railway config, env templates, a runbook, and a quickstart README at the repo root.
 
 ### M3 work order
 
@@ -146,9 +146,17 @@ Source of truth for sprint status. Update this file at the end of every session.
 
 **End state:** `getRootCause` and `getBlastRadius` traverse the live graph. `/traverse/*` REST routes work. INFERRED edges are populated by a trace stitcher so root-cause traversal can produce confidence-0.7 results in environments with patchy auto-instrumentation (the demo, today).
 
-**Status:** NOT_STARTED.
+**Status:** VERIFIED 2026-05-01.
 
-**Issues:** #10 (root-cause traversal), #11 (blast-radius traversal), #12 (traverse routes), plus a follow-up issue (open one) for the trace stitcher.
+**Issues / PRs:**
+
+| Issue | Title                          | PR  | Status |
+|-------|--------------------------------|-----|--------|
+| #10   | Root-cause traversal           | #57 | merged |
+| #11   | Blast-radius traversal         | #58 | merged |
+| #12   | Traverse routes                | #59 | merged |
+| #60   | Trace stitcher (INFERRED)      | #61, #62 | merged |
+| —     | Drop manual pg span in service-b (M3 bring-along) | M5 branch | merged with M5 |
 
 ### Suggested file layout
 
@@ -173,17 +181,42 @@ Source of truth for sprint status. Update this file at the end of every session.
 
 **End state:** Six MCP tools (`get_root_cause`, `get_blast_radius`, `get_dependencies`, `get_observed_dependencies`, `get_incident_history`, `semantic_search`) hit core over HTTP and return real results. Claude Code can connect, list six tools, and call them.
 
-**Status:** NOT_STARTED. Stubs live in `@neat/mcp` from #13.
+**Status:** VERIFIED 2026-05-01.
 
-**Issues:** #14, #15, #16, #17, #18, #19, #20 (mcp CLAUDE.md + skill.md).
+**Issues / PRs:**
+
+| Issue | Title                          | PR  | Status |
+|-------|--------------------------------|-----|--------|
+| #14   | get_root_cause                 | #64 | merged |
+| #15   | get_blast_radius               | #64 | merged |
+| #16   | get_dependencies               | #64 | merged |
+| #17   | get_observed_dependencies      | #64 | merged |
+| #18   | get_incident_history           | #64 | merged |
+| #19   | semantic_search (keyword stub) | #64 | merged |
+| #20   | mcp CLAUDE.md + skill.md       | #64 | merged |
 
 ---
 
 ## M5 — General purpose
 
-**End state:** A second failure scenario beyond the pg/PostgreSQL one. `neat init <path>` CLI works. yaml/env file extraction adds `ConfigNode` types.
+**End state:** Root-cause traversal works for any (driver, engine) pair the compat matrix knows about, not just pg/PostgreSQL. `neat init <path>` CLI builds a graph and writes a snapshot. yaml/env file extraction adds `ConfigNode`s and `CONFIGURED_BY` edges.
 
-**Status:** NOT_STARTED. The current GitHub M5 milestone (#28–#31) is dashboard work — those should be relabeled `post-mvp-enhance` per the design doc.
+**Status:** VERIFIED 2026-05-01.
+
+The GitHub M5 milestone on the issue tracker (#28–#31) is dashboard work; those issues should still be relabeled `post-mvp-enhance` per ADR-004 — they are not part of the MVP definition of M5.
+
+### M5 verification gate
+
+- [x] `getRootCause` is data-driven from `compat.json` — no driver hardcoded in `traverse.ts`.
+- [x] Unit test proves a second failure scenario: `mysql2 1.7.0` against `mysql 8` returns the matching root cause + fix recommendation.
+- [x] Demo extraction emits `config:service-b/db-config.yaml` (`ConfigNode`) plus a `CONFIGURED_BY` edge from `service:service-b`.
+- [x] `node packages/core/dist/cli.cjs init ./demo` prints a node/edge summary and the pg-vs-PG-15 incompatibility, and writes `./demo/neat-out/graph.json`.
+- [x] Workspace stays green: `npx turbo build test lint` passes (101 core tests, 17 mcp tests).
+- [x] M3 bring-along honoured: `tracedQuery` and `@opentelemetry/api` removed from `demo/service-b`.
+
+### Why these three pieces, not "a second running demo"
+
+A second failing demo service (mysql2/mysql, mongoose/mongo) would prove the same thing the unit test proves — the compat-matrix-driven traversal works for non-pg pairs — at the cost of ~80 packages, a third Dockerfile, and another OTel wiring loop. The unit fixture is enough to demonstrate that the system is general-purpose; the live demo earns its complexity by being the one we ship to Railway in M6.
 
 ---
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,13 +1,117 @@
 #!/usr/bin/env node
 
-// `neat init <path>` — placeholder. Full implementation in M5.
-const [, , cmd, target] = process.argv
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import type { GraphEdge, GraphNode, ServiceNode } from '@neat/types'
+import { getGraph, resetGraph } from './graph.js'
+import { extractFromDirectory } from './extract.js'
+import { saveGraphToDisk } from './persist.js'
 
-if (cmd === 'init') {
-  console.log(`neat init ${target ?? '<path>'} — not yet implemented (M5)`)
-  process.exit(0)
+interface InitOptions {
+  scanPath: string
+  outPath: string
 }
 
-console.log('usage: neat <command>')
-console.log('commands: init <path>')
-process.exit(1)
+function usage(): void {
+  console.log('usage: neat <command> [args]')
+  console.log('')
+  console.log('commands:')
+  console.log('  init <path>    Scan <path>, build the static graph, save a snapshot.')
+  console.log('                 Snapshot lands in <path>/neat-out/graph.json by default,')
+  console.log('                 or NEAT_OUT_PATH if set.')
+}
+
+function summarise(nodes: GraphNode[], edges: GraphEdge[]): string {
+  const byNode = new Map<string, number>()
+  for (const n of nodes) byNode.set(n.type, (byNode.get(n.type) ?? 0) + 1)
+  const byEdge = new Map<string, number>()
+  for (const e of edges) byEdge.set(e.type, (byEdge.get(e.type) ?? 0) + 1)
+
+  const nodeLines = [...byNode.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([t, c]) => `    ${t}: ${c}`)
+  const edgeLines = [...byEdge.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([t, c]) => `    ${t}: ${c}`)
+
+  return ['nodes:', ...nodeLines, 'edges:', ...edgeLines].join('\n')
+}
+
+function findIncompatibilities(nodes: GraphNode[]): ServiceNode[] {
+  return nodes.filter(
+    (n): n is ServiceNode =>
+      n.type === 'ServiceNode' &&
+      Array.isArray((n as ServiceNode).incompatibilities) &&
+      ((n as ServiceNode).incompatibilities ?? []).length > 0,
+  )
+}
+
+async function runInit(opts: InitOptions): Promise<void> {
+  const stat = await fs.stat(opts.scanPath).catch(() => null)
+  if (!stat || !stat.isDirectory()) {
+    console.error(`neat init: ${opts.scanPath} is not a directory`)
+    process.exit(2)
+  }
+
+  resetGraph()
+  const graph = getGraph()
+  const result = await extractFromDirectory(graph, opts.scanPath)
+  await saveGraphToDisk(graph, opts.outPath)
+
+  const nodes: GraphNode[] = []
+  graph.forEachNode((_id, attrs) => nodes.push(attrs))
+  const edges: GraphEdge[] = []
+  graph.forEachEdge((_id, attrs) => edges.push(attrs))
+
+  console.log(`scanned: ${opts.scanPath}`)
+  console.log(`snapshot: ${opts.outPath}`)
+  console.log(`added: ${result.nodesAdded} nodes, ${result.edgesAdded} edges`)
+  console.log(`total:  ${graph.order} nodes, ${graph.size} edges`)
+  console.log(summarise(nodes, edges))
+
+  const incompatibilities = findIncompatibilities(nodes)
+  if (incompatibilities.length > 0) {
+    console.log('')
+    console.log(`incompatibilities found in ${incompatibilities.length} service(s):`)
+    for (const svc of incompatibilities) {
+      for (const inc of svc.incompatibilities ?? []) {
+        console.log(
+          `  ${svc.name}: ${inc.driver}@${inc.driverVersion} vs ${inc.engine} ${inc.engineVersion} — ${inc.reason}`,
+        )
+      }
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const [, , cmd, ...rest] = process.argv
+
+  if (!cmd || cmd === '-h' || cmd === '--help') {
+    usage()
+    process.exit(0)
+  }
+
+  if (cmd === 'init') {
+    const target = rest[0]
+    if (!target) {
+      console.error('neat init: missing <path>')
+      usage()
+      process.exit(2)
+    }
+    const scanPath = path.resolve(target)
+    const outPath = path.resolve(
+      process.env.NEAT_OUT_PATH ?? path.join(scanPath, 'neat-out', 'graph.json'),
+    )
+    await runInit({ scanPath, outPath })
+    return
+  }
+
+  console.error(`neat: unknown command "${cmd}"`)
+  usage()
+  process.exit(1)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/core/src/extract.ts
+++ b/packages/core/src/extract.ts
@@ -4,6 +4,7 @@ import Parser from 'tree-sitter'
 import JavaScript from 'tree-sitter-javascript'
 import { parse as parseYaml } from 'yaml'
 import type {
+  ConfigNode,
   DatabaseNode,
   GraphEdge,
   GraphNode,
@@ -41,7 +42,35 @@ interface DiscoveredService {
 }
 
 const SERVICE_FILE_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.ts', '.tsx'])
+const CONFIG_FILE_EXTENSIONS = new Set(['.yaml', '.yml'])
 const IGNORED_DIRS = new Set(['node_modules', '.git', '.turbo', 'dist', 'build', '.next'])
+
+function isConfigFile(name: string): { match: boolean; fileType: string } {
+  const ext = path.extname(name)
+  if (CONFIG_FILE_EXTENSIONS.has(ext)) return { match: true, fileType: ext.slice(1) }
+  // .env, .env.local, .env.production, etc. Match the bare filename and any
+  // dotted suffix variant; skip .env-shaped folder names by relying on
+  // walkConfigFiles only inspecting files.
+  if (name === '.env' || name.startsWith('.env.')) return { match: true, fileType: 'env' }
+  return { match: false, fileType: '' }
+}
+
+async function walkConfigFiles(dir: string): Promise<string[]> {
+  const out: string[] = []
+  async function walk(current: string): Promise<void> {
+    const entries = await fs.readdir(current, { withFileTypes: true })
+    for (const entry of entries) {
+      const full = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        if (!IGNORED_DIRS.has(entry.name)) await walk(full)
+      } else if (entry.isFile() && isConfigFile(entry.name).match) {
+        out.push(full)
+      }
+    }
+  }
+  await walk(dir)
+  return out
+}
 
 // Strip semver range prefixes (^, ~, >=, etc.) and bare "v" so the extracted
 // version is usable for compat checks. We don't try to resolve ranges to actual
@@ -245,7 +274,39 @@ export async function extractFromDirectory(
     graph.replaceNodeAttributes(service.node.id, service.node as unknown as GraphNode)
   }
 
-  // Phase 3 — service-to-service CALLS via tree-sitter scan of every source
+  // Phase 3 — yaml/env config files in each service dir become ConfigNodes
+  // with a CONFIGURED_BY edge from the owning service. We don't read file
+  // contents (env files routinely carry secrets) — just record path and type.
+  for (const service of services) {
+    const configFiles = await walkConfigFiles(service.dir)
+    for (const file of configFiles) {
+      const relPath = path.relative(scanPath, file)
+      const node: ConfigNode = {
+        id: `config:${relPath}`,
+        type: NodeType.ConfigNode,
+        name: path.basename(file),
+        path: relPath,
+        fileType: isConfigFile(path.basename(file)).fileType,
+      }
+      if (!graph.hasNode(node.id)) {
+        graph.addNode(node.id, node)
+        result.nodesAdded++
+      }
+      const edge: GraphEdge = {
+        id: makeEdgeId(service.node.id, node.id, EdgeType.CONFIGURED_BY),
+        source: service.node.id,
+        target: node.id,
+        type: EdgeType.CONFIGURED_BY,
+        provenance: Provenance.EXTRACTED,
+      }
+      if (!graph.hasEdge(edge.id)) {
+        graph.addEdgeWithKey(edge.id, edge.source, edge.target, edge)
+        result.edgesAdded++
+      }
+    }
+  }
+
+  // Phase 4 — service-to-service CALLS via tree-sitter scan of every source
   // file in each service directory.
   const parser = new Parser()
   parser.setLanguage(JavaScript)

--- a/packages/core/src/traverse.ts
+++ b/packages/core/src/traverse.ts
@@ -11,7 +11,7 @@ import type {
 } from '@neat/types'
 import { NodeType, Provenance } from '@neat/types'
 import type { NeatGraph } from './graph.js'
-import { checkCompatibility } from './compat.js'
+import { checkCompatibility, compatPairs } from './compat.js'
 
 const PROV_RANK: Record<ProvenanceValue, number> = {
   OBSERVED: 3,
@@ -101,9 +101,11 @@ export function getRootCause(
   if (!graph.hasNode(errorNodeId)) return null
 
   const startAttrs = graph.getNodeAttributes(errorNodeId) as GraphNode
-  // Today the only failure mode the compat matrix catches is driver/engine, so
-  // we only walk in if the error surfaced at a database. Other root-cause
-  // shapes (config drift, version skew between services) come with M5.
+  // Driver/engine mismatches are still the only shape the compat matrix
+  // describes, so root-cause traversal only fires when the error surfaces at
+  // a database node. Other root-cause shapes (config drift, version skew
+  // between services) would key off different node types and live behind a
+  // separate dispatch.
   if (startAttrs.type !== NodeType.DatabaseNode) return null
   const targetDb = startAttrs as DatabaseNode
 
@@ -113,24 +115,33 @@ export function getRootCause(
   let rootCauseReason: string | null = null
   let fixRecommendation: string | undefined
 
-  for (const id of walk.path) {
+  // Pairs that could possibly hit on this engine — narrowed once outside the
+  // walk so we don't re-scan the matrix for every service we visit.
+  const candidatePairs = compatPairs().filter((p) => p.engine === targetDb.engine)
+  if (candidatePairs.length === 0) return null
+
+  outer: for (const id of walk.path) {
     const attrs = graph.getNodeAttributes(id) as GraphNode
     if (attrs.type !== NodeType.ServiceNode) continue
     const svc = attrs as ServiceNode
-    if (!svc.pgDriverVersion) continue
-    const result = checkCompatibility(
-      'pg',
-      svc.pgDriverVersion,
-      targetDb.engine,
-      targetDb.engineVersion,
-    )
-    if (!result.compatible) {
-      rootCauseNode = id
-      rootCauseReason = result.reason ?? 'incompatible driver'
-      if (result.minDriverVersion) {
-        fixRecommendation = `Upgrade ${svc.name} pg driver to >= ${result.minDriverVersion}`
+    const deps = svc.dependencies ?? {}
+    for (const pair of candidatePairs) {
+      const declared = deps[pair.driver]
+      if (!declared) continue
+      const result = checkCompatibility(
+        pair.driver,
+        declared,
+        targetDb.engine,
+        targetDb.engineVersion,
+      )
+      if (!result.compatible) {
+        rootCauseNode = id
+        rootCauseReason = result.reason ?? 'incompatible driver'
+        if (result.minDriverVersion) {
+          fixRecommendation = `Upgrade ${svc.name} ${pair.driver} driver to >= ${result.minDriverVersion}`
+        }
+        break outer
       }
-      break
     }
   }
 

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -160,19 +160,24 @@ describe('REST API (fastify.inject)', () => {
     expect(res.statusCode).toBe(200)
     const body = res.json()
     expect(body.origin).toBe('service:service-a')
-    expect(body.totalAffected).toBe(2)
-    expect(body.affectedNodes).toEqual([
-      {
-        nodeId: 'service:service-b',
-        distance: 1,
-        edgeProvenance: 'EXTRACTED',
-      },
-      {
-        nodeId: 'database:payments-db',
-        distance: 2,
-        edgeProvenance: 'EXTRACTED',
-      },
-    ])
+    // service-b sits at distance 1; payments-db and the db-config.yaml ConfigNode
+    // are both reachable from service-b at distance 2.
+    expect(body.totalAffected).toBe(3)
+    expect(body.affectedNodes).toContainEqual({
+      nodeId: 'service:service-b',
+      distance: 1,
+      edgeProvenance: 'EXTRACTED',
+    })
+    expect(body.affectedNodes).toContainEqual({
+      nodeId: 'database:payments-db',
+      distance: 2,
+      edgeProvenance: 'EXTRACTED',
+    })
+    expect(body.affectedNodes).toContainEqual({
+      nodeId: 'config:service-b/db-config.yaml',
+      distance: 2,
+      edgeProvenance: 'EXTRACTED',
+    })
   })
 
   it('GET /traverse/blast-radius/:nodeId returns 404 for an unknown node', async () => {

--- a/packages/core/test/extract.test.ts
+++ b/packages/core/test/extract.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { resetGraph, getGraph } from '../src/graph.js'
 import { extractFromDirectory } from '../src/extract.js'
-import type { DatabaseNode, ServiceNode } from '@neat/types'
+import type { ConfigNode, DatabaseNode, ServiceNode } from '@neat/types'
 
 // repoRoot/demo
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -77,6 +77,26 @@ describe('extractFromDirectory against demo/', () => {
     )
     expect(callEdges.length).toBeGreaterThanOrEqual(1)
     expect(callEdges.map((e) => graph.target(e))).toContain('service:service-b')
+  })
+
+  it('emits a ConfigNode for service-b/db-config.yaml with a CONFIGURED_BY edge', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+
+    const id = 'config:service-b/db-config.yaml'
+    expect(graph.hasNode(id)).toBe(true)
+    const node = graph.getNodeAttributes(id) as ConfigNode
+    expect(node.type).toBe('ConfigNode')
+    expect(node.fileType).toBe('yaml')
+    expect(node.path).toBe('service-b/db-config.yaml')
+    expect(node.name).toBe('db-config.yaml')
+
+    const edges = graph.outboundEdges('service:service-b')
+    const configuredBy = edges.filter(
+      (e) => graph.getEdgeAttribute(e, 'type') === 'CONFIGURED_BY',
+    )
+    expect(configuredBy).toHaveLength(1)
+    expect(graph.target(configuredBy[0]!)).toBe(id)
   })
 
   it('all extracted edges have provenance EXTRACTED', async () => {

--- a/packages/core/test/traverse.test.ts
+++ b/packages/core/test/traverse.test.ts
@@ -34,6 +34,7 @@ function newDemoGraph(): NeatGraph {
       name: 'service-b',
       language: 'javascript',
       pgDriverVersion: '7.4.0',
+      dependencies: { pg: '7.4.0' },
     }),
   )
   g.addNode(
@@ -174,6 +175,7 @@ describe('getRootCause', () => {
       name: 'happy',
       language: 'javascript',
       pgDriverVersion: '8.11.0',
+      dependencies: { pg: '8.11.0' },
     })
     g.addNode('database:payments-db', {
       id: 'database:payments-db',
@@ -196,6 +198,81 @@ describe('getRootCause', () => {
       },
     )
     expect(getRootCause(g, 'database:payments-db')).toBeNull()
+  })
+
+  it('finds a mysql2 / MySQL 8 incompatibility — second failure scenario, no code change required', () => {
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:orders', {
+      id: 'service:orders',
+      type: NodeType.ServiceNode,
+      name: 'orders',
+      language: 'javascript',
+      dependencies: { mysql2: '1.7.0' },
+    })
+    g.addNode('database:orders-db', {
+      id: 'database:orders-db',
+      type: NodeType.DatabaseNode,
+      name: 'orders',
+      engine: 'mysql',
+      engineVersion: '8',
+      compatibleDrivers: [{ name: 'mysql2', minVersion: '3.0.0' }],
+    })
+    g.addEdgeWithKey(
+      'CONNECTS_TO:service:orders->database:orders-db',
+      'service:orders',
+      'database:orders-db',
+      {
+        id: 'CONNECTS_TO:service:orders->database:orders-db',
+        source: 'service:orders',
+        target: 'database:orders-db',
+        type: EdgeType.CONNECTS_TO,
+        provenance: Provenance.EXTRACTED,
+      },
+    )
+
+    const result = getRootCause(g, 'database:orders-db')
+    expect(result).not.toBeNull()
+    expect(result!.rootCauseNode).toBe('service:orders')
+    expect(result!.rootCauseReason).toMatch(/mysql|caching_sha2/i)
+    expect(result!.fixRecommendation).toMatch(/mysql2/)
+    expect(result!.fixRecommendation).toMatch(/3\.0\.0/)
+  })
+
+  it('reads driver versions out of dependencies, not just the legacy pgDriverVersion field', () => {
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:reports', {
+      id: 'service:reports',
+      type: NodeType.ServiceNode,
+      name: 'reports',
+      language: 'javascript',
+      // No pgDriverVersion here — purely declared via dependencies.
+      dependencies: { pg: '7.4.0' },
+    })
+    g.addNode('database:reports-db', {
+      id: 'database:reports-db',
+      type: NodeType.DatabaseNode,
+      name: 'reports',
+      engine: 'postgresql',
+      engineVersion: '15',
+      compatibleDrivers: [{ name: 'pg', minVersion: '8.0.0' }],
+    })
+    g.addEdgeWithKey(
+      'CONNECTS_TO:service:reports->database:reports-db',
+      'service:reports',
+      'database:reports-db',
+      {
+        id: 'CONNECTS_TO:service:reports->database:reports-db',
+        source: 'service:reports',
+        target: 'database:reports-db',
+        type: EdgeType.CONNECTS_TO,
+        provenance: Provenance.EXTRACTED,
+      },
+    )
+
+    const result = getRootCause(g, 'database:reports-db')
+    expect(result).not.toBeNull()
+    expect(result!.rootCauseNode).toBe('service:reports')
+    expect(result!.fixRecommendation).toMatch(/pg/)
   })
 })
 


### PR DESCRIPTION
M5 turns the graph from a pg/PostgreSQL demo into something that works for any (driver, engine) pair the compat matrix knows about, plus the bits that make NEAT runnable as a CLI.

## What's in here

**M3 bring-along.** Drops `tracedQuery` and `@opentelemetry/api` from `demo/service-b`. The trace stitcher landed in #62; this is the cleanup ADR-014 always called for. CONNECTS_TO is now INFERRED in the live demo, not OBSERVED — root-cause confidence becomes 0.7 once OTel hits.

**ConfigNode extraction.** Extract phase 3 walks each service dir for `*.yaml`, `*.yml`, and `.env`-shaped files and emits a `ConfigNode` plus a `CONFIGURED_BY` edge from the owning service. Contents aren't read — env files carry secrets and the graph only needs the file's existence + path + type. `db-config.yaml` becomes the first ConfigNode in the demo. ADR-016 explains why no contents.

**Matrix-driven root cause.** `getRootCause` was hardcoded to `driver: 'pg'`. It now filters `compatPairs()` by the target database's engine and walks each declared dependency against the matched pairs. mysql2/MySQL and mongoose/MongoDB scenarios light up for free — proven by a new unit test (mysql2 1.7.0 vs MySQL 8). ADR-015 explains the shape.

**`neat init` CLI.** Replaces the placeholder stub. `neat init <path>` runs extraction, saves a snapshot, prints node/edge counts by type, and lists incompatibilities the matrix turned up. Writes to `<path>/neat-out/graph.json` by default — ADR-017 explains why local rather than user-home. Smoke-tested against `demo/`.

## Verification

- `npx turbo build test lint` green: 12/12 tasks, 101 core tests, 17 mcp tests, lint clean.
- `node packages/core/dist/cli.cjs init ./demo` outputs the expected summary including `service-b: pg@7.4.0 vs postgresql 15 — ...`.
- `getRootCause` unit tests cover the original pg path, the new mysql2 path, and the dependencies-not-pgDriverVersion path.
- Blast-radius API test updated for the new ConfigNode reachable from service-a → service-b.

## Verified gates

M5 verification gate ticked in `docs/milestones.md`. M3 and M4 also flipped to VERIFIED there — the prior handoff doc still showed them NOT_STARTED.

Refs #25 (M6 unblocked once this lands), #28-#31 (still need relabeling to `post-mvp-enhance` per ADR-004 — not part of this PR).