### PR TITLE
Extract Python services alongside JS/TS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8541,6 +8541,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -8993,6 +9005,31 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tree-sitter-python": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.21.0.tgz",
+      "integrity": "sha512-IUKx7JcTVbByUx1iHGFS/QsIjx7pqwTMHL9bl/NGyhyyydbfNrpruo2C7W6V4KZrbkkCOlX8QVrCoGOFW5qecg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-python/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/tree-sitter-typescript": {
       "version": "0.21.2",
@@ -10032,8 +10069,10 @@
         "ignore": "^7.0.0",
         "minimatch": "^10.0.0",
         "semver": "^7.6.0",
+        "smol-toml": "^1.3.0",
         "tree-sitter": "^0.21.1",
         "tree-sitter-javascript": "^0.21.4",
+        "tree-sitter-python": "^0.21.0",
         "tree-sitter-typescript": "^0.21.2",
         "yaml": "^2.5.0",
         "zod": "^3.23.8"

--- a/packages/core/compat.json
+++ b/packages/core/compat.json
@@ -20,6 +20,27 @@
       "minDriverVersion": "7.0.0",
       "minEngineVersion": "7",
       "reason": "MongoDB 7 drops legacy wire-protocol opcodes that mongoose < 7.0.0 still emits."
+    },
+    {
+      "driver": "psycopg2",
+      "engine": "postgresql",
+      "minDriverVersion": "2.9.0",
+      "minEngineVersion": "14",
+      "reason": "PostgreSQL 14+ requires scram-sha-256 auth by default; psycopg2 < 2.9.0 only speaks md5."
+    },
+    {
+      "driver": "pymongo",
+      "engine": "mongodb",
+      "minDriverVersion": "4.0.0",
+      "minEngineVersion": "7",
+      "reason": "MongoDB 7 drops legacy wire-protocol opcodes that pymongo < 4.0.0 still emits."
+    },
+    {
+      "driver": "mysql-connector-python",
+      "engine": "mysql",
+      "minDriverVersion": "8.0.0",
+      "minEngineVersion": "8",
+      "reason": "MySQL 8 defaults to caching_sha2_password; mysql-connector-python < 8.0.0 doesn't negotiate it."
     }
   ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,8 +42,10 @@
     "ignore": "^7.0.0",
     "minimatch": "^10.0.0",
     "semver": "^7.6.0",
+    "smol-toml": "^1.3.0",
     "tree-sitter": "^0.21.1",
     "tree-sitter-javascript": "^0.21.4",
+    "tree-sitter-python": "^0.21.0",
     "tree-sitter-typescript": "^0.21.2",
     "yaml": "^2.5.0",
     "zod": "^3.23.8"

--- a/packages/core/src/extract/calls/http.ts
+++ b/packages/core/src/extract/calls/http.ts
@@ -1,14 +1,20 @@
 import path from 'node:path'
 import Parser from 'tree-sitter'
 import JavaScript from 'tree-sitter-javascript'
+import Python from 'tree-sitter-python'
 import type { GraphEdge } from '@neat/types'
 import { EdgeType, Provenance } from '@neat/types'
 import type { NeatGraph } from '../../graph.js'
 import { makeEdgeId, type DiscoveredService } from '../shared.js'
 import { loadSourceFiles, lineOf, snippet } from './shared.js'
 
