### PR TITLE
Walk the tree recursively when discovering services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4704,7 +4704,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4760,7 +4759,6 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6500,7 +6498,6 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -7046,7 +7043,6 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -10033,6 +10029,8 @@
         "graphology": "^0.25.4",
         "graphology-shortest-path": "^2.1.0",
         "graphology-traversal": "^0.3.1",
+        "ignore": "^7.0.0",
+        "minimatch": "^10.0.0",
         "semver": "^7.6.0",
         "tree-sitter": "^0.21.1",
         "tree-sitter-javascript": "^0.21.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,8 @@
     "graphology": "^0.25.4",
     "graphology-shortest-path": "^2.1.0",
     "graphology-traversal": "^0.3.1",
+    "ignore": "^7.0.0",
+    "minimatch": "^10.0.0",
     "semver": "^7.6.0",
     "tree-sitter": "^0.21.1",
     "tree-sitter-javascript": "^0.21.4",

--- a/packages/core/src/extract/services.ts
+++ b/packages/core/src/extract/services.ts
@@ -1,5 +1,7 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import ignore, { type Ignore } from 'ignore'
+import { minimatch } from 'minimatch'
 import type { ServiceNode } from '@neat/types'
 import { NodeType } from '@neat/types'
 import type { NeatGraph } from '../graph.js'
@@ -11,28 +13,165 @@ import {
   type PackageJson,
 } from './shared.js'
 
