### PR TITLE
Per-edge confidence from runtime signals (#76)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,7 +31,7 @@ export {
   stitchTrace,
   type IngestContext,
 } from './ingest.js'
-export { getBlastRadius, getRootCause } from './traverse.js'
+export { confidenceForEdge, getBlastRadius, getRootCause } from './traverse.js'
 export {
   computeGraphDiff,
   loadSnapshotForDiff,

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -158,17 +158,25 @@ function upsertObservedEdge(
   source: string,
   target: string,
   ts: string,
+  isError = false,
 ): UpsertResult | null {
   if (!graph.hasNode(source) || !graph.hasNode(target)) return null
 
   const id = makeObservedEdgeId(type, source, target)
   if (graph.hasEdge(id)) {
     const existing = graph.getEdgeAttributes(id) as GraphEdge
+    const newSpanCount = (existing.signal?.spanCount ?? existing.callCount ?? 0) + 1
+    const newErrorCount = (existing.signal?.errorCount ?? 0) + (isError ? 1 : 0)
     const updated: GraphEdge = {
       ...existing,
       provenance: Provenance.OBSERVED,
       lastObserved: ts,
-      callCount: (existing.callCount ?? 0) + 1,
+      callCount: newSpanCount,
+      signal: {
+        spanCount: newSpanCount,
+        errorCount: newErrorCount,
+        lastObservedAgeMs: 0,
+      },
       confidence: 1.0,
     }
     graph.replaceEdgeAttributes(id, updated)
@@ -184,6 +192,11 @@ function upsertObservedEdge(
     confidence: 1.0,
     lastObserved: ts,
     callCount: 1,
+    signal: {
+      spanCount: 1,
+      errorCount: isError ? 1 : 0,
+      lastObservedAgeMs: 0,
+    },
   }
   graph.addEdgeWithKey(id, source, target, edge)
   return { edge, created: true }
@@ -254,6 +267,7 @@ async function appendErrorEvent(ctx: IngestContext, ev: ErrorEvent): Promise<voi
 export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<void> {
   const ts = nowIso(ctx)
   const sourceId = `service:${span.service}`
+  const isError = span.statusCode === 2
 
   let affectedNode = sourceId
 
@@ -262,7 +276,14 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
     const host = pickAddress(span)
     if (host) {
       const targetId = `database:${host}`
-      const result = upsertObservedEdge(ctx.graph, EdgeType.CONNECTS_TO, sourceId, targetId, ts)
+      const result = upsertObservedEdge(
+        ctx.graph,
+        EdgeType.CONNECTS_TO,
+        sourceId,
+        targetId,
+        ts,
+        isError,
+      )
       if (result) affectedNode = targetId
     }
   } else {
@@ -276,7 +297,14 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
     if (host && host !== span.service) {
       const targetId = resolveServiceId(ctx.graph, host)
       if (targetId && targetId !== sourceId) {
-        upsertObservedEdge(ctx.graph, EdgeType.CALLS, sourceId, targetId, ts)
+        upsertObservedEdge(
+          ctx.graph,
+          EdgeType.CALLS,
+          sourceId,
+          targetId,
+          ts,
+          isError,
+        )
         affectedNode = targetId
       } else if (!targetId) {
         const frontierId = ensureFrontierNode(ctx.graph, host, ts)

--- a/packages/core/src/traverse.ts
+++ b/packages/core/src/traverse.ts
@@ -9,7 +9,7 @@ import type {
   RootCauseResult,
   ServiceNode,
 } from '@neat/types'
-import { NodeType, Provenance } from '@neat/types'
+import { NodeType } from '@neat/types'
 import type { NeatGraph } from './graph.js'
 import { checkCompatibility, compatPairs } from './compat.js'
 
@@ -51,11 +51,87 @@ function bestEdgeByTarget(graph: NeatGraph, edgeIds: string[]): Map<string, Grap
   return best
 }
 
-function confidenceFromMix(edges: GraphEdge[]): number {
+// Per-edge confidence is provenance × volume × recency × cleanliness.
+//   * provenance gives a ceiling: OBSERVED 1.0, INFERRED 0.7, EXTRACTED 0.5,
+//     STALE/FRONTIER 0.3.
+//   * volume: log-scaled span count, saturating quickly so 1 span ≈ 0.55 and
+//     ~1k spans ≈ 1.0.
+//   * recency: 1.0 within an hour; decays toward 0.5 by 24h, toward 0.3 past.
+//   * cleanliness: error rate above ~10% pulls the score down — a flapping
+//     edge with thousands of spans shouldn't outrank a clean low-traffic one.
+// Bounded to [0, 1]. Walks of multiple edges multiply per-edge confidences.
+const PROVENANCE_CEILING: Record<string, number> = {
+  OBSERVED: 1.0,
+  INFERRED: 0.7,
+  EXTRACTED: 0.5,
+  STALE: 0.3,
+  FRONTIER: 0.3,
+}
+
+function volumeWeight(spanCount: number | undefined): number {
+  if (!spanCount || spanCount <= 0) return 0.5
+  // log10 saturating around ~1000 spans → ~1.0.
+  const w = 0.5 + Math.log10(spanCount + 1) / 3
+  return Math.min(1, w)
+}
+
+function recencyWeight(ageMs: number | undefined): number {
+  if (ageMs === undefined) return 0.8
+  const hour = 60 * 60 * 1000
+  if (ageMs <= hour) return 1.0
+  if (ageMs <= 24 * hour) {
+    const t = (ageMs - hour) / (23 * hour)
+    return 1.0 - 0.5 * t
+  }
+  return 0.3
+}
+
+function cleanlinessWeight(spanCount: number | undefined, errorCount: number | undefined): number {
+  if (!spanCount || spanCount <= 0) return 1
+  const rate = (errorCount ?? 0) / spanCount
+  if (rate <= 0.01) return 1
+  if (rate >= 0.5) return 0.3
+  return 1 - rate * 1.4
+}
+
+export function confidenceForEdge(edge: GraphEdge, now = Date.now()): number {
+  const ceiling = PROVENANCE_CEILING[edge.provenance] ?? 0.5
+
+  // No runtime signal yet → the provenance ceiling is all we have. This keeps
+  // EXTRACTED-only graphs returning the same coarse 0.3/0.5/0.7/1.0 ladder
+  // they always have, while letting OBSERVED edges with real OTel data move
+  // off the ceiling once ingest starts populating signal counters.
+  const spanCount = edge.signal?.spanCount ?? edge.callCount
+  const ageMs = edge.signal?.lastObservedAgeMs ?? lastObservedAge(edge, now)
+  if (spanCount === undefined && ageMs === undefined && edge.signal === undefined) {
+    return ceiling
+  }
+
+  const v = volumeWeight(spanCount)
+  const r = recencyWeight(ageMs)
+  const c = cleanlinessWeight(spanCount, edge.signal?.errorCount)
+  return Math.max(0, Math.min(1, ceiling * v * r * c))
+}
+
+function lastObservedAge(edge: GraphEdge, now: number): number | undefined {
+  if (!edge.lastObserved) return undefined
+  const t = Date.parse(edge.lastObserved)
+  if (!Number.isFinite(t)) return undefined
+  return Math.max(0, now - t)
+}
+
+// Path-level confidence is the bottleneck along the walk: the weakest edge
+// dictates the result. Multiplying would punish long-but-strong walks;
+// taking the min keeps the existing semantics while letting per-edge signal
+// pull the number down where it matters.
+function confidenceFromMix(edges: GraphEdge[], now = Date.now()): number {
   if (edges.length === 0) return 1.0
-  if (edges.every((e) => e.provenance === Provenance.OBSERVED)) return 1.0
-  if (edges.some((e) => e.provenance === Provenance.INFERRED)) return 0.7
-  return 0.5
+  let min = 1
+  for (const e of edges) {
+    const c = confidenceForEdge(e, now)
+    if (c < min) min = c
+  }
+  return Math.max(0, Math.min(1, min))
 }
 
 interface Walk {

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -144,6 +144,20 @@ describe('handleSpan', () => {
     expect(edge.lastObserved).toBeTruthy()
   })
 
+  it('populates edge.signal with span and error counts', async () => {
+    await handleSpan(ctx, clientHttpSpan())
+    await handleSpan(ctx, clientHttpSpan({ spanId: 'span-a2' }))
+    await handleSpan(
+      ctx,
+      clientHttpSpan({ spanId: 'span-a3', statusCode: 2, errorMessage: 'boom' }),
+    )
+    const id = `${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`
+    const edge = ctx.graph.getEdgeAttributes(id) as GraphEdge
+    expect(edge.signal?.spanCount).toBe(3)
+    expect(edge.signal?.errorCount).toBe(1)
+    expect(edge.signal?.lastObservedAgeMs).toBe(0)
+  })
+
   it('increments callCount on repeat observations without duplicating the edge', async () => {
     await handleSpan(ctx, clientHttpSpan())
     await handleSpan(ctx, clientHttpSpan({ spanId: 'span-a2' }))

--- a/packages/core/test/traverse.test.ts
+++ b/packages/core/test/traverse.test.ts
@@ -394,3 +394,63 @@ describe('getBlastRadius', () => {
     expect(c!.distance).toBe(1)
   })
 })
+
+describe('confidenceForEdge — signal-aware (#76)', () => {
+  it('returns provenance ceiling when no signal data is present', async () => {
+    const { confidenceForEdge } = await import('../src/traverse.js')
+    const e: GraphEdge = {
+      id: 'x',
+      source: 's',
+      target: 't',
+      type: EdgeType.CALLS,
+      provenance: Provenance.OBSERVED,
+    }
+    expect(confidenceForEdge(e)).toBe(1)
+  })
+
+  it('penalises a low-volume stale OBSERVED edge below a high-volume fresh one', async () => {
+    const { confidenceForEdge } = await import('../src/traverse.js')
+    const stale: GraphEdge = {
+      id: 'a',
+      source: 's',
+      target: 't',
+      type: EdgeType.CALLS,
+      provenance: Provenance.OBSERVED,
+      signal: { spanCount: 1, errorCount: 0, lastObservedAgeMs: 23 * 60 * 60 * 1000 },
+    }
+    const fresh: GraphEdge = {
+      id: 'b',
+      source: 's',
+      target: 't',
+      type: EdgeType.CALLS,
+      provenance: Provenance.OBSERVED,
+      signal: { spanCount: 10000, errorCount: 0, lastObservedAgeMs: 5 * 1000 },
+    }
+    const a = confidenceForEdge(stale)
+    const b = confidenceForEdge(fresh)
+    expect(a).toBeLessThan(b)
+    expect(a).toBeGreaterThanOrEqual(0)
+    expect(b).toBeLessThanOrEqual(1)
+  })
+
+  it('penalises a flapping edge with high error rate', async () => {
+    const { confidenceForEdge } = await import('../src/traverse.js')
+    const clean: GraphEdge = {
+      id: 'a',
+      source: 's',
+      target: 't',
+      type: EdgeType.CALLS,
+      provenance: Provenance.OBSERVED,
+      signal: { spanCount: 100, errorCount: 0, lastObservedAgeMs: 1000 },
+    }
+    const flapping: GraphEdge = {
+      id: 'b',
+      source: 's',
+      target: 't',
+      type: EdgeType.CALLS,
+      provenance: Provenance.OBSERVED,
+      signal: { spanCount: 100, errorCount: 60, lastObservedAgeMs: 1000 },
+    }
+    expect(confidenceForEdge(flapping)).toBeLessThan(confidenceForEdge(clean))
+  })
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -163,10 +163,31 @@ export async function getObservedDependencies(
 
 function edgeMeta(e: GraphEdge): string {
   const bits: string[] = []
-  if (e.callCount !== undefined) bits.push(`callCount=${e.callCount}`)
+  if (e.signal) {
+    // Prefer the runtime signal numbers — "saw 1,247 calls, 3 errors" reads
+    // better than a derived 0.94 confidence.
+    bits.push(`spans=${e.signal.spanCount}`)
+    if (e.signal.errorCount > 0) bits.push(`errors=${e.signal.errorCount}`)
+    if (e.signal.lastObservedAgeMs !== undefined) {
+      bits.push(`age=${formatDuration(e.signal.lastObservedAgeMs)}`)
+    }
+  } else if (e.callCount !== undefined) {
+    bits.push(`callCount=${e.callCount}`)
+  }
   if (e.lastObserved) bits.push(`lastObserved=${e.lastObserved}`)
   if (e.confidence !== undefined) bits.push(`confidence=${e.confidence}`)
   return bits.length ? ` [${bits.join(', ')}]` : ''
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  const s = Math.round(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.round(s / 60)
+  if (m < 60) return `${m}m`
+  const h = Math.round(m / 60)
+  if (h < 48) return `${h}h`
+  return `${Math.round(h / 24)}d`
 }
 
 // Two services can have an EXTRACTED edge AND an OBSERVED edge AND an INFERRED

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -220,6 +220,29 @@ describe('getDependencies', () => {
     const res = await getDependencies(client, { nodeId: 'database:payments-db' })
     expect(res.content[0].text).toContain('no outgoing dependencies')
   })
+
+  it('surfaces signal numbers (spans, errors, age) when the edge carries them', async () => {
+    const { client } = clientFor({
+      '/graph/edges/service:service-a': {
+        inbound: [],
+        outbound: [
+          {
+            id: 'CALLS:OBSERVED:service:service-a->service:service-b',
+            source: 'service:service-a',
+            target: 'service:service-b',
+            type: EdgeType.CALLS,
+            provenance: Provenance.OBSERVED,
+            signal: { spanCount: 1247, errorCount: 3, lastObservedAgeMs: 5000 },
+          },
+        ],
+      },
+    })
+    const res = await getDependencies(client, { nodeId: 'service:service-a' })
+    const out = res.content[0].text
+    expect(out).toContain('spans=1247')
+    expect(out).toContain('errors=3')
+    expect(out).toContain('age=5s')
+  })
 })
 
 describe('getObservedDependencies', () => {

--- a/packages/types/src/edges.ts
+++ b/packages/types/src/edges.ts
@@ -26,6 +26,16 @@ export const EdgeEvidenceSchema = z.object({
 })
 export type EdgeEvidence = z.infer<typeof EdgeEvidenceSchema>
 
+// Runtime signal for per-edge confidence (γ #76). Populated by ingest. Three
+// continuous numbers stand in for the previous coarse 0.3/0.5/0.7/1.0 ladder:
+// how much traffic, how clean, and how recent.
+export const EdgeSignalSchema = z.object({
+  spanCount: z.number().int().nonnegative(),
+  errorCount: z.number().int().nonnegative(),
+  lastObservedAgeMs: z.number().nonnegative().optional(),
+})
+export type EdgeSignal = z.infer<typeof EdgeSignalSchema>
+
 export const GraphEdgeSchema = z.object({
   id: z.string(),
   source: z.string(),
@@ -36,5 +46,6 @@ export const GraphEdgeSchema = z.object({
   lastObserved: z.string().datetime().optional(),
   callCount: z.number().int().nonnegative().optional(),
   evidence: EdgeEvidenceSchema.optional(),
+  signal: EdgeSignalSchema.optional(),
 })
 export type GraphEdge = z.infer<typeof GraphEdgeSchema>


### PR DESCRIPTION
## Summary

Confidence used to be a coarse provenance-derived 0.3 / 0.5 / 0.7 / 1.0 ladder. Now that ingest can carry real counters per OBSERVED edge, the score reflects actual runtime signal — and crucially, surfaces the raw numbers in MCP output so consumers can decide what trustworthy looks like.

- `EdgeSignalSchema` adds optional `signal: { spanCount, errorCount, lastObservedAgeMs }` to `GraphEdgeSchema`. Snapshot stays additive on v2; old edges parse fine.
- Ingest populates `signal` on every OBSERVED upsert and bumps `errorCount` whenever the span carried `statusCode === 2`.
- `confidenceForEdge` weights the provenance ceiling by log-scaled volume × recency decay × cleanliness. Path-level `confidenceFromMix` is now `min(per-edge confidence)` so the bottleneck wins. Edges without signal fall back to the provenance ceiling — existing tests still get 0.5 / 0.7 / 1.0.
- MCP `get_dependencies` / `get_observed_dependencies` print `spans=N, errors=M, age=Xs` instead of opaque confidence numbers.

## Test plan

- [x] `npx turbo build test lint` — green (136 core / 28 types / 18 mcp)
- [x] New `confidenceForEdge` tests covering signal-aware penalties (low volume + stale, high error rate)
- [x] Ingest test confirming `signal.spanCount` / `errorCount` populate as spans flow through
- [x] MCP test asserting `spans=… errors=… age=…` shows up in dependency output

Refs #76