### PR TITLE
Drop pgDriverVersion from ServiceNode; bump snapshot to v2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ MVP milestone summary for context:
 
 Work is scoped across three areas. Pick up from the open issues on GitHub, one issue per branch per the conventions below.
 
-**Extraction breadth** (#67–#73): recursive service discovery, generalised DB config parsing, call types beyond HTTP, Python support, infrastructure files, split `extract.ts` into modules, drop the legacy `pgDriverVersion` field.
+**Extraction breadth** (#67–#73): recursive service discovery, generalised DB config parsing, call types beyond HTTP, Python support, infrastructure files, split `extract.ts` into modules. (#67 — drop the legacy `pgDriverVersion` field — landed on the v0.1.2-α track.)
 
 **Graph correctness** (#74–#78): expand the compat matrix beyond drivers, FRONTIER/OBSERVED attribution, per-edge confidence signals, snapshot diffing, stale thresholds.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,7 +97,7 @@ Things that aren't load-bearing decisions but are non-obvious from reading the c
 
 - **Compat ignores garbage versions rather than erroring.** If `semver.coerce` can't make sense of a driver version string, `checkCompatibility` returns `{ compatible: true }`. Better to under-flag than to claim a known failure on input we can't reason about.
 
-- **`pgDriverVersion` lives on ServiceNode AND in `incompatibilities[]`.** The first is for cheap UI/lookup ("what version is this service on?"), the second is the audit trail ("here's what specifically is wrong"). Both are populated during extract phase 2.
+- **Driver versions live in `dependencies` and the audit trail in `incompatibilities[]`.** The first is whatever the service's `package.json` declares — the source of truth that compat traversal reads. The second is the audit trail ("here's what specifically is wrong"). Both are populated during extract phase 2.
 
 - **The yaml dependency is M1-scoped.** `db-config.yaml` is parsed today only because it's the cheapest path to `payments-db.engineVersion: "15"` for the demo. Full yaml/env extraction with first-class `ConfigNode` types and `CONFIGURED_BY` edges is M5. Don't expand the yaml parsing surface inside `extract.ts` — it goes to its own pass when M5 happens.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -183,7 +183,7 @@ M5 generalises the traversal: filter `compatPairs()` to the target database's en
 
 **Why this shape and not a per-engine handler:** The per-engine fan-out is what `compat.json` already encodes. Pulling that table into TypeScript would duplicate it. The matrix is the schema; traversal just executes against it.
 
-**`pgDriverVersion` stays on the schema** as a UI/lookup convenience but is no longer load-bearing — the dependencies map is the source of truth. Future schema work can drop it once nothing else reads it.
+**`pgDriverVersion` stayed on the schema** as a UI/lookup convenience after the M5 generalisation but was no longer load-bearing — the dependencies map became the source of truth. ADR-019 drops it.
 
 ---
 
@@ -225,3 +225,23 @@ The M6 deliverable for Railway is `docs/railway.md` plus a small set of supporti
 **The collector earns its own Dockerfile** because docker-compose mounts `config.yaml` into the upstream image, and Railway can't. Two configs coexist: `config.yaml` for local docker-compose, `config.railway.yaml` for the deployed collector (it parameterises the neat-core hostname via env). The Dockerfile copies the local one in by default; the runbook tells the operator to swap it for the Railway variant.
 
 **When to revisit.** If a second deploy target lands, or if Railway deploys become routine enough that the runbook drift starts hurting, codify in `railway.toml` per service and lift the env wiring into Railway's variable references (it already supports `${{ payments-db.PGHOST }}`). Until then, prose + concrete commands beats config we don't actively maintain.
+
+---
+
+## ADR-019 — Drop `pgDriverVersion` from `ServiceNode`; bump snapshot to v2
+
+**Date:** 2026-05-02
+**Status:** Active. Closes the loop ADR-015 left open.
+
+ADR-015 made `pgDriverVersion` non-load-bearing — `getRootCause` now reads `dependencies[driver]` for every driver in `compat.json`. The field stayed on `ServiceNodeSchema` as a UI/lookup convenience, but in practice it was a special case that only existed for one driver, and it would let a future contributor reintroduce pg-specific code paths without anyone noticing. v0.1.2-α removes it.
+
+**What changes.**
+
+- `pgDriverVersion` is gone from `ServiceNodeSchema` in `@neat/types`.
+- Phase 1 of `extractFromDirectory` no longer sets it — `dependencies` carries the raw `package.json` map and that's the only declaration we ship.
+- Snapshot `schemaVersion` bumps from `1` to `2`. `loadGraphFromDisk` migrates v1 snapshots in place by stripping `pgDriverVersion` from every node's attributes; the rest of the v1 payload flows through unchanged.
+- Tests that previously asserted `serviceB.pgDriverVersion === '7.4.0'` now read `serviceB.dependencies?.pg`.
+
+**Why migrate rather than hard-fail.** ADR-011 set the precedent that incompatible schema bumps throw on load; this bump is *forward-compatible*. Stripping a field that no consumer reads anymore is exactly the case where an automatic migration costs nothing and saves users a manual re-extract. The hard-fail path is reserved for genuinely incompatible changes (renaming an edge type, restructuring a node id format).
+
+**One-way door check.** Adding `pgDriverVersion` back later would be trivial — it'd be a Zod field plus an extract-phase write. Nothing about removing it now traps the schema. If the v0.1.2 compat work (#74) ends up wanting per-driver hot-fields on `ServiceNode`, that's a generalised mechanism, not a re-litigation of this one field.

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -86,7 +86,7 @@ M6's two unchecked manual verification steps (live Railway deploy + Claude Code 
 
 ## M1 — Static graph working
 
-**End state:** `NEAT_SCAN_PATH=./demo npm run dev --workspace @neat/core` starts. `curl localhost:8080/graph` returns the right shape: a `ServiceNode` for `service-b` with `pgDriverVersion: "7.4.0"`, a `DatabaseNode` for `payments-db` with `engineVersion: "15"`, and a `DEPENDS_ON` edge tying them together. The compat unit test for `pg 7.4.0 / postgresql 15` returns `compatible: false`.
+**End state:** `NEAT_SCAN_PATH=./demo npm run dev --workspace @neat/core` starts. `curl localhost:8080/graph` returns the right shape: a `ServiceNode` for `service-b` with `dependencies.pg = "7.4.0"`, a `DatabaseNode` for `payments-db` with `engineVersion: "15"`, and a `DEPENDS_ON` edge tying them together. The compat unit test for `pg 7.4.0 / postgresql 15` returns `compatible: false`.
 
 **Status:** VERIFIED 2026-05-01.
 
@@ -105,7 +105,7 @@ M6's two unchecked manual verification steps (live Railway deploy + Claude Code 
 - [x] `npm run dev --workspace @neat/core` starts with `NEAT_SCAN_PATH=./demo`
 - [x] `curl localhost:8080/health` returns `{ uptime, nodeCount, edgeCount, lastUpdated }`
 - [x] `curl localhost:8080/graph` returns ≥ 3 nodes and ≥ 2 edges (3 nodes, 2 edges on the demo)
-- [x] In `/graph` response: `ServiceNode` for `service-b` has `pgDriverVersion: "7.4.0"` and an `incompatibilities[0]` entry naming pg 7.4.0 vs PG 15
+- [x] In `/graph` response: `ServiceNode` for `service-b` has `dependencies.pg = "7.4.0"` and an `incompatibilities[0]` entry naming pg 7.4.0 vs PG 15
 - [x] In `/graph` response: `DatabaseNode` for `payments-db` has `engineVersion: "15"` and a `compatibleDrivers` entry for pg ≥ 8.0.0
 - [x] `checkCompatibility('pg', '7.4.0', 'postgresql', '15')` → `{ compatible: false, ... }` (unit test in `packages/core/test/compat.test.ts`)
 - [x] After SIGTERM, `neat-out/graph.json` exists and is valid JSON; restart loads it (smoked locally + covered by `persist.test.ts`)
@@ -170,7 +170,7 @@ M6's two unchecked manual verification steps (live Railway deploy + Claude Code 
 
 - Once the stitcher is producing INFERRED `CONNECTS_TO` edges, **delete `tracedQuery` and the `@opentelemetry/api` import in `demo/service-b/index.js`** and drop the `@opentelemetry/api` dep in `demo/service-b/package.json`. Keep the `connectionTimeoutMillis: 4000` line — that's separate from the instrumentation gap; it's there because pg 7.4.0 hangs on SCRAM regardless of whether anyone's watching.
 - Re-run the M2 verification gate. The OBSERVED CALLS stays. The OBSERVED CONNECTS_TO disappears, and an INFERRED CONNECTS_TO with confidence 0.6 should take its place. Update the M2 gate text above to reflect that `CONNECTS_TO` is INFERRED in the live demo.
-- Verify `getRootCause("database:payments-db")` lands on `pgDriverVersion: "7.4.0"` with confidence 0.7 (one INFERRED hop).
+- Verify `getRootCause("database:payments-db")` lands on service-b (`dependencies.pg = "7.4.0"`) with confidence 0.7 (one INFERRED hop).
 
 **Bring along when M3 lands:**
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -31,7 +31,7 @@ NEAT_SCAN_PATH=./demo npm run dev --workspace @neat/core
 # in another
 curl -s localhost:8080/health | jq
 curl -s localhost:8080/graph  | jq '.nodes[] | select(.id | contains("service-b"))'
-# → should have pgDriverVersion: "7.4.0"
+# → should have dependencies.pg: "7.4.0"
 
 curl -s localhost:8080/graph | jq '.nodes[] | select(.type == "DatabaseNode")'
 # → payments-db with engineVersion: "15", compatibleDrivers including pg ≥ 8.0.0

--- a/packages/core/src/extract.ts
+++ b/packages/core/src/extract.ts
@@ -120,9 +120,6 @@ async function discoverServices(scanPath: string): Promise<DiscoveredService[]> 
       dependencies: deps,
       repoPath: path.relative(scanPath, dir),
     }
-    if (deps.pg) {
-      node.pgDriverVersion = cleanVersion(deps.pg)
-    }
     out.push({ pkg, dir, node })
   }
   return out

--- a/packages/core/src/persist.ts
+++ b/packages/core/src/persist.ts
@@ -2,12 +2,28 @@ import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import type { NeatGraph } from './graph.js'
 
-const SCHEMA_VERSION = 1
+const SCHEMA_VERSION = 2
 
 interface PersistedGraph {
   schemaVersion: number
   exportedAt: string
   graph: ReturnType<NeatGraph['export']>
+}
+
+// v1 → v2: ServiceNode shed `pgDriverVersion` (ADR-019). Compat traversal reads
+// `dependencies[driver]` instead. Strip the field from any v1 snapshot rather
+// than hard-failing — a stale snapshot on disk shouldn't cost a re-extract.
+function migrateV1ToV2(payload: PersistedGraph): PersistedGraph {
+  const nodes = (payload.graph as { nodes?: Array<{ attributes?: Record<string, unknown> }> })
+    .nodes
+  if (Array.isArray(nodes)) {
+    for (const node of nodes) {
+      if (node.attributes && 'pgDriverVersion' in node.attributes) {
+        delete node.attributes.pgDriverVersion
+      }
+    }
+  }
+  return { ...payload, schemaVersion: 2 }
 }
 
 async function ensureDir(filePath: string): Promise<void> {
@@ -36,7 +52,10 @@ export async function loadGraphFromDisk(graph: NeatGraph, outPath: string): Prom
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return
     throw err
   }
-  const payload = JSON.parse(raw) as PersistedGraph
+  let payload = JSON.parse(raw) as PersistedGraph
+  if (payload.schemaVersion === 1) {
+    payload = migrateV1ToV2(payload)
+  }
   if (payload.schemaVersion !== SCHEMA_VERSION) {
     throw new Error(
       `persist: unsupported snapshot schemaVersion ${payload.schemaVersion} (expected ${SCHEMA_VERSION})`,

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -43,7 +43,7 @@ describe('REST API (fastify.inject)', () => {
     expect(body.edges.length).toBeGreaterThanOrEqual(2)
 
     const serviceB = body.nodes.find((n: { id: string }) => n.id === 'service:service-b')
-    expect(serviceB.pgDriverVersion).toBe('7.4.0')
+    expect(serviceB.dependencies.pg).toBe('7.4.0')
 
     const db = body.nodes.find((n: { id: string }) => n.id === 'database:payments-db')
     expect(db.engineVersion).toBe('15')
@@ -55,7 +55,7 @@ describe('REST API (fastify.inject)', () => {
   it('GET /graph/node/:id returns a single node', async () => {
     const res = await app.inject({ method: 'GET', url: '/graph/node/service:service-b' })
     expect(res.statusCode).toBe(200)
-    expect(res.json().pgDriverVersion).toBe('7.4.0')
+    expect(res.json().dependencies.pg).toBe('7.4.0')
   })
 
   it('GET /graph/node/:id returns 404 for an unknown node', async () => {

--- a/packages/core/test/extract.test.ts
+++ b/packages/core/test/extract.test.ts
@@ -22,13 +22,13 @@ describe('extractFromDirectory against demo/', () => {
     expect(graph.size).toBeGreaterThanOrEqual(2)
   })
 
-  it('emits a service-b ServiceNode with pgDriverVersion = "7.4.0"', async () => {
+  it('emits a service-b ServiceNode that declares pg 7.4.0 in its dependencies', async () => {
     const graph = getGraph()
     await extractFromDirectory(graph, DEMO_PATH)
 
     expect(graph.hasNode('service:service-b')).toBe(true)
     const serviceB = graph.getNodeAttributes('service:service-b') as ServiceNode
-    expect(serviceB.pgDriverVersion).toBe('7.4.0')
+    expect(serviceB.dependencies?.pg).toBe('7.4.0')
   })
 
   it('emits a payments-db DatabaseNode with engineVersion = "15"', async () => {

--- a/packages/core/test/persist.test.ts
+++ b/packages/core/test/persist.test.ts
@@ -31,7 +31,7 @@ describe('persistence', () => {
 
     const raw = await fs.readFile(outPath, 'utf8')
     const parsed = JSON.parse(raw)
-    expect(parsed.schemaVersion).toBe(1)
+    expect(parsed.schemaVersion).toBe(2)
     expect(parsed.exportedAt).toBeTypeOf('string')
     expect(parsed.graph.nodes.length).toBeGreaterThanOrEqual(3)
     expect(parsed.graph.edges.length).toBeGreaterThanOrEqual(2)
@@ -54,7 +54,7 @@ describe('persistence', () => {
     expect(restored.hasNode('database:payments-db')).toBe(true)
   })
 
-  it('round-trips node attributes (pgDriverVersion preserved)', async () => {
+  it('round-trips node attributes (dependencies preserved)', async () => {
     const graph = getGraph()
     await extractFromDirectory(graph, DEMO_PATH)
     await saveGraphToDisk(graph, outPath)
@@ -64,9 +64,45 @@ describe('persistence', () => {
     await loadGraphFromDisk(restored, outPath)
 
     const serviceB = restored.getNodeAttributes('service:service-b') as {
-      pgDriverVersion?: string
+      dependencies?: Record<string, string>
     }
-    expect(serviceB.pgDriverVersion).toBe('7.4.0')
+    expect(serviceB.dependencies?.pg).toBe('7.4.0')
+  })
+
+  it('migrates a v1 snapshot on load — strips pgDriverVersion, leaves the rest intact', async () => {
+    await fs.mkdir(path.dirname(outPath), { recursive: true })
+    const v1Snapshot = {
+      schemaVersion: 1,
+      exportedAt: '2026-04-30T00:00:00.000Z',
+      graph: {
+        attributes: {},
+        options: { allowSelfLoops: false, multi: true, type: 'directed' },
+        nodes: [
+          {
+            key: 'service:service-b',
+            attributes: {
+              id: 'service:service-b',
+              type: 'ServiceNode',
+              name: 'service-b',
+              language: 'javascript',
+              pgDriverVersion: '7.4.0',
+              dependencies: { pg: '7.4.0' },
+            },
+          },
+        ],
+        edges: [],
+      },
+    }
+    await fs.writeFile(outPath, JSON.stringify(v1Snapshot))
+
+    resetGraph()
+    const restored = getGraph()
+    await loadGraphFromDisk(restored, outPath)
+
+    expect(restored.hasNode('service:service-b')).toBe(true)
+    const attrs = restored.getNodeAttributes('service:service-b') as Record<string, unknown>
+    expect(attrs.pgDriverVersion).toBeUndefined()
+    expect((attrs.dependencies as Record<string, string>).pg).toBe('7.4.0')
   })
 
   it('writes atomically — only the final file lands, no .tmp leftover', async () => {

--- a/packages/core/test/traverse.test.ts
+++ b/packages/core/test/traverse.test.ts
@@ -33,7 +33,6 @@ function newDemoGraph(): NeatGraph {
       type: NodeType.ServiceNode,
       name: 'service-b',
       language: 'javascript',
-      pgDriverVersion: '7.4.0',
       dependencies: { pg: '7.4.0' },
     }),
   )
@@ -174,7 +173,6 @@ describe('getRootCause', () => {
       type: NodeType.ServiceNode,
       name: 'happy',
       language: 'javascript',
-      pgDriverVersion: '8.11.0',
       dependencies: { pg: '8.11.0' },
     })
     g.addNode('database:payments-db', {
@@ -238,14 +236,13 @@ describe('getRootCause', () => {
     expect(result!.fixRecommendation).toMatch(/3\.0\.0/)
   })
 
-  it('reads driver versions out of dependencies, not just the legacy pgDriverVersion field', () => {
+  it('reads driver versions out of dependencies', () => {
     const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
     g.addNode('service:reports', {
       id: 'service:reports',
       type: NodeType.ServiceNode,
       name: 'reports',
       language: 'javascript',
-      // No pgDriverVersion here — purely declared via dependencies.
       dependencies: { pg: '7.4.0' },
     })
     g.addNode('database:reports-db', {

--- a/packages/types/src/nodes.ts
+++ b/packages/types/src/nodes.ts
@@ -13,7 +13,6 @@ export const ServiceNodeSchema = z.object({
   name: z.string(),
   language: z.string(),
   version: z.string().optional(),
-  pgDriverVersion: z.string().optional(),
   dbConnectionTarget: z.string().optional(),
   repoPath: z.string().optional(),
   dependencies: z.record(z.string(), z.string()).optional(),

--- a/packages/types/test/schemas.test.ts
+++ b/packages/types/test/schemas.test.ts
@@ -34,7 +34,7 @@ describe('ServiceNodeSchema', () => {
       type: 'ServiceNode' as const,
       name: 'service-b',
       language: 'javascript',
-      pgDriverVersion: '7.4.0',
+      dependencies: { pg: '7.4.0' },
     }
     expect(ServiceNodeSchema.parse(node)).toEqual(node)
   })


### PR DESCRIPTION
ADR-015 already moved root-cause traversal off `pgDriverVersion` onto the generic `dependencies` map back in M5. The field stayed on `ServiceNodeSchema` as a UI/lookup convenience, but nothing read it any more — and leaving it there would let a future contributor reintroduce pg-specific code paths without anyone noticing. This PR drops it.

## What changed

- `pgDriverVersion` removed from `ServiceNodeSchema` in `@neat/types`.
- Phase 1 of `extractFromDirectory` no longer sets it — `dependencies` already carries the raw `package.json` map and that's the only declaration we ship.
- Snapshot `schemaVersion` bumps from 1 to 2. `loadGraphFromDisk` migrates v1 snapshots in place by stripping the field from every node's attributes; the rest of the v1 payload flows through unchanged.
- Tests that previously asserted `serviceB.pgDriverVersion === '7.4.0'` now read `serviceB.dependencies?.pg`, plus a new `persist.test.ts` case covers the v1 → v2 migration end to end.
- ADR-019 documents the decision and why we migrate rather than hard-fail (this is a forward-compatible removal — ADR-011's hard-fail rule was for incompatible changes).
- Doc references in `CLAUDE.md`, `docs/architecture.md`, `docs/runbook.md`, `docs/milestones.md`, and `docs/decisions.md` updated to point at `dependencies.pg` instead.

## Verification

- `npx turbo build test lint` clean (102 core tests / 25 types tests / 17 mcp tests, all green).
- `node packages/core/dist/cli.cjs init ./demo` produces a `schemaVersion: 2` snapshot; `service-b` attributes contain `dependencies.pg = "7.4.0"` and no `pgDriverVersion`. The pg/PG-15 incompatibility still surfaces.
- New persist test loads a synthesised v1 snapshot, confirms the field is stripped, and confirms `dependencies.pg` survives the migration.

Refs #67