### PR TITLE
Add OTLP/gRPC receiver alongside the HTTP one

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,14 +50,18 @@ Live (M2+):
 
 ```
 demo services emit OTel spans
-       ↓ OTLP/HTTP :4318
+       ↓ OTLP/HTTP :4318  (or OTLP/gRPC :4317 with NEAT_OTLP_GRPC=true)
 @opentelemetry/collector
-       ↓ OTLP/HTTP :4318
-core OTel receiver (packages/core/src/otel/*.ts — lands in M2)
-       ↓ span → edge mapper
+       ↓ OTLP/HTTP :4318  (or OTLP/gRPC :4317)
+core OTel receiver:
+   packages/core/src/otel.ts       — HTTP/JSON, always on
+   packages/core/src/otel-grpc.ts  — gRPC, opt-in via NEAT_OTLP_GRPC=true
+       ↓ span → edge mapper (parseOtlpRequest is shared)
 core graph: existing nodes get OBSERVED edges with confidence + lastObserved
        ↓ stale detection: edges not seen in N seconds → STALE
 ```
+
+The gRPC receiver loads `.proto` files bundled at `packages/core/proto/` via `@grpc/proto-loader` at startup, decodes the binary OTLP wire format, reshapes the snake_case message into the same `OtlpTracesRequest` shape the HTTP path uses, and reuses `parseOtlpRequest` so the downstream `onSpan` handler sees identical `ParsedSpan`s either way. Default port is `4317` (the OTLP/gRPC convention); override with `NEAT_OTLP_GRPC_PORT`.
 
 ## Provenance lifecycle
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -245,3 +245,20 @@ ADR-015 made `pgDriverVersion` non-load-bearing — `getRootCause` now reads `de
 **Why migrate rather than hard-fail.** ADR-011 set the precedent that incompatible schema bumps throw on load; this bump is *forward-compatible*. Stripping a field that no consumer reads anymore is exactly the case where an automatic migration costs nothing and saves users a manual re-extract. The hard-fail path is reserved for genuinely incompatible changes (renaming an edge type, restructuring a node id format).
 
 **One-way door check.** Adding `pgDriverVersion` back later would be trivial — it'd be a Zod field plus an extract-phase write. Nothing about removing it now traps the schema. If the v0.1.2 compat work (#74) ends up wanting per-driver hot-fields on `ServiceNode`, that's a generalised mechanism, not a re-litigation of this one field.
+
+---
+
+## ADR-020 — Bundle OTLP `.proto` files in-tree; opt-in gRPC receiver
+
+**Date:** 2026-05-02
+**Status:** Active.
+
+The OTLP/gRPC receiver lives in `packages/core/src/otel-grpc.ts` and is only started when `NEAT_OTLP_GRPC=true`. It loads `.proto` files from `packages/core/proto/opentelemetry/proto/...` via `@grpc/proto-loader` at startup, decodes the binary wire format, reshapes the snake_case message into the same `OtlpTracesRequest` shape the HTTP receiver uses, and then reuses `parseOtlpRequest`.
+
+**Why bundle the protos.** `@opentelemetry/proto` isn't published as an npm package, and the alternatives — pulling in `@opentelemetry/otlp-grpc-exporter-base` (the wrong direction; it's an exporter), hand-rolling protobuf decoding with `protobufjs`, or generating TypeScript stubs at build time — each carry more weight than four short `.proto` files copied verbatim from the upstream OpenTelemetry repo. The protos are Apache-2.0 / CC0 and stable across OTLP versions.
+
+**Why opt-in.** Most NEAT installs run the HTTP path because that's what docker-compose's collector ships in this repo. Turning on a second listener by default would surprise existing operators and risk a port collision on `:4317`. `NEAT_OTLP_GRPC=true` is the explicit affordance; the documented flag means "I know I'm adding a transport." `NEAT_OTLP_GRPC_PORT` lets non-default deployments rebind.
+
+**Why share `parseOtlpRequest`.** The HTTP and gRPC paths produce identical `ParsedSpan`s downstream. Anything past the receiver — `handleSpan`, `stitchTrace`, `upsertObservedEdge`, `markStaleEdges` — is transport-agnostic and stays that way. If the wire formats drift in a future OTLP rev, the divergence is contained in the receivers.
+
+**When to revisit.** If a third transport lands (gRPC over Unix socket? OTLP/Arrow?), the reshape step starts looking like an interface rather than a function, and we extract a `Decoded → ParsedSpan[]` adapter type. Until then, two transports calling one decoder is the simpler shape.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -77,6 +77,21 @@ npm run build --workspace @neat/mcp
 
 You should see two JSON-RPC responses: `serverInfo` from `initialize`, then a tool list with all six tools.
 
+## Enable OTLP/gRPC ingest
+
+Most NEAT installs land OTLP traffic over HTTP/JSON on `:4318`. If your collector or SDK exports over gRPC instead, flip the gRPC receiver on:
+
+```bash
+NEAT_SCAN_PATH=./demo \
+  NEAT_OTLP_GRPC=true \
+  npm run dev --workspace @neat/core
+# → http://localhost:8080  (REST API)
+# → http://localhost:4318  (OTLP/HTTP)
+# → 0.0.0.0:4317           (OTLP/gRPC)
+```
+
+`NEAT_OTLP_GRPC_PORT` overrides the default `:4317`. The HTTP receiver always stays on; gRPC is purely additive. Both transports go through the same `parseOtlpRequest` decoder so a span looks identical to ingest no matter which transport delivered it.
+
 ## Common failure modes
 
 - **`tsup` build fails with `Cannot find module '.../packages/<pkg>/node_modules/tsup/dist/cli-default.js'`** — leftover per-package node_modules from a different package manager. Wipe and reinstall (see "First-time setup").

--- a/package-lock.json
+++ b/package-lock.json
@@ -339,7 +339,6 @@
     "demo/service-b": {
       "version": "1.0.0",
       "dependencies": {
-        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.49.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.52.0",
         "@opentelemetry/sdk-node": "^0.52.0",
@@ -10027,6 +10026,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
+        "@grpc/grpc-js": "^1.14.3",
+        "@grpc/proto-loader": "^0.8.0",
         "@neat/types": "*",
         "fastify": "^5.0.0",
         "graphology": "^0.25.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,11 @@
   "bin": {
     "neat": "./dist/cli.cjs"
   },
-  "files": ["dist", "compat.json"],
+  "files": [
+    "dist",
+    "compat.json",
+    "proto"
+  ],
   "scripts": {
     "build": "tsup",
     "dev": "tsx watch src/server.ts",
@@ -28,6 +32,8 @@
   },
   "dependencies": {
     "@fastify/cors": "^10.0.0",
+    "@grpc/grpc-js": "^1.14.3",
+    "@grpc/proto-loader": "^0.8.0",
     "@neat/types": "*",
     "fastify": "^5.0.0",
     "graphology": "^0.25.4",

--- a/packages/core/proto/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/packages/core/proto/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -1,0 +1,31 @@
+// Copyright 2019, OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bundled from https://github.com/open-telemetry/opentelemetry-proto.
+syntax = "proto3";
+
+package opentelemetry.proto.collector.trace.v1;
+
+import "opentelemetry/proto/trace/v1/trace.proto";
+
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.collector.trace.v1";
+option java_outer_classname = "TraceServiceProto";
+option go_package = "go.opentelemetry.io/proto/otlp/collector/trace/v1";
+
+service TraceService {
+  rpc Export(ExportTraceServiceRequest) returns (ExportTraceServiceResponse) {}
+}
+
+message ExportTraceServiceRequest {
+  repeated opentelemetry.proto.trace.v1.ResourceSpans resource_spans = 1;
+}
+
+message ExportTraceServiceResponse {
+  ExportTracePartialSuccess partial_success = 1;
+}
+
+message ExportTracePartialSuccess {
+  int64 rejected_spans = 1;
+  string error_message = 2;
+}

--- a/packages/core/proto/opentelemetry/proto/common/v1/common.proto
+++ b/packages/core/proto/opentelemetry/proto/common/v1/common.proto
@@ -1,0 +1,46 @@
+// Copyright 2019, OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bundled from https://github.com/open-telemetry/opentelemetry-proto.
+// We carry this in-tree so @grpc/proto-loader can load OTLP at runtime
+// without an extra package dependency.
+syntax = "proto3";
+
+package opentelemetry.proto.common.v1;
+
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.common.v1";
+option java_outer_classname = "CommonProto";
+option go_package = "go.opentelemetry.io/proto/otlp/common/v1";
+
+message AnyValue {
+  oneof value {
+    string string_value = 1;
+    bool bool_value = 2;
+    int64 int_value = 3;
+    double double_value = 4;
+    ArrayValue array_value = 5;
+    KeyValueList kvlist_value = 6;
+    bytes bytes_value = 7;
+  }
+}
+
+message ArrayValue {
+  repeated AnyValue values = 1;
+}
+
+message KeyValueList {
+  repeated KeyValue values = 1;
+}
+
+message KeyValue {
+  string key = 1;
+  AnyValue value = 2;
+}
+
+message InstrumentationScope {
+  string name = 1;
+  string version = 2;
+  repeated KeyValue attributes = 3;
+  uint32 dropped_attributes_count = 4;
+}

--- a/packages/core/proto/opentelemetry/proto/resource/v1/resource.proto
+++ b/packages/core/proto/opentelemetry/proto/resource/v1/resource.proto
@@ -1,0 +1,19 @@
+// Copyright 2019, OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bundled from https://github.com/open-telemetry/opentelemetry-proto.
+syntax = "proto3";
+
+package opentelemetry.proto.resource.v1;
+
+import "opentelemetry/proto/common/v1/common.proto";
+
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.resource.v1";
+option java_outer_classname = "ResourceProto";
+option go_package = "go.opentelemetry.io/proto/otlp/resource/v1";
+
+message Resource {
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
+  uint32 dropped_attributes_count = 2;
+}

--- a/packages/core/proto/opentelemetry/proto/trace/v1/trace.proto
+++ b/packages/core/proto/opentelemetry/proto/trace/v1/trace.proto
@@ -1,0 +1,93 @@
+// Copyright 2019, OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bundled from https://github.com/open-telemetry/opentelemetry-proto.
+syntax = "proto3";
+
+package opentelemetry.proto.trace.v1;
+
+import "opentelemetry/proto/common/v1/common.proto";
+import "opentelemetry/proto/resource/v1/resource.proto";
+
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.trace.v1";
+option java_outer_classname = "TraceProto";
+option go_package = "go.opentelemetry.io/proto/otlp/trace/v1";
+
+message TracesData {
+  repeated ResourceSpans resource_spans = 1;
+}
+
+message ResourceSpans {
+  reserved 1000;
+  opentelemetry.proto.resource.v1.Resource resource = 1;
+  repeated ScopeSpans scope_spans = 2;
+  string schema_url = 3;
+}
+
+message ScopeSpans {
+  opentelemetry.proto.common.v1.InstrumentationScope scope = 1;
+  repeated Span spans = 2;
+  string schema_url = 3;
+}
+
+message Span {
+  reserved 3;
+  bytes trace_id = 1;
+  bytes span_id = 2;
+  string trace_state = 3;
+  bytes parent_span_id = 4;
+  string name = 5;
+
+  enum SpanKind {
+    SPAN_KIND_UNSPECIFIED = 0;
+    SPAN_KIND_INTERNAL = 1;
+    SPAN_KIND_SERVER = 2;
+    SPAN_KIND_CLIENT = 3;
+    SPAN_KIND_PRODUCER = 4;
+    SPAN_KIND_CONSUMER = 5;
+  }
+
+  SpanKind kind = 6;
+  fixed64 start_time_unix_nano = 7;
+  fixed64 end_time_unix_nano = 8;
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
+  uint32 dropped_attributes_count = 10;
+
+  message Event {
+    fixed64 time_unix_nano = 1;
+    string name = 2;
+    repeated opentelemetry.proto.common.v1.KeyValue attributes = 3;
+    uint32 dropped_attributes_count = 4;
+  }
+
+  repeated Event events = 11;
+  uint32 dropped_events_count = 12;
+
+  message Link {
+    bytes trace_id = 1;
+    bytes span_id = 2;
+    string trace_state = 3;
+    repeated opentelemetry.proto.common.v1.KeyValue attributes = 4;
+    uint32 dropped_attributes_count = 5;
+    uint32 flags = 6;
+  }
+
+  repeated Link links = 13;
+  uint32 dropped_links_count = 14;
+  Status status = 15;
+  uint32 flags = 16;
+}
+
+message Status {
+  reserved 1;
+  string message = 2;
+
+  enum StatusCode {
+    STATUS_CODE_UNSET = 0;
+    STATUS_CODE_OK = 1;
+    STATUS_CODE_ERROR = 2;
+  }
+
+  StatusCode code = 3;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,11 @@ export {
   type OtlpTracesRequest,
 } from './otel.js'
 export {
+  startOtelGrpcReceiver,
+  type BuildOtelGrpcReceiverOptions,
+  type OtelGrpcReceiver,
+} from './otel-grpc.js'
+export {
   handleSpan,
   makeSpanHandler,
   markStaleEdges,

--- a/packages/core/src/otel-grpc.ts
+++ b/packages/core/src/otel-grpc.ts
@@ -1,0 +1,233 @@
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import * as grpc from '@grpc/grpc-js'
+import * as protoLoader from '@grpc/proto-loader'
+import {
+  parseOtlpRequest,
+  type OtlpTracesRequest,
+  type ParsedSpan,
+  type SpanHandler,
+} from './otel.js'
+
+// OTLP/gRPC receiver. Sits next to buildOtelReceiver (HTTP/JSON) in otel.ts;
+// shares the same parseOtlpRequest decoder so a span looks identical to the
+// downstream onSpan handler whether it came in over JSON or protobuf.
+//
+// Default OFF — opts.enabled (typically NEAT_OTLP_GRPC=true) decides whether
+// server.ts wires this up. We keep gRPC behind a flag so existing HTTP-only
+// deployments don't get a surprise port binding on upgrade.
+
+export interface BuildOtelGrpcReceiverOptions {
+  onSpan: SpanHandler
+}
+
+// proto-loader output for the trace service has fields like resource_spans,
+// scope_spans, span_id, etc. (snake_case keys, since we leave keepCase: true
+// when loading). The HTTP path uses camelCase JSON, so we shape-shift the
+// gRPC payload onto the HTTP shape and let parseOtlpRequest do the rest.
+//
+// All `bytes` fields arrive as Buffers; the HTTP wire format encodes them as
+// hex strings, so we hex-encode for consistency.
+
+interface GrpcAnyValue {
+  string_value?: string
+  bool_value?: boolean
+  int_value?: string | number
+  double_value?: number
+  array_value?: { values?: GrpcAnyValue[] }
+  // bytes/kvlist fields exist in the proto but the demo doesn't use them.
+}
+
+interface GrpcKeyValue {
+  key?: string
+  value?: GrpcAnyValue
+}
+
+interface GrpcStatus {
+  code?: number
+  message?: string
+}
+
+interface GrpcSpan {
+  trace_id?: Buffer
+  span_id?: Buffer
+  parent_span_id?: Buffer
+  name?: string
+  kind?: number
+  start_time_unix_nano?: string | number
+  end_time_unix_nano?: string | number
+  attributes?: GrpcKeyValue[]
+  status?: GrpcStatus
+}
+
+interface GrpcScopeSpans {
+  spans?: GrpcSpan[]
+}
+
+interface GrpcResourceSpans {
+  resource?: { attributes?: GrpcKeyValue[] }
+  scope_spans?: GrpcScopeSpans[]
+}
+
+interface GrpcExportRequest {
+  resource_spans?: GrpcResourceSpans[]
+}
+
+function bytesToHex(buf: Buffer | undefined): string {
+  if (!buf) return ''
+  return Buffer.isBuffer(buf) ? buf.toString('hex') : ''
+}
+
+function nanosToString(n: string | number | undefined): string {
+  if (n === undefined || n === null) return '0'
+  return typeof n === 'string' ? n : String(n)
+}
+
+function reshapeAttributes(
+  attrs: GrpcKeyValue[] | undefined,
+): OtlpTracesRequest['resourceSpans'] extends Array<infer R>
+  ? R extends { resource?: { attributes?: infer A } }
+    ? A
+    : never
+  : never {
+  // Map snake_case oneof fields to the camelCase the JSON path expects.
+  const out = (attrs ?? []).map((kv) => ({
+    key: kv.key ?? '',
+    value: kv.value
+      ? {
+          stringValue: kv.value.string_value,
+          boolValue: kv.value.bool_value,
+          intValue: kv.value.int_value,
+          doubleValue: kv.value.double_value,
+          arrayValue: kv.value.array_value
+            ? {
+                values: (kv.value.array_value.values ?? []).map((v) => ({
+                  stringValue: v.string_value,
+                  boolValue: v.bool_value,
+                  intValue: v.int_value,
+                  doubleValue: v.double_value,
+                })),
+              }
+            : undefined,
+        }
+      : undefined,
+  }))
+  return out as never
+}
+
+export function reshapeGrpcRequest(req: GrpcExportRequest): OtlpTracesRequest {
+  return {
+    resourceSpans: (req.resource_spans ?? []).map((rs) => ({
+      resource: rs.resource ? { attributes: reshapeAttributes(rs.resource.attributes) } : undefined,
+      scopeSpans: (rs.scope_spans ?? []).map((ss) => ({
+        spans: (ss.spans ?? []).map((s) => ({
+          traceId: bytesToHex(s.trace_id),
+          spanId: bytesToHex(s.span_id),
+          parentSpanId: s.parent_span_id ? bytesToHex(s.parent_span_id) : undefined,
+          name: s.name,
+          kind: s.kind,
+          startTimeUnixNano: nanosToString(s.start_time_unix_nano),
+          endTimeUnixNano: nanosToString(s.end_time_unix_nano),
+          attributes: reshapeAttributes(s.attributes),
+          status: s.status ? { code: s.status.code, message: s.status.message } : undefined,
+        })),
+      })),
+    })),
+  }
+}
+
+// Find the bundled .proto tree at packages/core/proto/. The dev server runs
+// from the source tree (tsx); the built bundles run from dist/. tsup keeps
+// source layout, so __dirname-relative resolution works for both — we look two
+// levels up from this file.
+function resolveProtoRoot(): string {
+  // Built output (CJS) sets __dirname natively; ESM build is bundled by tsup
+  // and keeps a dirname injection. import.meta.url is the safe bet.
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  // src/ → packages/core/proto/, dist/ → packages/core/proto/.
+  return path.resolve(here, '..', 'proto')
+}
+
+function loadTraceService(): grpc.ServiceDefinition {
+  const protoRoot = resolveProtoRoot()
+  const def = protoLoader.loadSync(
+    'opentelemetry/proto/collector/trace/v1/trace_service.proto',
+    {
+      keepCase: true,
+      longs: String,
+      enums: Number,
+      defaults: true,
+      oneofs: true,
+      includeDirs: [protoRoot],
+    },
+  )
+  const pkg = grpc.loadPackageDefinition(def) as unknown as {
+    opentelemetry: {
+      proto: {
+        collector: {
+          trace: {
+            v1: {
+              TraceService: { service: grpc.ServiceDefinition }
+            }
+          }
+        }
+      }
+    }
+  }
+  return pkg.opentelemetry.proto.collector.trace.v1.TraceService.service
+}
+
+export interface OtelGrpcReceiver {
+  // Bound address (host:port) once .start() has resolved. Useful for tests.
+  address: string
+  // Stop accepting new requests, shut down the server.
+  stop: () => Promise<void>
+}
+
+export async function startOtelGrpcReceiver(
+  opts: BuildOtelGrpcReceiverOptions & { host?: string; port?: number },
+): Promise<OtelGrpcReceiver> {
+  const server = new grpc.Server()
+  const service = loadTraceService()
+
+  server.addService(service, {
+    Export: (
+      call: grpc.ServerUnaryCall<GrpcExportRequest, unknown>,
+      callback: grpc.sendUnaryData<{ partial_success: object }>,
+    ) => {
+      void (async () => {
+        try {
+          const reshaped = reshapeGrpcRequest(call.request ?? {})
+          const spans: ParsedSpan[] = parseOtlpRequest(reshaped)
+          for (const span of spans) {
+            await opts.onSpan(span)
+          }
+          callback(null, { partial_success: {} })
+        } catch (err) {
+          callback({
+            code: grpc.status.INTERNAL,
+            message: err instanceof Error ? err.message : String(err),
+          })
+        }
+      })()
+    },
+  })
+
+  const host = opts.host ?? '0.0.0.0'
+  const port = opts.port ?? 4317
+
+  const boundPort = await new Promise<number>((resolve, reject) => {
+    server.bindAsync(`${host}:${port}`, grpc.ServerCredentials.createInsecure(), (err, p) => {
+      if (err) return reject(err)
+      resolve(p)
+    })
+  })
+
+  return {
+    address: `${host}:${boundPort}`,
+    stop: () =>
+      new Promise<void>((resolve) => {
+        server.tryShutdown(() => resolve())
+      }),
+  }
+}

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -4,6 +4,7 @@ import { buildApi } from './api.js'
 import { extractFromDirectory } from './extract.js'
 import { loadGraphFromDisk, startPersistLoop } from './persist.js'
 import { buildOtelReceiver } from './otel.js'
+import { startOtelGrpcReceiver } from './otel-grpc.js'
 import { makeSpanHandler, startStalenessLoop } from './ingest.js'
 
 async function main(): Promise<void> {
@@ -43,6 +44,15 @@ async function main(): Promise<void> {
   const otelApp = await buildOtelReceiver({ onSpan })
   await otelApp.listen({ port: otelPort, host })
   console.log(`neat-core OTLP receiver on http://${host}:${otelPort}/v1/traces`)
