### PR TITLE
Per-edge-type stale thresholds + stale-events log (#78)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,11 @@ Run **after δ merges**, not before. Stand up Railway per `docs/railway.md` → 
 - OTLP `.proto` files bundled in-tree; gRPC receiver is opt-in (ADR-020)
 - Python extraction reads source via `tree-sitter-python`; NEAT's runtime stays Node-only (ADR-021)
 - `infra:<kind>:<name>` id format; one `InfraNode` type, free-string `kind` for sub-typing (ADR-022)
+<<<<<<< HEAD
 - `FrontierNode` is a fifth node type for unresolved span peers; promoted away once an alias matches (ADR-023)
+=======
+- Per-edge-type stale thresholds + `stale-events.ndjson` transition log (ADR-024)
+>>>>>>> 959e891 (Per-edge-type stale thresholds + stale-events log (#78))
 
 ## Conventions
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -305,11 +305,16 @@ v0.1.2-β #73 populated `InfraNode` from docker-compose, Dockerfile, Terraform, 
 
 ---
 
+<<<<<<< HEAD
 ## ADR-023 — `FrontierNode` as a fifth top-level node type
+=======
+## ADR-024 — Per-edge-type stale thresholds
+>>>>>>> 959e891 (Per-edge-type stale thresholds + stale-events log (#78))
 
 **Date:** 2026-05-02
 **Status:** Active.
 
+<<<<<<< HEAD
 v0.1.2-γ #75 added a fifth member to `GraphNodeSchema`: `FrontierNode`. A frontier node is the placeholder ingest writes when an OTel span peer (`server.address`, `net.peer.name`, etc.) doesn't resolve to any known service. The id format is `frontier:<host>`. A later extraction round picks up the host as an alias on a real service, `promoteFrontierNodes` re-links the edges, and the placeholder goes away.
 
 **Why a new node type, not an `InfraNode` kind.** ADR-022 deliberately kept the discriminated union at four. Frontier nodes broke that ceiling because they aren't classified by *what they are* — they're classified by *what they don't yet know*. They have a distinct lifecycle (placeholder → promoted → deleted), they carry temporal fields (`firstObserved`, `lastObserved`) that don't make sense on infra catalog entries, and a frontier node is supposed to disappear once extraction catches up. Cramming that into `InfraNode.kind = "frontier"` would have meant teaching every consumer of `InfraNode` to filter out a special case, and would have leaked frontier semantics into a node type whose whole job is to be permanent.
@@ -323,3 +328,18 @@ v0.1.2-γ #75 added a fifth member to `GraphNodeSchema`: `FrontierNode`. A front
 **Where promotion runs.** At the end of every `extractFromDirectory` pass, after services + databases + configs + calls + infra. Promotion needs the full alias state from the latest extraction round, so it has to run last. Re-running ingest doesn't trigger promotion directly — it just keeps pinning frontier `lastObserved` — which is fine because the next extraction round will sweep them up.
 
 **When to revisit.** If frontier nodes start sticking around (a host that never resolves no matter how many rounds pass), they become a UX signal: "you have unknown peers." That's a γ #76 concern (per-edge confidence) or δ ergonomics, not this ADR. The placeholder will continue to do its job until then.
+=======
+A single 24h `STALE_THRESHOLD_MS` doesn't survive contact with diverse traffic. HTTP `CALLS` recur in seconds — 24h means a service could go down for the whole afternoon and the graph would still claim everything was fine. Infra `DEPENDS_ON` is the opposite — a docker-compose service idle overnight isn't a problem. v0.1.2-γ #78 splits the threshold per edge type: `CALLS` go stale at 1h, `CONNECTS_TO` / `PUBLISHES_TO` / `CONSUMES_FROM` at 4h, infra `DEPENDS_ON` / `CONFIGURED_BY` / `RUNS_ON` at 24h.
+
+**Why a hardcoded default map, not a single tunable.** The defaults encode operational knowledge — "HTTP traffic is chatty, infra dependencies aren't" — and shouldn't have to be rediscovered per deployment. The map lives next to `markStaleEdges` in `ingest.ts`; new edge types fall back to 24h via a single sentinel constant, so adding to `EdgeType` doesn't silently bypass staleness sweeps.
+
+**Why `NEAT_STALE_THRESHOLDS` is JSON, not per-flag env vars.** The variable count grows with `EdgeType` cardinality, and most deployments won't override anything — a single JSON blob is the path of least resistance. The parser tolerates malformed input (warn + fall back to defaults) so a typo can't take down the staleness loop.
+
+**Why a stale-events ndjson log, not just edge mutations.** The graph stores the *current* state — once an edge flips to STALE, the OBSERVED → STALE transition is gone. That transition is the load-bearing fact (oncall wants to know "what just stopped working", not "what's currently quiet"). A per-line ndjson log is the same shape as `errors.ndjson`, replays cleanly, and a downstream consumer (alerting, dashboard) can tail it without touching the graph.
+
+**Why expose it as `/incidents/stale` rather than another resource.** Stale-edge transitions *are* incidents in the operational sense — something stopped, oncall might care. Co-locating with `/incidents` keeps the surface coherent. The MCP tool `get_recent_stale_edges` mirrors `get_incident_history` so the questions ("what just broke?" / "what just went quiet?") have parallel answers.
+
+**Where this could go wrong.** A flapping integration that calls every 65 minutes will oscillate between OBSERVED and STALE under the 1h `CALLS` default. The fix is to nudge the threshold (`NEAT_STALE_THRESHOLDS={"CALLS":7200000}`); the ndjson log will record both transitions so the oscillation itself is observable.
+
+**When to revisit.** When δ #79's `neat watch` daemon runs continuously, the stale-events log will grow unbounded. Rotation / TTL belongs there, not here — this ADR's job is to define the shape; that one will define the lifecycle.
+>>>>>>> 959e891 (Per-edge-type stale thresholds + stale-events log (#78))

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -3,7 +3,7 @@ import cors from '@fastify/cors'
 import type { ErrorEvent, GraphEdge, GraphNode } from '@neat/types'
 import type { NeatGraph } from './graph.js'
 import { extractFromDirectory } from './extract.js'
-import { readErrorEvents } from './ingest.js'
+import { readErrorEvents, readStaleEvents } from './ingest.js'
 import { getBlastRadius, getRootCause } from './traverse.js'
 import { computeGraphDiff, loadSnapshotForDiff } from './diff.js'
 
@@ -14,6 +14,8 @@ export interface BuildApiOptions {
   scanPath?: string
   // ndjson path the /incidents endpoints read from. Optional for tests.
   errorsPath?: string
+  // ndjson path /incidents/stale reads from. Optional for tests.
+  staleEventsPath?: string
 }
 
 interface SerializedGraph {
@@ -71,6 +73,20 @@ export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> 
     if (!opts.errorsPath) return []
     return readErrorEvents(opts.errorsPath)
   })
+  app.get<{ Querystring: { limit?: string; edgeType?: string } }>(
+    '/incidents/stale',
+    async (req) => {
+      if (!opts.staleEventsPath) return []
+      const events = await readStaleEvents(opts.staleEventsPath)
+      const filtered = req.query.edgeType
+        ? events.filter((e) => e.edgeType === req.query.edgeType)
+        : events
+      // Most-recent first; ndjson is append-time so the tail is newest.
+      const ordered = [...filtered].reverse()
+      const limit = req.query.limit ? Number(req.query.limit) : 50
+      return ordered.slice(0, Number.isFinite(limit) && limit > 0 ? limit : 50)
+    },
+  )
   app.get<{ Params: { nodeId: string } }>('/incidents/:nodeId', async (req, reply) => {
     const { nodeId } = req.params
     if (!graph.hasNode(nodeId)) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,9 +27,14 @@ export {
   makeSpanHandler,
   markStaleEdges,
   readErrorEvents,
+  readStaleEvents,
   startStalenessLoop,
   stitchTrace,
+  thresholdForEdgeType,
   type IngestContext,
+  type MarkStaleOptions,
+  type StaleEvent,
+  type StalenessLoopOptions,
 } from './ingest.js'
 export { getBlastRadius, getRootCause } from './traverse.js'
 export {

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -22,7 +22,51 @@ export interface IngestContext {
   now?: () => number
 }
 
-const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+
+// Per-edge-type stale thresholds. HTTP CALLS at 24h is meaningless because
+// healthy traffic recurs in seconds; infra DEPENDS_ON is the opposite — a
+// docker-compose service can sit idle overnight without anything being wrong.
+// Override via NEAT_STALE_THRESHOLDS (JSON, ms-per-edge-type).
+const DEFAULT_STALE_THRESHOLDS: Record<string, number> = {
+  CALLS: HOUR_MS,
+  CONNECTS_TO: 4 * HOUR_MS,
+  PUBLISHES_TO: 4 * HOUR_MS,
+  CONSUMES_FROM: 4 * HOUR_MS,
+  DEPENDS_ON: DAY_MS,
+  CONFIGURED_BY: DAY_MS,
+  RUNS_ON: DAY_MS,
+}
+// Fallback for any edge type not in the map (forward compat — adding a new
+// EdgeType shouldn't break staleness sweeps).
+const FALLBACK_STALE_THRESHOLD_MS = DAY_MS
+
+function loadStaleThresholdsFromEnv(): Record<string, number> {
+  const raw = process.env.NEAT_STALE_THRESHOLDS
+  if (!raw) return DEFAULT_STALE_THRESHOLDS
+  try {
+    const overrides = JSON.parse(raw) as Record<string, unknown>
+    const merged = { ...DEFAULT_STALE_THRESHOLDS }
+    for (const [k, v] of Object.entries(overrides)) {
+      if (typeof v === 'number' && Number.isFinite(v) && v >= 0) merged[k] = v
+    }
+    return merged
+  } catch (err) {
+    console.warn(
+      `[neat] NEAT_STALE_THRESHOLDS could not be parsed (${(err as Error).message}); using defaults`,
+    )
+    return DEFAULT_STALE_THRESHOLDS
+  }
+}
+
+export function thresholdForEdgeType(
+  edgeType: string,
+  overrides?: Record<string, number>,
+): number {
+  const map = overrides ?? loadStaleThresholdsFromEnv()
+  return map[edgeType] ?? FALLBACK_STALE_THRESHOLD_MS
+}
 
 function nowIso(ctx: IngestContext): string {
   return new Date(ctx.now ? ctx.now() : Date.now()).toISOString()
@@ -402,44 +446,113 @@ export function makeSpanHandler(ctx: IngestContext): (span: ParsedSpan) => Promi
   return (span) => handleSpan(ctx, span)
 }
 
-// Demote OBSERVED edges that haven't been seen in a while. Returns the count
-// of demotions for visibility in tests + logs.
-export function markStaleEdges(
+export interface StaleEvent {
+  edgeId: string
+  source: string
+  target: string
+  edgeType: string
+  thresholdMs: number
+  ageMs: number
+  lastObserved: string
+  transitionedAt: string
+}
+
+export interface MarkStaleOptions {
+  // Per-edge-type override map. Defaults to DEFAULT_STALE_THRESHOLDS, merged
+  // with NEAT_STALE_THRESHOLDS if the env var is set.
+  thresholds?: Record<string, number>
+  now?: number
+  // ndjson path. When set, every OBSERVED → STALE transition appends one
+  // line. Skipped if undefined — tests and embedded use cases don't need a
+  // log.
+  staleEventsPath?: string
+}
+
+// Demote OBSERVED edges that haven't been seen in a while. Per-edge-type
+// thresholds: HTTP CALLS go stale fast; infra DEPENDS_ON is patient. Returns
+// the count of demotions and the events appended to the log.
+export async function markStaleEdges(
   graph: NeatGraph,
-  thresholdMs = STALE_THRESHOLD_MS,
-  now = Date.now(),
-): number {
-  let count = 0
+  options: MarkStaleOptions = {},
+): Promise<{ count: number; events: StaleEvent[] }> {
+  const thresholds = options.thresholds ?? loadStaleThresholdsFromEnv()
+  const now = options.now ?? Date.now()
+  const events: StaleEvent[] = []
+
   graph.forEachEdge((id, attrs) => {
     const e = attrs as GraphEdge
     if (e.provenance !== Provenance.OBSERVED) return
     if (!e.lastObserved) return
+    const threshold = thresholdForEdgeType(e.type, thresholds)
     const age = now - new Date(e.lastObserved).getTime()
-    if (age > thresholdMs) {
+    if (age > threshold) {
       const updated: GraphEdge = { ...e, provenance: Provenance.STALE, confidence: 0.3 }
       graph.replaceEdgeAttributes(id, updated)
-      count++
+      events.push({
+        edgeId: id,
+        source: e.source,
+        target: e.target,
+        edgeType: e.type,
+        thresholdMs: threshold,
+        ageMs: age,
+        lastObserved: e.lastObserved,
+        transitionedAt: new Date(now).toISOString(),
+      })
     }
   })
-  return count
+
+  if (options.staleEventsPath && events.length > 0) {
+    await appendStaleEvents(options.staleEventsPath, events)
+  }
+
+  return { count: events.length, events }
+}
+
+async function appendStaleEvents(staleEventsPath: string, events: StaleEvent[]): Promise<void> {
+  await fs.mkdir(path.dirname(staleEventsPath), { recursive: true })
+  const lines = events.map((e) => JSON.stringify(e)).join('\n') + '\n'
+  await fs.appendFile(staleEventsPath, lines, 'utf8')
+}
+
+export async function readStaleEvents(staleEventsPath: string): Promise<StaleEvent[]> {
+  try {
+    const raw = await fs.readFile(staleEventsPath, 'utf8')
+    return raw
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line) as StaleEvent)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw err
+  }
+}
+
+export interface StalenessLoopOptions {
+  thresholds?: Record<string, number>
+  intervalMs?: number
+  staleEventsPath?: string
 }
 
 export function startStalenessLoop(
   graph: NeatGraph,
-  thresholdMs = STALE_THRESHOLD_MS,
-  intervalMs = 60_000,
+  options: StalenessLoopOptions = {},
 ): () => void {
   let stopped = false
+  const intervalMs = options.intervalMs ?? 60_000
   const tick = (): void => {
     if (stopped) return
-    try {
-      markStaleEdges(graph, thresholdMs)
-    } catch (err) {
-      console.error('staleness tick failed', err)
-    }
+    void (async () => {
+      try {
+        await markStaleEdges(graph, {
+          thresholds: options.thresholds,
+          staleEventsPath: options.staleEventsPath,
+        })
+      } catch (err) {
+        console.error('staleness tick failed', err)
+      }
+    })()
   }
   const interval = setInterval(tick, intervalMs)
-  // Don't keep the process alive just for this.
   if (typeof interval.unref === 'function') interval.unref()
   return () => {
     stopped = true

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -14,6 +14,10 @@ async function main(): Promise<void> {
   const errorsPath = path.resolve(
     process.env.NEAT_ERRORS_PATH ?? path.join(path.dirname(outPath), 'errors.ndjson'),
   )
+  const staleEventsPath = path.resolve(
+    process.env.NEAT_STALE_EVENTS_PATH ??
+      path.join(path.dirname(outPath), 'stale-events.ndjson'),
+  )
 
   // Load any existing snapshot first so a restart doesn't lose runtime
   // (M2 OBSERVED) edges that won't be reproduced by a fresh extract.
@@ -27,13 +31,13 @@ async function main(): Promise<void> {
   )
 
   startPersistLoop(graph, outPath)
-  startStalenessLoop(graph)
+  startStalenessLoop(graph, { staleEventsPath })
 
   const host = process.env.HOST ?? '0.0.0.0'
   const port = Number(process.env.PORT ?? 8080)
   const otelPort = Number(process.env.OTEL_PORT ?? 4318)
 
-  const app = await buildApi({ graph, scanPath, errorsPath })
+  const app = await buildApi({ graph, scanPath, errorsPath, staleEventsPath })
   await app.listen({ port, host })
   console.log(`neat-core listening on http://${host}:${port}`)
   console.log(`  scan path:     ${scanPath}`)

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -202,6 +202,12 @@ describe('REST API (fastify.inject)', () => {
     expect(res.statusCode).toBe(400)
   })
 
+  it('GET /incidents/stale returns [] when no stale-events log is configured', async () => {
+    const res = await app.inject({ method: 'GET', url: '/incidents/stale' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual([])
+  })
+
   it('GET /traverse/blast-radius/:nodeId honours a custom depth', async () => {
     const res = await app.inject({
       method: 'GET',
@@ -274,5 +280,79 @@ describe('GET /graph/diff', () => {
       'config:service-b/db-config.yaml',
     )
     expect(body.added.nodes).toEqual([])
+  })
+})
+
+describe('GET /incidents/stale (with log)', () => {
+  let app: FastifyInstance
+  let tmpDir: string
+  let staleEventsPath: string
+
+  beforeEach(async () => {
+    const { promises: fs } = await import('node:fs')
+    const os = await import('node:os')
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-stale-api-'))
+    staleEventsPath = path.join(tmpDir, 'stale-events.ndjson')
+
+    const events = [
+      {
+        edgeId: 'CALLS:OBSERVED:service:a->service:b',
+        source: 'service:a',
+        target: 'service:b',
+        edgeType: 'CALLS',
+        thresholdMs: 3600000,
+        ageMs: 5400000,
+        lastObserved: '2026-05-02T10:00:00.000Z',
+        transitionedAt: '2026-05-02T11:30:00.000Z',
+      },
+      {
+        edgeId: 'CONNECTS_TO:OBSERVED:service:b->database:c',
+        source: 'service:b',
+        target: 'database:c',
+        edgeType: 'CONNECTS_TO',
+        thresholdMs: 14400000,
+        ageMs: 15000000,
+        lastObserved: '2026-05-02T07:00:00.000Z',
+        transitionedAt: '2026-05-02T11:10:00.000Z',
+      },
+    ]
+    await fs.writeFile(
+      staleEventsPath,
+      events.map((e) => JSON.stringify(e)).join('\n') + '\n',
+      'utf8',
+    )
+
+    resetGraph()
+    app = await buildApi({ graph: getGraph(), staleEventsPath })
+  })
+
+  afterEach(async () => {
+    await app.close()
+    const { promises: fs } = await import('node:fs')
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns the events newest-first', async () => {
+    const res = await app.inject({ method: 'GET', url: '/incidents/stale' })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body).toHaveLength(2)
+    expect(body[0].edgeType).toBe('CONNECTS_TO')
+    expect(body[1].edgeType).toBe('CALLS')
+  })
+
+  it('filters by edgeType', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/incidents/stale?edgeType=CALLS',
+    })
+    const body = res.json()
+    expect(body).toHaveLength(1)
+    expect(body[0].edgeType).toBe('CALLS')
+  })
+
+  it('honours limit', async () => {
+    const res = await app.inject({ method: 'GET', url: '/incidents/stale?limit=1' })
+    expect(res.json()).toHaveLength(1)
   })
 })

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -16,7 +16,9 @@ import {
   markStaleEdges,
   promoteFrontierNodes,
   readErrorEvents,
+  readStaleEvents,
   stitchTrace,
+  thresholdForEdgeType,
   type IngestContext,
 } from '../src/ingest.js'
 import type { ParsedSpan } from '../src/otel.js'
@@ -310,8 +312,14 @@ describe('markStaleEdges', () => {
         confidence: 1,
       },
     )
-    const demoted = markStaleEdges(graph, 24 * 60 * 60 * 1000, fresh.getTime())
-    expect(demoted).toBe(1)
+    const result = await markStaleEdges(graph, {
+      thresholds: {
+        CALLS: 24 * 60 * 60 * 1000,
+        CONNECTS_TO: 24 * 60 * 60 * 1000,
+      },
+      now: fresh.getTime(),
+    })
+    expect(result.count).toBe(1)
     const stale = graph.getEdgeAttributes('CALLS:OBSERVED:service:service-a->service:service-b') as GraphEdge
     expect(stale.provenance).toBe(Provenance.STALE)
     expect(stale.confidence).toBe(0.3)
@@ -321,7 +329,7 @@ describe('markStaleEdges', () => {
     expect(still.provenance).toBe(Provenance.OBSERVED)
   })
 
-  it('leaves EXTRACTED edges alone', () => {
+  it('leaves EXTRACTED edges alone', async () => {
     const graph = newGraph()
     graph.addEdgeWithKey(
       'CALLS:service:service-a->service:service-b',
@@ -335,7 +343,112 @@ describe('markStaleEdges', () => {
         provenance: Provenance.EXTRACTED,
       },
     )
-    expect(markStaleEdges(graph, 0, Date.now())).toBe(0)
+    const result = await markStaleEdges(graph, { thresholds: { CALLS: 0 } })
+    expect(result.count).toBe(0)
+  })
+
+  it('uses per-edge-type defaults: CALLS goes stale faster than CONNECTS_TO', async () => {
+    const graph = newGraph()
+    const now = new Date('2026-05-02T12:00:00.000Z').getTime()
+    const ninetyMinAgo = new Date(now - 90 * 60 * 1000).toISOString()
+
+    graph.addEdgeWithKey(
+      'CALLS:OBSERVED:service:service-a->service:service-b',
+      'service:service-a',
+      'service:service-b',
+      {
+        id: 'CALLS:OBSERVED:service:service-a->service:service-b',
+        source: 'service:service-a',
+        target: 'service:service-b',
+        type: EdgeType.CALLS,
+        provenance: Provenance.OBSERVED,
+        lastObserved: ninetyMinAgo,
+      },
+    )
+    graph.addEdgeWithKey(
+      'CONNECTS_TO:OBSERVED:service:service-b->database:payments-db',
+      'service:service-b',
+      'database:payments-db',
+      {
+        id: 'CONNECTS_TO:OBSERVED:service:service-b->database:payments-db',
+        source: 'service:service-b',
+        target: 'database:payments-db',
+        type: EdgeType.CONNECTS_TO,
+        provenance: Provenance.OBSERVED,
+        lastObserved: ninetyMinAgo,
+      },
+    )
+
+    const result = await markStaleEdges(graph, { now })
+    expect(result.count).toBe(1)
+    expect(
+      (graph.getEdgeAttributes(
+        'CALLS:OBSERVED:service:service-a->service:service-b',
+      ) as GraphEdge).provenance,
+    ).toBe(Provenance.STALE)
+    // CONNECTS_TO threshold is 4h by default — 90 min isn't long enough.
+    expect(
+      (graph.getEdgeAttributes(
+        'CONNECTS_TO:OBSERVED:service:service-b->database:payments-db',
+      ) as GraphEdge).provenance,
+    ).toBe(Provenance.OBSERVED)
+  })
+
+  it('appends a StaleEvent to the log on transition', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-stale-'))
+    const staleEventsPath = path.join(tmpDir, 'stale-events.ndjson')
+    try {
+      const graph = newGraph()
+      const now = new Date('2026-05-02T12:00:00.000Z').getTime()
+      graph.addEdgeWithKey(
+        'CALLS:OBSERVED:service:service-a->service:service-b',
+        'service:service-a',
+        'service:service-b',
+        {
+          id: 'CALLS:OBSERVED:service:service-a->service:service-b',
+          source: 'service:service-a',
+          target: 'service:service-b',
+          type: EdgeType.CALLS,
+          provenance: Provenance.OBSERVED,
+          lastObserved: new Date(now - 90 * 60 * 1000).toISOString(),
+        },
+      )
+      const { events } = await markStaleEdges(graph, { now, staleEventsPath })
+      expect(events).toHaveLength(1)
+      const persisted = await readStaleEvents(staleEventsPath)
+      expect(persisted).toHaveLength(1)
+      expect(persisted[0].edgeType).toBe(EdgeType.CALLS)
+      expect(persisted[0].thresholdMs).toBe(60 * 60 * 1000)
+      expect(persisted[0].source).toBe('service:service-a')
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('thresholdForEdgeType', () => {
+  const originalEnv = process.env.NEAT_STALE_THRESHOLDS
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.NEAT_STALE_THRESHOLDS
+    else process.env.NEAT_STALE_THRESHOLDS = originalEnv
+  })
+
+  it('returns the per-edge-type default when no override is set', () => {
+    expect(thresholdForEdgeType('CALLS')).toBe(60 * 60 * 1000)
+    expect(thresholdForEdgeType('CONNECTS_TO')).toBe(4 * 60 * 60 * 1000)
+    expect(thresholdForEdgeType('DEPENDS_ON')).toBe(24 * 60 * 60 * 1000)
+  })
+
+  it('applies NEAT_STALE_THRESHOLDS overrides', () => {
+    process.env.NEAT_STALE_THRESHOLDS = JSON.stringify({ CALLS: 5 * 60 * 1000 })
+    expect(thresholdForEdgeType('CALLS')).toBe(5 * 60 * 1000)
+    // Unaffected types keep their defaults.
+    expect(thresholdForEdgeType('CONNECTS_TO')).toBe(4 * 60 * 60 * 1000)
+  })
+
+  it('falls back to the default map when the env var is malformed JSON', () => {
+    process.env.NEAT_STALE_THRESHOLDS = 'not-json'
+    expect(thresholdForEdgeType('CALLS')).toBe(60 * 60 * 1000)
   })
 })
 

--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -1,6 +1,6 @@
 # @neat/mcp
 
-The NEAT MCP server. Stdio JSON-RPC, seven tools, talks to a running `@neat/core` instance over HTTP.
+The NEAT MCP server. Stdio JSON-RPC, eight tools, talks to a running `@neat/core` instance over HTTP.
 
 ## When to use these tools
 
@@ -17,6 +17,7 @@ Rule of thumb: if the question would take more than two file reads to answer fro
 | "Show me recent errors on X"                         | `get_incident_history`     |
 | "Find nodes matching …"                              | `semantic_search`          |
 | "What changed since the last snapshot?"              | `get_graph_diff`           |
+| "Which integrations have gone quiet?"                | `get_recent_stale_edges`   |
 
 If a tool returns "not found" or empty, check that core is running (`curl $NEAT_CORE_URL/health`) before falling back to source reads.
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -10,6 +10,7 @@ import {
   getGraphDiff,
   getIncidentHistory,
   getObservedDependencies,
+  getRecentStaleEdges,
   getRootCause,
   semanticSearch,
 } from './tools.js'
@@ -95,6 +96,25 @@ server.tool(
       ),
   },
   async (input) => getGraphDiff(client, input),
+)
+
+server.tool(
+  'get_recent_stale_edges',
+  'List the most recent OBSERVED → STALE edge transitions. Use this to spot integrations that have gone quiet — a CALLS edge that just went stale typically means an upstream stopped calling, not that the link is healthy.',
+  {
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(200)
+      .optional()
+      .describe('Max events to return (default 50)'),
+    edgeType: z
+      .string()
+      .optional()
+      .describe('Filter by edge type — e.g. "CALLS" or "CONNECTS_TO"'),
+  },
+  async (input) => getRecentStaleEdges(client, input),
 )
 
 async function main(): Promise<void> {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -341,3 +341,61 @@ function summariseAttrDiff(
     ? 'attributes differ'
     : `fields changed: ${changed.sort().join(', ')}`
 }
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  const s = Math.round(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.round(s / 60)
+  if (m < 60) return `${m}m`
+  const h = Math.round(m / 60)
+  if (h < 48) return `${h}h`
+  return `${Math.round(h / 24)}d`
+}
+
+export interface RecentStaleEdgesInput {
+  limit?: number
+  edgeType?: string
+}
+
+interface StaleEventResponse {
+  edgeId: string
+  source: string
+  target: string
+  edgeType: string
+  thresholdMs: number
+  ageMs: number
+  lastObserved: string
+  transitionedAt: string
+}
+
+export async function getRecentStaleEdges(
+  client: HttpClient,
+  input: RecentStaleEdgesInput,
+): Promise<ToolResponse> {
+  const params = new URLSearchParams()
+  if (input.limit !== undefined) params.set('limit', String(input.limit))
+  if (input.edgeType) params.set('edgeType', input.edgeType)
+  const qs = params.size > 0 ? `?${params.toString()}` : ''
+
+  try {
+    const events = await client.get<StaleEventResponse[]>(`/incidents/stale${qs}`)
+    if (events.length === 0) {
+      return text(
+        input.edgeType
+          ? `No stale ${input.edgeType} edges recorded.`
+          : 'No stale-edge transitions recorded yet.',
+      )
+    }
+    const lines = [`Recent stale-edge transitions (${events.length}):`, '']
+    for (const e of events) {
+      lines.push(
+        `  ${e.transitionedAt} — ${e.source} -[${e.edgeType}]-> ${e.target}` +
+          ` (last seen ${e.lastObserved}, threshold ${formatDuration(e.thresholdMs)})`,
+      )
+    }
+    return text(lines.join('\n'))
+  } catch (err) {
+    return errorText(`Error talking to neat-core: ${(err as Error).message}`)
+  }
+}

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -7,6 +7,7 @@ import {
   getGraphDiff,
   getIncidentHistory,
   getObservedDependencies,
+  getRecentStaleEdges,
   getRootCause,
   semanticSearch,
 } from '../src/tools.js'
@@ -455,5 +456,55 @@ describe('getGraphDiff', () => {
     const res = await getGraphDiff(client, { againstSnapshot: 'oops' })
     expect(res.isError).toBe(true)
     expect(res.content[0].text).toContain('Could not load snapshot oops')
+  })
+})
+
+describe('getRecentStaleEdges', () => {
+  it('formats a list of stale-edge transitions newest-first', async () => {
+    const { client, capture } = clientFor({
+      '/incidents/stale': [
+        {
+          edgeId: 'CONNECTS_TO:OBSERVED:service:b->database:c',
+          source: 'service:b',
+          target: 'database:c',
+          edgeType: 'CONNECTS_TO',
+          thresholdMs: 14400000,
+          ageMs: 15000000,
+          lastObserved: '2026-05-02T07:00:00.000Z',
+          transitionedAt: '2026-05-02T11:10:00.000Z',
+        },
+        {
+          edgeId: 'CALLS:OBSERVED:service:a->service:b',
+          source: 'service:a',
+          target: 'service:b',
+          edgeType: 'CALLS',
+          thresholdMs: 3600000,
+          ageMs: 5400000,
+          lastObserved: '2026-05-02T10:00:00.000Z',
+          transitionedAt: '2026-05-02T11:30:00.000Z',
+        },
+      ],
+    })
+    const res = await getRecentStaleEdges(client, {})
+    const out = res.content[0].text
+    expect(out).toContain('Recent stale-edge transitions (2)')
+    expect(out).toContain('service:b -[CONNECTS_TO]-> database:c')
+    expect(out).toContain('service:a -[CALLS]-> service:b')
+    expect(capture.paths[0]).toBe('/incidents/stale')
+  })
+
+  it('returns a friendly empty message', async () => {
+    const { client } = clientFor({ '/incidents/stale': [] })
+    const res = await getRecentStaleEdges(client, {})
+    expect(res.content[0].text).toContain('No stale-edge transitions')
+  })
+
+  it('passes edgeType + limit query params', async () => {
+    const { client, capture } = clientFor({
+      '/incidents/stale?limit=10&edgeType=CALLS': [],
+    })
+    await getRecentStaleEdges(client, { limit: 10, edgeType: 'CALLS' })
+    expect(capture.paths[0]).toContain('limit=10')
+    expect(capture.paths[0]).toContain('edgeType=CALLS')
   })
 })


### PR DESCRIPTION
## Summary

A single 24h threshold meant HTTP `CALLS` could go quiet all afternoon and the graph would still claim everything was fine. Now each edge type runs its own clock, and every OBSERVED → STALE transition is logged to a tail-able ndjson so consumers can spot the *moment* something went quiet rather than just the current state.

- Per-edge-type defaults in `ingest.ts`: `CALLS` 1h; `CONNECTS_TO` / `PUBLISHES_TO` / `CONSUMES_FROM` 4h; `DEPENDS_ON` / `CONFIGURED_BY` / `RUNS_ON` 24h. `NEAT_STALE_THRESHOLDS` overrides via JSON; malformed input warns and falls back.
- `markStaleEdges` now returns `{ count, events }` and accepts an options object; the callsite in `startStalenessLoop` plumbs `staleEventsPath` through.
- `GET /incidents/stale?limit=&edgeType=` returns events newest-first, filterable by edge type.
- New MCP tool `get_recent_stale_edges(limit?, edgeType?)` formats the transitions for chat output.
- Rationale in **ADR-024**: why per-type defaults, why a single JSON env override, why an ndjson log, where this could go wrong.

## Test plan

- [x] `npx turbo build test lint` — green (141 core / 28 types / 20 mcp)
- [x] New `thresholdForEdgeType` tests covering defaults, JSON override, malformed env fallback
- [x] New `markStaleEdges` test confirming CALLS goes stale at 90 min while CONNECTS_TO doesn't
- [x] New stale-events log test confirming the ndjson append + readback shape
- [x] New `/incidents/stale` API tests covering newest-first ordering, edgeType filter, limit
- [x] New MCP tool tests for the formatter + empty-state message + query-param plumbing

Refs #78