### PR TITLE
M6: Railway deploy + quickstart README + PROVENANCE.md

### DIFF
--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,82 @@
+# Provenance
+
+NEAT's graph never claims more than it can defend. Every edge — and every result that's built out of edges — carries a `provenance` that says where the information came from. Tools and traversals read it. Confidence cascades from it. Treat this file as the contract between what NEAT knows and how loudly it gets to say so.
+
+## The four states
+
+### EXTRACTED — read from source
+
+Found in code or config. `package.json` declared the dep. `db-config.yaml` named the host. tree-sitter saw the URL literal pointing at another service.
+
+EXTRACTED is the base layer. It is always available — no runtime, no telemetry, no clock — and it goes stale the moment the code changes without a re-scan. Re-running `extractFromDirectory` (or `POST /graph/scan`) is idempotent: same source, same nodes, same edge ids. Don't trust it past your last extraction.
+
+### INFERRED — derived from other edges
+
+Computed, not observed. Today there's exactly one source of INFERRED edges: the trace stitcher. When an upstream span errors (`statusCode === 2`), the stitcher walks the static graph from that service along EXTRACTED edges depth ≤ 2 and writes INFERRED twins of every edge it crosses with `confidence: 0.6`.
+
+Why 0.6? Because we know the system was actively exercising those dependencies during the failing call (the span errored, so traffic was real), but we didn't see the dependency hop directly — we reconstructed it from the static graph. That's worth more than EXTRACTED-only (the code says it's there, nobody confirmed) and less than OBSERVED (we watched it happen).
+
+The stitcher exists for environments with patchy auto-instrumentation. The canonical case is the demo: pg 7.4.0 is too old for `@opentelemetry/instrumentation-pg`, so service-b's `pool.query` calls don't emit a `db.system: postgresql` span. Without INFERRED edges, root-cause traversal would lose the CONNECTS_TO hop and never reach payments-db. The stitcher fills that gap without claiming OBSERVED-grade certainty.
+
+### OBSERVED — seen in production
+
+Live OTel data. A span carried the right semconv attributes (`server.address`, `db.system`, `url.full`), the receiver decoded it, and ingest mapped it to a graph edge with `lastObserved` set to now and `callCount` incremented.
+
+OBSERVED is ground truth at the moment it was recorded. `confidence: 1.0`. If the demo is running and traffic is hitting `localhost:3000/data`, you will see `CALLS:OBSERVED:service:service-a->service:service-b` with a non-zero `callCount` and a `lastObserved` from the last few seconds.
+
+### STALE — was OBSERVED, hasn't been seen recently
+
+OBSERVED edges that haven't been refreshed inside the staleness threshold (24 hours by default; `markStaleEdges` runs on a 60s loop in production). The edge stays in the graph — knowing the relationship existed yesterday is information — but its provenance flips to STALE and confidence drops to 0.3.
+
+STALE is not the same as gone. A service that's been down for an hour has STALE edges; a service that was renamed and never deploys again has STALE edges that may persist forever. Treat STALE as a signal to look, not a verdict.
+
+### A note on FRONTIER
+
+The `Provenance` enum carries a fifth value, `FRONTIER`, for placeholder nodes — "we know this dependency exists because logs name it, but we have no node for the other end." Nothing writes FRONTIER today. It's reserved for the inference layer described in the seed design doc; M5 doesn't ship it.
+
+## Why provenance ranks the way it does
+
+Traversal, in both `getRootCause` and `getBlastRadius`, picks the highest-provenance edge available between any neighbour pair. The order is:
+
+```
+OBSERVED  >  INFERRED  >  EXTRACTED  >  STALE  ≥  FRONTIER
+```
+
+OBSERVED beats everything because it's the only one anyone watched. INFERRED beats EXTRACTED because the system was demonstrably running when we drew the edge. STALE drops to the floor because "we used to see this" is less useful than "we just looked at the code." FRONTIER is for placeholders that don't have data either way.
+
+## Confidence cascades
+
+`getRootCause` returns a `confidence` between 0 and 1. The rule is:
+
+- **1.0** — every edge in the traversal path was OBSERVED.
+- **0.7** — at least one edge was INFERRED. (None had to be EXTRACTED-only.)
+- **0.5** — every edge was EXTRACTED-only. The path is plausible from the source code but nobody watched it run.
+
+This is the headline number the consumer reads. A 1.0 root cause is reproducible from real traffic. A 0.5 root cause is a hypothesis derived from `package.json` and YAML.
+
+## How tools surface this
+
+The MCP tools include provenance in their text output. You'll see lines like:
+
+```
+Edge provenances: OBSERVED, INFERRED
+Confidence: 0.70
+```
+
+or, in `get_blast_radius`:
+
+```
+  • database:payments-db (distance 2, INFERRED)
+  • service:service-old (distance 1, STALE — last seen too long ago)
+```
+
+Read the provenance the same way you'd read a citation: the more authoritative the source, the more weight you put on the claim.
+
+## Where to look in the code
+
+- Edge ids encode provenance. EXTRACTED: `${type}:${source}->${target}`. OBSERVED: `${type}:OBSERVED:${source}->${target}`. INFERRED: `${type}:INFERRED:${source}->${target}`. The graph is a `MultiDirectedGraph`, so multiple edges between the same pair coexist by design.
+- `packages/core/src/ingest.ts` — `handleSpan`, `upsertObservedEdge`, `stitchTrace`, `markStaleEdges`. Everything that turns runtime signal into graph state.
+- `packages/core/src/traverse.ts` — `PROV_RANK`, `bestEdgeBySource`, `bestEdgeByTarget`, `confidenceFromMix`. Where provenance ranking is enforced during traversal.
+- `packages/types/src/constants.ts` — the `Provenance` enum itself. Adding a sixth state means touching this first.
+
+For the architectural rationale, see `docs/architecture.md` (provenance lifecycle) and `docs/decisions.md` ADR-014 (why INFERRED exists at all).

--- a/README.md
+++ b/README.md
@@ -1,109 +1,154 @@
 # NEAT
 
-> **⚠️ Work in Progress**
-> This repository is currently an MVP under active development.
-> Many architectural and code design decisions were intentionally optimised for development speed.
+> **⚠️ Work in progress.** This repository is an MVP under active development. Many architectural decisions were intentionally optimised for development speed.
 
 [![CI](https://github.com/neat-tools/Neat/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/neat-tools/Neat/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/neat-tools/Neat)](https://github.com/neat-tools/Neat)
 [![Release](https://img.shields.io/github/v/release/neat-tools/Neat)](https://github.com/neat-tools/Neat/releases)
 [![Website](https://img.shields.io/badge/website-neat.is-black)](https://neat.is)
 
-A unified runtime that maintains a live semantic model of your codebase, infrastructure, and production.
-
-Query it. Assert policies against it. Emit IaC from it. Run agents against it.
+A unified runtime that maintains a live semantic graph of your codebase, infrastructure, and production. Query it. Assert policies against it. Run agents against it.
 
 ---
 
-## Statement
+## What it does
 
-**Architecture is the first decision.**  
-Everything else follows from it.
+NEAT continuously builds a graph of your system from two sources:
 
-Modern tooling gives developers:
-- dashboards
-- logs
-- alerts
-- traces
+- **Static analysis** of source files, `package.json`, and yaml/env config.
+- **Runtime telemetry** from OpenTelemetry spans.
 
-But these are fragments.
+Every edge carries a `provenance` (EXTRACTED, INFERRED, OBSERVED, STALE) so consumers know how much weight to put on each claim. See [`PROVENANCE.md`](./PROVENANCE.md) for the full model.
 
-NEAT builds a continuously updated semantic graph of your system by combining:
-
-- **Static analysis** of source code and configuration
-- **Runtime telemetry** from production systems
-
-This creates a live architecture model that can be queried by both humans and AI agents.
-
-With NEAT, you can:
-
-- inspect service and infrastructure dependencies
-- identify root causes across service boundaries
-- analyse blast radius before changes
-- assert architecture policies
-- expose your system as an AI-queryable runtime
+Six MCP tools expose the graph to AI agents: `get_root_cause`, `get_blast_radius`, `get_dependencies`, `get_observed_dependencies`, `get_incident_history`, `semantic_search`.
 
 ---
 
-## Features
+## Quickstart — reproduce the demo locally in under ten minutes
 
-- Live architecture graph
-- Tree-sitter powered code extraction
-- OpenTelemetry ingestion
-- Root cause traversal
-- Blast radius analysis
-- MCP server for AI agents
-- Infrastructure graph querying
+The demo runs two Node services against a Postgres 15 database. `service-b` is pinned to `pg` 7.4.0 — too old for SCRAM auth, so every call fails. The demo proves NEAT can trace that failure back to the version mismatch two graph hops away.
 
----
-
-## Quickstart
+### 1. Clone and install
 
 ```bash
+git clone https://github.com/neat-tools/Neat
+cd Neat
 npm install
 npm run build
-npm test
 ```
 
-Run the development environment:
+Requires Node 20.x. `nvm use` honours `.nvmrc`.
+
+### 2. Start the stack
 
 ```bash
-docker compose up
+docker compose up --build
 ```
+
+Boots five containers: `payments-db` (Postgres 15), `service-a`, `service-b`, `otel-collector`, and `neat-core`. The collector streams spans into core on `:4318`. Core's REST API is on `:8080`.
+
+### 3. Generate traffic
+
+```bash
+for i in {1..10}; do curl -s localhost:3000/data; done
+```
+
+Every request 500s — that's expected. The errors are what populate the graph.
+
+### 4. Confirm the graph saw it
+
+```bash
+curl -s localhost:8080/graph | jq '.edges[] | select(.id | contains("OBSERVED"))'
+curl -s localhost:8080/incidents | jq '.[0]'
+```
+
+You should see an `OBSERVED` `CALLS` edge from `service:service-a` to `service:service-b`, an `INFERRED` `CONNECTS_TO` edge from `service:service-b` to `database:payments-db` (the trace stitcher fills the auto-instrumentation gap — see `docs/decisions.md` ADR-014), and an incident attributed to `database:payments-db`.
+
+### 5. Wire NEAT into Claude Code
+
+```bash
+claude mcp add neat -- node "$(pwd)/packages/mcp/dist/index.cjs"
+```
+
+Or add it manually to `~/.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "neat": {
+      "command": "node",
+      "args": ["/absolute/path/to/Neat/packages/mcp/dist/index.cjs"],
+      "env": { "NEAT_CORE_URL": "http://localhost:8080" }
+    }
+  }
+}
+```
+
+### 6. Ask Claude
+
+In any Claude Code session:
+
+> **Why is payments-db failing?**
+
+Expected:
+
+```
+Root cause identified: service:service-b.
+PostgreSQL 14+ requires scram-sha-256 auth by default; pg < 8.0.0 only speaks md5.
+
+Traversal path: database:payments-db ← service:service-b ← service:service-a
+Edge provenances: INFERRED, OBSERVED
+Confidence: 0.70
+
+Recommended fix: Upgrade service-b pg driver to >= 8.0.0
+```
+
+The confidence is 0.7 because the `CONNECTS_TO` hop is INFERRED (pg 7.4.0 is too old for OTel's pg auto-instrumenter, so the trace stitcher fills it in from the static graph). With a modern driver every edge would be OBSERVED and confidence would be 1.0.
 
 ---
 
-## Repository Layout
+## CLI
+
+`neat init <path>` builds the static graph from a directory and writes a snapshot:
 
 ```bash
+node packages/core/dist/cli.cjs init ./demo
+```
+
+Prints node and edge counts by type plus any incompatibilities the compat matrix found. Snapshot goes to `<path>/neat-out/graph.json` unless `NEAT_OUT_PATH` overrides.
+
+---
+
+## Repository layout
+
+```
 packages/
-  types/   # Shared Zod schemas and types
-  core/    # Graph engine, tree-sitter extraction, OTel ingest, REST API
-  mcp/     # MCP server exposing graph queries to AI agents
-  web/     # Next.js web shell (dashboard WIP)
+  types/   shared Zod schemas — node, edge, event, result types
+  core/    graph engine, tree-sitter extraction, OTel ingest, REST API, neat CLI
+  mcp/     stdio MCP server exposing six tools to AI agents
+  web/     Next.js shell — wordmark + /api/health (dashboard is post-MVP)
 
 demo/
-  service-a/   # Node.js service calling service-b
-  service-b/   # Intentional pg/PostgreSQL mismatch for root-cause demo
+  service-a/      express + axios. Calls service-b.
+  service-b/      express + pg 7.4.0. Talks to payments-db (PG 15).
+  collector/      OpenTelemetry collector config.
 ```
 
 ---
 
 ## Documentation
 
-- `CLAUDE.md` — contributor and AI agent guide
-- `docs/` — architecture, milestones, decisions, and runbooks
-
----
-
-## Vision
-
-Software systems should be queryable as architecture, not just inspected as code and logs.
-
-NEAT turns your stack into a live semantic runtime.
+- [`PROVENANCE.md`](./PROVENANCE.md) — the four edge states and how confidence cascades.
+- [`CLAUDE.md`](./CLAUDE.md) — agent + contributor guide for this repo.
+- [`docs/architecture.md`](./docs/architecture.md) — pocket reference to package boundaries and data flow.
+- [`docs/decisions.md`](./docs/decisions.md) — ADR log.
+- [`docs/milestones.md`](./docs/milestones.md) — sprint status, source of truth for what's done.
+- [`docs/runbook.md`](./docs/runbook.md) — common commands and recovery recipes.
+- [`docs/railway.md`](./docs/railway.md) — deploy the demo to Railway.
+- [`packages/mcp/skill.md`](./packages/mcp/skill.md) — Claude Code skill metadata for the MCP tools.
 
 ---
 
 ## License
 
-Licensed under the Apache 2.0 License.
+Apache 2.0.

--- a/demo/collector/Dockerfile
+++ b/demo/collector/Dockerfile
@@ -1,0 +1,11 @@
+# Tiny image that bakes the collector config in, since Railway doesn't have
+# the same "mount a host file at /etc" path that docker-compose does. The
+# config still references neat-core via an internal hostname; on Railway that
+# resolves through the private-network DNS once the service is wired up.
+FROM otel/opentelemetry-collector-contrib:0.96.0
+
+COPY config.yaml /etc/otel-collector-config.yaml
+
+EXPOSE 4318
+
+CMD ["--config=/etc/otel-collector-config.yaml"]

--- a/demo/collector/config.railway.yaml
+++ b/demo/collector/config.railway.yaml
@@ -1,0 +1,38 @@
+# Railway variant of demo/collector/config.yaml. Identical except the neat-core
+# endpoint references Railway's private-network DNS instead of the
+# docker-compose service name.
+#
+# When deploying, copy this to config.yaml in the collector service's build
+# context (or set this as the file the Dockerfile copies in). Local
+# docker-compose still uses config.yaml verbatim.
+
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 1s
+
+exporters:
+  otlphttp/neat:
+    # Railway exposes services to siblings on PRIVATE_NETWORK. Set NEAT_CORE_HOST
+    # in the collector service to the neat-core service's private hostname (e.g.
+    # neat-core.railway.internal). The 4318 port is fixed by the receiver in
+    # @neat/core.
+    endpoint: http://${env:NEAT_CORE_HOST}:4318
+    encoding: json
+    compression: none
+    tls:
+      insecure: true
+  logging:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/neat, logging]

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -169,3 +169,18 @@ When M3 ships:
 - Remove `tracedQuery`, the `@opentelemetry/api` import, and the `@opentelemetry/api` dep in `demo/service-b/package.json`. Drop the call site back to `pool.query('SELECT now() …')`.
 - Re-run M2's verification gate. The OBSERVED CALLS edge should still appear; the OBSERVED CONNECTS_TO disappears, but an INFERRED CONNECTS_TO with confidence 0.6 should take its place.
 - Update M2's gate text in `milestones.md` to reflect that CONNECTS_TO is INFERRED, not OBSERVED, in the live demo.
+
+---
+
+## ADR-018 — Railway deployment is documented, not codified
+
+**Date:** 2026-05-01
+**Status:** Active for the MVP. Revisit if deploys become routine.
+
+The M6 deliverable for Railway is `docs/railway.md` plus a small set of supporting files (`demo/collector/Dockerfile`, `demo/collector/config.railway.yaml`). It is not a `railway.toml`-driven IaC setup, and it is not a one-button deploy.
+
+**Why no Railway IaC.** The MVP has six services, four of them backed by simple Dockerfiles, one Postgres plugin, and one Next.js auto-detect. The Railway config language adds another file format the team has to keep in sync with the docker-compose source of truth. For a one-shot demo deploy, a runbook is more honest about the manual steps (variables to wire, domains to generate, public/private toggles) than a `railway.toml` that elides them.
+
+**The collector earns its own Dockerfile** because docker-compose mounts `config.yaml` into the upstream image, and Railway can't. Two configs coexist: `config.yaml` for local docker-compose, `config.railway.yaml` for the deployed collector (it parameterises the neat-core hostname via env). The Dockerfile copies the local one in by default; the runbook tells the operator to swap it for the Railway variant.
+
+**When to revisit.** If a second deploy target lands, or if Railway deploys become routine enough that the runbook drift starts hurting, codify in `railway.toml` per service and lift the env wiring into Railway's variable references (it already supports `${{ payments-db.PGHOST }}`). Until then, prose + concrete commands beats config we don't actively maintain.

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -189,8 +189,23 @@ Source of truth for sprint status. Update this file at the end of every session.
 
 ## M6 — Demo on Railway
 
-**End state:** All demo services deployed; demo reproducible without running docker-compose locally.
+**End state:** All demo services deployable to Railway from this repo without copying or transforming any source. Quickstart README at the repo root walks an unfamiliar developer through the local demo end-to-end. PROVENANCE.md documents the four-state edge model.
 
-**Status:** NOT_STARTED.
+**Status:** IN_PROGRESS — code/docs are in place, the actual deploy has not been performed and verified. Flip to VERIFIED once a fresh Railway project boots from this guide and Claude Code returns the expected root cause against the deployed neat-core.
 
-**Issues:** #25 (Railway), #26 (quickstart README).
+**Issues / PRs:**
+
+| Issue | Title                                | PR  | Status |
+|-------|--------------------------------------|-----|--------|
+| #26   | Local quickstart README              | M6 branch | open |
+| #32   | PROVENANCE.md                        | M6 branch | open |
+| #25   | Deploy demo to Railway               | M6 branch | open (config + runbook in this PR; deploy is a manual follow-up) |
+
+### M6 verification gate
+
+- [x] `README.md` walks a fresh developer from clone to "Why is payments-db failing?" in Claude Code.
+- [x] `PROVENANCE.md` exists, covers the four states + confidence cascade, linked from README.md and `packages/mcp/skill.md`.
+- [x] `docs/railway.md` is a runnable deploy guide for all six services + the Postgres plugin, with concrete env values.
+- [x] `demo/collector/Dockerfile` lets the collector run on Railway (which can't volume-mount `config.yaml`); `demo/collector/config.railway.yaml` carries the Railway-flavoured collector config.
+- [ ] **Manual:** a Railway deploy following the guide produces a public service-a domain that responds to `/data`, a public neat-core domain whose `/graph` shows OBSERVED CALLS + INFERRED CONNECTS_TO edges, and a public neat-web domain.
+- [ ] **Manual:** `claude mcp add neat -- node packages/mcp/dist/index.cjs` with `NEAT_CORE_URL` pointing at the deployed core; Claude Code answers "Why is payments-db failing?" with confidence ≥ 0.7.

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -1,0 +1,147 @@
+# Deploying the demo to Railway
+
+The local stack is `docker compose up`. Railway runs the same six pieces as separate services on a private network, plus the managed Postgres plugin in place of the `payments-db` container.
+
+This runbook is a step-by-step. None of it is automated yet — Railway's IaC is opt-in and we haven't taken on the dependency. Follow it linearly and you'll end up with a deployed demo Claude Code can connect to.
+
+## Prerequisites
+
+- A Railway account on a plan that allows six services and one Postgres plugin (the free hobby plan is enough for the demo).
+- The Railway CLI installed (`brew install railwayapp/railway/railway` or `npm i -g @railway/cli`) — only required for the optional MCP-from-anywhere step at the end.
+- `gh` and `git` set up against `neat-tools/Neat`.
+
+## Service map
+
+| Railway service | Source                            | Public? | Notes |
+|-----------------|-----------------------------------|---------|-------|
+| `payments-db`   | Postgres plugin, pinned to v15    | private | not a deploy — the Add → Database → PostgreSQL flow |
+| `service-b`     | `demo/service-b/`                 | private | uses pg 7.4.0 against PG 15 — this is the failing call |
+| `service-a`     | `demo/service-a/`                 | public  | only this one needs a public URL — it's the entry point hit by `/data` |
+| `otel-collector`| `demo/collector/`                 | private | needs a one-line config swap, see below |
+| `neat-core`     | `packages/core/Dockerfile`        | public  | the REST API + OTLP receiver. MCP server connects here. |
+| `neat-web`      | `packages/web/`                   | public  | Next.js shell — `/api/health` proxies to neat-core |
+
+Public means "Generate a Domain" in Railway's networking tab. Private services only need the internal `*.railway.internal` DNS that Railway provisions automatically.
+
+## 1. Create the project and the database
+
+1. New project → "Deploy from GitHub repo" → pick `neat-tools/Neat`. Don't deploy any services yet — we'll add them one by one.
+2. Add → Database → PostgreSQL. Once it provisions, change the version to `15` from the plugin's settings (Railway defaults to the latest major; the demo's failure mode requires 14+ specifically).
+3. From the plugin's Variables tab, note the `DATABASE_URL`. Railway also exposes individual `PG*` vars; we'll wire those into `service-b` directly rather than parsing the URL.
+
+## 2. Deploy `neat-core`
+
+1. New service → "GitHub repo" → `neat-tools/Neat`. Set the root directory to `/` (the `packages/core/Dockerfile` build context is the repo root).
+2. Settings → Build → Dockerfile Path: `packages/core/Dockerfile`.
+3. Variables:
+
+   ```
+   HOST = 0.0.0.0
+   PORT = 8080
+   NEAT_SCAN_PATH = /demo
+   NEAT_OUT_PATH = /neat-out/graph.json
+   ```
+
+   `NEAT_SCAN_PATH = /demo` matches the Dockerfile's expectation; the demo source files are baked in at build time. `/neat-out` lives on Railway's ephemeral container filesystem — if you want snapshots to survive restarts, attach a volume mounted at `/neat-out`.
+4. Networking → Generate Domain. The MCP server will point at this URL.
+
+`neat-core` exposes two ports: `8080` (REST API) and `4318` (OTLP receiver). Railway only exposes one HTTP port externally; the `4318` port is reachable internally via `*.railway.internal:4318`.
+
+## 3. Deploy `otel-collector`
+
+The collector image we use locally (`otel/opentelemetry-collector-contrib:0.96.0`) reads its config from a file. Docker-compose mounts the config in; Railway can't, so we ship a tiny image that bakes the config. That image is in `demo/collector/Dockerfile`.
+
+The local config points at `http://neat-core:4318` (the docker-compose service name). On Railway, swap that hostname for the private DNS name of your neat-core service. `demo/collector/config.railway.yaml` is the variant ready to use — it reads `NEAT_CORE_HOST` from the environment.
+
+1. New service → "GitHub repo" → `Neat`. Root directory `/demo/collector`.
+2. Build → Dockerfile Path: `Dockerfile`.
+3. Before deploying, replace `demo/collector/config.yaml` (the one the Dockerfile copies) with `demo/collector/config.railway.yaml` — easiest is a symlink or a small Railway-only branch. (We're keeping both files in tree because the local docker-compose stack still needs the original.)
+4. Variables:
+
+   ```
+   NEAT_CORE_HOST = neat-core.railway.internal
+   ```
+
+   Replace `neat-core` with whatever you named the service in step 2 if it's different.
+
+The collector listens on `4318` internally only.
+
+## 4. Deploy `service-b`
+
+1. New service → root directory `/demo/service-b`. Dockerfile Path: `Dockerfile` (the one already there).
+2. Variables — pull the `PG*` values from the Postgres plugin's variable references (Railway lets you `${{ payments-db.PGHOST }}` style):
+
+   ```
+   PORT = 3001
+   PGHOST = ${{ payments-db.PGHOST }}
+   PGPORT = ${{ payments-db.PGPORT }}
+   PGUSER = ${{ payments-db.PGUSER }}
+   PGPASSWORD = ${{ payments-db.PGPASSWORD }}
+   PGDATABASE = ${{ payments-db.PGDATABASE }}
+   OTEL_EXPORTER_OTLP_ENDPOINT = http://otel-collector.railway.internal:4318/v1/traces
+   OTEL_SERVICE_NAME = service-b
+   ```
+
+3. No public domain — service-a calls service-b on the private network.
+
+## 5. Deploy `service-a`
+
+1. New service → root directory `/demo/service-a`. Dockerfile Path: `Dockerfile`.
+2. Variables:
+
+   ```
+   PORT = 3000
+   SERVICE_B_URL = http://service-b.railway.internal:3001
+   OTEL_EXPORTER_OTLP_ENDPOINT = http://otel-collector.railway.internal:4318/v1/traces
+   OTEL_SERVICE_NAME = service-a
+   ```
+
+3. Networking → Generate Domain. This is the `/data` endpoint you'll curl to drive traffic.
+
+## 6. Deploy `neat-web`
+
+1. New service → root directory `/packages/web`. Railway should auto-detect Next.js; no Dockerfile required.
+2. Variables:
+
+   ```
+   NEAT_CORE_URL = https://<your neat-core domain>
+   ```
+
+3. Networking → Generate Domain.
+
+## 7. Smoke-test the deployment
+
+```bash
+# Drive traffic through the failure path.
+for i in {1..10}; do curl -s https://<service-a domain>/data; done
+
+# Confirm core saw the spans + the inferred edge.
+curl -s https://<neat-core domain>/graph | jq '.edges[] | select(.id | contains("OBSERVED") or contains("INFERRED"))'
+
+# Confirm the incident log.
+curl -s https://<neat-core domain>/incidents | jq '.[0]'
+```
+
+Expected: at least two edges (OBSERVED `CALLS`, INFERRED `CONNECTS_TO`) and one incident with `affectedNode: "database:payments-db"`.
+
+## 8. Point Claude Code at the deployed core
+
+The MCP server runs locally and talks to deployed neat-core over HTTPS. From your laptop:
+
+```bash
+NEAT_CORE_URL=https://<your neat-core domain> \
+  claude mcp add neat -- node "$(pwd)/packages/mcp/dist/index.cjs"
+```
+
+Then in any Claude Code session: *"Why is payments-db failing?"* — same expected output as the local quickstart, with confidence 0.7 once the trace stitcher has populated the INFERRED CONNECTS_TO edge from the deployed traffic.
+
+## Cost guardrails
+
+The demo idles at near-zero CPU when nothing's hitting `/data`. The two cost surprises:
+
+- **OTel collector buffer** — the `logging` exporter writes spans to stdout, which ends up in Railway's log stream. If you leave the demo idle for days under high traffic the log volume will dominate the bill. Drop the `logging` exporter from `config.railway.yaml` once you've verified spans are flowing.
+- **Postgres storage** — the demo never inserts anything, so storage stays in MB. Don't attach the Postgres plugin to anything else.
+
+## Rollback / teardown
+
+Each service is independent. To tear down: delete the services and the Postgres plugin. The repo is unchanged.

--- a/packages/mcp/skill.md
+++ b/packages/mcp/skill.md
@@ -58,6 +58,10 @@ Free-text match across node ids and names. Keyword-only for the MVP; vector sear
 
 Inputs: `query`.
 
+## Provenance and confidence
+
+Every edge in the graph — and every result that comes out of these tools — carries a provenance: OBSERVED (live OTel traffic, confidence 1.0), INFERRED (derived from other edges, confidence 0.6), EXTRACTED (read from source, confidence 0.5), or STALE (was OBSERVED, hasn't been seen recently, confidence 0.3). Tools surface this in their text output so you can weight claims accordingly. See [PROVENANCE.md](../../PROVENANCE.md) at the repo root for the full model.
+
 ## Configuration
 
 Set `NEAT_CORE_URL` if `@neat/core` is not running on `http://localhost:8080`.


### PR DESCRIPTION
M6 is the docs-and-deploy milestone. Three deliverables:

## What's in here

**Quickstart README (#26).** Replaces the high-level wordmark/manifesto with a ten-minute walkthrough: clone, install, docker compose up, drive traffic at `/data`, wire MCP into Claude Code, ask "why is payments-db failing?". Includes the expected root-cause output verbatim (with confidence 0.7 — INFERRED CONNECTS_TO via the trace stitcher) so an unfamiliar developer can tell whether their stack is working.

**PROVENANCE.md (#32).** Documents the four-state edge model — EXTRACTED, INFERRED, OBSERVED, STALE — and how confidence cascades through `getRootCause` (1.0 / 0.7 / 0.5). Linked from README.md and packages/mcp/skill.md per the issue's definition of done.

**Railway deploy guide (#25).** `docs/railway.md` is a runnable step-by-step for the six services + the Postgres plugin. Earns the collector its own Dockerfile (`demo/collector/Dockerfile`) because Railway can't volume-mount `config.yaml` the way docker-compose does, plus `demo/collector/config.railway.yaml` for the parameterised variant the deployed collector uses. ADR-018 explains why docs-over-IaC for the MVP.

## Verification

- `npx turbo build test lint` green: 12/12 tasks, no regressions.
- README links resolve to files that actually exist (PROVENANCE.md, docs/railway.md, etc.).
- `demo/collector/Dockerfile` builds the same image the local stack uses today, just with `config.yaml` baked in.

## What this PR doesn't do

The actual Railway deploy is manual and requires a Railway account + credentials. The M6 verification gate flags two boxes for the operator to tick:

- Boot a Railway project from `docs/railway.md` and confirm `/data` 500s, `/graph` shows the OBSERVED + INFERRED edges, and neat-web loads.
- Point Claude Code at the deployed core via `claude mcp add neat -- node packages/mcp/dist/index.cjs` and confirm "why is payments-db failing?" returns confidence ≥ 0.7.

M6 stays IN_PROGRESS until those two boxes tick. The repo side of M6 is done in this PR.

Refs #25, #26, #32. Depends-on #65 (M5 — quickstart references `neat init` and the matrix-driven root cause that landed there).