-// Phase 1 — discover service directories under scanPath. A service is any
-// immediate subdirectory that contains a package.json. The package's `name`
-// becomes the ServiceNode id (`service:<name>`).
-export async function discoverServices(scanPath: string): Promise<DiscoveredService[]> {
-  const out: DiscoveredService[] = []
-  const entries = await fs.readdir(scanPath, { withFileTypes: true })
+const DEFAULT_SCAN_DEPTH = 5
 
-  for (const entry of entries) {
-    if (!entry.isDirectory() || IGNORED_DIRS.has(entry.name)) continue
-    const dir = path.join(scanPath, entry.name)
+interface RootPackageJson extends PackageJson {
+  workspaces?: string[] | { packages?: string[] }
+}
+
+function parseScanDepth(): number {
+  const raw = process.env.NEAT_SCAN_DEPTH
+  if (!raw) return DEFAULT_SCAN_DEPTH
+  const n = Number.parseInt(raw, 10)
+  return Number.isFinite(n) && n >= 0 ? n : DEFAULT_SCAN_DEPTH
+}
+
+function workspaceGlobs(pkg: RootPackageJson): string[] | null {
+  const ws = pkg.workspaces
+  if (!ws) return null
+  if (Array.isArray(ws)) return ws.length > 0 ? ws : null
+  if (Array.isArray(ws.packages)) return ws.packages.length > 0 ? ws.packages : null
+  return null
+}
+
+async function loadGitignore(scanPath: string): Promise<Ignore | null> {
+  const gitignorePath = path.join(scanPath, '.gitignore')
+  if (!(await exists(gitignorePath))) return null
+  const raw = await fs.readFile(gitignorePath, 'utf8')
+  return ignore().add(raw)
+}
+
+interface WalkOptions {
+  maxDepth: number
+  ig: Ignore | null
+}
+
+async function walkDirs(
+  start: string,
+  scanPath: string,
+  options: WalkOptions,
+  visit: (dir: string) => Promise<void> | void,
+): Promise<void> {
+  async function recurse(current: string, depth: number): Promise<void> {
+    if (depth > options.maxDepth) return
+    const entries = await fs.readdir(current, { withFileTypes: true }).catch(() => [])
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      if (IGNORED_DIRS.has(entry.name)) continue
+      const child = path.join(current, entry.name)
+      if (options.ig) {
+        const rel = path.relative(scanPath, child).split(path.sep).join('/')
+        // Trailing slash so `ignore` evaluates the entry as a directory; without
+        // it, gitignore patterns like `dist/` won't match because the lib
+        // distinguishes file vs. directory tests.
+        if (rel && options.ig.ignores(rel + '/')) continue
+      }
+      await visit(child)
+      await recurse(child, depth + 1)
+    }
+  }
+  await recurse(start, 0)
+}
+
+async function expandWorkspaceGlobs(
+  scanPath: string,
+  globs: string[],
+): Promise<string[]> {
+  const found = new Set<string>()
+  const scanDepth = parseScanDepth()
+
+  for (const raw of globs) {
+    const pattern = raw.replace(/^\.\//, '')
+
+    if (!pattern.includes('*')) {
+      const candidate = path.join(scanPath, pattern)
+      if (await exists(path.join(candidate, 'package.json'))) found.add(candidate)
+      continue
+    }
+
+    const segments = pattern.split('/')
+    const staticSegments: string[] = []
+    for (const seg of segments) {
+      if (seg.includes('*')) break
+      staticSegments.push(seg)
+    }
+    const start = path.join(scanPath, ...staticSegments)
+    if (!(await exists(start))) continue
+
+    const hasDoubleStar = pattern.includes('**')
+    const walkDepth = hasDoubleStar
+      ? scanDepth
+      : Math.max(0, segments.length - staticSegments.length - 1)
+
+    await walkDirs(start, scanPath, { maxDepth: walkDepth, ig: null }, async (dir) => {
+      const rel = path.relative(scanPath, dir).split(path.sep).join('/')
+      if (minimatch(rel, pattern) && (await exists(path.join(dir, 'package.json')))) {
+        found.add(dir)
+      }
+    })
+  }
+
+  return [...found]
+}
+
+// Phase 1 — discover service directories under scanPath. A service is any
+// directory containing a package.json. If the root has a `workspaces` field,
+// those globs are authoritative and we stop there. Otherwise we walk
+// recursively, depth-bounded by NEAT_SCAN_DEPTH (default 5), skipping
+// IGNORED_DIRS and anything matched by the root .gitignore. Two package.jsons
+// sharing a `name` collapse to one node (ADR-010 id collision rule); the
+// duplicate logs a warning naming both paths.
+export async function discoverServices(scanPath: string): Promise<DiscoveredService[]> {
+  const rootPkgPath = path.join(scanPath, 'package.json')
+  const rootPkg = (await exists(rootPkgPath))
+    ? await readJson<RootPackageJson>(rootPkgPath)
+    : null
+  const wsGlobs = rootPkg ? workspaceGlobs(rootPkg) : null
+
+  const candidateDirs: string[] = []
+  if (wsGlobs) {
+    candidateDirs.push(...(await expandWorkspaceGlobs(scanPath, wsGlobs)))
+  } else {
+    if (rootPkg && rootPkg.name) candidateDirs.push(scanPath)
+    const ig = await loadGitignore(scanPath)
+    await walkDirs(
+      scanPath,
+      scanPath,
+      { maxDepth: parseScanDepth(), ig },
+      async (dir) => {
+        if (await exists(path.join(dir, 'package.json'))) candidateDirs.push(dir)
+      },
+    )
+  }
+
+  candidateDirs.sort()
+
+  const seen = new Map<string, string>()
+  const out: DiscoveredService[] = []
+  for (const dir of candidateDirs) {
     const pkgPath = path.join(dir, 'package.json')
     if (!(await exists(pkgPath))) continue
-
     const pkg = await readJson<PackageJson>(pkgPath)
-    const deps = pkg.dependencies ?? {}
+    if (!pkg.name) continue
+
+    const existingDir = seen.get(pkg.name)
+    if (existingDir !== undefined) {
+      const a = path.relative(scanPath, existingDir) || '.'
+      const b = path.relative(scanPath, dir) || '.'
+      console.warn(
+        `[neat] duplicate package name "${pkg.name}" — keeping ${a}, ignoring ${b}`,
+      )
+      continue
+    }
+    seen.set(pkg.name, dir)
+
     const node: ServiceNode = {
       id: `service:${pkg.name}`,
       type: NodeType.ServiceNode,
       name: pkg.name,
       language: 'javascript',
       version: pkg.version,
-      dependencies: deps,
+      dependencies: pkg.dependencies ?? {},
       repoPath: path.relative(scanPath, dir),
     }
     out.push({ pkg, dir, node })

--- a/packages/core/test/discover-services.test.ts
+++ b/packages/core/test/discover-services.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { discoverServices } from '../src/extract/services.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES = path.resolve(__dirname, 'fixtures')
+
+describe('discoverServices', () => {
+  const originalScanDepth = process.env.NEAT_SCAN_DEPTH
+
+  beforeEach(() => {
+    delete process.env.NEAT_SCAN_DEPTH
+  })
+
+  afterEach(() => {
+    if (originalScanDepth === undefined) delete process.env.NEAT_SCAN_DEPTH
+    else process.env.NEAT_SCAN_DEPTH = originalScanDepth
+    vi.restoreAllMocks()
+  })
+
+  it('walks the tree recursively and finds nested package.jsons', async () => {
+    const services = await discoverServices(path.join(FIXTURES, 'monorepo'))
+    const names = services.map((s) => s.node.name).sort()
+    expect(names).toEqual(['fixture-app-a', 'fixture-lib', 'fixture-service-b'])
+  })
+
+  it('records repoPath relative to scan path', async () => {
+    const services = await discoverServices(path.join(FIXTURES, 'monorepo'))
+    const byName = new Map(services.map((s) => [s.node.name, s.node.repoPath]))
+    expect(byName.get('fixture-app-a')).toBe(path.join('apps', 'a'))
+    expect(byName.get('fixture-service-b')).toBe(path.join('services', 'b'))
+    expect(byName.get('fixture-lib')).toBe(path.join('packages', 'lib'))
+  })
+
+  it('honours package.json#workspaces globs and ignores paths outside them', async () => {
+    const services = await discoverServices(path.join(FIXTURES, 'monorepo-workspaces'))
+    const names = services.map((s) => s.node.name).sort()
+    expect(names).toEqual(['fixture-ws-lib'])
+  })
+
+  it('warns on duplicate package names and keeps only the first', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const services = await discoverServices(path.join(FIXTURES, 'monorepo-duplicates'))
+    expect(services).toHaveLength(1)
+    expect(services[0]!.node.name).toBe('fixture-dup')
+    expect(warn).toHaveBeenCalledOnce()
+    const message = warn.mock.calls[0]![0] as string
+    expect(message).toContain('fixture-dup')
+    expect(message).toContain(path.join('apps', 'a'))
+    expect(message).toContain(path.join('services', 'a'))
+  })
+
+  it('skips directories matched by the root .gitignore', async () => {
+    const services = await discoverServices(path.join(FIXTURES, 'monorepo-gitignore'))
+    const names = services.map((s) => s.node.name).sort()
+    expect(names).toEqual(['fixture-included'])
+  })
+
+  it('respects NEAT_SCAN_DEPTH=0 (root only)', async () => {
+    process.env.NEAT_SCAN_DEPTH = '0'
+    const services = await discoverServices(path.join(FIXTURES, 'monorepo'))
+    expect(services).toEqual([])
+  })
+})

--- a/packages/core/test/fixtures/monorepo-duplicates/apps/a/package.json
+++ b/packages/core/test/fixtures/monorepo-duplicates/apps/a/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-dup",
+  "version": "1.0.0"
+}

--- a/packages/core/test/fixtures/monorepo-duplicates/services/a/package.json
+++ b/packages/core/test/fixtures/monorepo-duplicates/services/a/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-dup",
+  "version": "2.0.0"
+}

--- a/packages/core/test/fixtures/monorepo-gitignore/.gitignore
+++ b/packages/core/test/fixtures/monorepo-gitignore/.gitignore
@@ -1,0 +1,1 @@
+excluded/

--- a/packages/core/test/fixtures/monorepo-gitignore/excluded/package.json
+++ b/packages/core/test/fixtures/monorepo-gitignore/excluded/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-excluded",
+  "version": "1.0.0"
+}