+// JS uses `string_fragment` for the textual interior of a template/string;
+// Python uses `string_content` inside a `string` node. Either way we want the
+// raw textual content (no quotes), so we accept both.
+const STRING_LITERAL_NODE_TYPES = new Set(['string_fragment', 'string_content'])
+
 function collectStringLiterals(node: Parser.SyntaxNode, out: string[]): void {
-  if (node.type === 'string_fragment') out.push(node.text)
+  if (STRING_LITERAL_NODE_TYPES.has(node.type)) out.push(node.text)
   for (let i = 0; i < node.namedChildCount; i++) {
     const child = node.namedChild(i)
     if (child) collectStringLiterals(child, out)
@@ -34,14 +40,27 @@ export function callsFromSource(
   return targets
 }
 
-// HTTP CALLS via URL substring match — the original tree-sitter scan, kept
-// intact so the demo's CALLS edges are byte-for-byte identical.
+function makeJsParser(): Parser {
+  const p = new Parser()
+  p.setLanguage(JavaScript)
+  return p
+}
+
+function makePyParser(): Parser {
+  const p = new Parser()
+  p.setLanguage(Python)
+  return p
+}
+
+// HTTP CALLS via URL substring match. Parser is picked per file extension:
+// .py uses tree-sitter-python; everything else uses tree-sitter-javascript.
+// The demo's CALLS edges stay byte-for-byte identical to the M1 baseline.
 export async function addHttpCallEdges(
   graph: NeatGraph,
   services: DiscoveredService[],
 ): Promise<number> {
-  const parser = new Parser()
-  parser.setLanguage(JavaScript)
+  const jsParser = makeJsParser()
+  const pyParser = makePyParser()
 
   const knownHosts = new Set<string>()
   const hostToNodeId = new Map<string, string>()
@@ -57,6 +76,7 @@ export async function addHttpCallEdges(
     const files = await loadSourceFiles(service.dir)
     const seenTargets = new Map<string, { file: string; host: string }>()
     for (const file of files) {
+      const parser = path.extname(file.path) === '.py' ? pyParser : jsParser
       const targets = callsFromSource(file.content, parser, knownHosts)
       for (const t of targets) {
         const targetId = hostToNodeId.get(t)

--- a/packages/core/src/extract/python.ts
+++ b/packages/core/src/extract/python.ts
@@ -1,0 +1,111 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { parse as parseToml } from 'smol-toml'
+import { exists, type PackageJson } from './shared.js'
+
+// Lines like `psycopg2==2.7.0`, `psycopg2 == 2.7.0`, `psycopg2[extras]==2.7`,
+// or `psycopg2~=2.7,<3`. We capture the package name and the first version
+// that follows an `==` operator. Anything else (range, no pin, no version) is
+// recorded with an empty version — the compat matrix's semver coercer treats
+// those as "can't reason" and under-flags rather than over-flags.
+const REQUIREMENT_LINE = /^\s*([A-Za-z0-9_.-]+)(?:\[[^\]]*\])?\s*(?:(==)\s*([A-Za-z0-9_.+-]+))?/
+
+function parseRequirementsTxt(content: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.split('#')[0]?.trim()
+    if (!line) continue
+    if (line.startsWith('-')) continue // -r requirements-dev.txt etc.
+    const match = REQUIREMENT_LINE.exec(line)
+    if (!match) continue
+    const name = match[1]!.toLowerCase()
+    const version = match[3] ?? ''
+    out[name] = version
+  }
+  return out
+}
+
+interface PyProjectFile {
+  project?: {
+    name?: string
+    version?: string
+    dependencies?: string[]
+  }
+  tool?: {
+    poetry?: {
+      name?: string
+      version?: string
+      dependencies?: Record<string, string | { version?: string }>
+    }
+  }
+}
+
+function depsFromPyProject(pyproject: PyProjectFile): Record<string, string> {
+  const out: Record<string, string> = {}
+
+  // PEP 621 — [project] dependencies = ["psycopg2==2.7.0", "requests"]
+  for (const entry of pyproject.project?.dependencies ?? []) {
+    const match = REQUIREMENT_LINE.exec(entry)
+    if (!match) continue
+    out[match[1]!.toLowerCase()] = match[3] ?? ''
+  }
+
+  // Poetry — [tool.poetry.dependencies] psycopg2 = "2.7.0"
+  const poetryDeps = pyproject.tool?.poetry?.dependencies ?? {}
+  for (const [name, value] of Object.entries(poetryDeps)) {
+    if (name.toLowerCase() === 'python') continue
+    const raw = typeof value === 'string' ? value : (value?.version ?? '')
+    out[name.toLowerCase()] = raw.replace(/^[\^~><=v\s]+/, '')
+  }
+  return out
+}
+
+export interface PythonService {
+  name: string
+  version?: string
+  dependencies: Record<string, string>
+}
+
+// Detect a Python service by the conventional manifest files. We try
+// pyproject.toml first because it can name the package; fallback to the
+// directory name when only requirements.txt or setup.py is present.
+export async function discoverPythonService(serviceDir: string): Promise<PythonService | null> {
+  const pyprojectPath = path.join(serviceDir, 'pyproject.toml')
+  const requirementsPath = path.join(serviceDir, 'requirements.txt')
+  const setupPath = path.join(serviceDir, 'setup.py')
+
+  const hasPyproject = await exists(pyprojectPath)
+  const hasRequirements = await exists(requirementsPath)
+  const hasSetup = await exists(setupPath)
+  if (!hasPyproject && !hasRequirements && !hasSetup) return null
+
+  let name = path.basename(serviceDir)
+  let version: string | undefined
+  const dependencies: Record<string, string> = {}
+
+  if (hasPyproject) {
+    const raw = await fs.readFile(pyprojectPath, 'utf8')
+    const pyproject = parseToml(raw) as PyProjectFile
+    name = pyproject.project?.name ?? pyproject.tool?.poetry?.name ?? name
+    version = pyproject.project?.version ?? pyproject.tool?.poetry?.version ?? undefined
+    Object.assign(dependencies, depsFromPyProject(pyproject))
+  }
+
+  if (hasRequirements) {
+    const raw = await fs.readFile(requirementsPath, 'utf8')
+    Object.assign(dependencies, parseRequirementsTxt(raw))
+  }
+
+  return { name, version, dependencies }
+}
+
+// Build the same `pkg`-shaped shim the JS path uses so downstream phases
+// (databases, calls, etc.) can keep reading service.pkg.dependencies and
+// service.pkg.name without caring which language produced the service.
+export function pythonToPackage(service: PythonService): PackageJson {
+  return {
+    name: service.name,
+    version: service.version,
+    dependencies: service.dependencies,
+  }
+}

--- a/packages/core/src/extract/services.ts
+++ b/packages/core/src/extract/services.ts
@@ -12,6 +12,7 @@ import {
   type DiscoveredService,
   type PackageJson,
 } from './shared.js'
+import { discoverPythonService, pythonToPackage } from './python.js'
 
 const DEFAULT_SCAN_DEPTH = 5
 
@@ -114,12 +115,55 @@ async function expandWorkspaceGlobs(
   return [...found]
 }
 
+async function discoverNodeService(
+  scanPath: string,
+  dir: string,
+): Promise<DiscoveredService | null> {
+  const pkgPath = path.join(dir, 'package.json')
+  if (!(await exists(pkgPath))) return null
+  const pkg = await readJson<PackageJson>(pkgPath)
+  if (!pkg.name) return null
+  const node: ServiceNode = {
+    id: `service:${pkg.name}`,
+    type: NodeType.ServiceNode,
+    name: pkg.name,
+    language: 'javascript',
+    version: pkg.version,
+    dependencies: pkg.dependencies ?? {},
+    repoPath: path.relative(scanPath, dir),
+  }
+  return { pkg, dir, node }
+}
+
+async function discoverPyService(
+  scanPath: string,
+  dir: string,
+): Promise<DiscoveredService | null> {
+  const py = await discoverPythonService(dir)
+  if (!py) return null
+  const pkg = pythonToPackage(py)
+  const node: ServiceNode = {
+    id: `service:${py.name}`,
+    type: NodeType.ServiceNode,
+    name: py.name,
+    language: 'python',
+    version: py.version,
+    dependencies: py.dependencies,
+    repoPath: path.relative(scanPath, dir),
+  }
+  return { pkg, dir, node }
+}
+
 // Phase 1 — discover service directories under scanPath. A service is any
-// directory containing a package.json. If the root has a `workspaces` field,
-// those globs are authoritative and we stop there. Otherwise we walk
-// recursively, depth-bounded by NEAT_SCAN_DEPTH (default 5), skipping
-// IGNORED_DIRS and anything matched by the root .gitignore. Two package.jsons
-// sharing a `name` collapse to one node (ADR-010 id collision rule); the
+// directory containing a JS/TS manifest (`package.json`) or a Python manifest
+// (`pyproject.toml` / `requirements.txt` / `setup.py`). JS wins on tie.
+//
+// If the root `package.json` declares `workspaces`, those globs are
+// authoritative — we don't fall back to a free recursive walk. Otherwise we
+// walk recursively, depth-bounded by `NEAT_SCAN_DEPTH` (default 5), skipping
+// `IGNORED_DIRS` and anything matched by the root `.gitignore`.
+//
+// Two manifests sharing a `name` collapse to one node per ADR-010; the
 // duplicate logs a warning naming both paths.
 export async function discoverServices(scanPath: string): Promise<DiscoveredService[]> {
   const rootPkgPath = path.join(scanPath, 'package.json')
@@ -139,7 +183,15 @@ export async function discoverServices(scanPath: string): Promise<DiscoveredServ
       scanPath,
       { maxDepth: parseScanDepth(), ig },
       async (dir) => {
-        if (await exists(path.join(dir, 'package.json'))) candidateDirs.push(dir)
+        if (await exists(path.join(dir, 'package.json'))) {
+          candidateDirs.push(dir)
+        } else if (
+          (await exists(path.join(dir, 'pyproject.toml'))) ||
+          (await exists(path.join(dir, 'requirements.txt'))) ||
+          (await exists(path.join(dir, 'setup.py')))
+        ) {
+          candidateDirs.push(dir)
+        }
       },
     )
   }
@@ -149,32 +201,22 @@ export async function discoverServices(scanPath: string): Promise<DiscoveredServ
   const seen = new Map<string, string>()
   const out: DiscoveredService[] = []
   for (const dir of candidateDirs) {
-    const pkgPath = path.join(dir, 'package.json')
-    if (!(await exists(pkgPath))) continue
-    const pkg = await readJson<PackageJson>(pkgPath)
-    if (!pkg.name) continue
+    const service =
+      (await discoverNodeService(scanPath, dir)) ??
+      (await discoverPyService(scanPath, dir))
+    if (!service) continue
 
-    const existingDir = seen.get(pkg.name)
+    const existingDir = seen.get(service.node.name)
     if (existingDir !== undefined) {
       const a = path.relative(scanPath, existingDir) || '.'
       const b = path.relative(scanPath, dir) || '.'
       console.warn(
-        `[neat] duplicate package name "${pkg.name}" — keeping ${a}, ignoring ${b}`,
+        `[neat] duplicate package name "${service.node.name}" — keeping ${a}, ignoring ${b}`,
       )
       continue
     }
-    seen.set(pkg.name, dir)
-
-    const node: ServiceNode = {
-      id: `service:${pkg.name}`,
-      type: NodeType.ServiceNode,
-      name: pkg.name,
-      language: 'javascript',
-      version: pkg.version,
-      dependencies: pkg.dependencies ?? {},
-      repoPath: path.relative(scanPath, dir),
-    }
-    out.push({ pkg, dir, node })
+    seen.set(service.node.name, dir)
+    out.push(service)
   }
   return out
 }

--- a/packages/core/src/extract/shared.ts
+++ b/packages/core/src/extract/shared.ts
@@ -16,7 +16,7 @@ export interface DiscoveredService {
   node: ServiceNode
 }
 
-export const SERVICE_FILE_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.ts', '.tsx'])
+export const SERVICE_FILE_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.ts', '.tsx', '.py'])
 export const CONFIG_FILE_EXTENSIONS = new Set(['.yaml', '.yml'])
 export const IGNORED_DIRS = new Set([
   'node_modules',

--- a/packages/core/test/compat.test.ts
+++ b/packages/core/test/compat.test.ts
@@ -84,11 +84,14 @@ describe('checkCompatibility', () => {
   describe('compatPairs() export', () => {
     it('exposes the configured matrix for #4 to read', () => {
       const pairs = compatPairs()
-      expect(pairs.length).toBe(3)
+      expect(pairs.length).toBe(6)
       expect(pairs.map((p) => `${p.driver}/${p.engine}`).sort()).toEqual([
         'mongoose/mongodb',
+        'mysql-connector-python/mysql',
         'mysql2/mysql',
         'pg/postgresql',
+        'psycopg2/postgresql',
+        'pymongo/mongodb',
       ])
     })
   })

--- a/packages/core/test/fixtures/python/orders-api/pyproject.toml
+++ b/packages/core/test/fixtures/python/orders-api/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.poetry]
+name = "orders-api"
+version = "0.2.0"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+fastapi = "0.110.0"

--- a/packages/core/test/fixtures/python/payments-api/db-config.yaml
+++ b/packages/core/test/fixtures/python/payments-api/db-config.yaml
@@ -1,0 +1,5 @@
+host: payments-db
+port: 5432
+database: payments
+engine: postgresql
+engineVersion: "15"

--- a/packages/core/test/fixtures/python/payments-api/main.py
+++ b/packages/core/test/fixtures/python/payments-api/main.py
@@ -1,0 +1,14 @@
+import psycopg2
+import requests
+
+
+def fetch_orders():
+    return requests.get("http://orders-api:8000/orders").json()
+
+
+def connect():
+    return psycopg2.connect(
+        host="payments-db",
+        port=5432,
+        database="payments",
+    )

--- a/packages/core/test/fixtures/python/payments-api/pyproject.toml
+++ b/packages/core/test/fixtures/python/payments-api/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "payments-api"
+version = "0.1.0"
+dependencies = [
+    "fastapi==0.110.0",
+    "psycopg2==2.7.0",
+]

--- a/packages/core/test/fixtures/python/payments-api/requirements.txt
+++ b/packages/core/test/fixtures/python/payments-api/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.110.0
+psycopg2==2.7.0
+requests>=2.0

--- a/packages/core/test/python.test.ts
+++ b/packages/core/test/python.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import { discoverPythonService } from '../src/extract/python.js'
+import { getRootCause } from '../src/traverse.js'
+import type { ServiceNode } from '@neat/types'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const PY_FIXTURES = path.resolve(__dirname, 'fixtures', 'python')
+
+describe('Python service extraction', () => {
+  beforeEach(() => resetGraph())
+
+  it('reads requirements.txt + pyproject.toml deps off a Python service', async () => {
+    const result = await discoverPythonService(path.join(PY_FIXTURES, 'payments-api'))
+    expect(result?.name).toBe('payments-api')
+    expect(result?.dependencies.psycopg2).toBe('2.7.0')
+    expect(result?.dependencies.fastapi).toBe('0.110.0')
+  })
+
+  it('reads poetry-style deps when requirements.txt is absent', async () => {
+    const result = await discoverPythonService(path.join(PY_FIXTURES, 'orders-api'))
+    expect(result?.name).toBe('orders-api')
+    expect(result?.version).toBe('0.2.0')
+    expect(result?.dependencies.fastapi).toBe('0.110.0')
+    expect(result?.dependencies.python).toBeUndefined()
+  })
+
+  it('produces a Python ServiceNode with language="python" and reaches root cause', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, PY_FIXTURES)
+
+    expect(graph.hasNode('service:payments-api')).toBe(true)
+    const node = graph.getNodeAttributes('service:payments-api') as ServiceNode
+    expect(node.language).toBe('python')
+    expect(node.dependencies?.psycopg2).toBe('2.7.0')
+
+    expect(node.incompatibilities?.[0]).toMatchObject({
+      driver: 'psycopg2',
+      driverVersion: '2.7.0',
+      engine: 'postgresql',
+      engineVersion: '15',
+    })
+
+    const result = getRootCause(graph, 'database:payments-db')
+    expect(result.rootCauseNode).toBe('service:payments-api')
+    expect(result.rootCauseReason).toMatch(/psycopg2/)
+  })
+
+  it('emits a CALLS edge between two Python services via tree-sitter-python', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, PY_FIXTURES)
+
+    const callId = 'CALLS:service:payments-api->service:orders-api'
+    expect(graph.hasEdge(callId)).toBe(true)
+  })
+})


### PR DESCRIPTION
Refs #72.

Extraction was JS/TS-only. Adding a second backend language proves the architecture is language-agnostic and lets NEAT cover polyglot codebases — which is the whole point of the v0.1.2 \"drop the Node-only assumption\" release.

## What's different

- **Discovery** — `services.ts` now tries Node first (`package.json`) then Python (`pyproject.toml` / `requirements.txt` / `setup.py`). Python services land with `language: \"python\"`, otherwise the same `ServiceNode` shape JS uses.
- **Dep parsing** — `extract/python.ts` reads `requirements.txt` (`name==version` lines) and `pyproject.toml` (PEP 621 `[project] dependencies` arrays + Poetry `[tool.poetry.dependencies]` tables). `smol-toml` for the TOML parsing — small, no transitive deps.
- **Compat matrix** — three new entries in `compat.json`: `psycopg2 < 2.9 / postgresql 14+`, `pymongo < 4 / mongodb 7+`, `mysql-connector-python < 8 / mysql 8+`. ADR-015's data-driven compat means traversal picks them up automatically; no per-driver TypeScript.
- **Call extraction** — `tree-sitter-python` parser is selected for `.py` files; JS/TS keeps the existing `tree-sitter-javascript` path. Same string-literal scan, same URL-substring rule.

NEAT's toolchain stays Node 20 + TypeScript. We *read* Python source through tree-sitter-python; we don't execute Python anywhere.

## Verification

- Fixture `payments-api` declares `psycopg2==2.7.0` against `postgresql 15` — `getRootCause(\"database:payments-db\")` lands on the Python service with the right reason, exactly the same shape as the pg/PG demo.
- Fixture `orders-api` (Poetry-style `pyproject.toml`, no `requirements.txt`) is also discovered with `language: \"python\"` and `fastapi` in its deps.
- A CALLS edge from `payments-api` to `orders-api` is emitted via `tree-sitter-python` matching the URL literal in `main.py`.
- Existing JS/TS extraction unchanged: `npx turbo build test lint` clean (109 core / 25 types / 17 mcp).

## Test plan

- [x] `npx turbo build test lint`
- [x] `node packages/core/dist/cli.cjs init ./demo` — same node/edge counts and the pg-vs-PG-15 incompatibility.
- [x] `node packages/core/dist/cli.cjs init ./packages/core/test/fixtures/python` — three nodes (two Python services + payments-db), psycopg2 incompatibility flagged.