### PR TITLE
Populate InfraNode from real sources

### DIFF
--- a/packages/core/src/extract/index.ts
+++ b/packages/core/src/extract/index.ts
@@ -3,6 +3,7 @@ import { addServiceNodes, discoverServices } from './services.js'
 import { addDatabasesAndCompat } from './databases/index.js'
 import { addConfigNodes } from './configs.js'
 import { addCallEdges } from './calls/index.js'
+import { addInfra } from './infra/index.js'
 
 export interface ExtractResult {
   nodesAdded: number
@@ -19,9 +20,16 @@ export async function extractFromDirectory(
   const phase2 = await addDatabasesAndCompat(graph, services)
   const phase3 = await addConfigNodes(graph, services, scanPath)
   const phase4 = await addCallEdges(graph, services)
+  const phase5 = await addInfra(graph, scanPath, services)
 
   return {
-    nodesAdded: phase1Nodes + phase2.nodesAdded + phase3.nodesAdded + phase4.nodesAdded,
-    edgesAdded: phase2.edgesAdded + phase3.edgesAdded + phase4.edgesAdded,
+    nodesAdded:
+      phase1Nodes +
+      phase2.nodesAdded +
+      phase3.nodesAdded +
+      phase4.nodesAdded +
+      phase5.nodesAdded,
+    edgesAdded:
+      phase2.edgesAdded + phase3.edgesAdded + phase4.edgesAdded + phase5.edgesAdded,
   }
 }

--- a/packages/core/src/extract/infra/docker-compose.ts
+++ b/packages/core/src/extract/infra/docker-compose.ts
@@ -1,0 +1,98 @@
+import path from 'node:path'
+import type { GraphEdge } from '@neat/types'
+import { EdgeType, Provenance } from '@neat/types'
+import type { NeatGraph } from '../../graph.js'
+import { exists, makeEdgeId, readYaml, type DiscoveredService } from '../shared.js'
+import { classifyImage, makeInfraNode } from './shared.js'
+
+interface ComposeService {
+  image?: string
+  build?: string | { context?: string }
+  depends_on?: string[] | Record<string, unknown>
+}
+
+interface ComposeFile {
+  services?: Record<string, ComposeService>
+}
+
+function dependsOnList(value: ComposeService['depends_on']): string[] {
+  if (!value) return []
+  if (Array.isArray(value)) return value
+  return Object.keys(value)
+}
+
+function serviceNameToServiceNode(
+  name: string,
+  services: DiscoveredService[],
+): string | null {
+  for (const s of services) {
+    if (s.node.name === name || path.basename(s.dir) === name) return s.node.id
+  }
+  return null
+}
+
+// Project-level docker-compose.yml describes deployment topology. Each compose
+// service that is *not* one of the discovered ServiceNodes becomes an
+// InfraNode (databases, brokers, caches). depends_on lists become DEPENDS_ON
+// edges from the dependent to its dependency, regardless of whether the
+// endpoint is a ServiceNode or InfraNode — the edge itself is the deployment
+// fact, not the role.
+export async function addComposeInfra(
+  graph: NeatGraph,
+  scanPath: string,
+  services: DiscoveredService[],
+): Promise<{ nodesAdded: number; edgesAdded: number }> {
+  let nodesAdded = 0
+  let edgesAdded = 0
+
+  let composePath: string | null = null
+  for (const name of ['docker-compose.yml', 'docker-compose.yaml']) {
+    const abs = path.join(scanPath, name)
+    if (await exists(abs)) {
+      composePath = abs
+      break
+    }
+  }
+  if (!composePath) return { nodesAdded, edgesAdded }
+
+  const compose = await readYaml<ComposeFile>(composePath)
+  if (!compose?.services) return { nodesAdded, edgesAdded }
+
+  const composeNameToNodeId = new Map<string, string>()
+  for (const [composeName, svc] of Object.entries(compose.services)) {
+    const matchedServiceId = serviceNameToServiceNode(composeName, services)
+    if (matchedServiceId) {
+      composeNameToNodeId.set(composeName, matchedServiceId)
+      continue
+    }
+    const kind = svc.image ? classifyImage(svc.image) : 'container'
+    const node = makeInfraNode(kind, composeName)
+    if (!graph.hasNode(node.id)) {
+      graph.addNode(node.id, node)
+      nodesAdded++
+    }
+    composeNameToNodeId.set(composeName, node.id)
+  }
+
+  for (const [composeName, svc] of Object.entries(compose.services)) {
+    const sourceId = composeNameToNodeId.get(composeName)
+    if (!sourceId) continue
+    for (const dep of dependsOnList(svc.depends_on)) {
+      const targetId = composeNameToNodeId.get(dep)
+      if (!targetId) continue
+      const edgeId = makeEdgeId(sourceId, targetId, EdgeType.DEPENDS_ON)
+      if (graph.hasEdge(edgeId)) continue
+      const edge: GraphEdge = {
+        id: edgeId,
+        source: sourceId,
+        target: targetId,
+        type: EdgeType.DEPENDS_ON,
+        provenance: Provenance.EXTRACTED,
+      }
+      graph.addEdgeWithKey(edgeId, edge.source, edge.target, edge)
+      edgesAdded++
+    }
+  }
+
+  return { nodesAdded, edgesAdded }
+}

--- a/packages/core/src/extract/infra/dockerfile.ts
+++ b/packages/core/src/extract/infra/dockerfile.ts
@@ -1,0 +1,66 @@
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import type { GraphEdge } from '@neat/types'
+import { EdgeType, Provenance } from '@neat/types'
+import type { NeatGraph } from '../../graph.js'
+import { exists, makeEdgeId, type DiscoveredService } from '../shared.js'
+import { makeInfraNode } from './shared.js'
+
+// Pull the first non-`scratch` `FROM` line out of a Dockerfile, ignoring
+// multi-stage `as` aliases. Returns the image including tag (e.g. `node:20`,
+// `python:3.11-slim`). Multi-stage builds report the *runtime* image — the
+// last FROM that isn't aliasing a previous stage.
+function runtimeImage(content: string): string | null {
+  const lines = content.split('\n')
+  let last: string | null = null
+  for (const raw of lines) {
+    const line = raw.trim()
+    if (!line || line.startsWith('#')) continue
+    if (!/^from\s+/i.test(line)) continue
+    const tokens = line.split(/\s+/)
+    const image = tokens[1]
+    if (!image || image.toLowerCase() === 'scratch') continue
+    last = image
+  }
+  return last
+}
+
+// For each ServiceNode that has a Dockerfile in its dir, emit a
+// `infra:container-image:<image>` InfraNode and a RUNS_ON edge from the
+// service to the image.
+export async function addDockerfileRuntimes(
+  graph: NeatGraph,
+  services: DiscoveredService[],
+): Promise<{ nodesAdded: number; edgesAdded: number }> {
+  let nodesAdded = 0
+  let edgesAdded = 0
+
+  for (const service of services) {
+    const dockerfilePath = path.join(service.dir, 'Dockerfile')
+    if (!(await exists(dockerfilePath))) continue
+    const content = await fs.readFile(dockerfilePath, 'utf8')
+    const image = runtimeImage(content)
+    if (!image) continue
+
+    const node = makeInfraNode('container-image', image)
+    if (!graph.hasNode(node.id)) {
+      graph.addNode(node.id, node)
+      nodesAdded++
+    }
+
+    const edgeId = makeEdgeId(service.node.id, node.id, EdgeType.RUNS_ON)
+    if (!graph.hasEdge(edgeId)) {
+      const edge: GraphEdge = {
+        id: edgeId,
+        source: service.node.id,
+        target: node.id,
+        type: EdgeType.RUNS_ON,
+        provenance: Provenance.EXTRACTED,
+      }
+      graph.addEdgeWithKey(edgeId, edge.source, edge.target, edge)
+      edgesAdded++
+    }
+  }
+
+  return { nodesAdded, edgesAdded }
+}

--- a/packages/core/src/extract/infra/index.ts
+++ b/packages/core/src/extract/infra/index.ts
@@ -1,0 +1,32 @@
+import type { NeatGraph } from '../../graph.js'
+import { type DiscoveredService } from '../shared.js'
+import { addComposeInfra } from './docker-compose.js'
+import { addDockerfileRuntimes } from './dockerfile.js'
+import { addTerraformResources } from './terraform.js'
+import { addK8sResources } from './k8s.js'
+
+export interface InfraExtractResult {
+  nodesAdded: number
+  edgesAdded: number
+}
+
+// Phase 5 — infrastructure. Runs after services so RUNS_ON edges have a
+// ServiceNode to anchor on. Each sub-source contributes its own nodes/edges
+// independently; nothing here mutates ServiceNodes themselves.
+export async function addInfra(
+  graph: NeatGraph,
+  scanPath: string,
+  services: DiscoveredService[],
+): Promise<InfraExtractResult> {
+  const compose = await addComposeInfra(graph, scanPath, services)
+  const dockerfile = await addDockerfileRuntimes(graph, services)
+  const terraform = await addTerraformResources(graph, scanPath)
+  const k8s = await addK8sResources(graph, scanPath)
+
+  return {
+    nodesAdded:
+      compose.nodesAdded + dockerfile.nodesAdded + terraform.nodesAdded + k8s.nodesAdded,
+    edgesAdded:
+      compose.edgesAdded + dockerfile.edgesAdded + terraform.edgesAdded + k8s.edgesAdded,
+  }
+}

--- a/packages/core/src/extract/infra/k8s.ts
+++ b/packages/core/src/extract/infra/k8s.ts
@@ -1,0 +1,71 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { parseAllDocuments } from 'yaml'
+import type { NeatGraph } from '../../graph.js'
+import { CONFIG_FILE_EXTENSIONS, IGNORED_DIRS } from '../shared.js'
+import { makeInfraNode } from './shared.js'
+
+interface K8sDoc {
+  kind?: string
+  metadata?: { name?: string; namespace?: string }
+}
+
+const K8S_KIND_TO_INFRA_KIND: Record<string, string> = {
+  Service: 'k8s-service',
+  Deployment: 'k8s-deployment',
+  StatefulSet: 'k8s-statefulset',
+  DaemonSet: 'k8s-daemonset',
+  CronJob: 'k8s-cronjob',
+  Job: 'k8s-job',
+  Ingress: 'k8s-ingress',
+}
+
+async function walkYamlFiles(start: string, depth = 0, max = 5): Promise<string[]> {
+  if (depth > max) return []
+  const out: string[] = []
+  const entries = await fs.readdir(start, { withFileTypes: true }).catch(() => [])
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (IGNORED_DIRS.has(entry.name)) continue
+      out.push(...(await walkYamlFiles(path.join(start, entry.name), depth + 1, max)))
+    } else if (entry.isFile() && CONFIG_FILE_EXTENSIONS.has(path.extname(entry.name))) {
+      out.push(path.join(start, entry.name))
+    }
+  }
+  return out
+}
+
+// Multi-document YAML with kind/metadata.name. We keep the matching simple:
+// any file whose first doc looks k8s-shaped. The match is on `kind` only —
+// random YAML configs (db-config.yaml, etc.) are usually flat objects with no
+// `kind` field, so they're ignored without false positives.
+export async function addK8sResources(
+  graph: NeatGraph,
+  scanPath: string,
+): Promise<{ nodesAdded: number; edgesAdded: number }> {
+  let nodesAdded = 0
+  const files = await walkYamlFiles(scanPath)
+  for (const file of files) {
+    const content = await fs.readFile(file, 'utf8')
+    let docs: K8sDoc[]
+    try {
+      docs = parseAllDocuments(content).map((d) => d.toJSON() as K8sDoc)
+    } catch {
+      continue
+    }
+    for (const doc of docs) {
+      if (!doc?.kind || !doc.metadata?.name) continue
+      const infraKind = K8S_KIND_TO_INFRA_KIND[doc.kind]
+      if (!infraKind) continue
+      const namespaced = doc.metadata.namespace
+        ? `${doc.metadata.namespace}/${doc.metadata.name}`
+        : doc.metadata.name
+      const node = makeInfraNode(infraKind, namespaced, 'kubernetes')
+      if (!graph.hasNode(node.id)) {
+        graph.addNode(node.id, node)
+        nodesAdded++
+      }
+    }
+  }
+  return { nodesAdded, edgesAdded: 0 }
+}