+
+  // gRPC OTLP receiver — off by default. Most NEAT installs run the HTTP path
+  // because that's what docker-compose's collector ships, but plenty of OTel
+  // deployments default to gRPC, so this is the "drop NEAT in" affordance.
+  if (process.env.NEAT_OTLP_GRPC === 'true') {
+    const grpcPort = Number(process.env.NEAT_OTLP_GRPC_PORT ?? 4317)
+    const grpcReceiver = await startOtelGrpcReceiver({ onSpan, host, port: grpcPort })
+    console.log(`neat-core OTLP/gRPC receiver on ${grpcReceiver.address}`)
+  }
 }
 
 main().catch((err) => {

--- a/packages/core/test/otel-grpc.test.ts
+++ b/packages/core/test/otel-grpc.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as grpc from '@grpc/grpc-js'
+import * as protoLoader from '@grpc/proto-loader'
+import { startOtelGrpcReceiver, type OtelGrpcReceiver } from '../src/otel-grpc.js'
+import type { ParsedSpan } from '../src/otel.js'
+
+// Same shape as the canned HTTP body in otel.test.ts, just expressed in the
+// gRPC-side snake_case + Buffer format.
+const TRACE_ID = Buffer.from('aabbccddeeff00112233445566778899', 'hex')
+const SPAN_A = Buffer.from('1111111111111111', 'hex')
+const SPAN_B = Buffer.from('2222222222222222', 'hex')
+
+const SAMPLE_GRPC_REQUEST = {
+  resource_spans: [
+    {
+      resource: {
+        attributes: [{ key: 'service.name', value: { string_value: 'service-a' } }],
+      },
+      scope_spans: [
+        {
+          spans: [
+            {
+              trace_id: TRACE_ID,
+              span_id: SPAN_A,
+              name: 'GET /data',
+              kind: 2,
+              start_time_unix_nano: '1000000000000000000',
+              end_time_unix_nano: '1000000000050000000',
+              attributes: [
+                { key: 'http.method', value: { string_value: 'GET' } },
+                { key: 'http.status_code', value: { int_value: '500' } },
+              ],
+              status: { code: 0 },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      resource: {
+        attributes: [{ key: 'service.name', value: { string_value: 'service-b' } }],
+      },
+      scope_spans: [
+        {
+          spans: [
+            {
+              trace_id: TRACE_ID,
+              span_id: SPAN_B,
+              parent_span_id: SPAN_A,
+              name: 'pg.query',
+              kind: 3,
+              start_time_unix_nano: '1000000000010000000',
+              end_time_unix_nano: '1000000000040000000',
+              attributes: [
+                { key: 'db.system', value: { string_value: 'postgresql' } },
+                { key: 'db.name', value: { string_value: 'neatdemo' } },
+              ],
+              status: { code: 2, message: 'SASL: SCRAM-SERVER-FIRST-MESSAGE' },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+function loadClientStub(): {
+  TraceService: grpc.ServiceClientConstructor
+} {
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  const protoRoot = path.resolve(here, '..', 'proto')
+  const def = protoLoader.loadSync(
+    'opentelemetry/proto/collector/trace/v1/trace_service.proto',
+    {
+      keepCase: true,
+      longs: String,
+      enums: Number,
+      defaults: true,
+      oneofs: true,
+      includeDirs: [protoRoot],
+    },
+  )
+  const pkg = grpc.loadPackageDefinition(def) as unknown as {
+    opentelemetry: {
+      proto: { collector: { trace: { v1: { TraceService: grpc.ServiceClientConstructor } } } }
+    }
+  }
+  return { TraceService: pkg.opentelemetry.proto.collector.trace.v1.TraceService }
+}
+
+describe('startOtelGrpcReceiver', () => {
+  let receiver: OtelGrpcReceiver
+  let collected: ParsedSpan[]
+
+  beforeEach(async () => {
+    collected = []
+    receiver = await startOtelGrpcReceiver({
+      onSpan: (s) => {
+        collected.push(s)
+      },
+      port: 0,
+    })
+  })
+
+  afterEach(async () => {
+    await receiver.stop()
+  })
+
+  it('decodes a gRPC Export request and dispatches each span via onSpan', async () => {
+    const { TraceService } = loadClientStub()
+    const client = new TraceService(receiver.address, grpc.credentials.createInsecure())
+
+    const response = await new Promise<unknown>((resolve, reject) => {
+      ;(client as unknown as { Export: Function }).Export(
+        SAMPLE_GRPC_REQUEST,
+        (err: grpc.ServiceError | null, res: unknown) => {
+          if (err) return reject(err)
+          resolve(res)
+        },
+      )
+    })
+    client.close()
+
+    expect(response).toMatchObject({ partial_success: {} })
+    expect(collected).toHaveLength(2)
+    expect(collected[0].service).toBe('service-a')
+    expect(collected[1].service).toBe('service-b')
+    expect(collected[1].dbSystem).toBe('postgresql')
+    expect(collected[1].dbName).toBe('neatdemo')
+    expect(collected[1].statusCode).toBe(2)
+    expect(collected[1].errorMessage).toMatch(/SCRAM/)
+    // bytes → hex round-trip preserves trace/span identity.
+    expect(collected[0].traceId).toBe('aabbccddeeff00112233445566778899')
+    expect(collected[0].spanId).toBe('1111111111111111')
+    expect(collected[1].parentSpanId).toBe('1111111111111111')
+  })
+
+  it('binds on an ephemeral port (port=0) and reports the resolved address', async () => {
+    expect(receiver.address).toMatch(/^0\.0\.0\.0:\d+$/)
+    const port = Number(receiver.address.split(':')[1])
+    expect(port).toBeGreaterThan(0)
+  })
+
+  it('handles an empty request without erroring', async () => {
+    const { TraceService } = loadClientStub()
+    const client = new TraceService(receiver.address, grpc.credentials.createInsecure())
+
+    await new Promise<void>((resolve, reject) => {
+      ;(client as unknown as { Export: Function }).Export(
+        { resource_spans: [] },
+        (err: grpc.ServiceError | null) => {
+          if (err) return reject(err)
+          resolve()
+        },
+      )
+    })
+    client.close()
+
+    expect(collected).toEqual([])
+  })
+})


### PR DESCRIPTION
Most NEAT installs land OTLP traffic over HTTP/JSON on \`:4318\` because that's what the demo collector ships in this repo. But many OTel deployments default to gRPC, and "drop NEAT in" shouldn't require swapping the collector config first. This PR wires gRPC ingest in next to the HTTP receiver.

## What's added

- \`packages/core/src/otel-grpc.ts\` — \`startOtelGrpcReceiver({ onSpan, host, port })\`. Loads the OTLP traces protos via \`@grpc/proto-loader\`, registers \`opentelemetry.proto.collector.trace.v1.TraceService.Export\`, decodes each request's binary wire format, reshapes the snake_case payload onto the camelCase \`OtlpTracesRequest\` shape, and reuses \`parseOtlpRequest\` so downstream \`onSpan\` handlers see identical \`ParsedSpan\`s.
- \`packages/core/proto/opentelemetry/proto/...\` — bundled OTLP \`.proto\` files (collector/trace/v1, trace/v1, common/v1, resource/v1). ADR-020 explains why we bundle in-tree rather than pulling in a third-party package.
- \`packages/core/test/otel-grpc.test.ts\` — three tests that round-trip the canned demo trace through a real \`@grpc/grpc-js\` client/server pair on an ephemeral port.
- \`server.ts\` gates the gRPC listener on \`NEAT_OTLP_GRPC=true\` (with \`NEAT_OTLP_GRPC_PORT\` defaulting to \`4317\`) so existing HTTP-only deployments don't get a surprise port binding on upgrade.

## What stays the same

- HTTP receiver on \`:4318\` is untouched.
- \`parseOtlpRequest\`, \`handleSpan\`, \`stitchTrace\`, \`upsertObservedEdge\`, \`markStaleEdges\` — all transport-agnostic. A span is a span downstream of the receiver.
- Without \`NEAT_OTLP_GRPC=true\`, no gRPC port is opened and \`@grpc/grpc-js\` is loaded but idle.

## Verification

- \`npx turbo build test lint\` clean: 104 core tests / 25 types tests / 17 mcp tests, all green. The three new \`otel-grpc.test.ts\` cases exercise the full round-trip (client → server → \`onSpan\`), the empty-request edge case, and the ephemeral-port binding for tests.
- The reshape preserves \`trace_id\`/\`span_id\` byte-encoding (Buffer → hex), ints (\`int_value: '500'\` survives as \`500\`), \`db.system\` / \`db.name\` hoisting, and \`status.code === 2\` errors.

## Documentation

- \`docs/architecture.md\` data-flow diagram now shows both transports and the shared decoder.
- \`docs/runbook.md\` has an "Enable OTLP/gRPC ingest" section.
- \`docs/decisions.md\` adds **ADR-020** covering the in-tree proto bundling and the opt-in default.

Refs #80