### PR TITLE
Diff a saved snapshot against the live graph (#77)

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -5,6 +5,7 @@ import type { NeatGraph } from './graph.js'
 import { extractFromDirectory } from './extract.js'
 import { readErrorEvents } from './ingest.js'
 import { getBlastRadius, getRootCause } from './traverse.js'
+import { computeGraphDiff, loadSnapshotForDiff } from './diff.js'
 
 export interface BuildApiOptions {
   graph: NeatGraph
@@ -127,6 +128,21 @@ export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> 
       }
     })
     return { query: q, matches }
+  })
+
+  app.get<{ Querystring: { against?: string } }>('/graph/diff', async (req, reply) => {
+    const against = req.query.against
+    if (!against) {
+      return reply.code(400).send({ error: 'query parameter `against` is required' })
+    }
+    try {
+      const snapshot = await loadSnapshotForDiff(against)
+      return computeGraphDiff(graph, snapshot)
+    } catch (err) {
+      return reply
+        .code(400)
+        .send({ error: 'failed to load snapshot', against, detail: (err as Error).message })
+    }
   })
 
   app.post('/graph/scan', async (_req, reply) => {

--- a/packages/core/src/diff.ts
+++ b/packages/core/src/diff.ts
@@ -1,0 +1,139 @@
+import { promises as fs } from 'node:fs'
+import type { GraphEdge, GraphNode } from '@neat/types'
+import type { NeatGraph } from './graph.js'
+
+// Diff a snapshot on disk (or fetched over HTTP) against the live in-memory
+// graph. The "base" is the snapshot you supplied; the "current" is whatever
+// the server has loaded right now. Symmetric in shape, but consumers usually
+// want to read it as "what changed since base."
+//
+// The shape mirrors the issue's spec (#77):
+//   { added: { nodes, edges }, removed: { nodes, edges },
+//     changed: { nodes: [{id, before, after}], edges: [{id, before, after}] } }
+//
+// Both timestamps are echoed back so the caller doesn't have to track them
+// separately.
+
+interface PersistedNodeEntry {
+  key?: string
+  attributes?: Record<string, unknown>
+}
+
+interface PersistedEdgeEntry {
+  key?: string
+  source?: string
+  target?: string
+  attributes?: Record<string, unknown>
+}
+
+export interface PersistedSnapshot {
+  schemaVersion?: number
+  exportedAt?: string
+  graph?: {
+    nodes?: PersistedNodeEntry[]
+    edges?: PersistedEdgeEntry[]
+  }
+}
+
+export interface GraphDiff {
+  base: { exportedAt?: string }
+  current: { exportedAt: string }
+  added: { nodes: GraphNode[]; edges: GraphEdge[] }
+  removed: { nodes: GraphNode[]; edges: GraphEdge[] }
+  changed: {
+    nodes: { id: string; before: GraphNode; after: GraphNode }[]
+    edges: { id: string; before: GraphEdge; after: GraphEdge }[]
+  }
+}
+
+export async function loadSnapshotForDiff(target: string): Promise<PersistedSnapshot> {
+  if (/^https?:\/\//i.test(target)) {
+    const res = await fetch(target)
+    if (!res.ok) {
+      throw new Error(`fetch ${target} failed: ${res.status} ${res.statusText}`)
+    }
+    return (await res.json()) as PersistedSnapshot
+  }
+  const raw = await fs.readFile(target, 'utf8')
+  return JSON.parse(raw) as PersistedSnapshot
+}
+
+function indexEntries<T>(
+  entries: { key?: string; attributes?: Record<string, unknown> }[] | undefined,
+): Map<string, T> {
+  const m = new Map<string, T>()
+  if (!entries) return m
+  for (const entry of entries) {
+    const id = (entry.attributes?.id as string | undefined) ?? entry.key
+    if (!id) continue
+    m.set(id, entry.attributes as T)
+  }
+  return m
+}
+
+export function computeGraphDiff(
+  liveGraph: NeatGraph,
+  baseSnapshot: PersistedSnapshot,
+  currentExportedAt: string = new Date().toISOString(),
+): GraphDiff {
+  const baseNodes = indexEntries<GraphNode>(baseSnapshot.graph?.nodes)
+  const baseEdges = indexEntries<GraphEdge>(baseSnapshot.graph?.edges)
+
+  const liveNodes = new Map<string, GraphNode>()
+  liveGraph.forEachNode((id, attrs) => liveNodes.set(id, attrs as GraphNode))
+  const liveEdges = new Map<string, GraphEdge>()
+  liveGraph.forEachEdge((id, attrs) => liveEdges.set(id, attrs as GraphEdge))
+
+  const result: GraphDiff = {
+    base: { exportedAt: baseSnapshot.exportedAt },
+    current: { exportedAt: currentExportedAt },
+    added: { nodes: [], edges: [] },
+    removed: { nodes: [], edges: [] },
+    changed: { nodes: [], edges: [] },
+  }
+
+  for (const [id, after] of liveNodes) {
+    const before = baseNodes.get(id)
+    if (!before) {
+      result.added.nodes.push(after)
+    } else if (!shallowEqual(before, after)) {
+      result.changed.nodes.push({ id, before, after })
+    }
+  }
+  for (const [id, before] of baseNodes) {
+    if (!liveNodes.has(id)) result.removed.nodes.push(before)
+  }
+  for (const [id, after] of liveEdges) {
+    const before = baseEdges.get(id)
+    if (!before) {
+      result.added.edges.push(after)
+    } else if (!shallowEqual(before, after)) {
+      result.changed.edges.push({ id, before, after })
+    }
+  }
+  for (const [id, before] of baseEdges) {
+    if (!liveEdges.has(id)) result.removed.edges.push(before)
+  }
+
+  return result
+}
+
+// Stable JSON comparison. Snapshot order isn't guaranteed, so canonicalising
+// keys before stringify keeps the comparison robust against re-ordered fields.
+function shallowEqual(a: unknown, b: unknown): boolean {
+  return canonicalJson(a) === canonicalJson(b)
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(value, (_key, v) => {
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      return Object.keys(v as Record<string, unknown>)
+        .sort()
+        .reduce<Record<string, unknown>>((acc, k) => {
+          acc[k] = (v as Record<string, unknown>)[k]
+          return acc
+        }, {})
+    }
+    return v
+  })
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,3 +32,9 @@ export {
   type IngestContext,
 } from './ingest.js'
 export { getBlastRadius, getRootCause } from './traverse.js'
+export {
+  computeGraphDiff,
+  loadSnapshotForDiff,
+  type GraphDiff,
+  type PersistedSnapshot,
+} from './diff.js'

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -216,4 +216,63 @@ describe('REST API (fastify.inject)', () => {
       'service:service-b',
     ])
   })