--- a/packages/core/src/extract/infra/shared.ts
+++ b/packages/core/src/extract/infra/shared.ts
@@ -1,0 +1,37 @@
+import type { InfraNode } from '@neat/types'
+import { NodeType } from '@neat/types'
+
+// ADR-010 reserves the `infra:` prefix; the kind segment lets traversal and
+// MCP tools sub-type without inventing a new top-level NodeType per source.
+export function makeInfraNode(
+  kind: string,
+  name: string,
+  provider = 'self',
+  extras?: { region?: string },
+): InfraNode {
+  return {
+    id: `infra:${kind}:${name}`,
+    type: NodeType.InfraNode,
+    name,
+    provider,
+    kind,
+    ...(extras?.region ? { region: extras.region } : {}),
+  }
+}
+
+// Stable kind for an image string like "postgres:15-alpine" or "mysql:8".
+// The image name itself ends up in the InfraNode `name` field; this function
+// only classifies what the image *is*, so callers can group similar runtimes.
+export function classifyImage(image: string): string {
+  const lower = image.toLowerCase()
+  const repo = lower.split(':')[0]!
+  const last = repo.split('/').pop() ?? repo
+  if (last.startsWith('postgres')) return 'postgres'
+  if (last.startsWith('mysql') || last.startsWith('mariadb')) return 'mysql'
+  if (last.startsWith('mongo')) return 'mongodb'
+  if (last.startsWith('redis')) return 'redis'
+  if (last.startsWith('rabbitmq')) return 'rabbitmq'
+  if (last.startsWith('kafka') || last.includes('kafka')) return 'kafka'
+  if (last.startsWith('memcached')) return 'memcached'
+  return 'container'
+}

