### PR TITLE
Extract calls beyond HTTP URL substrings

### DIFF
--- a/packages/core/src/extract/calls/aws.ts
+++ b/packages/core/src/extract/calls/aws.ts
@@ -1,0 +1,68 @@
+import path from 'node:path'
+import { lineOf, snippet, type ExternalEndpoint, type SourceFile } from './shared.js'
+
+// AWS SDK v3 calls. We catch S3 (`Bucket: "x"` near a `S3Client`-using
+// PutObjectCommand / GetObjectCommand / DeleteObjectCommand) and DynamoDB
+// (`TableName: "x"` near GetCommand / PutCommand / DynamoDBClient). The
+// pattern is intentionally permissive: a literal Bucket/TableName near an
+// SDK constant is good enough evidence; misses are fine because non-static
+// resources can't be catalogued anyway.
+const S3_BUCKET_RE = /Bucket\s*:\s*['"`]([^'"`]+)['"`]/g
+const DYNAMO_TABLE_RE = /TableName\s*:\s*['"`]([^'"`]+)['"`]/g
+
+function hasMarker(text: string, markers: string[]): boolean {
+  return markers.some((m) => text.includes(m))
+}
+
+function findAll(re: RegExp, text: string): { name: string; index: number }[] {
+  re.lastIndex = 0
+  const out: { name: string; index: number }[] = []
+  let m: RegExpExecArray | null
+  while ((m = re.exec(text)) !== null) {
+    out.push({ name: m[1]!, index: m.index })
+  }
+  return out
+}
+
+export function awsEndpointsFromFile(
+  file: SourceFile,
+  serviceDir: string,
+): ExternalEndpoint[] {
+  const out: ExternalEndpoint[] = []
+  const seen = new Set<string>()
+  const make = (kind: string, name: string): void => {
+    const key = `${kind}|${name}`
+    if (seen.has(key)) return
+    seen.add(key)
+    const line = lineOf(file.content, name)
+    out.push({
+      infraId: `infra:${kind}:${name}`,
+      name,
+      kind,
+      edgeType: 'CALLS',
+      evidence: {
+        file: path.relative(serviceDir, file.path),
+        line,
+        snippet: snippet(file.content, line),
+      },
+    })
+  }
+
+  if (hasMarker(file.content, ['S3Client', 'PutObjectCommand', 'GetObjectCommand', 'DeleteObjectCommand'])) {
+    for (const { name } of findAll(S3_BUCKET_RE, file.content)) make('s3-bucket', name)
+  }
+  if (
+    hasMarker(file.content, [
+      'DynamoDBClient',
+      'DynamoDBDocumentClient',
+      'GetCommand',
+      'PutCommand',
+      'QueryCommand',
+      'UpdateCommand',
+      'DeleteCommand',
+    ])
+  ) {
+    for (const { name } of findAll(DYNAMO_TABLE_RE, file.content)) make('dynamodb-table', name)
+  }
+  return out
+}

--- a/packages/core/src/extract/calls/grpc.ts
+++ b/packages/core/src/extract/calls/grpc.ts
@@ -1,0 +1,48 @@
+import path from 'node:path'
+import { lineOf, snippet, type ExternalEndpoint, type SourceFile } from './shared.js'
+
+// gRPC client construction in JS/TS:
+//
+//   const client = new orders_proto.OrderService(...)
+//   const client = new OrdersClient('orders.internal:50051', ...)
+//
+// We catch `new <Name>Client(...)` and `new <namespace>.<Name>Service(...)`
+// patterns and use the symbol name as the inferred service id. The address
+// argument, when statically resolvable, becomes the host hint on the
+// resulting CALLS edge — but resolution is best-effort.
+const GRPC_CLIENT_RE = /new\s+([A-Z][A-Za-z0-9_]*)Client\s*\(\s*['"`]?([^,'"`)]+)?/g
+
+function isLikelyAddress(value: string | undefined): boolean {
+  if (!value) return false
+  return /:\d{2,5}$/.test(value) || value.includes('.')
+}
+
+export function grpcEndpointsFromFile(
+  file: SourceFile,
+  serviceDir: string,
+): ExternalEndpoint[] {
+  const out: ExternalEndpoint[] = []
+  const seen = new Set<string>()
+  GRPC_CLIENT_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = GRPC_CLIENT_RE.exec(file.content)) !== null) {
+    const symbol = m[1]!
+    const addr = m[2]?.trim()
+    const name = isLikelyAddress(addr) ? addr! : symbol
+    if (seen.has(name)) continue
+    seen.add(name)
+    const line = lineOf(file.content, m[0])
+    out.push({
+      infraId: `infra:grpc-service:${name}`,
+      name,
+      kind: 'grpc-service',
+      edgeType: 'CALLS',
+      evidence: {
+        file: path.relative(serviceDir, file.path),
+        line,
+        snippet: snippet(file.content, line),
+      },
+    })
+  }
+  return out
+}

--- a/packages/core/src/extract/calls/http.ts
+++ b/packages/core/src/extract/calls/http.ts
@@ -1,33 +1,11 @@
-import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import Parser from 'tree-sitter'
 import JavaScript from 'tree-sitter-javascript'
 import type { GraphEdge } from '@neat/types'
 import { EdgeType, Provenance } from '@neat/types'
-import type { NeatGraph } from '../graph.js'
-import {
-  IGNORED_DIRS,
-  SERVICE_FILE_EXTENSIONS,
-  makeEdgeId,
-  type DiscoveredService,
-} from './shared.js'
-
-export async function walkSourceFiles(dir: string): Promise<string[]> {
-  const out: string[] = []
-  async function walk(current: string): Promise<void> {
-    const entries = await fs.readdir(current, { withFileTypes: true })
-    for (const entry of entries) {
-      const full = path.join(current, entry.name)
-      if (entry.isDirectory()) {
-        if (!IGNORED_DIRS.has(entry.name)) await walk(full)
-      } else if (entry.isFile() && SERVICE_FILE_EXTENSIONS.has(path.extname(entry.name))) {
-        out.push(full)
-      }
-    }
-  }
-  await walk(dir)
-  return out
-}
+import type { NeatGraph } from '../../graph.js'
+import { makeEdgeId, type DiscoveredService } from '../shared.js'
+import { loadSourceFiles, lineOf, snippet } from './shared.js'
 
 function collectStringLiterals(node: Parser.SyntaxNode, out: string[]): void {
   if (node.type === 'string_fragment') out.push(node.text)
@@ -37,9 +15,6 @@ function collectStringLiterals(node: Parser.SyntaxNode, out: string[]): void {
   }
 }
 
-// Find URL-like literals in the AST that point at one of the known service
-// hostnames (the directory name OR the package.json name). Each match implies a
-// CALLS edge from the file's owning service to the target.
 export function callsFromSource(
   source: string,
   parser: Parser,
@@ -59,8 +34,9 @@ export function callsFromSource(
   return targets
 }
 
-// Phase 4 — service-to-service CALLS via tree-sitter URL-literal scan.
-export async function addCallEdges(
+// HTTP CALLS via URL substring match — the original tree-sitter scan, kept
+// intact so the demo's CALLS edges are byte-for-byte identical.
+export async function addHttpCallEdges(
   graph: NeatGraph,
   services: DiscoveredService[],
 ): Promise<number> {
@@ -78,24 +54,32 @@ export async function addCallEdges(
 
   let edgesAdded = 0
   for (const service of services) {
-    const files = await walkSourceFiles(service.dir)
-    const seenTargets = new Set<string>()
+    const files = await loadSourceFiles(service.dir)
+    const seenTargets = new Map<string, { file: string; host: string }>()
     for (const file of files) {
-      const source = await fs.readFile(file, 'utf8')
-      const targets = callsFromSource(source, parser, knownHosts)
+      const targets = callsFromSource(file.content, parser, knownHosts)
       for (const t of targets) {
         const targetId = hostToNodeId.get(t)
         if (!targetId || targetId === service.node.id) continue
-        seenTargets.add(targetId)
+        if (!seenTargets.has(targetId)) {
+          seenTargets.set(targetId, { file: file.path, host: t })
+        }
       }
     }
-    for (const targetId of seenTargets) {
+    for (const [targetId, evidenceFile] of seenTargets) {
+      const fileContent = files.find((f) => f.path === evidenceFile.file)?.content ?? ''
+      const line = lineOf(fileContent, `//${evidenceFile.host}`)
       const edge: GraphEdge = {
         id: makeEdgeId(service.node.id, targetId, EdgeType.CALLS),
         source: service.node.id,
         target: targetId,
         type: EdgeType.CALLS,
         provenance: Provenance.EXTRACTED,
+        evidence: {
+          file: path.relative(service.dir, evidenceFile.file),
+          line,
+          snippet: snippet(fileContent, line),
+        },
       }
       if (!graph.hasEdge(edge.id)) {
         graph.addEdgeWithKey(edge.id, edge.source, edge.target, edge)

--- a/packages/core/src/extract/calls/index.ts
+++ b/packages/core/src/extract/calls/index.ts
@@ -1,0 +1,91 @@
+import type { GraphEdge, InfraNode } from '@neat/types'
+import { EdgeType, NodeType, Provenance } from '@neat/types'
+import type { NeatGraph } from '../../graph.js'
+import { makeEdgeId, type DiscoveredService } from '../shared.js'
+import { addHttpCallEdges } from './http.js'
+import { loadSourceFiles, type ExternalEndpoint } from './shared.js'
+import { kafkaEndpointsFromFile } from './kafka.js'
+import { redisEndpointsFromFile } from './redis.js'
+import { awsEndpointsFromFile } from './aws.js'
+import { grpcEndpointsFromFile } from './grpc.js'
+
+export interface CallExtractResult {
+  nodesAdded: number
+  edgesAdded: number
+}
+
+function edgeTypeFromEndpoint(ep: ExternalEndpoint): (typeof EdgeType)[keyof typeof EdgeType] {
+  switch (ep.edgeType) {
+    case 'PUBLISHES_TO':
+      return EdgeType.PUBLISHES_TO
+    case 'CONSUMES_FROM':
+      return EdgeType.CONSUMES_FROM
+    default:
+      return EdgeType.CALLS
+  }
+}
+
+async function addExternalEndpointEdges(
+  graph: NeatGraph,
+  services: DiscoveredService[],
+): Promise<CallExtractResult> {
+  let nodesAdded = 0
+  let edgesAdded = 0
+
+  for (const service of services) {
+    const files = await loadSourceFiles(service.dir)
+    const endpoints: ExternalEndpoint[] = []
+    for (const file of files) {
+      endpoints.push(...kafkaEndpointsFromFile(file, service.dir))
+      endpoints.push(...redisEndpointsFromFile(file, service.dir))
+      endpoints.push(...awsEndpointsFromFile(file, service.dir))
+      endpoints.push(...grpcEndpointsFromFile(file, service.dir))
+    }
+    if (endpoints.length === 0) continue
+
+    const seenEdges = new Set<string>()
+    for (const ep of endpoints) {
+      if (!graph.hasNode(ep.infraId)) {
+        const node: InfraNode = {
+          id: ep.infraId,
+          type: NodeType.InfraNode,
+          name: ep.name,
+          provider: ep.kind.startsWith('s3') || ep.kind.startsWith('dynamodb') ? 'aws' : 'self',
+          kind: ep.kind,
+        }
+        graph.addNode(node.id, node)
+        nodesAdded++
+      }
+
+      const edgeType = edgeTypeFromEndpoint(ep)
+      const edgeId = makeEdgeId(service.node.id, ep.infraId, edgeType)
+      if (seenEdges.has(edgeId)) continue
+      seenEdges.add(edgeId)
+      if (!graph.hasEdge(edgeId)) {
+        const edge: GraphEdge = {
+          id: edgeId,
+          source: service.node.id,
+          target: ep.infraId,
+          type: edgeType,
+          provenance: Provenance.EXTRACTED,
+          evidence: ep.evidence,
+        }
+        graph.addEdgeWithKey(edgeId, edge.source, edge.target, edge)
+        edgesAdded++
+      }
+    }
+  }
+  return { nodesAdded, edgesAdded }
+}
+
+export async function addCallEdges(
+  graph: NeatGraph,
+  services: DiscoveredService[],
+): Promise<CallExtractResult> {
+  const httpEdges = await addHttpCallEdges(graph, services)
+  const ext = await addExternalEndpointEdges(graph, services)
+  return {
+    nodesAdded: ext.nodesAdded,
+    edgesAdded: httpEdges + ext.edgesAdded,
+  }
+}

--- a/packages/core/src/extract/calls/kafka.ts
+++ b/packages/core/src/extract/calls/kafka.ts
@@ -1,0 +1,50 @@
+import path from 'node:path'
+import { lineOf, snippet, type ExternalEndpoint, type SourceFile } from './shared.js'
+
+// Match `producer.send({ topic: "orders" ... })` and `producer.send({
+// topic: 'orders' })` plus the two-arg form `producer.send("orders", ...)`.
+// Kafka client libraries vary; these two forms cover kafkajs + node-rdkafka
+// well enough for static extraction. Same shape covers consumer.subscribe.
+const PRODUCER_TOPIC_RE =
+  /(?:producer|kafkaProducer)[\s\S]{0,40}?\.send\s*\(\s*\{[\s\S]{0,200}?topic\s*:\s*['"`]([^'"`]+)['"`]/g
+const CONSUMER_TOPIC_RE =
+  /(?:consumer|kafkaConsumer)[\s\S]{0,40}?\.(?:subscribe|run)\s*\(\s*\{[\s\S]{0,200}?topic[s]?\s*:\s*(?:\[\s*)?['"`]([^'"`]+)['"`]/g
+
+function findAll(re: RegExp, text: string): { topic: string; index: number }[] {
+  re.lastIndex = 0
+  const out: { topic: string; index: number }[] = []
+  let m: RegExpExecArray | null
+  while ((m = re.exec(text)) !== null) {
+    out.push({ topic: m[1]!, index: m.index })
+  }
+  return out
+}
+
+export function kafkaEndpointsFromFile(
+  file: SourceFile,
+  serviceDir: string,
+): ExternalEndpoint[] {
+  const out: ExternalEndpoint[] = []
+  const seen = new Set<string>()
+  const make = (topic: string, edgeType: 'PUBLISHES_TO' | 'CONSUMES_FROM'): void => {
+    const key = `${edgeType}|${topic}`
+    if (seen.has(key)) return
+    seen.add(key)
+    const line = lineOf(file.content, topic)
+    out.push({
+      infraId: `infra:kafka-topic:${topic}`,
+      name: topic,
+      kind: 'kafka-topic',
+      edgeType,
+      evidence: {
+        file: path.relative(serviceDir, file.path),
+        line,
+        snippet: snippet(file.content, line),
+      },
+    })
+  }
+
+  for (const { topic } of findAll(PRODUCER_TOPIC_RE, file.content)) make(topic, 'PUBLISHES_TO')
+  for (const { topic } of findAll(CONSUMER_TOPIC_RE, file.content)) make(topic, 'CONSUMES_FROM')
+  return out
+}

--- a/packages/core/src/extract/calls/redis.ts
+++ b/packages/core/src/extract/calls/redis.ts
@@ -1,0 +1,35 @@
+import path from 'node:path'
+import { lineOf, snippet, type ExternalEndpoint, type SourceFile } from './shared.js'
+
+// Redis URLs in source — `redis://host[:port]` or `rediss://...`. We only
+// catch literal strings; env-driven URLs go through the database parsers
+// (.env, ormconfig, etc.) and don't need a CALLS edge.
+const REDIS_URL_RE = /redis(?:s)?:\/\/(?:[^@'"`\s]+@)?([^:/'"`\s]+)(?::(\d+))?/g
+
+export function redisEndpointsFromFile(
+  file: SourceFile,
+  serviceDir: string,
+): ExternalEndpoint[] {
+  const out: ExternalEndpoint[] = []
+  const seen = new Set<string>()
+  REDIS_URL_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = REDIS_URL_RE.exec(file.content)) !== null) {
+    const host = m[1]!
+    if (seen.has(host)) continue
+    seen.add(host)
+    const line = lineOf(file.content, host)
+    out.push({
+      infraId: `infra:redis:${host}`,
+      name: host,
+      kind: 'redis',
+      edgeType: 'CALLS',
+      evidence: {
+        file: path.relative(serviceDir, file.path),
+        line,
+        snippet: snippet(file.content, line),
+      },
+    })
+  }
+  return out
+}

--- a/packages/core/src/extract/calls/shared.ts
+++ b/packages/core/src/extract/calls/shared.ts
@@ -1,0 +1,65 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import type { EdgeEvidence } from '@neat/types'
+import { IGNORED_DIRS, SERVICE_FILE_EXTENSIONS } from '../shared.js'
+
+export interface SourceFile {
+  path: string
+  content: string
+}
+
+export interface ExternalEndpoint {
+  // Stable id of the InfraNode this evidence implies. Format
+  // `infra:<kind>:<name>` so the orchestrator can dedupe across services.
+  infraId: string
+  // Display name on the InfraNode (e.g., "orders" for kafka-topic:orders).
+  name: string
+  kind: string
+  edgeType: 'CALLS' | 'PUBLISHES_TO' | 'CONSUMES_FROM'
+  evidence: EdgeEvidence
+}
+
+export async function walkSourceFiles(dir: string): Promise<string[]> {
+  const out: string[] = []
+  async function walk(current: string): Promise<void> {
+    const entries = await fs.readdir(current, { withFileTypes: true }).catch(() => [])
+    for (const entry of entries) {
+      const full = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        if (!IGNORED_DIRS.has(entry.name)) await walk(full)
+      } else if (entry.isFile() && SERVICE_FILE_EXTENSIONS.has(path.extname(entry.name))) {
+        out.push(full)
+      }
+    }
+  }
+  await walk(dir)
+  return out
+}
+
+export async function loadSourceFiles(dir: string): Promise<SourceFile[]> {
+  const paths = await walkSourceFiles(dir)
+  const out: SourceFile[] = []
+  for (const p of paths) {
+    try {
+      const content = await fs.readFile(p, 'utf8')
+      out.push({ path: p, content })
+    } catch {
+      // unreadable, skip
+    }
+  }
+  return out
+}
+
+// Locate the line of the first occurrence of `needle` in `text`, 1-indexed.
+// Falls back to line 1 if the needle isn't found verbatim — better to point at
+// the file than to drop the evidence entirely.
+export function lineOf(text: string, needle: string): number {
+  const idx = text.indexOf(needle)
+  if (idx < 0) return 1
+  return text.slice(0, idx).split('\n').length
+}
+
+export function snippet(text: string, line: number): string {
+  const lines = text.split('\n')
+  return (lines[line - 1] ?? '').trim()
+}

--- a/packages/core/src/extract/index.ts
+++ b/packages/core/src/extract/index.ts
@@ -2,7 +2,7 @@ import type { NeatGraph } from '../graph.js'
 import { addServiceNodes, discoverServices } from './services.js'
 import { addDatabasesAndCompat } from './databases/index.js'
 import { addConfigNodes } from './configs.js'
-import { addCallEdges } from './calls.js'
+import { addCallEdges } from './calls/index.js'
 
 export interface ExtractResult {
   nodesAdded: number
@@ -18,10 +18,10 @@ export async function extractFromDirectory(
   const phase1Nodes = addServiceNodes(graph, services)
   const phase2 = await addDatabasesAndCompat(graph, services)
   const phase3 = await addConfigNodes(graph, services, scanPath)
-  const phase4Edges = await addCallEdges(graph, services)
+  const phase4 = await addCallEdges(graph, services)
 
   return {
-    nodesAdded: phase1Nodes + phase2.nodesAdded + phase3.nodesAdded,
-    edgesAdded: phase2.edgesAdded + phase3.edgesAdded + phase4Edges,
+    nodesAdded: phase1Nodes + phase2.nodesAdded + phase3.nodesAdded + phase4.nodesAdded,
+    edgesAdded: phase2.edgesAdded + phase3.edgesAdded + phase4.edgesAdded,
   }
 }

--- a/packages/core/test/calls.test.ts
+++ b/packages/core/test/calls.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import type { GraphEdge, InfraNode } from '@neat/types'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES = path.resolve(__dirname, 'fixtures', 'calls')
+
+describe('call extraction beyond HTTP', () => {
+  beforeEach(() => resetGraph())
+
+  it('emits PUBLISHES_TO + CONSUMES_FROM kafka edges with evidence', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    expect(graph.hasNode('infra:kafka-topic:orders')).toBe(true)
+    expect(graph.hasNode('infra:kafka-topic:shipments')).toBe(true)
+
+    const ordersTopic = graph.getNodeAttributes('infra:kafka-topic:orders') as InfraNode
+    expect(ordersTopic.kind).toBe('kafka-topic')
+    expect(ordersTopic.name).toBe('orders')
+
+    const publishEdgeId =
+      'PUBLISHES_TO:service:fixture-kafka-service->infra:kafka-topic:orders'
+    expect(graph.hasEdge(publishEdgeId)).toBe(true)
+    const publishEdge = graph.getEdgeAttributes(publishEdgeId) as GraphEdge
+    expect(publishEdge.evidence?.file).toBe('index.js')
+    expect(publishEdge.evidence?.line).toBeGreaterThan(0)
+    expect(publishEdge.evidence?.snippet).toContain('orders')
+
+    const consumeEdgeId =
+      'CONSUMES_FROM:service:fixture-kafka-service->infra:kafka-topic:shipments'
+    expect(graph.hasEdge(consumeEdgeId)).toBe(true)
+  })
+
+  it('emits redis InfraNode + CALLS edge from a redis:// URL', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    expect(graph.hasNode('infra:redis:cache.internal')).toBe(true)
+    const redisNode = graph.getNodeAttributes('infra:redis:cache.internal') as InfraNode
+    expect(redisNode.kind).toBe('redis')
+
+    const edgeId = 'CALLS:service:fixture-redis-service->infra:redis:cache.internal'
+    expect(graph.hasEdge(edgeId)).toBe(true)
+  })
+
+  it('emits S3 + DynamoDB InfraNodes from AWS SDK calls', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    const bucket = graph.getNodeAttributes('infra:s3-bucket:invoices') as InfraNode
+    expect(bucket.provider).toBe('aws')
+    expect(bucket.kind).toBe('s3-bucket')
+
+    const table = graph.getNodeAttributes('infra:dynamodb-table:orders-table') as InfraNode
+    expect(table.kind).toBe('dynamodb-table')
+  })
+
+  it('emits a gRPC infra node + CALLS edge', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    expect(graph.hasNode('infra:grpc-service:orders.internal:50051')).toBe(true)
+    const edgeId =
+      'CALLS:service:fixture-grpc-service->infra:grpc-service:orders.internal:50051'
+    expect(graph.hasEdge(edgeId)).toBe(true)
+  })
+})

--- a/packages/core/test/fixtures/calls/aws-service/index.js
+++ b/packages/core/test/fixtures/calls/aws-service/index.js
@@ -1,0 +1,13 @@
+const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3')
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb')
+const { GetCommand } = require('@aws-sdk/lib-dynamodb')
+
+const s3 = new S3Client({})
+const dynamo = new DynamoDBClient({})
+
+async function write() {
+  await s3.send(new PutObjectCommand({ Bucket: 'invoices', Key: 'a.pdf', Body: 'x' }))
+  await dynamo.send(new GetCommand({ TableName: 'orders-table', Key: { id: '1' } }))
+}
+
+module.exports = { write }

--- a/packages/core/test/fixtures/calls/aws-service/package.json
+++ b/packages/core/test/fixtures/calls/aws-service/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-aws-service",
+  "version": "1.0.0"
+}

--- a/packages/core/test/fixtures/calls/grpc-service/index.js
+++ b/packages/core/test/fixtures/calls/grpc-service/index.js
@@ -1,0 +1,6 @@
+const grpc = require('@grpc/grpc-js')
+const { OrdersClient } = require('./generated/orders_grpc_pb')
+
+const client = new OrdersClient('orders.internal:50051', grpc.credentials.createInsecure())
+
+module.exports = { client }

--- a/packages/core/test/fixtures/calls/grpc-service/package.json
+++ b/packages/core/test/fixtures/calls/grpc-service/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-grpc-service",
+  "version": "1.0.0"
+}

--- a/packages/core/test/fixtures/calls/kafka-service/index.js
+++ b/packages/core/test/fixtures/calls/kafka-service/index.js
@@ -1,0 +1,18 @@
+const { Kafka } = require('kafkajs')
+
+const kafka = new Kafka({ clientId: 'demo', brokers: ['kafka:9092'] })
+const producer = kafka.producer()
+const consumer = kafka.consumer({ groupId: 'demo-group' })
+
+async function publish() {
+  await producer.send({
+    topic: 'orders',
+    messages: [{ value: 'hello' }],
+  })
+}
+
+async function listen() {
+  await consumer.subscribe({ topic: 'shipments', fromBeginning: true })
+}
+
+module.exports = { publish, listen }

--- a/packages/core/test/fixtures/calls/kafka-service/package.json
+++ b/packages/core/test/fixtures/calls/kafka-service/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-kafka-service",
+  "version": "1.0.0"
+}

--- a/packages/core/test/fixtures/calls/redis-service/index.js
+++ b/packages/core/test/fixtures/calls/redis-service/index.js
@@ -1,0 +1,5 @@
+const { createClient } = require('redis')
+
+const client = createClient({ url: 'redis://cache.internal:6379' })
+
+module.exports = { client }

--- a/packages/core/test/fixtures/calls/redis-service/package.json
+++ b/packages/core/test/fixtures/calls/redis-service/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-redis-service",
+  "version": "1.0.0"
+}

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -13,6 +13,8 @@ export const EdgeType = {
   DEPENDS_ON: 'DEPENDS_ON',
   CONNECTS_TO: 'CONNECTS_TO',
   CONFIGURED_BY: 'CONFIGURED_BY',
+  PUBLISHES_TO: 'PUBLISHES_TO',
+  CONSUMES_FROM: 'CONSUMES_FROM',
 } as const
 
 export type EdgeTypeValue = (typeof EdgeType)[keyof typeof EdgeType]

--- a/packages/types/src/edges.ts
+++ b/packages/types/src/edges.ts
@@ -14,7 +14,16 @@ export const EdgeTypeSchema = z.enum([
   EdgeType.DEPENDS_ON,
   EdgeType.CONNECTS_TO,
   EdgeType.CONFIGURED_BY,
+  EdgeType.PUBLISHES_TO,
+  EdgeType.CONSUMES_FROM,
 ])
+
+export const EdgeEvidenceSchema = z.object({
+  file: z.string(),
+  line: z.number().int().nonnegative(),
+  snippet: z.string(),
+})
+export type EdgeEvidence = z.infer<typeof EdgeEvidenceSchema>
 
 export const GraphEdgeSchema = z.object({
   id: z.string(),
@@ -25,5 +34,6 @@ export const GraphEdgeSchema = z.object({
   confidence: z.number().min(0).max(1).optional(),
   lastObserved: z.string().datetime().optional(),
   callCount: z.number().int().nonnegative().optional(),
+  evidence: EdgeEvidenceSchema.optional(),
 })
 export type GraphEdge = z.infer<typeof GraphEdgeSchema>

--- a/packages/types/src/nodes.ts
+++ b/packages/types/src/nodes.ts
@@ -57,6 +57,7 @@ export const InfraNodeSchema = z.object({
   name: z.string(),
   provider: z.string(),
   region: z.string().optional(),
+  kind: z.string().optional(),
 })
 export type InfraNode = z.infer<typeof InfraNodeSchema>
 

--- a/packages/types/test/schemas.test.ts
+++ b/packages/types/test/schemas.test.ts
@@ -19,8 +19,8 @@ describe('runtime constants', () => {
   it('Provenance has 5 values', () => {
     expect(Object.values(Provenance)).toHaveLength(5)
   })
-  it('EdgeType has 4 values', () => {
-    expect(Object.values(EdgeType)).toHaveLength(4)
+  it('EdgeType has 6 values', () => {
+    expect(Object.values(EdgeType)).toHaveLength(6)
   })
   it('NodeType has 4 values', () => {
     expect(Object.values(NodeType)).toHaveLength(4)


### PR DESCRIPTION
Refs #71.

ADR-012 capped extraction at \"URL substring matching only.\" Real codebases use Kafka, Redis, gRPC, and the AWS SDK alongside (or instead of) HTTP, so the graph stayed silent on a lot of real traffic.

## What's different

`extract/calls.ts` becomes a directory: one detector per transport, plus an orchestrator that walks every service's source files and emits the right shape of node + edge.

| Source | Node | Edge |
|---|---|---|
| `producer.send({ topic: 'orders' })` (kafkajs / node-rdkafka shape) | `infra:kafka-topic:<topic>` | `PUBLISHES_TO` |
| `consumer.subscribe({ topic: 'orders' })` | `infra:kafka-topic:<topic>` | `CONSUMES_FROM` |
| `redis://host[:port]` literal | `infra:redis:<host>` | `CALLS` |
| `S3Client` + `Bucket: 'x'` | `infra:s3-bucket:x` (provider=`aws`) | `CALLS` |
| `DynamoDBClient` + `TableName: 'y'` | `infra:dynamodb-table:y` | `CALLS` |
| `new <Name>Client('host:port', ...)` (gRPC) | `infra:grpc-service:<addr-or-symbol>` | `CALLS` |
| HTTP URL substring (existing) | (target service) | `CALLS` |

`PUBLISHES_TO` and `CONSUMES_FROM` are new entries on `EdgeType` + `EdgeTypeSchema`. `InfraNodeSchema` gets an optional `kind` field for sub-typing (mentioned in #73 too — added here so #71 has somewhere to put `kafka-topic` / `redis` / `s3-bucket` / etc.).

## Edge evidence

`GraphEdgeSchema` gains an optional `evidence: { file, line, snippet }`. Every detector populates it pointing at the source location that justified the edge. The HTTP detector populates it too — the edge id is unchanged, just richer.

Snapshot stays at v2: every change is additive (new optional fields, new enum values).

## Verification

- New `calls.test.ts` walks a fixtures dir with one service per transport and asserts the right nodes / edges / evidence land in the graph.
- Existing `extract.test.ts` still passes against `demo/` — the HTTP `CALLS:service-a->service-b` edge is byte-for-byte the same it was, just with evidence attached.
- Workspace stays green: `npx turbo build test lint` clean (109 core / 25 types / 17 mcp tests).

## Test plan

- [x] `npx turbo build test lint`
- [x] `node packages/core/dist/cli.cjs init ./demo` — same node/edge counts, same incompatibility list.