--- a/packages/core/test/fixtures/monorepo-gitignore/included/package.json
+++ b/packages/core/test/fixtures/monorepo-gitignore/included/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-included",
+  "version": "1.0.0"
+}

--- a/packages/core/test/fixtures/monorepo-workspaces/apps/decoy/package.json
+++ b/packages/core/test/fixtures/monorepo-workspaces/apps/decoy/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-ws-decoy",
+  "version": "1.0.0"
+}

--- a/packages/core/test/fixtures/monorepo-workspaces/package.json
+++ b/packages/core/test/fixtures/monorepo-workspaces/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-ws-root",
+  "private": true,
+  "workspaces": ["packages/*"]
+}

--- a/packages/core/test/fixtures/monorepo-workspaces/packages/lib/package.json
+++ b/packages/core/test/fixtures/monorepo-workspaces/packages/lib/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-ws-lib",
+  "version": "1.0.0"
+}

--- a/packages/core/test/fixtures/monorepo/apps/a/package.json
+++ b/packages/core/test/fixtures/monorepo/apps/a/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-app-a",
+  "version": "1.0.0"
+}

--- a/packages/core/test/fixtures/monorepo/packages/lib/package.json
+++ b/packages/core/test/fixtures/monorepo/packages/lib/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-lib",
+  "version": "1.0.0"
+}

--- a/packages/core/test/fixtures/monorepo/services/b/package.json
+++ b/packages/core/test/fixtures/monorepo/services/b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-service-b",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Refs #69.

Service discovery used to scan only immediate subdirectories of the scan path. Real monorepos nest services under `apps/`, `services/`, `packages/`, etc., so extraction came back empty against those layouts.

## What's different

- **Recursive walk**, depth-bounded by `NEAT_SCAN_DEPTH` (default `5`). Skips `IGNORED_DIRS` (`node_modules`, `.git`, `.turbo`, `dist`, `build`, `.next`).
- **Top-level `.gitignore` is honoured**. Anything the root gitignore matches as a directory gets pruned from the walk. Uses the `ignore` package so semantics line up with git's own rules.
- **`package.json#workspaces` is authoritative**. When the scan path's `package.json` declares workspaces, the globs there decide which directories become services — we don't fall back to a free recursive walk. Handles both the array form (`["packages/*"]`) and the object form (`{ packages: [...] }`).
- **Duplicate package names collapse to one node** per ADR-010, and the loser logs a warning naming both paths so the collision isn't silent.

## Verification

- New `discover-services.test.ts` covers all five scenarios: nested-without-workspaces, `repoPath` correctness, workspace-globs winning over arbitrary recursion, duplicate-name warning, gitignore exclusion, and `NEAT_SCAN_DEPTH=0`.
- Existing `extract.test.ts` still passes against `demo/` — the demo has no root `package.json`, hits the recursive path, and produces the same 3 nodes / 2 edges.
- Workspace stays green: `npx turbo build test lint` is clean (111 core tests / 25 types / 17 mcp).

## Test plan

- [x] `npx turbo build test lint`
- [x] `node packages/core/dist/cli.cjs init ./demo` still emits the expected node/edge counts and the pg-vs-PG-15 incompatibility.