--- a/packages/core/src/extract/infra/terraform.ts
+++ b/packages/core/src/extract/infra/terraform.ts
@@ -1,0 +1,49 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import type { NeatGraph } from '../../graph.js'
+import { IGNORED_DIRS } from '../shared.js'
+import { makeInfraNode } from './shared.js'
+
+// Light pass: catalogue `resource "aws_*" "name"` blocks in any *.tf file.
+// We don't interpret references — a real Terraform backend would resolve
+// those — but the resource-type/name pair is enough to register the node so
+// later cross-references can hang off it.
+const RESOURCE_RE = /resource\s+"(aws_[A-Za-z0-9_]+)"\s+"([A-Za-z0-9_-]+)"/g
+
+async function walkTfFiles(start: string, depth = 0, max = 5): Promise<string[]> {
+  if (depth > max) return []
+  const out: string[] = []
+  const entries = await fs.readdir(start, { withFileTypes: true }).catch(() => [])
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (IGNORED_DIRS.has(entry.name) || entry.name === '.terraform') continue
+      out.push(...(await walkTfFiles(path.join(start, entry.name), depth + 1, max)))
+    } else if (entry.isFile() && entry.name.endsWith('.tf')) {
+      out.push(path.join(start, entry.name))
+    }
+  }
+  return out
+}
+
+export async function addTerraformResources(
+  graph: NeatGraph,
+  scanPath: string,
+): Promise<{ nodesAdded: number; edgesAdded: number }> {
+  let nodesAdded = 0
+  const files = await walkTfFiles(scanPath)
+  for (const file of files) {
+    const content = await fs.readFile(file, 'utf8')
+    RESOURCE_RE.lastIndex = 0
+    let m: RegExpExecArray | null
+    while ((m = RESOURCE_RE.exec(content)) !== null) {
+      const kind = m[1]!
+      const name = m[2]!
+      const node = makeInfraNode(kind, name, 'aws')
+      if (!graph.hasNode(node.id)) {
+        graph.addNode(node.id, node)
+        nodesAdded++
+      }
+    }
+  }
+  return { nodesAdded, edgesAdded: 0 }
+}

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -160,9 +160,10 @@ describe('REST API (fastify.inject)', () => {
     expect(res.statusCode).toBe(200)
     const body = res.json()
     expect(body.origin).toBe('service:service-a')
-    // service-b sits at distance 1; payments-db and the db-config.yaml ConfigNode
-    // are both reachable from service-b at distance 2.
-    expect(body.totalAffected).toBe(3)
+    // service-b and the container-image both sit at distance 1; payments-db
+    // and the db-config.yaml ConfigNode are reachable from service-b at
+    // distance 2.
+    expect(body.totalAffected).toBe(4)
     expect(body.affectedNodes).toContainEqual({
       nodeId: 'service:service-b',
       distance: 1,
@@ -176,6 +177,11 @@ describe('REST API (fastify.inject)', () => {
     expect(body.affectedNodes).toContainEqual({
       nodeId: 'config:service-b/db-config.yaml',
       distance: 2,
+      edgeProvenance: 'EXTRACTED',
+    })
+    expect(body.affectedNodes).toContainEqual({
+      nodeId: 'infra:container-image:node:20-bookworm-slim',
+      distance: 1,
       edgeProvenance: 'EXTRACTED',
     })
   })
@@ -203,7 +209,11 @@ describe('REST API (fastify.inject)', () => {
     })
     expect(res.statusCode).toBe(200)
     const body = res.json()
-    expect(body.totalAffected).toBe(1)
-    expect(body.affectedNodes[0].nodeId).toBe('service:service-b')
+    // service-b via CALLS + container-image via RUNS_ON both sit at distance 1.
+    expect(body.totalAffected).toBe(2)
+    expect(body.affectedNodes.map((n: { nodeId: string }) => n.nodeId).sort()).toEqual([
+      'infra:container-image:node:20-bookworm-slim',
+      'service:service-b',
+    ])
   })
 })

