### PR TITLE
Resolve unknown span peers via aliases or a frontier placeholder (#75)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Run **after δ merges**, not before. Stand up Railway per `docs/railway.md` → 
 - OTLP `.proto` files bundled in-tree; gRPC receiver is opt-in (ADR-020)
 - Python extraction reads source via `tree-sitter-python`; NEAT's runtime stays Node-only (ADR-021)
 - `infra:<kind>:<name>` id format; one `InfraNode` type, free-string `kind` for sub-typing (ADR-022)
+- `FrontierNode` is a fifth node type for unresolved span peers; promoted away once an alias matches (ADR-023)
 
 ## Conventions
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -302,3 +302,24 @@ v0.1.2-β #73 populated `InfraNode` from docker-compose, Dockerfile, Terraform, 
 **Coexistence with DatabaseNode.** A docker-compose declaring Postgres produces both an `infra:postgres:<compose-name>` (from #73) and possibly a `database:<host>` (if a service's #70 parser reads that compose). They describe the same physical thing from different perspectives — the compose topology vs. the service's connection target — and they coexist. γ's #75 (FRONTIER population) is the natural place to deduplicate if it ever becomes a problem; right now it isn't.
 
 **When to revisit.** If a `kind` value's vocabulary needs validation (e.g. compat reasoning that says "if `kind === 'postgres'` then..."), promote it to a constant set. The schema can stay a free string and just typecheck the values that matter.
+
+---
+
+## ADR-023 — `FrontierNode` as a fifth top-level node type
+
+**Date:** 2026-05-02
+**Status:** Active.
+
+v0.1.2-γ #75 added a fifth member to `GraphNodeSchema`: `FrontierNode`. A frontier node is the placeholder ingest writes when an OTel span peer (`server.address`, `net.peer.name`, etc.) doesn't resolve to any known service. The id format is `frontier:<host>`. A later extraction round picks up the host as an alias on a real service, `promoteFrontierNodes` re-links the edges, and the placeholder goes away.
+
+**Why a new node type, not an `InfraNode` kind.** ADR-022 deliberately kept the discriminated union at four. Frontier nodes broke that ceiling because they aren't classified by *what they are* — they're classified by *what they don't yet know*. They have a distinct lifecycle (placeholder → promoted → deleted), they carry temporal fields (`firstObserved`, `lastObserved`) that don't make sense on infra catalog entries, and a frontier node is supposed to disappear once extraction catches up. Cramming that into `InfraNode.kind = "frontier"` would have meant teaching every consumer of `InfraNode` to filter out a special case, and would have leaked frontier semantics into a node type whose whole job is to be permanent.
+
+**Why a top-level type rather than a flag on `ServiceNode`.** A frontier doesn't have a language, dependencies, or a repo path — none of `ServiceNode`'s required fields apply. We considered making `ServiceNodeSchema` looser, but the schema's job is to fail loudly when something pretending to be a service isn't one. Promotion *converts* a frontier into the matching real service by re-linking edges and dropping the placeholder; the two never coexist as the same node.
+
+**Why provenance `FRONTIER` already existed but the node type didn't.** The provenance enum has carried `FRONTIER` since M0 (it shipped in `@neat/types`'s constants). The original intent was always "we observed something but can't fully attribute it." γ #75 finally wired up the producer (ingest) and the consumer (extract's promotion phase). The provenance is set on the edge between the source service and the placeholder; once promoted, those edges flip to `OBSERVED` because the call certainty is real — only the target identity was the unknown.
+
+**Aliases live on `ServiceNode`, not as a new edge type.** The alternative was an explicit `ALIASED_AS` edge from a service to each hostname. That would have grown the edge count linearly with cluster-DNS variants (`<name>`, `<name>.<ns>`, `<name>.<ns>.svc`, `<name>.<ns>.svc.cluster.local`) for every service every k8s manifest mentions. Storing them as a `string[]` on the service keeps the resolve path one map lookup and keeps the graph topology focused on real relationships.
+
+**Where promotion runs.** At the end of every `extractFromDirectory` pass, after services + databases + configs + calls + infra. Promotion needs the full alias state from the latest extraction round, so it has to run last. Re-running ingest doesn't trigger promotion directly — it just keeps pinning frontier `lastObserved` — which is fine because the next extraction round will sweep them up.
+
+**When to revisit.** If frontier nodes start sticking around (a host that never resolves no matter how many rounds pass), they become a UX signal: "you have unknown peers." That's a γ #76 concern (per-edge confidence) or δ ergonomics, not this ADR. The placeholder will continue to do its job until then.

--- a/packages/core/src/extract/aliases.ts
+++ b/packages/core/src/extract/aliases.ts
@@ -1,0 +1,233 @@
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import { parseAllDocuments } from 'yaml'
+import type { ServiceNode } from '@neat/types'
+import { NodeType } from '@neat/types'
+import type { NeatGraph } from '../graph.js'
+import {
+  CONFIG_FILE_EXTENSIONS,
+  IGNORED_DIRS,
+  exists,
+  readYaml,
+  type DiscoveredService,
+} from './shared.js'
+
+// Populate ServiceNode.aliases from sources that the OTel layer is likely to
+// see in span attributes:
+//
+//   - docker-compose service names (compose-DNS).
+//   - Dockerfile LABEL values that name the service.
+//   - k8s metadata.name (and the cluster-DNS variants) for Service /
+//     Deployment / StatefulSet whose name matches a known service.
+//
+// resolveServiceId in ingest.ts checks aliases before falling back to a
+// FRONTIER placeholder; promoteFrontierNodes uses them to retire stale
+// placeholders once they map to a real service.
+
+interface ComposeService {
+  container_name?: string
+  hostname?: string
+  networks?: string[] | Record<string, unknown>
+}
+
+interface ComposeFile {
+  services?: Record<string, ComposeService>
+}
+
+interface K8sDoc {
+  kind?: string
+  metadata?: {
+    name?: string
+    namespace?: string
+    labels?: Record<string, string>
+  }
+  spec?: {
+    selector?: {
+      app?: string
+      matchLabels?: Record<string, string>
+    }
+  }
+}
+
+const K8S_KINDS_WITH_HOSTNAMES = new Set([
+  'Service',
+  'Deployment',
+  'StatefulSet',
+  'DaemonSet',
+])
+
+function addAliases(graph: NeatGraph, serviceId: string, candidates: Iterable<string>): void {
+  if (!graph.hasNode(serviceId)) return
+  const node = graph.getNodeAttributes(serviceId) as ServiceNode & { type?: string }
+  if (node.type !== NodeType.ServiceNode) return
+  const set = new Set(node.aliases ?? [])
+  for (const c of candidates) {
+    if (!c) continue
+    if (c === node.name) continue
+    set.add(c)
+  }
+  if (set.size === 0) return
+  const updated: ServiceNode = { ...node, aliases: [...set].sort() }
+  graph.replaceNodeAttributes(serviceId, updated)
+}
+
+function indexServicesByName(services: DiscoveredService[]): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const s of services) {
+    map.set(s.node.name, s.node.id)
+    map.set(path.basename(s.dir), s.node.id)
+  }
+  return map
+}
+
+async function collectComposeAliases(
+  graph: NeatGraph,
+  scanPath: string,
+  serviceIndex: Map<string, string>,
+): Promise<void> {
+  let composePath: string | null = null
+  for (const name of ['docker-compose.yml', 'docker-compose.yaml']) {
+    const abs = path.join(scanPath, name)
+    if (await exists(abs)) {
+      composePath = abs
+      break
+    }
+  }
+  if (!composePath) return
+
+  const compose = await readYaml<ComposeFile>(composePath)
+  if (!compose?.services) return
+
+  for (const [composeName, svc] of Object.entries(compose.services)) {
+    const serviceId = serviceIndex.get(composeName)
+    if (!serviceId) continue
+    const aliases = new Set<string>([composeName])
+    if (svc.container_name) aliases.add(svc.container_name)
+    if (svc.hostname) aliases.add(svc.hostname)
+    addAliases(graph, serviceId, aliases)
+  }
+}
+
+const LABEL_KEYS = new Set([
+  'service',
+  'service.name',
+  'app',
+  'app.name',
+  'com.docker.compose.service',
+  'org.opencontainers.image.title',
+])
+
+function parseDockerfileLabels(content: string): string[] {
+  const out: string[] = []
+  // Support `LABEL key=value`, `LABEL key="value with spaces"`, and the
+  // multi-pair form `LABEL k1=v1 k2=v2`. We don't try to honour line
+  // continuations — the common single-line form is enough.
+  const lineRegex = /^\s*label\s+(.+)$/i
+  for (const raw of content.split('\n')) {
+    const m = lineRegex.exec(raw)
+    if (!m) continue
+    const rest = m[1]!
+    const pairRegex = /([\w.-]+)\s*=\s*("([^"]*)"|'([^']*)'|([^\s]+))/g
+    let pair: RegExpExecArray | null
+    while ((pair = pairRegex.exec(rest)) !== null) {
+      const key = pair[1]!.toLowerCase()
+      if (!LABEL_KEYS.has(key)) continue
+      const value = pair[3] ?? pair[4] ?? pair[5] ?? ''
+      if (value) out.push(value)
+    }
+  }
+  return out
+}
+
+async function collectDockerfileAliases(
+  graph: NeatGraph,
+  services: DiscoveredService[],
+): Promise<void> {
+  for (const service of services) {
+    const dockerfilePath = path.join(service.dir, 'Dockerfile')
+    if (!(await exists(dockerfilePath))) continue
+    const content = await fs.readFile(dockerfilePath, 'utf8')
+    const aliases = parseDockerfileLabels(content)
+    if (aliases.length > 0) addAliases(graph, service.node.id, aliases)
+  }
+}
+
+async function walkYamlFiles(start: string, depth = 0, max = 5): Promise<string[]> {
+  if (depth > max) return []
+  const out: string[] = []
+  const entries = await fs.readdir(start, { withFileTypes: true }).catch(() => [])
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (IGNORED_DIRS.has(entry.name)) continue
+      out.push(...(await walkYamlFiles(path.join(start, entry.name), depth + 1, max)))
+    } else if (entry.isFile() && CONFIG_FILE_EXTENSIONS.has(path.extname(entry.name))) {
+      out.push(path.join(start, entry.name))
+    }
+  }
+  return out
+}
+
+function k8sHostnames(name: string, namespace: string | undefined): string[] {
+  const ns = namespace ?? 'default'
+  return [
+    name,
+    `${name}.${ns}`,
+    `${name}.${ns}.svc`,
+    `${name}.${ns}.svc.cluster.local`,
+  ]
+}
+
+function k8sServiceTarget(
+  doc: K8sDoc,
+  byName: Map<string, string>,
+): string | null {
+  // For `Service` resources, the target is whatever app the spec selects, not
+  // necessarily the Service's own metadata.name. We prefer that mapping; if no
+  // selector, fall back to the metadata.name match.
+  const selector = doc.spec?.selector
+  const selectorApp = selector?.app ?? selector?.matchLabels?.app
+  if (selectorApp && byName.has(selectorApp)) return byName.get(selectorApp)!
+
+  const labelApp = doc.metadata?.labels?.app
+  if (labelApp && byName.has(labelApp)) return byName.get(labelApp)!
+
+  const metaName = doc.metadata?.name
+  if (metaName && byName.has(metaName)) return byName.get(metaName)!
+
+  return null
+}
+
+async function collectK8sAliases(
+  graph: NeatGraph,
+  scanPath: string,
+  serviceIndex: Map<string, string>,
+): Promise<void> {
+  const files = await walkYamlFiles(scanPath)
+  for (const file of files) {
+    const content = await fs.readFile(file, 'utf8')
+    let docs: K8sDoc[]
+    try {
+      docs = parseAllDocuments(content).map((d) => d.toJSON() as K8sDoc)
+    } catch {
+      continue
+    }
+    for (const doc of docs) {
+      if (!doc?.kind || !doc.metadata?.name) continue
+      if (!K8S_KINDS_WITH_HOSTNAMES.has(doc.kind)) continue
+      const target = k8sServiceTarget(doc, serviceIndex)
+      if (!target) continue
+      addAliases(graph, target, k8sHostnames(doc.metadata.name, doc.metadata.namespace))
+    }
+  }
+}
+
+export async function addServiceAliases(
+  graph: NeatGraph,
+  scanPath: string,
+  services: DiscoveredService[],
+): Promise<void> {
+  const byName = indexServicesByName(services)
+  await collectComposeAliases(graph, scanPath, byName)
+  await collectDockerfileAliases(graph, services)
+  await collectK8sAliases(graph, scanPath, byName)
+}

