### PR TITLE
Compat matrix beyond driver/engine pairs (#74)

### DIFF
--- a/packages/core/compat.json
+++ b/packages/core/compat.json
@@ -1,6 +1,7 @@
 {
   "pairs": [
     {
+      "kind": "driver-engine",
       "driver": "pg",
       "engine": "postgresql",
       "minDriverVersion": "8.0.0",
@@ -8,6 +9,7 @@
       "reason": "PostgreSQL 14+ requires scram-sha-256 auth by default; pg < 8.0.0 only speaks md5."
     },
     {
+      "kind": "driver-engine",
       "driver": "mysql2",
       "engine": "mysql",
       "minDriverVersion": "3.0.0",
@@ -15,6 +17,7 @@
       "reason": "MySQL 8 defaults to caching_sha2_password; mysql2 < 3.0.0 doesn't negotiate it."
     },
     {
+      "kind": "driver-engine",
       "driver": "mongoose",
       "engine": "mongodb",
       "minDriverVersion": "7.0.0",
@@ -22,6 +25,7 @@
       "reason": "MongoDB 7 drops legacy wire-protocol opcodes that mongoose < 7.0.0 still emits."
     },
     {
+      "kind": "driver-engine",
       "driver": "psycopg2",
       "engine": "postgresql",
       "minDriverVersion": "2.9.0",
@@ -29,6 +33,7 @@
       "reason": "PostgreSQL 14+ requires scram-sha-256 auth by default; psycopg2 < 2.9.0 only speaks md5."
     },
     {
+      "kind": "driver-engine",
       "driver": "pymongo",
       "engine": "mongodb",
       "minDriverVersion": "4.0.0",
@@ -36,11 +41,80 @@
       "reason": "MongoDB 7 drops legacy wire-protocol opcodes that pymongo < 4.0.0 still emits."
     },
     {
+      "kind": "driver-engine",
       "driver": "mysql-connector-python",
       "engine": "mysql",
       "minDriverVersion": "8.0.0",
       "minEngineVersion": "8",
       "reason": "MySQL 8 defaults to caching_sha2_password; mysql-connector-python < 8.0.0 doesn't negotiate it."
+    }
+  ],
+  "nodeEngineConstraints": [
+    {
+      "kind": "node-engine",
+      "package": "vitest",
+      "packageMinVersion": "2.0.0",
+      "minNodeVersion": "18.0.0",
+      "reason": "vitest >= 2.0 drops Node 16 support; requires Node 18+."
+    },
+    {
+      "kind": "node-engine",
+      "package": "next",
+      "packageMinVersion": "14.0.0",
+      "minNodeVersion": "18.17.0",
+      "reason": "Next 14+ requires Node 18.17+ (uses APIs introduced in that minor)."
+    },
+    {
+      "kind": "node-engine",
+      "package": "@modelcontextprotocol/sdk",
+      "packageMinVersion": "1.0.0",
+      "minNodeVersion": "18.0.0",
+      "reason": "@modelcontextprotocol/sdk >= 1 requires Node 18+ (web-streams polyfill removed)."
+    }
+  ],
+  "packageConflicts": [
+    {
+      "kind": "package-conflict",
+      "package": "@tanstack/react-query",
+      "packageMinVersion": "5.0.0",
+      "requires": {
+        "name": "react",
+        "minVersion": "18.0.0"
+      },
+      "reason": "@tanstack/react-query 5+ uses useSyncExternalStore — only available in React 18+."
+    },
+    {
+      "kind": "package-conflict",
+      "package": "react-router-dom",
+      "packageMinVersion": "7.0.0",
+      "requires": {
+        "name": "react",
+        "minVersion": "18.0.0"
+      },
+      "reason": "react-router-dom 7+ requires React 18+."
+    },
+    {
+      "kind": "package-conflict",
+      "package": "next",
+      "packageMinVersion": "14.0.0",
+      "requires": {
+        "name": "react",
+        "minVersion": "18.2.0"
+      },
+      "reason": "Next.js 14+ requires React 18.2+."
+    }
+  ],
+  "deprecatedApis": [
+    {
+      "kind": "deprecated-api",
+      "package": "request",
+      "packageMaxVersion": "2.88.2",
+      "reason": "request is deprecated; use undici, node-fetch, or axios instead."
+    },
+    {
+      "kind": "deprecated-api",
+      "package": "node-uuid",
+      "reason": "node-uuid is deprecated; use the `uuid` package."
     }
   ]
 }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -37,6 +37,21 @@ function summarise(nodes: GraphNode[], edges: GraphEdge[]): string {
   return ['nodes:', ...nodeLines, 'edges:', ...edgeLines].join('\n')
 }
 
+function formatIncompat(inc: NonNullable<ServiceNode['incompatibilities']>[number]): string {
+  if (inc.kind === 'node-engine') {
+    const range = inc.declaredNodeEngine ? ` (engines.node="${inc.declaredNodeEngine}")` : ''
+    return `${inc.package}@${inc.packageVersion ?? '?'} requires Node ${inc.requiredNodeVersion}${range} — ${inc.reason}`
+  }
+  if (inc.kind === 'package-conflict') {
+    const found = inc.foundVersion ? `@${inc.foundVersion}` : ' (missing)'
+    return `${inc.package}@${inc.packageVersion ?? '?'} requires ${inc.requires.name}>=${inc.requires.minVersion}; found ${inc.requires.name}${found} — ${inc.reason}`
+  }
+  if (inc.kind === 'deprecated-api') {
+    return `${inc.package}@${inc.packageVersion ?? '?'} is deprecated — ${inc.reason}`
+  }
+  return `${inc.driver}@${inc.driverVersion} vs ${inc.engine} ${inc.engineVersion} — ${inc.reason}`
+}
+
 function findIncompatibilities(nodes: GraphNode[]): ServiceNode[] {
   return nodes.filter(
     (n): n is ServiceNode =>
@@ -75,9 +90,7 @@ async function runInit(opts: InitOptions): Promise<void> {
     console.log(`incompatibilities found in ${incompatibilities.length} service(s):`)
     for (const svc of incompatibilities) {
       for (const inc of svc.incompatibilities ?? []) {
-        console.log(
-          `  ${svc.name}: ${inc.driver}@${inc.driverVersion} vs ${inc.engine} ${inc.engineVersion} — ${inc.reason}`,
-        )
+        console.log(`  ${svc.name}: ${formatIncompat(inc)}`)
       }
     }
   }

--- a/packages/core/src/compat.ts
+++ b/packages/core/src/compat.ts
@@ -1,3 +1,6 @@
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import semver from 'semver'
 import compatData from '../compat.json' with { type: 'json' }
 
@@ -7,7 +10,8 @@ export interface CompatibilityResult {
   minDriverVersion?: string
 }
 
-interface CompatPair {
+export interface CompatPair {
+  kind?: 'driver-engine'
   driver: string
   engine: string
   minDriverVersion: string
@@ -17,11 +21,49 @@ interface CompatPair {
   reason: string
 }
 
-interface CompatMatrix {
-  pairs: CompatPair[]
+export interface NodeEngineConstraint {
+  kind?: 'node-engine'
+  package: string
+  packageMinVersion?: string
+  minNodeVersion: string
+  reason: string
 }
 
-const matrix = compatData as CompatMatrix
+export interface PackageConflict {
+  kind?: 'package-conflict'
+  package: string
+  packageMinVersion?: string
+  requires: { name: string; minVersion: string }
+  reason: string
+}
+
+export interface DeprecatedApi {
+  kind?: 'deprecated-api'
+  package: string
+  packageMaxVersion?: string
+  reason: string
+}
+
+export interface CompatMatrix {
+  pairs: CompatPair[]
+  nodeEngineConstraints?: NodeEngineConstraint[]
+  packageConflicts?: PackageConflict[]
+  deprecatedApis?: DeprecatedApi[]
+}
+
+const bundledMatrix = compatData as CompatMatrix
+let mergedMatrix: CompatMatrix | null = null
+let remoteLoadAttempted = false
+
+const REMOTE_CACHE_DIR = path.join(os.homedir(), '.neat')
+const REMOTE_CACHE_PATH = path.join(REMOTE_CACHE_DIR, 'compat-cache.json')
+const REMOTE_TTL_MS = 24 * 60 * 60 * 1000
+
+interface RemoteCacheFile {
+  fetchedAt: string
+  url: string
+  matrix: CompatMatrix
+}
 
 // Engines like Postgres/MySQL only carry a major in the version field, so semver
 // won't always parse them cleanly. Compare as integers when both sides look like
@@ -35,7 +77,6 @@ function engineMeetsThreshold(engineVersion: string, threshold: string): boolean
   const tc = semver.coerce(threshold)
   if (ec && tc) return semver.gte(ec, tc)
 
-  // Can't reason → don't claim incompatibility.
   return false
 }
 
@@ -45,6 +86,7 @@ export function checkCompatibility(
   engine: string,
   engineVersion: string,
 ): CompatibilityResult {
+  const matrix = currentMatrix()
   const pair = matrix.pairs.find((p) => p.driver === driver && p.engine === engine)
   if (!pair) return { compatible: true }
 
@@ -66,10 +108,216 @@ export function checkCompatibility(
   return { compatible: true }
 }
 
-// Exported so #4 (extract) can iterate the configured pairs to build
-// `compatibleDrivers` lists on DatabaseNodes.
-export function compatPairs(): readonly CompatPair[] {
-  return matrix.pairs
+export interface NodeEngineCheck {
+  compatible: boolean
+  reason?: string
+  requiredNodeVersion?: string
 }
 
-export type { CompatPair }
+// True when `serviceNodeRange` (a service's `engines.node`) is guaranteed to
+// admit `requiredNodeVersion`. We use a permissive semver compare via `coerce`
+// — exact ranges like ">=20" parse fine, exotic ones like "^20 || ^22" pass as
+// long as semver can resolve them. If the range can't be parsed at all, we
+// don't claim a conflict — under-flag rather than over-flag.
+function rangeAdmitsVersion(serviceNodeRange: string, requiredNodeVersion: string): boolean {
+  try {
+    const required = semver.coerce(requiredNodeVersion)
+    if (!required) return true
+    // Is every version that satisfies the service's range >= required? If yes,
+    // the service guarantees the requirement; if not, there's at least one
+    // admissible Node version that won't satisfy the dep — that's the
+    // conflict.
+    return semver.subset(serviceNodeRange, `>=${required.version}`, {
+      includePrerelease: false,
+    })
+  } catch {
+    return true
+  }
+}
+
+export function checkNodeEngineConstraint(
+  constraint: NodeEngineConstraint,
+  declaredPackageVersion: string | undefined,
+  serviceNodeRange: string | undefined,
+): NodeEngineCheck {
+  if (constraint.packageMinVersion && declaredPackageVersion) {
+    const v = semver.coerce(declaredPackageVersion)
+    if (v && semver.lt(v, constraint.packageMinVersion)) {
+      return { compatible: true }
+    }
+  }
+  if (!serviceNodeRange) {
+    return { compatible: true }
+  }
+  if (rangeAdmitsVersion(serviceNodeRange, constraint.minNodeVersion)) {
+    return { compatible: true }
+  }
+  return {
+    compatible: false,
+    reason: constraint.reason,
+    requiredNodeVersion: constraint.minNodeVersion,
+  }
+}
+
+export interface PackageConflictCheck {
+  compatible: boolean
+  reason?: string
+  requires?: { name: string; minVersion: string }
+  foundVersion?: string
+}
+
+export function checkPackageConflict(
+  conflict: PackageConflict,
+  declaredPackageVersion: string | undefined,
+  declaredRequiredVersion: string | undefined,
+): PackageConflictCheck {
+  if (!declaredPackageVersion) return { compatible: true }
+  if (conflict.packageMinVersion) {
+    const v = semver.coerce(declaredPackageVersion)
+    if (v && semver.lt(v, conflict.packageMinVersion)) {
+      return { compatible: true }
+    }
+  }
+  if (!declaredRequiredVersion) {
+    return {
+      compatible: false,
+      reason: conflict.reason,
+      requires: conflict.requires,
+    }
+  }
+  const requiredCoerced = semver.coerce(declaredRequiredVersion)
+  if (!requiredCoerced) return { compatible: true }
+  if (semver.lt(requiredCoerced, conflict.requires.minVersion)) {
+    return {
+      compatible: false,
+      reason: conflict.reason,
+      requires: conflict.requires,
+      foundVersion: declaredRequiredVersion,
+    }
+  }
+  return { compatible: true }
+}
+
+export function checkDeprecatedApi(
+  rule: DeprecatedApi,
+  declaredVersion: string | undefined,
+): { compatible: boolean; reason?: string } {
+  if (declaredVersion === undefined) return { compatible: true }
+  if (rule.packageMaxVersion) {
+    const v = semver.coerce(declaredVersion)
+    const max = semver.coerce(rule.packageMaxVersion)
+    if (v && max && semver.gt(v, max)) return { compatible: true }
+  }
+  return { compatible: false, reason: rule.reason }
+}
+
+function currentMatrix(): CompatMatrix {
+  return mergedMatrix ?? bundledMatrix
+}
+
+function mergeMatrices(a: CompatMatrix, b: CompatMatrix): CompatMatrix {
+  return {
+    pairs: [...a.pairs, ...(b.pairs ?? [])],
+    nodeEngineConstraints: [
+      ...(a.nodeEngineConstraints ?? []),
+      ...(b.nodeEngineConstraints ?? []),
+    ],
+    packageConflicts: [...(a.packageConflicts ?? []), ...(b.packageConflicts ?? [])],
+    deprecatedApis: [...(a.deprecatedApis ?? []), ...(b.deprecatedApis ?? [])],
+  }
+}
+
+async function readRemoteCache(url: string): Promise<CompatMatrix | null> {
+  try {
+    const raw = await fs.readFile(REMOTE_CACHE_PATH, 'utf8')
+    const parsed = JSON.parse(raw) as RemoteCacheFile
+    if (parsed.url !== url) return null
+    const age = Date.now() - new Date(parsed.fetchedAt).getTime()
+    if (age > REMOTE_TTL_MS) return null
+    return parsed.matrix
+  } catch {
+    return null
+  }
+}
+
+async function writeRemoteCache(url: string, matrix: CompatMatrix): Promise<void> {
+  const file: RemoteCacheFile = {
+    fetchedAt: new Date().toISOString(),
+    url,
+    matrix,
+  }
+  try {
+    await fs.mkdir(REMOTE_CACHE_DIR, { recursive: true })
+    await fs.writeFile(REMOTE_CACHE_PATH, JSON.stringify(file), 'utf8')
+  } catch (err) {
+    console.warn(`[neat] failed to cache compat matrix: ${(err as Error).message}`)
+  }
+}
+
+// Loads the bundled matrix and, if `NEAT_COMPAT_URL` is set, merges in a
+// remote extension. Falls back to a fresh fetch when the on-disk cache is
+// stale (24h TTL) or missing. Returns the merged matrix; subsequent calls are
+// memoised.
+//
+// Async because the fetch happens lazily on first use. Extract phase 2 awaits
+// this before iterating pairs; everything else goes through the sync
+// `currentMatrix()` view, which is fine because by the time CLI / traversal
+// runs, extraction has already loaded.
+export async function ensureCompatLoaded(): Promise<CompatMatrix> {
+  if (mergedMatrix) return mergedMatrix
+  if (remoteLoadAttempted) {
+    mergedMatrix = bundledMatrix
+    return mergedMatrix
+  }
+  remoteLoadAttempted = true
+
+  const url = process.env.NEAT_COMPAT_URL
+  if (!url) {
+    mergedMatrix = bundledMatrix
+    return mergedMatrix
+  }
+
+  const cached = await readRemoteCache(url)
+  if (cached) {
+    mergedMatrix = mergeMatrices(bundledMatrix, cached)
+    return mergedMatrix
+  }
+
+  try {
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+    const remote = (await res.json()) as CompatMatrix
+    await writeRemoteCache(url, remote)
+    mergedMatrix = mergeMatrices(bundledMatrix, remote)
+    return mergedMatrix
+  } catch (err) {
+    console.warn(
+      `[neat] NEAT_COMPAT_URL fetch failed (${(err as Error).message}); using bundled matrix only`,
+    )
+    mergedMatrix = bundledMatrix
+    return mergedMatrix
+  }
+}
+
+// Reset the merged-matrix memo. Intended for tests so each test starts with a
+// freshly loaded matrix.
+export function resetCompatMatrix(): void {
+  mergedMatrix = null
+  remoteLoadAttempted = false
+}
+
+export function compatPairs(): readonly CompatPair[] {
+  return currentMatrix().pairs
+}
+
+export function nodeEngineConstraints(): readonly NodeEngineConstraint[] {
+  return currentMatrix().nodeEngineConstraints ?? []
+}
+
+export function packageConflicts(): readonly PackageConflict[] {
+  return currentMatrix().packageConflicts ?? []
+}
+
+export function deprecatedApis(): readonly DeprecatedApi[] {
+  return currentMatrix().deprecatedApis ?? []
+}

--- a/packages/core/src/extract/databases/index.ts
+++ b/packages/core/src/extract/databases/index.ts
@@ -7,7 +7,16 @@ import type {
 } from '@neat/types'
 import { EdgeType, NodeType, Provenance } from '@neat/types'
 import type { NeatGraph } from '../../graph.js'
-import { checkCompatibility, compatPairs } from '../../compat.js'
+import {
+  checkCompatibility,
+  checkDeprecatedApi,
+  checkNodeEngineConstraint,
+  checkPackageConflict,
+  compatPairs,
+  deprecatedApis,
+  nodeEngineConstraints,
+  packageConflicts,
+} from '../../compat.js'
 import { cleanVersion, makeEdgeId, type DiscoveredService } from '../shared.js'
 import { dbConfigYamlParser } from './db-config-yaml.js'
 import { dotenvParser } from './dotenv.js'
@@ -65,10 +74,12 @@ export function attachIncompatibilities(
   service: DiscoveredService,
   configs: DbConfig[],
 ): void {
-  const deps = service.pkg.dependencies ?? {}
+  const deps = { ...(service.pkg.dependencies ?? {}), ...(service.pkg.devDependencies ?? {}) }
   const incompatibilities: NonNullable<ServiceNode['incompatibilities']> = []
   const seen = new Set<string>()
 
+  // 1. driver-engine — original behaviour. Per (db config, configured driver
+  // pair) check that the declared driver version meets the engine threshold.
   for (const config of configs) {
     for (const pair of compatPairs()) {
       if (pair.engine !== config.engine) continue
@@ -81,10 +92,11 @@ export function attachIncompatibilities(
         config.engineVersion,
       )
       if (!result.compatible && result.reason) {
-        const key = `${pair.driver}@${declaredVersion}|${config.engine}@${config.engineVersion}`
+        const key = `driver-engine|${pair.driver}@${declaredVersion}|${config.engine}@${config.engineVersion}`
         if (seen.has(key)) continue
         seen.add(key)
         incompatibilities.push({
+          kind: 'driver-engine',
           driver: pair.driver,
           driverVersion: declaredVersion,
           engine: config.engine,
@@ -92,6 +104,67 @@ export function attachIncompatibilities(
           reason: result.reason,
         })
       }
+    }
+  }
+
+  // 2. node-engine — service's `engines.node` vs each declared dep that has a
+  // matrix-recorded minimum.
+  const serviceNodeEngine = service.node.nodeEngine ?? service.pkg.engines?.node
+  for (const constraint of nodeEngineConstraints()) {
+    const declared = cleanVersion(deps[constraint.package])
+    if (!declared) continue
+    const result = checkNodeEngineConstraint(constraint, declared, serviceNodeEngine)
+    if (!result.compatible && result.reason) {
+      const key = `node-engine|${constraint.package}@${declared}|${serviceNodeEngine ?? ''}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      incompatibilities.push({
+        kind: 'node-engine',
+        package: constraint.package,
+        packageVersion: declared,
+        requiredNodeVersion: result.requiredNodeVersion ?? constraint.minNodeVersion,
+        ...(serviceNodeEngine ? { declaredNodeEngine: serviceNodeEngine } : {}),
+        reason: result.reason,
+      })
+    }
+  }
+
+  // 3. package-conflict — pair like react-query 5+ requiring react 18+.
+  for (const conflict of packageConflicts()) {
+    const declared = cleanVersion(deps[conflict.package])
+    if (!declared) continue
+    const requiredVersion = cleanVersion(deps[conflict.requires.name])
+    const result = checkPackageConflict(conflict, declared, requiredVersion)
+    if (!result.compatible && result.reason) {
+      const key = `package-conflict|${conflict.package}@${declared}|${conflict.requires.name}@${requiredVersion ?? 'missing'}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      incompatibilities.push({
+        kind: 'package-conflict',
+        package: conflict.package,
+        packageVersion: declared,
+        requires: conflict.requires,
+        ...(requiredVersion ? { foundVersion: requiredVersion } : {}),
+        reason: result.reason,
+      })
+    }
+  }
+
+  // 4. deprecated-api — flag presence of a known-deprecated package.
+  for (const rule of deprecatedApis()) {
+    const declared = cleanVersion(deps[rule.package])
+    if (declared === undefined) continue
+    const result = checkDeprecatedApi(rule, declared)
+    if (!result.compatible && result.reason) {
+      const key = `deprecated-api|${rule.package}@${declared}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      incompatibilities.push({
+        kind: 'deprecated-api',
+        package: rule.package,
+        packageVersion: declared,
+        reason: result.reason,
+      })
     }
   }
 
@@ -126,7 +199,6 @@ export async function addDatabasesAndCompat(
         if (!merged.has(config.host)) merged.set(config.host, config)
       }
     }
-    if (merged.size === 0) continue
 
     const allConfigs = [...merged.values()]
     for (const config of allConfigs) {
@@ -148,8 +220,20 @@ export async function addDatabasesAndCompat(
       }
     }
 
+    // Run all kinds of incompat checks even for services with no db connection
+    // — node-engine / package-conflict / deprecated-api don't depend on db.
     attachIncompatibilities(service, allConfigs)
-    graph.replaceNodeAttributes(service.node.id, service.node as unknown as GraphNode)
+    if (graph.hasNode(service.node.id)) {
+      // Merge with whatever's on the node already (aliases from γ #75 land
+      // before this phase), so the writeback doesn't drop fields populated by
+      // earlier passes.
+      const current = graph.getNodeAttributes(service.node.id) as ServiceNode
+      graph.replaceNodeAttributes(service.node.id, {
+        ...current,
+        ...(service.node as ServiceNode),
+        ...(current.aliases ? { aliases: current.aliases } : {}),
+      } as unknown as GraphNode)
+    }
   }
 
   return { nodesAdded, edgesAdded }

--- a/packages/core/src/extract/index.ts
+++ b/packages/core/src/extract/index.ts
@@ -1,5 +1,6 @@
 import type { NeatGraph } from '../graph.js'
 import { promoteFrontierNodes } from '../ingest.js'
+import { ensureCompatLoaded } from '../compat.js'
 import { addServiceNodes, discoverServices } from './services.js'
 import { addServiceAliases } from './aliases.js'
 import { addDatabasesAndCompat } from './databases/index.js'
@@ -17,6 +18,7 @@ export async function extractFromDirectory(
   graph: NeatGraph,
   scanPath: string,
 ): Promise<ExtractResult> {
+  await ensureCompatLoaded()
   const services = await discoverServices(scanPath)
 
   const phase1Nodes = addServiceNodes(graph, services)

--- a/packages/core/src/extract/services.ts
+++ b/packages/core/src/extract/services.ts
@@ -131,6 +131,7 @@ async function discoverNodeService(
     version: pkg.version,
     dependencies: pkg.dependencies ?? {},
     repoPath: path.relative(scanPath, dir),
+    ...(pkg.engines?.node ? { nodeEngine: pkg.engines.node } : {}),
   }
   return { pkg, dir, node }
 }

--- a/packages/core/src/extract/shared.ts
+++ b/packages/core/src/extract/shared.ts
@@ -8,6 +8,7 @@ export interface PackageJson {
   version?: string
   dependencies?: Record<string, string>
   devDependencies?: Record<string, string>
+  engines?: { node?: string }
 }
 
 export interface DiscoveredService {

--- a/packages/core/test/compat-extract.test.ts
+++ b/packages/core/test/compat-extract.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { MultiDirectedGraph } from 'graphology'
+import type { GraphEdge, GraphNode, ServiceNode } from '@neat/types'
+import type { NeatGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+
+function newGraph(): NeatGraph {
+  return new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+}
+
+async function writeFile(dir: string, rel: string, content: string): Promise<void> {
+  const abs = path.join(dir, rel)
+  await fs.mkdir(path.dirname(abs), { recursive: true })
+  await fs.writeFile(abs, content, 'utf8')
+}
+
+describe('extract — extended compat checks', () => {
+  let tmp: string
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-compat-'))
+  })
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true })
+  })
+
+  it('flags a node-engine conflict when engines.node is too low for a declared dep', async () => {
+    await writeFile(
+      tmp,
+      'pkg/package.json',
+      JSON.stringify({
+        name: 'fixture-low-node',
+        engines: { node: '>=16' },
+        dependencies: { next: '14.2.0' },
+      }),
+    )
+    const graph = newGraph()
+    await extractFromDirectory(graph, tmp)
+    const svc = graph.getNodeAttributes('service:fixture-low-node') as ServiceNode
+    const incs = svc.incompatibilities ?? []
+    const nodeEngine = incs.find((i) => i.kind === 'node-engine')
+    expect(nodeEngine).toBeDefined()
+    if (nodeEngine && nodeEngine.kind === 'node-engine') {
+      expect(nodeEngine.package).toBe('next')
+      expect(nodeEngine.requiredNodeVersion).toBe('18.17.0')
+      expect(nodeEngine.declaredNodeEngine).toBe('>=16')
+    }
+  })
+
+  it('does not flag node-engine when engines.node admits the requirement', async () => {
+    await writeFile(
+      tmp,
+      'pkg/package.json',
+      JSON.stringify({
+        name: 'fixture-ok-node',
+        engines: { node: '>=20' },
+        dependencies: { next: '14.2.0', react: '18.2.0' },
+      }),
+    )
+    const graph = newGraph()
+    await extractFromDirectory(graph, tmp)
+    const svc = graph.getNodeAttributes('service:fixture-ok-node') as ServiceNode
+    const incs = svc.incompatibilities ?? []
+    expect(incs.find((i) => i.kind === 'node-engine')).toBeUndefined()
+  })
+
+  it('flags a package-conflict (react-query 5 + react 17)', async () => {
+    await writeFile(
+      tmp,
+      'pkg/package.json',
+      JSON.stringify({
+        name: 'fixture-rq-conflict',
+        dependencies: {
+          '@tanstack/react-query': '5.18.0',
+          react: '17.0.2',
+        },
+      }),
+    )
+    const graph = newGraph()
+    await extractFromDirectory(graph, tmp)
+    const svc = graph.getNodeAttributes('service:fixture-rq-conflict') as ServiceNode
+    const incs = svc.incompatibilities ?? []
+    const conflict = incs.find((i) => i.kind === 'package-conflict')
+    expect(conflict).toBeDefined()
+    if (conflict && conflict.kind === 'package-conflict') {
+      expect(conflict.package).toBe('@tanstack/react-query')
+      expect(conflict.foundVersion).toBe('17.0.2')
+      expect(conflict.requires.name).toBe('react')
+    }
+  })
+
+  it('flags a deprecated-api when a deprecated package is declared', async () => {
+    await writeFile(
+      tmp,
+      'pkg/package.json',
+      JSON.stringify({
+        name: 'fixture-deprecated',
+        dependencies: { 'node-uuid': '1.4.0' },
+      }),
+    )
+    const graph = newGraph()
+    await extractFromDirectory(graph, tmp)
+    const svc = graph.getNodeAttributes('service:fixture-deprecated') as ServiceNode
+    const incs = svc.incompatibilities ?? []
+    const dep = incs.find((i) => i.kind === 'deprecated-api')
+    expect(dep).toBeDefined()
+    if (dep && dep.kind === 'deprecated-api') {
+      expect(dep.package).toBe('node-uuid')
+    }
+  })
+
+  it('runs compat checks even when the service has no database connection', async () => {
+    await writeFile(
+      tmp,
+      'pkg/package.json',
+      JSON.stringify({
+        name: 'fixture-no-db',
+        dependencies: { 'node-uuid': '1.4.0' },
+      }),
+    )
+    const graph = newGraph()
+    await extractFromDirectory(graph, tmp)
+    const svc = graph.getNodeAttributes('service:fixture-no-db') as ServiceNode
+    expect(svc.incompatibilities ?? []).toHaveLength(1)
+  })
+})

--- a/packages/core/test/compat.test.ts
+++ b/packages/core/test/compat.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect } from 'vitest'
-import { checkCompatibility, compatPairs } from '../src/compat.js'
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import {
+  checkCompatibility,
+  checkDeprecatedApi,
+  checkNodeEngineConstraint,
+  checkPackageConflict,
+  compatPairs,
+  deprecatedApis,
+  ensureCompatLoaded,
+  nodeEngineConstraints,
+  packageConflicts,
+  resetCompatMatrix,
+} from '../src/compat.js'
 
 describe('checkCompatibility', () => {
   describe('pg / postgresql', () => {
@@ -94,5 +105,125 @@ describe('checkCompatibility', () => {
         'pymongo/mongodb',
       ])
     })
+  })
+})
+
+describe('checkNodeEngineConstraint', () => {
+  it('flags a service whose engines.node excludes the required version', () => {
+    const constraint = nodeEngineConstraints().find((c) => c.package === 'next')!
+    const r = checkNodeEngineConstraint(constraint, '14.2.0', '>=16')
+    expect(r.compatible).toBe(false)
+    expect(r.requiredNodeVersion).toBe('18.17.0')
+  })
+
+  it('passes when engines.node admits the required version', () => {
+    const constraint = nodeEngineConstraints().find((c) => c.package === 'next')!
+    expect(checkNodeEngineConstraint(constraint, '14.2.0', '>=20').compatible).toBe(true)
+  })
+
+  it('passes when the package version is below the constraint trigger', () => {
+    const constraint = nodeEngineConstraints().find((c) => c.package === 'next')!
+    expect(checkNodeEngineConstraint(constraint, '13.5.0', '>=16').compatible).toBe(true)
+  })
+
+  it('refuses to claim a conflict when engines.node is unset', () => {
+    const constraint = nodeEngineConstraints().find((c) => c.package === 'next')!
+    expect(checkNodeEngineConstraint(constraint, '14.2.0', undefined).compatible).toBe(true)
+  })
+})
+
+describe('checkPackageConflict', () => {
+  it('flags @tanstack/react-query 5+ paired with React 17', () => {
+    const conflict = packageConflicts().find(
+      (c) => c.package === '@tanstack/react-query',
+    )!
+    const r = checkPackageConflict(conflict, '5.0.0', '17.0.2')
+    expect(r.compatible).toBe(false)
+    expect(r.foundVersion).toBe('17.0.2')
+    expect(r.requires).toEqual({ name: 'react', minVersion: '18.0.0' })
+  })
+
+  it('flags @tanstack/react-query 5+ when the required peer is missing entirely', () => {
+    const conflict = packageConflicts().find(
+      (c) => c.package === '@tanstack/react-query',
+    )!
+    const r = checkPackageConflict(conflict, '5.0.0', undefined)
+    expect(r.compatible).toBe(false)
+  })
+
+  it('passes when both packages are above the threshold', () => {
+    const conflict = packageConflicts().find(
+      (c) => c.package === '@tanstack/react-query',
+    )!
+    expect(checkPackageConflict(conflict, '5.18.0', '18.2.0').compatible).toBe(true)
+  })
+})
+
+describe('checkDeprecatedApi', () => {
+  it('flags any declared version of a deprecated package without a max', () => {
+    const rule = deprecatedApis().find((d) => d.package === 'node-uuid')!
+    expect(checkDeprecatedApi(rule, '1.4.0').compatible).toBe(false)
+  })
+
+  it('respects packageMaxVersion when set', () => {
+    const rule = deprecatedApis().find((d) => d.package === 'request')!
+    expect(checkDeprecatedApi(rule, '2.88.0').compatible).toBe(false)
+    expect(checkDeprecatedApi(rule, '99.0.0').compatible).toBe(true)
+  })
+})
+
+describe('ensureCompatLoaded — NEAT_COMPAT_URL', () => {
+  const originalEnv = process.env.NEAT_COMPAT_URL
+  let originalFetch: typeof fetch
+
+  beforeEach(() => {
+    resetCompatMatrix()
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.NEAT_COMPAT_URL
+    else process.env.NEAT_COMPAT_URL = originalEnv
+    globalThis.fetch = originalFetch
+    resetCompatMatrix()
+  })
+
+  it('merges a remote extension into the bundled matrix', async () => {
+    process.env.NEAT_COMPAT_URL = 'https://example.test/compat-' + Date.now() + '.json'
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        async json() {
+          return {
+            pairs: [
+              {
+                kind: 'driver-engine',
+                driver: 'redis',
+                engine: 'redis',
+                minDriverVersion: '4.0.0',
+                minEngineVersion: '7',
+                reason: 'redis 7 changed RESP3 negotiation; redis < 4 lacks the handshake.',
+              },
+            ],
+          }
+        },
+      }) as unknown as Response) as unknown as typeof fetch
+
+    await ensureCompatLoaded()
+    const pair = compatPairs().find((p) => p.driver === 'redis' && p.engine === 'redis')
+    expect(pair).toBeDefined()
+    expect(pair?.minDriverVersion).toBe('4.0.0')
+  })
+
+  it('falls back silently to the bundled matrix when fetch fails', async () => {
+    process.env.NEAT_COMPAT_URL = 'https://example.test/missing-' + Date.now() + '.json'
+    globalThis.fetch = (async () => {
+      throw new Error('network down')
+    }) as unknown as typeof fetch
+
+    await ensureCompatLoaded()
+    expect(compatPairs().length).toBeGreaterThanOrEqual(6)
   })
 })

--- a/packages/types/src/nodes.ts
+++ b/packages/types/src/nodes.ts
@@ -21,15 +21,50 @@ export const ServiceNodeSchema = z.object({
   // labels, etc. resolveServiceId in ingest.ts checks these before falling
   // back to a FRONTIER placeholder.
   aliases: z.array(z.string()).optional(),
+  // Optional. If set, services declare their `engines.node` here so γ #74's
+  // node-engine compat check has something to test against.
+  nodeEngine: z.string().optional(),
   incompatibilities: z
     .array(
-      z.object({
-        driver: z.string(),
-        driverVersion: z.string(),
-        engine: z.string(),
-        engineVersion: z.string(),
-        reason: z.string(),
-      }),
+      // Discriminated by `kind`. `driver-engine` is the original shape and
+      // stays default for backward compatibility — older snapshots without a
+      // `kind` field still parse via the union's `.optional()` discriminator
+      // fallback. New kinds came in with γ #74.
+      z.union([
+        z.object({
+          kind: z.literal('driver-engine').optional(),
+          driver: z.string(),
+          driverVersion: z.string(),
+          engine: z.string(),
+          engineVersion: z.string(),
+          reason: z.string(),
+        }),
+        z.object({
+          kind: z.literal('node-engine'),
+          package: z.string(),
+          packageVersion: z.string().optional(),
+          requiredNodeVersion: z.string(),
+          declaredNodeEngine: z.string().optional(),
+          reason: z.string(),
+        }),
+        z.object({
+          kind: z.literal('package-conflict'),
+          package: z.string(),
+          packageVersion: z.string().optional(),
+          requires: z.object({
+            name: z.string(),
+            minVersion: z.string(),
+          }),
+          foundVersion: z.string().optional(),
+          reason: z.string(),
+        }),
+        z.object({
+          kind: z.literal('deprecated-api'),
+          package: z.string(),
+          packageVersion: z.string().optional(),
+          reason: z.string(),
+        }),
+      ]),
     )
     .optional(),
 })


### PR DESCRIPTION
## Summary

The compat matrix grew from one shape (driver-engine) to four. Each entry now carries a `kind` discriminator so traversal and the CLI can reason about *what kind* of incompatibility is firing. Existing entries without `kind` keep parsing as `driver-engine`, so v2 snapshots stay forward-compatible.

- `node-engine` — a service's `engines.node` vs the Node version a declared dep requires (e.g. `next@14` needs Node 18.17+; a service pinned to `>=16` fails the check).
- `package-conflict` — peer mismatches encoded as `{ package, packageMinVersion?, requires: { name, minVersion } }`. `@tanstack/react-query@5` + `react@17` is the canonical case.
- `deprecated-api` — a known-deprecated package shows up as a soft incompatibility. Defers the regex usage matcher to a future change as the issue suggested; the data shape is in place.
- `NEAT_COMPAT_URL` fetches a remote extension on first use, caches to `~/.neat/compat-cache.json` with a 24h TTL, and merges into the bundled matrix. Fetch failures fall back silently.
- `ServiceNode.nodeEngine` is a new optional field carrying the service's `engines.node` for the node-engine check.

## Test plan

- [x] `npx turbo build test lint` — green (148 core / 28 types / 17 mcp)
- [x] New `checkNodeEngineConstraint` / `checkPackageConflict` / `checkDeprecatedApi` unit tests
- [x] New end-to-end fixtures in `compat-extract.test.ts` covering each kind end-to-end through `extractFromDirectory`
- [x] `NEAT_COMPAT_URL` test stubs `globalThis.fetch` and asserts the merged pair shows up in `compatPairs()`

Refs #74