--- a/packages/core/test/fixtures/infra/compose/docker-compose.yml
+++ b/packages/core/test/fixtures/infra/compose/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.9'
+services:
+  web:
+    build: ./web
+    depends_on:
+      - postgres
+      - cache
+  postgres:
+    image: postgres:15-alpine
+  cache:
+    image: redis:7

--- a/packages/core/test/fixtures/infra/compose/web/package.json
+++ b/packages/core/test/fixtures/infra/compose/web/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-web",
+  "version": "1.0.0"
+}

--- a/packages/core/test/fixtures/infra/dockerfile/api/Dockerfile
+++ b/packages/core/test/fixtures/infra/dockerfile/api/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:20
+WORKDIR /app
+COPY . .
+CMD ["node", "index.js"]

--- a/packages/core/test/fixtures/infra/dockerfile/api/package.json
+++ b/packages/core/test/fixtures/infra/dockerfile/api/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-api",
+  "version": "1.0.0"
+}

--- a/packages/core/test/fixtures/infra/k8s/manifests.yaml
+++ b/packages/core/test/fixtures/infra/k8s/manifests.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  namespace: default
+spec:
+  selector:
+    app: web
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: default
+spec:
+  replicas: 2

--- a/packages/core/test/fixtures/infra/terraform/main.tf
+++ b/packages/core/test/fixtures/infra/terraform/main.tf
@@ -1,0 +1,7 @@
+resource "aws_s3_bucket" "uploads" {
+  bucket = "fixture-uploads"
+}
+
+resource "aws_dynamodb_table" "orders" {
+  name = "fixture-orders"
+}