--- a/packages/core/src/extract/index.ts
+++ b/packages/core/src/extract/index.ts
@@ -1,5 +1,7 @@
 import type { NeatGraph } from '../graph.js'
+import { promoteFrontierNodes } from '../ingest.js'
 import { addServiceNodes, discoverServices } from './services.js'
+import { addServiceAliases } from './aliases.js'
 import { addDatabasesAndCompat } from './databases/index.js'
 import { addConfigNodes } from './configs.js'
 import { addCallEdges } from './calls/index.js'
@@ -8,6 +10,7 @@ import { addInfra } from './infra/index.js'
 export interface ExtractResult {
   nodesAdded: number
   edgesAdded: number
+  frontiersPromoted: number
 }
 
 export async function extractFromDirectory(
@@ -17,10 +20,12 @@ export async function extractFromDirectory(
   const services = await discoverServices(scanPath)
 
   const phase1Nodes = addServiceNodes(graph, services)
+  await addServiceAliases(graph, scanPath, services)
   const phase2 = await addDatabasesAndCompat(graph, services)
   const phase3 = await addConfigNodes(graph, services, scanPath)
   const phase4 = await addCallEdges(graph, services)
   const phase5 = await addInfra(graph, scanPath, services)
+  const frontiersPromoted = promoteFrontierNodes(graph)
 
   return {
     nodesAdded:
@@ -31,5 +36,6 @@ export async function extractFromDirectory(
       phase5.nodesAdded,
     edgesAdded:
       phase2.edgesAdded + phase3.edgesAdded + phase4.edgesAdded + phase5.edgesAdded,
+    frontiersPromoted,
   }
 }

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
-import type { ErrorEvent, GraphEdge } from '@neat/types'
+import type { ErrorEvent, FrontierNode, GraphEdge, ServiceNode } from '@neat/types'
 import { EdgeType, NodeType, Provenance, type EdgeTypeValue } from '@neat/types'
 import type { NeatGraph } from './graph.js'
 import type { ParsedSpan } from './otel.js'
@@ -71,15 +71,80 @@ function resolveServiceId(graph: NeatGraph, host: string): string | null {
   if (graph.hasNode(direct)) return direct
 
   // Service hostnames in the demo can match either the package name (which the
-  // node id is built from) or the directory basename. We've already tried the
-  // direct id; fall back to scanning service nodes for a matching name.
+  // node id is built from) or the directory basename — handled by the name
+  // check below. Beyond that, anything in `aliases` (compose service names,
+  // k8s metadata.name + cluster-DNS variants, Dockerfile labels) should
+  // resolve too. Population happens in the extract phases; consumption is
+  // here.
   let found: string | null = null
   graph.forEachNode((id, attrs) => {
     if (found) return
-    const a = attrs as { type?: string; name?: string }
-    if (a.type === NodeType.ServiceNode && a.name === host) found = id
+    const a = attrs as ServiceNode & { type?: string }
+    if (a.type !== NodeType.ServiceNode) return
+    if (a.name === host) {
+      found = id
+      return
+    }
+    if (a.aliases && a.aliases.includes(host)) {
+      found = id
+    }
   })
   return found
+}
+
+export function frontierIdFor(host: string): string {
+  return `frontier:${host}`
+}
+
+function ensureFrontierNode(graph: NeatGraph, host: string, ts: string): string {
+  const id = frontierIdFor(host)
+  if (graph.hasNode(id)) {
+    const existing = graph.getNodeAttributes(id) as FrontierNode
+    graph.replaceNodeAttributes(id, { ...existing, lastObserved: ts })
+    return id
+  }
+  const node: FrontierNode = {
+    id,
+    type: NodeType.FrontierNode,
+    name: host,
+    host,
+    firstObserved: ts,
+    lastObserved: ts,
+  }
+  graph.addNode(id, node)
+  return id
+}
+
+function upsertFrontierEdge(
+  graph: NeatGraph,
+  type: EdgeTypeValue,
+  source: string,
+  target: string,
+  ts: string,
+): void {
+  const id = `${type}:FRONTIER:${source}->${target}`
+  if (graph.hasEdge(id)) {
+    const existing = graph.getEdgeAttributes(id) as GraphEdge
+    const updated: GraphEdge = {
+      ...existing,
+      provenance: Provenance.FRONTIER,
+      lastObserved: ts,
+      callCount: (existing.callCount ?? 0) + 1,
+    }
+    graph.replaceEdgeAttributes(id, updated)
+    return
+  }
+  const edge: GraphEdge = {
+    id,
+    source,
+    target,
+    type,
+    provenance: Provenance.FRONTIER,
+    confidence: 1.0,
+    lastObserved: ts,
+    callCount: 1,
+  }
+  graph.addEdgeWithKey(id, source, target, edge)
 }
 
 interface UpsertResult {
@@ -201,14 +266,24 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
       if (result) affectedNode = targetId
     }
   } else {
-    // Possibly a cross-service call — only if the address resolves to a known
-    // service node, and isn't ourselves.
+    // Possibly a cross-service call. Resolve the peer; if it matches a known
+    // ServiceNode, record an OBSERVED CALLS edge. If it matches nothing — pod
+    // IP, ingress hostname, AWS PrivateLink endpoint — drop a FRONTIER
+    // placeholder so the call isn't lost. promoteFrontierNodes (run by the
+    // extract orchestrator) replaces it once a later round records the host
+    // as an alias on a real service.
     const host = pickAddress(span)
     if (host && host !== span.service) {
       const targetId = resolveServiceId(ctx.graph, host)
       if (targetId && targetId !== sourceId) {
         upsertObservedEdge(ctx.graph, EdgeType.CALLS, sourceId, targetId, ts)
         affectedNode = targetId
+      } else if (!targetId) {
+        const frontierId = ensureFrontierNode(ctx.graph, host, ts)
+        if (ctx.graph.hasNode(sourceId)) {
+          upsertFrontierEdge(ctx.graph, EdgeType.CALLS, sourceId, frontierId, ts)
+        }
+        affectedNode = frontierId
       }
     }
   }
@@ -229,6 +304,99 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
 }
 
 export { stitchTrace }