+
+  it('GET /graph/diff returns 400 when `against` is missing', async () => {
+    const res = await app.inject({ method: 'GET', url: '/graph/diff' })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('GET /graph/diff returns 400 when the snapshot path is unreadable', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/graph/diff?against=/no/such/path.json',
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().error).toBe('failed to load snapshot')
+  })
+})
+
+describe('GET /graph/diff', () => {
+  let app: FastifyInstance
+  let tmpDir: string
+  let basePath: string
+
+  beforeEach(async () => {
+    const { promises: fs } = await import('node:fs')
+    const os = await import('node:os')
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-api-diff-'))
+    basePath = path.join(tmpDir, 'base.json')
+
+    resetGraph()
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+
+    const { saveGraphToDisk } = await import('../src/persist.js')
+    await saveGraphToDisk(graph, basePath)
+
+    // Drop one node from the live graph so the diff has something to report.
+    graph.dropNode('config:service-b/db-config.yaml')
+    app = await buildApi({ graph })
+  })
+
+  afterEach(async () => {
+    await app.close()
+    const { promises: fs } = await import('node:fs')
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('reports the dropped node as removed', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/graph/diff?against=${encodeURIComponent(basePath)}`,
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.base.exportedAt).toBeTruthy()
+    expect(body.current.exportedAt).toBeTruthy()
+    expect(body.removed.nodes.map((n: { id: string }) => n.id)).toContain(
+      'config:service-b/db-config.yaml',
+    )
+    expect(body.added.nodes).toEqual([])
+  })
 })

--- a/packages/core/test/diff.test.ts
+++ b/packages/core/test/diff.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { MultiDirectedGraph } from 'graphology'
+import {
+  EdgeType,
+  type GraphEdge,
+  type GraphNode,
+  NodeType,
+  Provenance,
+} from '@neat/types'
+import { computeGraphDiff, loadSnapshotForDiff } from '../src/diff.js'
+import { saveGraphToDisk } from '../src/persist.js'
+import type { NeatGraph } from '../src/graph.js'
+
+function newGraph(): NeatGraph {
+  return new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+}
+
+function addServiceA(g: NeatGraph): void {
+  g.addNode('service:service-a', {
+    id: 'service:service-a',
+    type: NodeType.ServiceNode,
+    name: 'service-a',
+    language: 'javascript',
+  })
+}
+
+function addServiceB(g: NeatGraph): void {
+  g.addNode('service:service-b', {
+    id: 'service:service-b',
+    type: NodeType.ServiceNode,
+    name: 'service-b',
+    language: 'javascript',
+  })
+}
+
+describe('computeGraphDiff', () => {
+  let tmp: string
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-diff-'))
+  })
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true })
+  })
+
+  it('reports an added node, no removed, and a changed edge', async () => {
+    // Base = service-a + service-b + EXTRACTED edge between them
+    const baseGraph = newGraph()
+    addServiceA(baseGraph)
+    addServiceB(baseGraph)
+    baseGraph.addEdgeWithKey(
+      'CALLS:service:service-a->service:service-b',
+      'service:service-a',
+      'service:service-b',
+      {
+        id: 'CALLS:service:service-a->service:service-b',
+        source: 'service:service-a',
+        target: 'service:service-b',
+        type: EdgeType.CALLS,
+        provenance: Provenance.EXTRACTED,
+      },
+    )
+    const basePath = path.join(tmp, 'base.json')
+    await saveGraphToDisk(baseGraph, basePath)
+
+    // Current = base + an extra service-c, and the original edge is now STALE
+    const currentGraph = newGraph()
+    addServiceA(currentGraph)
+    addServiceB(currentGraph)
+    currentGraph.addNode('service:service-c', {
+      id: 'service:service-c',
+      type: NodeType.ServiceNode,
+      name: 'service-c',
+      language: 'javascript',
+    })
+    currentGraph.addEdgeWithKey(
+      'CALLS:service:service-a->service:service-b',
+      'service:service-a',
+      'service:service-b',
+      {
+        id: 'CALLS:service:service-a->service:service-b',
+        source: 'service:service-a',
+        target: 'service:service-b',
+        type: EdgeType.CALLS,
+        provenance: Provenance.STALE,
+        confidence: 0.3,
+      },
+    )
+
+    const baseSnapshot = await loadSnapshotForDiff(basePath)
+    const diff = computeGraphDiff(currentGraph, baseSnapshot)
+
+    expect(diff.base.exportedAt).toBeTruthy()
+    expect(diff.current.exportedAt).toBeTruthy()
+    expect(diff.added.nodes.map((n) => n.id)).toEqual(['service:service-c'])
+    expect(diff.added.edges).toEqual([])
+    expect(diff.removed.nodes).toEqual([])
+    expect(diff.removed.edges).toEqual([])
+    expect(diff.changed.edges).toHaveLength(1)
+    expect(diff.changed.edges[0].id).toBe('CALLS:service:service-a->service:service-b')
+    expect(diff.changed.edges[0].before.provenance).toBe(Provenance.EXTRACTED)
+    expect(diff.changed.edges[0].after.provenance).toBe(Provenance.STALE)
+  })
+
+  it('reports a removed node when the live graph dropped it', async () => {
+    const baseGraph = newGraph()
+    addServiceA(baseGraph)
+    addServiceB(baseGraph)
+    const basePath = path.join(tmp, 'base.json')
+    await saveGraphToDisk(baseGraph, basePath)
+
+    const currentGraph = newGraph()
+    addServiceA(currentGraph)
+
+    const diff = computeGraphDiff(currentGraph, await loadSnapshotForDiff(basePath))
+    expect(diff.removed.nodes.map((n) => n.id)).toEqual(['service:service-b'])
+    expect(diff.added.nodes).toEqual([])
+  })
+
+  it('returns an empty diff for two structurally identical graphs', async () => {
+    const baseGraph = newGraph()
+    addServiceA(baseGraph)
+    addServiceB(baseGraph)
+    const basePath = path.join(tmp, 'base.json')
+    await saveGraphToDisk(baseGraph, basePath)
+
+    const currentGraph = newGraph()
+    addServiceA(currentGraph)
+    addServiceB(currentGraph)
+
+    const diff = computeGraphDiff(currentGraph, await loadSnapshotForDiff(basePath))
+    expect(diff.added.nodes).toEqual([])
+    expect(diff.added.edges).toEqual([])
+    expect(diff.removed.nodes).toEqual([])
+    expect(diff.removed.edges).toEqual([])
+    expect(diff.changed.nodes).toEqual([])
+    expect(diff.changed.edges).toEqual([])
+  })
+})
+
+describe('loadSnapshotForDiff', () => {
+  it('reads a local snapshot file', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-diff-load-'))
+    try {
+      const g = newGraph()
+      addServiceA(g)
+      const p = path.join(tmp, 's.json')
+      await saveGraphToDisk(g, p)
+      const snap = await loadSnapshotForDiff(p)
+      expect(snap.exportedAt).toBeTruthy()
+      expect(snap.graph?.nodes?.length).toBe(1)
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -1,6 +1,6 @@
 # @neat/mcp
 
-The NEAT MCP server. Stdio JSON-RPC, six tools, talks to a running `@neat/core` instance over HTTP.
+The NEAT MCP server. Stdio JSON-RPC, seven tools, talks to a running `@neat/core` instance over HTTP.
 
 ## When to use these tools
 
@@ -16,6 +16,7 @@ Rule of thumb: if the question would take more than two file reads to answer fro
 | "What does X actually call at runtime?"              | `get_observed_dependencies`|
 | "Show me recent errors on X"                         | `get_incident_history`     |
 | "Find nodes matching …"                              | `semantic_search`          |
+| "What changed since the last snapshot?"              | `get_graph_diff`           |
 
 If a tool returns "not found" or empty, check that core is running (`curl $NEAT_CORE_URL/health`) before falling back to source reads.
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,6 +7,7 @@ import { createHttpClient } from './client.js'
 import {
   getBlastRadius,
   getDependencies,
+  getGraphDiff,
   getIncidentHistory,
   getObservedDependencies,
   getRootCause,
@@ -81,6 +82,19 @@ server.tool(
   'Search nodes by free-text query. Currently a keyword match over node ids and names; vector search lands post-MVP.',
   { query: z.string().describe('Search text') },
   async (input) => semanticSearch(client, input),
+)
+
+server.tool(
+  'get_graph_diff',
+  'Diff a saved graph snapshot against the current live graph. Useful for change reviews and post-incidents — answers "what changed in the architecture between then and now." Returns added/removed/changed nodes and edges with both snapshot timestamps.',
+  {
+    againstSnapshot: z
+      .string()
+      .describe(
+        'Path or http(s) URL of the snapshot to diff against (the "before" state). The current graph is the "after".',
+      ),
+  },
+  async (input) => getGraphDiff(client, input),
 )
 
 async function main(): Promise<void> {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -249,3 +249,95 @@ export async function semanticSearch(
     return errorText(`Error talking to neat-core: ${(err as Error).message}`)
   }
 }
+
+export interface GraphDiffInput {
+  againstSnapshot: string
+}
+
+interface GraphDiffResponse {
+  base: { exportedAt?: string }
+  current: { exportedAt: string }
+  added: { nodes: GraphNode[]; edges: GraphEdge[] }
+  removed: { nodes: GraphNode[]; edges: GraphEdge[] }
+  changed: {
+    nodes: { id: string; before: GraphNode; after: GraphNode }[]
+    edges: { id: string; before: GraphEdge; after: GraphEdge }[]
+  }
+}
+
+export async function getGraphDiff(
+  client: HttpClient,
+  input: GraphDiffInput,
+): Promise<ToolResponse> {
+  try {
+    const result = await client.get<GraphDiffResponse>(
+      `/graph/diff?against=${encodeURIComponent(input.againstSnapshot)}`,
+    )
+    const total =
+      result.added.nodes.length +
+      result.added.edges.length +
+      result.removed.nodes.length +
+      result.removed.edges.length +
+      result.changed.nodes.length +
+      result.changed.edges.length
+    const baseLabel = result.base.exportedAt ?? 'unknown'
+    if (total === 0) {
+      return text(
+        `No differences between the current graph and ${input.againstSnapshot} (base exportedAt=${baseLabel}).`,
+      )
+    }
+    const lines = [
+      `Diff against ${input.againstSnapshot}:`,
+      `  base exportedAt:    ${baseLabel}`,
+      `  current exportedAt: ${result.current.exportedAt}`,
+      '',
+    ]
+    if (result.added.nodes.length || result.added.edges.length) {
+      lines.push('Added:')
+      for (const n of result.added.nodes) lines.push(`  + node ${n.id} (${n.type})`)
+      for (const e of result.added.edges)
+        lines.push(`  + edge ${e.id} — ${e.source} -> ${e.target} (${e.type}, ${e.provenance})`)
+      lines.push('')
+    }
+    if (result.removed.nodes.length || result.removed.edges.length) {
+      lines.push('Removed:')
+      for (const n of result.removed.nodes) lines.push(`  - node ${n.id} (${n.type})`)
+      for (const e of result.removed.edges)
+        lines.push(`  - edge ${e.id} — ${e.source} -> ${e.target} (${e.type}, ${e.provenance})`)
+      lines.push('')
+    }
+    if (result.changed.nodes.length || result.changed.edges.length) {
+      lines.push('Changed:')
+      for (const c of result.changed.nodes) {
+        lines.push(`  ~ node ${c.id} — ${summariseAttrDiff(c.before, c.after)}`)
+      }
+      for (const c of result.changed.edges) {
+        const provBit =
+          c.before.provenance !== c.after.provenance
+            ? `provenance ${c.before.provenance} → ${c.after.provenance}`
+            : summariseAttrDiff(c.before, c.after)
+        lines.push(`  ~ edge ${c.id} — ${provBit}`)
+      }
+    }
+    return text(lines.join('\n').trimEnd())
+  } catch (err) {
+    if (err instanceof HttpError && err.status === 400) {
+      return errorText(`Could not load snapshot ${input.againstSnapshot}: ${err.message}`)
+    }
+    return errorText(`Error talking to neat-core: ${(err as Error).message}`)
+  }
+}
+
+function summariseAttrDiff(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): string {
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)])
+  const changed: string[] = []
+  for (const k of keys) {
+    if (JSON.stringify(before[k]) !== JSON.stringify(after[k])) changed.push(k)
+  }
+  return changed.length === 0
+    ? 'attributes differ'
+    : `fields changed: ${changed.sort().join(', ')}`
+}

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -4,6 +4,7 @@ import { HttpError, type HttpClient } from '../src/client.js'
 import {
   getBlastRadius,
   getDependencies,
+  getGraphDiff,
   getIncidentHistory,
   getObservedDependencies,
   getRootCause,
@@ -355,5 +356,104 @@ describe('semanticSearch', () => {
     })
     const res = await semanticSearch(client, { query: 'nothing' })
     expect(res.content[0].text).toContain('No matches')
+  })
+})
+
+describe('getGraphDiff', () => {
+  const baseExportedAt = '2026-04-25T10:00:00.000Z'
+  const currentExportedAt = '2026-05-02T10:00:00.000Z'
+
+  it('formats added/removed/changed sections', async () => {
+    const { client, capture } = clientFor({
+      '/graph/diff?against=.%2Fsnapshots%2Flast-week.json': {
+        base: { exportedAt: baseExportedAt },
+        current: { exportedAt: currentExportedAt },
+        added: {
+          nodes: [
+            {
+              id: 'service:checkout',
+              type: NodeType.ServiceNode,
+              name: 'checkout',
+              language: 'javascript',
+            },
+          ],
+          edges: [
+            {
+              id: 'CALLS:OBSERVED:service:service-a->service:checkout',
+              source: 'service:service-a',
+              target: 'service:checkout',
+              type: EdgeType.CALLS,
+              provenance: Provenance.OBSERVED,
+            },
+          ],
+        },
+        removed: { nodes: [], edges: [] },
+        changed: {
+          nodes: [],
+          edges: [
+            {
+              id: 'CONNECTS_TO:OBSERVED:service:service-b->database:payments-db',
+              before: {
+                id: 'CONNECTS_TO:OBSERVED:service:service-b->database:payments-db',
+                source: 'service:service-b',
+                target: 'database:payments-db',
+                type: EdgeType.CONNECTS_TO,
+                provenance: Provenance.OBSERVED,
+                callCount: 12,
+              },
+              after: {
+                id: 'CONNECTS_TO:OBSERVED:service:service-b->database:payments-db',
+                source: 'service:service-b',
+                target: 'database:payments-db',
+                type: EdgeType.CONNECTS_TO,
+                provenance: Provenance.STALE,
+                callCount: 12,
+                confidence: 0.3,
+              },
+            },
+          ],
+        },
+      },
+    })
+    const res = await getGraphDiff(client, { againstSnapshot: './snapshots/last-week.json' })
+    expect(res.isError).toBeFalsy()
+    const out = res.content[0].text
+    expect(out).toContain('Diff against ./snapshots/last-week.json')
+    expect(out).toContain(`base exportedAt:    ${baseExportedAt}`)
+    expect(out).toContain(`current exportedAt: ${currentExportedAt}`)
+    expect(out).toContain('+ node service:checkout')
+    expect(out).toContain('+ edge CALLS:OBSERVED:service:service-a->service:checkout')
+    expect(out).toContain(
+      '~ edge CONNECTS_TO:OBSERVED:service:service-b->database:payments-db — provenance OBSERVED → STALE',
+    )
+    expect(capture.paths).toEqual([
+      '/graph/diff?against=.%2Fsnapshots%2Flast-week.json',
+    ])
+  })
+
+  it('reports an empty diff with both timestamps', async () => {
+    const { client } = clientFor({
+      '/graph/diff?against=.%2Fsame.json': {
+        base: { exportedAt: baseExportedAt },
+        current: { exportedAt: currentExportedAt },
+        added: { nodes: [], edges: [] },
+        removed: { nodes: [], edges: [] },
+        changed: { nodes: [], edges: [] },
+      },
+    })
+    const res = await getGraphDiff(client, { againstSnapshot: './same.json' })
+    expect(res.content[0].text).toContain('No differences')
+    expect(res.content[0].text).toContain(baseExportedAt)
+  })
+
+  it('surfaces a friendly error when the snapshot cannot be loaded', async () => {
+    const client: HttpClient = {
+      async get<T>(): Promise<T> {
+        throw new HttpError(400, '400 on /graph/diff?against=oops')
+      },
+    }
+    const res = await getGraphDiff(client, { againstSnapshot: 'oops' })
+    expect(res.isError).toBe(true)
+    expect(res.content[0].text).toContain('Could not load snapshot oops')
   })
 })


### PR DESCRIPTION
## Summary

Two snapshots, one comparison: useful for change reviews and post-incident reads. The shape mirrors the issue spec — `added` / `removed` / `changed` buckets for both nodes and edges, both `exportedAt` timestamps echoed back.

- `GET /graph/diff?against=<path-or-url>` loads the snapshot via `fs` (local paths) or `fetch` (http/https) and walks both graphs by id. The result is a `GraphDiff` object exported from `@neat/core` so other packages can consume it directly.
- New MCP tool `get_graph_diff(againstSnapshot)` formats the diff as `+ node …` / `- edge …` / `~ edge … provenance OBSERVED → STALE` lines. Empty diffs report both timestamps so the caller can confirm they're comparing the right pair.
- Failures resolving the snapshot return 400 with a `failed to load snapshot` error code so MCP can distinguish "endpoint missing" from "path wrong."

## Test plan

- [x] `npx turbo build test lint` — green (139 core / 30 types / 20 mcp)
- [x] New unit tests in `packages/core/test/diff.test.ts` covering added/removed/changed and identity diffs
- [x] New API tests in `packages/core/test/api.test.ts` for the 400 paths and the live diff round-trip
- [x] New MCP tool tests covering the formatter, the empty-diff message, and the 400 → friendly error path

Refs #77