--- a/packages/core/test/infra.test.ts
+++ b/packages/core/test/infra.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import type { GraphEdge, InfraNode } from '@neat/types'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES = path.resolve(__dirname, 'fixtures', 'infra')
+
+describe('infrastructure extraction', () => {
+  beforeEach(() => resetGraph())
+
+  it('docker-compose: emits InfraNodes for non-service entries + DEPENDS_ON edges', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'compose'))
+
+    expect(graph.hasNode('service:fixture-web')).toBe(true)
+    expect(graph.hasNode('infra:postgres:postgres')).toBe(true)
+    expect(graph.hasNode('infra:redis:cache')).toBe(true)
+
+    const postgres = graph.getNodeAttributes('infra:postgres:postgres') as InfraNode
+    expect(postgres.kind).toBe('postgres')
+    expect(postgres.provider).toBe('self')
+
+    const dependsPg = 'DEPENDS_ON:service:fixture-web->infra:postgres:postgres'
+    const dependsRedis = 'DEPENDS_ON:service:fixture-web->infra:redis:cache'
+    expect(graph.hasEdge(dependsPg)).toBe(true)
+    expect(graph.hasEdge(dependsRedis)).toBe(true)
+  })
+
+  it('Dockerfile: emits container-image InfraNode + RUNS_ON edge', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'dockerfile'))
+
+    expect(graph.hasNode('infra:container-image:node:20')).toBe(true)
+    const image = graph.getNodeAttributes('infra:container-image:node:20') as InfraNode
+    expect(image.kind).toBe('container-image')
+
+    const edgeId = 'RUNS_ON:service:fixture-api->infra:container-image:node:20'
+    expect(graph.hasEdge(edgeId)).toBe(true)
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.type).toBe('RUNS_ON')
+  })
+
+  it('terraform: catalogues aws_* resources as InfraNodes', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'terraform'))
+
+    const bucket = graph.getNodeAttributes('infra:aws_s3_bucket:uploads') as InfraNode
+    expect(bucket.kind).toBe('aws_s3_bucket')
+    expect(bucket.provider).toBe('aws')
+
+    const table = graph.getNodeAttributes('infra:aws_dynamodb_table:orders') as InfraNode
+    expect(table.kind).toBe('aws_dynamodb_table')
+  })
+
+  it('k8s: catalogues Service + Deployment manifests as InfraNodes', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'k8s'))
+
+    const svc = graph.getNodeAttributes('infra:k8s-service:default/web') as InfraNode
+    expect(svc.kind).toBe('k8s-service')
+    expect(svc.provider).toBe('kubernetes')
+
+    const deploy = graph.getNodeAttributes('infra:k8s-deployment:default/web') as InfraNode
+    expect(deploy.kind).toBe('k8s-deployment')
+  })
+})

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -15,6 +15,7 @@ export const EdgeType = {
   CONFIGURED_BY: 'CONFIGURED_BY',
   PUBLISHES_TO: 'PUBLISHES_TO',
   CONSUMES_FROM: 'CONSUMES_FROM',
+  RUNS_ON: 'RUNS_ON',
 } as const
 
 export type EdgeTypeValue = (typeof EdgeType)[keyof typeof EdgeType]