+
+// Promote any frontier:<host> placeholder whose host matches an alias on a
+// real ServiceNode: re-link inbound/outbound edges to the service, then drop
+// the placeholder. Returns the count of nodes promoted, for tests + logs.
+//
+// Called at the end of every extraction round. Static rounds are when new
+// aliases land (compose names, k8s metadata.name, Dockerfile labels), so
+// running it there picks up the case the issue describes: ingest fills in a
+// frontier when traffic arrives for an unknown host, and the next extraction
+// round resolves it.
+export function promoteFrontierNodes(graph: NeatGraph): number {
+  const aliasIndex = new Map<string, string>()
+  graph.forEachNode((id, attrs) => {
+    const a = attrs as ServiceNode & { type?: string }
+    if (a.type !== NodeType.ServiceNode) return
+    aliasIndex.set(a.name, id)
+    if (a.aliases) {
+      for (const alias of a.aliases) aliasIndex.set(alias, id)
+    }
+  })
+
+  const toPromote: { frontierId: string; serviceId: string }[] = []
+  graph.forEachNode((id, attrs) => {
+    const a = attrs as FrontierNode & { type?: string }
+    if (a.type !== NodeType.FrontierNode) return
+    const target = aliasIndex.get(a.host)
+    if (!target) return
+    if (target === id) return
+    toPromote.push({ frontierId: id, serviceId: target })
+  })
+
+  for (const { frontierId, serviceId } of toPromote) {
+    rewireFrontierEdges(graph, frontierId, serviceId)
+    graph.dropNode(frontierId)
+  }
+  return toPromote.length
+}
+
+function rewireFrontierEdges(graph: NeatGraph, frontierId: string, serviceId: string): void {
+  const inbound = [...graph.inboundEdges(frontierId)]
+  const outbound = [...graph.outboundEdges(frontierId)]
+
+  for (const edgeId of inbound) {
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    rebuildEdge(graph, edge, edge.source, serviceId, edgeId)
+  }
+  for (const edgeId of outbound) {
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    rebuildEdge(graph, edge, serviceId, edge.target, edgeId)
+  }
+}
+
+function rebuildEdge(
+  graph: NeatGraph,
+  edge: GraphEdge,
+  newSource: string,
+  newTarget: string,
+  oldEdgeId: string,
+): void {
+  graph.dropEdge(oldEdgeId)
+  // FRONTIER provenance gets upgraded to OBSERVED on promotion: the call
+  // certainty was always there; only the target identity was unknown, and now
+  // it isn't.
+  const promotedProvenance =
+    edge.provenance === Provenance.FRONTIER ? Provenance.OBSERVED : edge.provenance
+  const newId = `${edge.type}:${promotedProvenance}:${newSource}->${newTarget}`
+
+  if (graph.hasEdge(newId)) {
+    const existing = graph.getEdgeAttributes(newId) as GraphEdge
+    const merged: GraphEdge = {
+      ...existing,
+      callCount: (existing.callCount ?? 0) + (edge.callCount ?? 0),
+      lastObserved: pickLater(existing.lastObserved, edge.lastObserved),
+    }
+    graph.replaceEdgeAttributes(newId, merged)
+    return
+  }
+
+  const rebuilt: GraphEdge = {
+    ...edge,
+    id: newId,
+    source: newSource,
+    target: newTarget,
+    provenance: promotedProvenance,
+  }
+  graph.addEdgeWithKey(newId, newSource, newTarget, rebuilt)
+}
+
+function pickLater(a: string | undefined, b: string | undefined): string | undefined {
+  if (!a) return b
+  if (!b) return a
+  return new Date(a).getTime() >= new Date(b).getTime() ? a : b
+}
 
 export function makeSpanHandler(ctx: IngestContext): (span: ParsedSpan) => Promise<void> {
   return (span) => handleSpan(ctx, span)

--- a/packages/core/test/aliases.test.ts
+++ b/packages/core/test/aliases.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { MultiDirectedGraph } from 'graphology'
+import {
+  EdgeType,
+  type GraphEdge,
+  type GraphNode,
+  NodeType,
+  Provenance,
+  type ServiceNode,
+} from '@neat/types'
+import type { NeatGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import { handleSpan, type IngestContext } from '../src/ingest.js'
+
+function newGraph(): NeatGraph {
+  return new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+}
+
+async function writeFile(dir: string, rel: string, content: string): Promise<void> {
+  const abs = path.join(dir, rel)
+  await fs.mkdir(path.dirname(abs), { recursive: true })
+  await fs.writeFile(abs, content, 'utf8')
+}
+
+async function makeTmp(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'neat-aliases-'))
+}
+
+function getServiceNode(graph: NeatGraph, id: string): ServiceNode {
+  return graph.getNodeAttributes(id) as ServiceNode
+}
+
+describe('addServiceAliases — docker-compose', () => {
+  let tmp: string
+  beforeEach(async () => {
+    tmp = await makeTmp()
+  })
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true })
+  })
+
+  it('records compose service name + container_name + hostname as aliases', async () => {
+    await writeFile(tmp, 'web/package.json', JSON.stringify({ name: 'fixture-web' }))
+    await writeFile(
+      tmp,
+      'docker-compose.yml',
+      `services:\n  web:\n    build: ./web\n    container_name: web-prod\n    hostname: web-internal\n`,
+    )
+    const graph = newGraph()
+    await extractFromDirectory(graph, tmp)
+    const node = getServiceNode(graph, 'service:fixture-web')
+    expect(node.aliases).toBeDefined()
+    expect(node.aliases).toEqual(expect.arrayContaining(['web', 'web-prod', 'web-internal']))
+  })
+})
+
+describe('addServiceAliases — Dockerfile labels', () => {
+  let tmp: string
+  beforeEach(async () => {
+    tmp = await makeTmp()
+  })
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true })
+  })
+
+  it('records LABEL service= and friends as aliases', async () => {
+    await writeFile(tmp, 'api/package.json', JSON.stringify({ name: 'fixture-api' }))
+    await writeFile(
+      tmp,
+      'api/Dockerfile',
+      `FROM node:20
+LABEL service=payments-api
+LABEL service.name="payments-api.cluster.local"
+LABEL org.opencontainers.image.title=payments
+WORKDIR /app
+`,
+    )
+    const graph = newGraph()
+    await extractFromDirectory(graph, tmp)
+    const node = getServiceNode(graph, 'service:fixture-api')
+    expect(node.aliases).toEqual(
+      expect.arrayContaining(['payments-api', 'payments-api.cluster.local', 'payments']),
+    )
+  })
+
+  it('ignores unrelated LABEL keys', async () => {
+    await writeFile(tmp, 'api/package.json', JSON.stringify({ name: 'fixture-api' }))
+    await writeFile(
+      tmp,
+      'api/Dockerfile',
+      `FROM node:20
+LABEL maintainer="ops@example.com"
+LABEL version=1.0
+`,
+    )
+    const graph = newGraph()
+    await extractFromDirectory(graph, tmp)
+    const node = getServiceNode(graph, 'service:fixture-api')
+    expect(node.aliases ?? []).toEqual([])
+  })
+})
+
+describe('addServiceAliases — k8s', () => {
+  let tmp: string
+  beforeEach(async () => {
+    tmp = await makeTmp()
+  })
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true })
+  })
+
+  it('records k8s metadata.name + cluster-DNS variants when selector targets the service', async () => {
+    await writeFile(
+      tmp,
+      'svc/package.json',
+      JSON.stringify({ name: 'fixture-svc' }),
+    )
+    await writeFile(
+      tmp,
+      'k8s/manifests.yaml',
+      `apiVersion: v1
+kind: Service
+metadata:
+  name: payments
+  namespace: prod
+spec:
+  selector:
+    app: fixture-svc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fixture-svc
+  namespace: prod
+`,
+    )
+    const graph = newGraph()
+    await extractFromDirectory(graph, tmp)
+    const node = getServiceNode(graph, 'service:fixture-svc')
+    expect(node.aliases).toEqual(
+      expect.arrayContaining([
+        'payments',
+        'payments.prod',
+        'payments.prod.svc',
+        'payments.prod.svc.cluster.local',
+        'fixture-svc.prod',
+        'fixture-svc.prod.svc',
+        'fixture-svc.prod.svc.cluster.local',
+      ]),
+    )
+  })
+})
+
+describe('FRONTIER end-to-end via extractFromDirectory', () => {
+  let tmp: string
+  beforeEach(async () => {
+    tmp = await makeTmp()
+  })
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true })
+  })
+
+  it('promotes a frontier once a later extraction round records the host as an alias', async () => {
+    await writeFile(
+      tmp,
+      'service-a/package.json',
+      JSON.stringify({ name: 'service-a' }),
+    )
+    await writeFile(
+      tmp,
+      'service-b/package.json',
+      JSON.stringify({ name: 'service-b' }),
+    )
+
+    const graph = newGraph()
+    const result1 = await extractFromDirectory(graph, tmp)
+    expect(result1.frontiersPromoted).toBe(0)
+
+    const errorsPath = path.join(tmp, 'errors.ndjson')
+    const ctx: IngestContext = { graph, errorsPath }
+
+    await handleSpan(ctx, {
+      service: 'service-a',
+      traceId: 't',
+      spanId: 's',
+      name: 'GET',
+      kind: 3,
+      startTimeUnixNano: '0',
+      endTimeUnixNano: '0',
+      durationNanos: 0n,
+      attributes: { 'server.address': 'payments-api.cluster.local' },
+      statusCode: 0,
+    })
+
+    expect(graph.hasNode('frontier:payments-api.cluster.local')).toBe(true)
+
+    await writeFile(
+      tmp,
+      'docker-compose.yml',
+      `services:\n  service-b:\n    build: ./service-b\n    hostname: payments-api.cluster.local\n`,
+    )
+
+    const result2 = await extractFromDirectory(graph, tmp)
+    expect(result2.frontiersPromoted).toBe(1)
+    expect(graph.hasNode('frontier:payments-api.cluster.local')).toBe(false)
+    expect(
+      graph.hasEdge(
+        `${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`,
+      ),
+    ).toBe(true)
+
+    const promoted = graph.getEdgeAttributes(
+      `${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`,
+    ) as GraphEdge
+    expect(promoted.provenance).toBe(Provenance.OBSERVED)
+  })
+
+  it('still records direct service-name OBSERVED edges (regression check)', async () => {
+    await writeFile(
+      tmp,
+      'service-a/package.json',
+      JSON.stringify({ name: 'service-a' }),
+    )
+    await writeFile(
+      tmp,
+      'service-b/package.json',
+      JSON.stringify({ name: 'service-b' }),
+    )
+    const graph = newGraph()
+    await extractFromDirectory(graph, tmp)
+
+    const ctx: IngestContext = {
+      graph,
+      errorsPath: path.join(tmp, 'errors.ndjson'),
+    }
+    await handleSpan(ctx, {
+      service: 'service-a',
+      traceId: 't',
+      spanId: 's',
+      name: 'GET',
+      kind: 3,
+      startTimeUnixNano: '0',
+      endTimeUnixNano: '0',
+      durationNanos: 0n,
+      attributes: { 'server.address': 'service-b' },
+      statusCode: 0,
+    })
+
+    expect(
+      graph.hasEdge(`${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`),
+    ).toBe(true)
+    let frontiers = 0
+    graph.forEachNode((id, attrs) => {
+      if ((attrs as { type: string }).type === NodeType.FrontierNode) frontiers++
+      void id
+    })
+    expect(frontiers).toBe(0)
+  })
+})

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   handleSpan,
   markStaleEdges,
+  promoteFrontierNodes,
   readErrorEvents,
   stitchTrace,
   type IngestContext,
@@ -193,13 +194,45 @@ describe('handleSpan', () => {
     ).toBe(true)
   })
 
-  it('skips spans whose target service node does not exist in the graph', async () => {
-    await handleSpan(ctx, clientHttpSpan({ attributes: { 'server.address': 'unknown-service' } }))
-    let calls = 0
+  it('emits a FRONTIER placeholder when the span peer matches no service node', async () => {
+    await handleSpan(
+      ctx,
+      clientHttpSpan({ attributes: { 'server.address': 'payments-api.cluster.local' } }),
+    )
+    let observedCalls = 0
     ctx.graph.forEachEdge((k) => {
-      if (k.startsWith(`${EdgeType.CALLS}:OBSERVED:`)) calls++
+      if (k.startsWith(`${EdgeType.CALLS}:OBSERVED:`)) observedCalls++
     })
-    expect(calls).toBe(0)
+    expect(observedCalls).toBe(0)
+
+    expect(ctx.graph.hasNode('frontier:payments-api.cluster.local')).toBe(true)
+    const frontier = ctx.graph.getNodeAttributes(
+      'frontier:payments-api.cluster.local',
+    ) as { type: string; host: string; firstObserved?: string }
+    expect(frontier.type).toBe(NodeType.FrontierNode)
+    expect(frontier.host).toBe('payments-api.cluster.local')
+    expect(frontier.firstObserved).toBeTruthy()
+
+    const frontierEdgeId = `${EdgeType.CALLS}:FRONTIER:service:service-a->frontier:payments-api.cluster.local`
+    expect(ctx.graph.hasEdge(frontierEdgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(frontierEdgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.FRONTIER)
+    expect(edge.callCount).toBe(1)
+  })
+
+  it('resolves a span peer through ServiceNode.aliases', async () => {
+    ctx.graph.replaceNodeAttributes('service:service-b', {
+      ...(ctx.graph.getNodeAttributes('service:service-b') as Record<string, unknown>),
+      aliases: ['payments-api.cluster.local'],
+    })
+    await handleSpan(
+      ctx,
+      clientHttpSpan({ attributes: { 'server.address': 'payments-api.cluster.local' } }),
+    )
+    expect(
+      ctx.graph.hasEdge(`${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`),
+    ).toBe(true)
+    expect(ctx.graph.hasNode('frontier:payments-api.cluster.local')).toBe(false)
   })
 
   it('does not touch a pre-existing EXTRACTED edge between the same services', async () => {
@@ -440,5 +473,73 @@ describe('stitchTrace', () => {
       graph.hasEdge(`${EdgeType.CONNECTS_TO}:INFERRED:service:service-b->database:payments-db`),
     ).toBe(true)
     await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+})
+
+describe('promoteFrontierNodes', () => {
+  it('replaces a frontier node once a service records its host as an alias', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-frontier-'))
+    const graph = newGraph()
+    const ctx: IngestContext = { graph, errorsPath: path.join(tmpDir, 'errors.ndjson') }
+
+    await handleSpan(
+      ctx,
+      clientHttpSpan({ attributes: { 'server.address': 'payments-api.cluster.local' } }),
+    )
+    expect(graph.hasNode('frontier:payments-api.cluster.local')).toBe(true)
+
+    graph.replaceNodeAttributes('service:service-b', {
+      ...(graph.getNodeAttributes('service:service-b') as Record<string, unknown>),
+      aliases: ['payments-api.cluster.local'],
+    })
+
+    const promoted = promoteFrontierNodes(graph)
+    expect(promoted).toBe(1)
+    expect(graph.hasNode('frontier:payments-api.cluster.local')).toBe(false)
+
+    const promotedEdgeId = `${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`
+    expect(graph.hasEdge(promotedEdgeId)).toBe(true)
+    const edge = graph.getEdgeAttributes(promotedEdgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.callCount).toBe(1)
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('merges with an existing OBSERVED edge if one already targets the service', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-frontier-merge-'))
+    const graph = newGraph()
+    const ctx: IngestContext = { graph, errorsPath: path.join(tmpDir, 'errors.ndjson') }
+
+    await handleSpan(ctx, clientHttpSpan())
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        spanId: 'span-a2',
+        attributes: { 'server.address': 'payments-api.cluster.local' },
+      }),
+    )
+
+    graph.replaceNodeAttributes('service:service-b', {
+      ...(graph.getNodeAttributes('service:service-b') as Record<string, unknown>),
+      aliases: ['payments-api.cluster.local'],
+    })
+    promoteFrontierNodes(graph)
+
+    const id = `${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`
+    const edge = graph.getEdgeAttributes(id) as GraphEdge
+    expect(edge.callCount).toBe(2)
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('leaves a frontier alone if no alias matches yet', () => {
+    const graph = newGraph()
+    graph.addNode('frontier:unknown', {
+      id: 'frontier:unknown',
+      type: NodeType.FrontierNode,
+      name: 'unknown',
+      host: 'unknown',
+    })
+    expect(promoteFrontierNodes(graph)).toBe(0)
+    expect(graph.hasNode('frontier:unknown')).toBe(true)
   })
 })

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -25,6 +25,7 @@ export const NodeType = {
   DatabaseNode: 'DatabaseNode',
   ConfigNode: 'ConfigNode',
   InfraNode: 'InfraNode',
+  FrontierNode: 'FrontierNode',
 } as const
 
 export type NodeTypeValue = (typeof NodeType)[keyof typeof NodeType]

--- a/packages/types/src/nodes.ts
+++ b/packages/types/src/nodes.ts
@@ -16,6 +16,11 @@ export const ServiceNodeSchema = z.object({
   dbConnectionTarget: z.string().optional(),
   repoPath: z.string().optional(),
   dependencies: z.record(z.string(), z.string()).optional(),
+  // Hostnames OTel spans might mention for this service: compose service
+  // names, k8s metadata.name (and the cluster-DNS variants), Dockerfile
+  // labels, etc. resolveServiceId in ingest.ts checks these before falling
+  // back to a FRONTIER placeholder.
+  aliases: z.array(z.string()).optional(),
   incompatibilities: z
     .array(
       z.object({
@@ -61,10 +66,24 @@ export const InfraNodeSchema = z.object({
 })
 export type InfraNode = z.infer<typeof InfraNodeSchema>
 
+// Placeholder for a span peer the ingest layer couldn't resolve to a known
+// ServiceNode. Lives at id `frontier:<host>` and gets replaced by the real
+// service once a later extraction round records that host as an alias.
+export const FrontierNodeSchema = z.object({
+  id: z.string(),
+  type: z.literal(NodeType.FrontierNode),
+  name: z.string(),
+  host: z.string(),
+  firstObserved: z.string().datetime().optional(),
+  lastObserved: z.string().datetime().optional(),
+})
+export type FrontierNode = z.infer<typeof FrontierNodeSchema>
+
 export const GraphNodeSchema = z.discriminatedUnion('type', [
   ServiceNodeSchema,
   DatabaseNodeSchema,
   ConfigNodeSchema,
   InfraNodeSchema,
+  FrontierNodeSchema,
 ])
 export type GraphNode = z.infer<typeof GraphNodeSchema>

--- a/packages/types/test/schemas.test.ts
+++ b/packages/types/test/schemas.test.ts
@@ -4,6 +4,7 @@ import {
   DatabaseNodeSchema,
   ConfigNodeSchema,
   InfraNodeSchema,
+  FrontierNodeSchema,
   GraphEdgeSchema,
   ProvenanceSchema,
   EdgeTypeSchema,
@@ -22,8 +23,8 @@ describe('runtime constants', () => {
   it('EdgeType has 7 values', () => {
     expect(Object.values(EdgeType)).toHaveLength(7)
   })
-  it('NodeType has 4 values', () => {
-    expect(Object.values(NodeType)).toHaveLength(4)
+  it('NodeType has 5 values', () => {
+    expect(Object.values(NodeType)).toHaveLength(5)
   })
 })
 
@@ -96,6 +97,29 @@ describe('InfraNodeSchema', () => {
       region: 'us-east-1',
     }
     expect(InfraNodeSchema.parse(node)).toEqual(node)
+  })
+})
+
+describe('FrontierNodeSchema', () => {
+  it('accepts a valid FrontierNode', () => {
+    const node = {
+      id: 'frontier:payments-api.cluster.local',
+      type: 'FrontierNode' as const,
+      name: 'payments-api.cluster.local',
+      host: 'payments-api.cluster.local',
+    }
+    expect(FrontierNodeSchema.parse(node)).toEqual(node)
+  })
+  it('accepts firstObserved/lastObserved timestamps', () => {
+    const node = {
+      id: 'frontier:x',
+      type: 'FrontierNode' as const,
+      name: 'x',
+      host: 'x',
+      firstObserved: new Date().toISOString(),
+      lastObserved: new Date().toISOString(),
+    }
+    expect(FrontierNodeSchema.parse(node)).toEqual(node)
   })
 })
 


### PR DESCRIPTION
## Summary

OBSERVED-edge attribution was assuming `server.address` matched a service name. In real deployments it usually doesn't — pod IPs, ingress hostnames, and AWS PrivateLink endpoints all show up instead, and ingest silently dropped those spans on the floor. This PR fills both gaps: aliases on `ServiceNode` so the resolver can match on more than one hostname, and a `FrontierNode` placeholder for the genuinely unknown case.

- `ServiceNodeSchema.aliases` is populated by a new `addServiceAliases` phase from docker-compose service names, k8s `metadata.name` (and the four cluster-DNS variants), and a small set of Dockerfile `LABEL` keys. `resolveServiceId` in `ingest.ts` checks aliases before giving up.
- When a span peer matches nothing, ingest writes a `frontier:<host>` placeholder + a `FRONTIER`-provenance edge so the call survives. `promoteFrontierNodes` runs at the end of every extraction round: any frontier whose host now matches an alias is rewired to the real service, and the placeholder is dropped. Rewired edges flip from FRONTIER to OBSERVED.
- `FrontierNode` is a fifth top-level node type rather than an `InfraNode` kind — the placeholder lifecycle (created → promoted → deleted) doesn't fit a permanent infra catalog entry. Rationale in ADR-023.
- Schema changes are additive on v2 — `aliases` is optional, the new node type is just a new union member, no migration needed.

## Test plan

- [x] `npx turbo build test lint` — green (142 core / 32 types / 17 mcp)
- [x] New unit tests for FRONTIER emission + alias-based resolution + promotion in `packages/core/test/ingest.test.ts`
- [x] New end-to-end test in `packages/core/test/aliases.test.ts` exercising the flow: ingest writes a frontier, second extraction round adds the alias, `promoteFrontierNodes` retires the placeholder
- [x] Demo extraction smoke (`extractFromDirectory(./demo)`) still produces 5 nodes / 5 edges / 0 frontiers

Refs #75