--- a/packages/types/src/edges.ts
+++ b/packages/types/src/edges.ts
@@ -16,6 +16,7 @@ export const EdgeTypeSchema = z.enum([
   EdgeType.CONFIGURED_BY,
   EdgeType.PUBLISHES_TO,
   EdgeType.CONSUMES_FROM,
+  EdgeType.RUNS_ON,
 ])
 
 export const EdgeEvidenceSchema = z.object({

--- a/packages/types/test/schemas.test.ts
+++ b/packages/types/test/schemas.test.ts
@@ -19,8 +19,8 @@ describe('runtime constants', () => {
   it('Provenance has 5 values', () => {
     expect(Object.values(Provenance)).toHaveLength(5)
   })
-  it('EdgeType has 6 values', () => {
-    expect(Object.values(EdgeType)).toHaveLength(6)
+  it('EdgeType has 7 values', () => {
+    expect(Object.values(EdgeType)).toHaveLength(7)
   })
   it('NodeType has 4 values', () => {
     expect(Object.values(NodeType)).toHaveLength(4)


### PR DESCRIPTION
Refs #73.

`InfraNodeSchema` was in `@neat/types` since M0 and unused. This PR populates it from four real infrastructure descriptors so the graph reflects deployment shape, not just code.

## What's different

A new phase 5 — `extract/infra/` — runs after services so RUNS_ON edges have a ServiceNode to anchor on. Four sub-extractors:

| Source | Node id | Edges |
|---|---|---|
| Project-level `docker-compose.yml` | `infra:<kind>:<compose-name>` (kind derived from image: postgres / redis / kafka / mysql / mongodb / ...) for compose services that *aren't* discovered ServiceNodes | `DEPENDS_ON` from each compose service to entries in its `depends_on:` list |
| Per-service `Dockerfile` | `infra:container-image:<image>` (multi-stage builds: last non-`scratch` `FROM` wins) | `RUNS_ON` from the service to the image |
| Repo-walked `*.tf` | `infra:aws_<resource>:<name>` (provider=`aws`) for every `resource \"aws_*\" \"name\"` block | none — light catalogue pass; reference resolution is out of scope |
| Repo-walked `*.yaml`/`*.yml` with k8s `kind` | `infra:k8s-<kind-lower>:<namespace>/<name>` (provider=`kubernetes`) for `Service`, `Deployment`, `StatefulSet`, `DaemonSet`, `CronJob`, `Job`, `Ingress` | none yet — same catalogue intent |

## Schema additions

All additive — snapshot stays at v2, no migration needed.

- `InfraNodeSchema` gets an optional `kind: string` for sub-typing.
- `EdgeType` / `EdgeTypeSchema` gains `RUNS_ON`.

## Demo impact

The demo's per-service Dockerfiles (`FROM node:20-bookworm-slim`) now produce an `infra:container-image:node:20-bookworm-slim` InfraNode with `RUNS_ON` edges from both demo services. The blast-radius API tests updated to match — service-a now reaches 4 nodes at depth 10 (was 3) and 2 nodes at depth 1 (was 1).

## Verification

- `infra.test.ts` covers each of the four sources with a fixture: docker-compose w/ Postgres + Redis + Node service producing the expected three InfraNodes (postgres + redis + container-image) plus the original ServiceNode + DEPENDS_ON wiring; Dockerfile producing `container-image:node:20` + RUNS_ON edge; Terraform cataloguing `aws_s3_bucket` + `aws_dynamodb_table`; k8s manifest cataloguing `k8s-service` + `k8s-deployment`.
- Existing `extract.test.ts` passes — demo node/edge shape extends but every previous assertion still holds.
- Workspace stays green: `npx turbo build test lint` clean (109 core / 25 types / 17 mcp tests).

## Test plan

- [x] `npx turbo build test lint`
- [x] `node packages/core/dist/cli.cjs init ./demo` — same incompatibility list, plus the new container-image InfraNode + RUNS_ON edges from each service.