### PR TITLE
neat watch: live re-extraction daemon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4949,7 +4949,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -8074,7 +8073,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -10062,6 +10060,7 @@
         "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
         "@neat/types": "*",
+        "chokidar": "^4.0.3",
         "fastify": "^5.0.0",
         "graphology": "^0.25.4",
         "graphology-shortest-path": "^2.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,7 @@
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
     "@neat/types": "*",
+    "chokidar": "^4.0.3",
     "fastify": "^5.0.0",
     "graphology": "^0.25.4",
     "graphology-shortest-path": "^2.1.0",

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -6,6 +6,7 @@ import type { GraphEdge, GraphNode, ServiceNode } from '@neat/types'
 import { getGraph, resetGraph } from './graph.js'
 import { extractFromDirectory } from './extract.js'
 import { saveGraphToDisk } from './persist.js'
+import { startWatch, type WatchHandle } from './watch.js'
 
 interface InitOptions {
   scanPath: string
@@ -19,6 +20,9 @@ function usage(): void {
   console.log('  init <path>    Scan <path>, build the static graph, save a snapshot.')
   console.log('                 Snapshot lands in <path>/neat-out/graph.json by default,')
   console.log('                 or NEAT_OUT_PATH if set.')
+  console.log('  watch <path>   Start neat-core, watch <path>, re-extract on changes.')
+  console.log('                 PORT (default 8080), OTEL_PORT (4318), HOST (0.0.0.0)')
+  console.log('                 control listeners. NEAT_OTLP_GRPC=true also opens 4317.')
 }
 
 function summarise(nodes: GraphNode[], edges: GraphEdge[]): string {
@@ -116,6 +120,61 @@ async function main(): Promise<void> {
       process.env.NEAT_OUT_PATH ?? path.join(scanPath, 'neat-out', 'graph.json'),
     )
     await runInit({ scanPath, outPath })
+    return
+  }
+
+  if (cmd === 'watch') {
+    const target = rest[0]
+    if (!target) {
+      console.error('neat watch: missing <path>')
+      usage()
+      process.exit(2)
+    }
+    const scanPath = path.resolve(target)
+    const stat = await fs.stat(scanPath).catch(() => null)
+    if (!stat || !stat.isDirectory()) {
+      console.error(`neat watch: ${scanPath} is not a directory`)
+      process.exit(2)
+    }
+    const outPath = path.resolve(
+      process.env.NEAT_OUT_PATH ?? path.join(scanPath, 'neat-out', 'graph.json'),
+    )
+    const errorsPath = path.resolve(
+      process.env.NEAT_ERRORS_PATH ?? path.join(path.dirname(outPath), 'errors.ndjson'),
+    )
+    const staleEventsPath = path.resolve(
+      process.env.NEAT_STALE_EVENTS_PATH ??
+        path.join(path.dirname(outPath), 'stale-events.ndjson'),
+    )
+
+    const handle: WatchHandle = await startWatch(getGraph(), {
+      scanPath,
+      outPath,
+      errorsPath,
+      staleEventsPath,
+      host: process.env.HOST ?? '0.0.0.0',
+      port: Number(process.env.PORT ?? 8080),
+      otelPort: Number(process.env.OTEL_PORT ?? 4318),
+      otelGrpc: process.env.NEAT_OTLP_GRPC === 'true',
+      otelGrpcPort: process.env.NEAT_OTLP_GRPC_PORT
+        ? Number(process.env.NEAT_OTLP_GRPC_PORT)
+        : undefined,
+    })
+
+    // startPersistLoop already wires SIGTERM/SIGINT to flush + exit. Hook in
+    // ahead of it so the watcher closes cleanly first; the persist handler's
+    // `process.exit(0)` will still run after our stop() resolves.
+    let shuttingDown = false
+    const shutdown = (signal: NodeJS.Signals): void => {
+      if (shuttingDown) return
+      shuttingDown = true
+      console.log(`neat watch: ${signal} received, stopping…`)
+      void handle.stop().catch((err) => {
+        console.error('neat watch: shutdown error', err)
+      })
+    }
+    process.on('SIGTERM', shutdown)
+    process.on('SIGINT', shutdown)
     return
   }
 

--- a/packages/core/src/extract/databases/index.ts
+++ b/packages/core/src/extract/databases/index.ts
@@ -228,11 +228,19 @@ export async function addDatabasesAndCompat(
       // before this phase), so the writeback doesn't drop fields populated by
       // earlier passes.
       const current = graph.getNodeAttributes(service.node.id) as ServiceNode
-      graph.replaceNodeAttributes(service.node.id, {
+      const updated: ServiceNode = {
         ...current,
         ...(service.node as ServiceNode),
         ...(current.aliases ? { aliases: current.aliases } : {}),
-      } as unknown as GraphNode)
+      }
+      // attachIncompatibilities only sets the field when there's something to
+      // flag. On a re-extract (`neat watch`, `POST /graph/scan`), a stale
+      // entry on `current` would otherwise survive the spread and leave the
+      // graph reporting a problem the new manifest no longer has.
+      if (!service.node.incompatibilities || service.node.incompatibilities.length === 0) {
+        delete (updated as { incompatibilities?: unknown }).incompatibilities
+      }
+      graph.replaceNodeAttributes(service.node.id, updated as unknown as GraphNode)
     }
   }
 

--- a/packages/core/src/watch.ts
+++ b/packages/core/src/watch.ts
@@ -1,0 +1,317 @@
+import path from 'node:path'
+import chokidar, { type FSWatcher } from 'chokidar'
+import type { FastifyInstance } from 'fastify'
+import type { NeatGraph } from './graph.js'
+import { buildApi } from './api.js'
+import { ensureCompatLoaded } from './compat.js'
+import { discoverServices, addServiceNodes } from './extract/services.js'
+import { addServiceAliases } from './extract/aliases.js'
+import { addDatabasesAndCompat } from './extract/databases/index.js'
+import { addConfigNodes } from './extract/configs.js'
+import { addCallEdges } from './extract/calls/index.js'
+import { addInfra } from './extract/infra/index.js'
+import { makeSpanHandler, promoteFrontierNodes, startStalenessLoop } from './ingest.js'
+import { buildOtelReceiver } from './otel.js'
+import { startOtelGrpcReceiver } from './otel-grpc.js'
+import { loadGraphFromDisk, startPersistLoop } from './persist.js'
+
+export type ExtractPhase =
+  | 'services'
+  | 'aliases'
+  | 'databases'
+  | 'configs'
+  | 'calls'
+  | 'infra'
+
+const ALL_PHASES: ExtractPhase[] = [
+  'services',
+  'aliases',
+  'databases',
+  'configs',
+  'calls',
+  'infra',
+]
+
+// Map a changed path to the phases that need re-running. Anything not matched
+// here falls back to a full re-extract — better an extra ~50ms of work than a
+// missed update because the path didn't fit a regex.
+//
+// Mapping:
+//   package.json / requirements.txt / pyproject.toml → services + aliases + databases
+//     (deps drive compat; aliases pull from manifest fields)
+//   .env / *.env.* / prisma / knex / ormconfig → databases + configs
+//   docker-compose / Dockerfile / *.tf / k8s yaml → infra + aliases
+//     (compose labels and Dockerfile labels feed alias discovery)
+//   *.js / *.ts / *.tsx / *.py / *.jsx / *.mjs / *.cjs → calls
+//   *.yaml / *.yml that isn't compose → databases + configs (ORM yaml fallbacks)
+export function classifyChange(relPath: string): Set<ExtractPhase> {
+  const phases = new Set<ExtractPhase>()
+  const base = path.basename(relPath).toLowerCase()
+  const segments = relPath.split(path.sep).map((s) => s.toLowerCase())
+
+  if (
+    base === 'package.json' ||
+    base === 'requirements.txt' ||
+    base === 'pyproject.toml' ||
+    base === 'setup.py'
+  ) {
+    phases.add('services')
+    phases.add('aliases')
+    phases.add('databases')
+  }
+
+  if (
+    base === '.env' ||
+    base.startsWith('.env.') ||
+    base === 'schema.prisma' ||
+    /^knexfile\.(?:js|ts|cjs|mjs)$/.test(base) ||
+    /^ormconfig\.(?:js|ts|json|ya?ml)$/.test(base)
+  ) {
+    phases.add('databases')
+    phases.add('configs')
+  }
+
+  if (
+    base === 'dockerfile' ||
+    /^docker-compose.*\.ya?ml$/.test(base) ||
+    base.endsWith('.tf') ||
+    segments.includes('k8s') ||
+    segments.includes('kustomize') ||
+    segments.includes('manifests')
+  ) {
+    phases.add('infra')
+    phases.add('aliases')
+  }
+
+  if (/\.(?:js|jsx|mjs|cjs|ts|tsx|py)$/.test(base)) {
+    phases.add('calls')
+  }
+
+  if (/\.ya?ml$/.test(base) && !/^docker-compose.*\.ya?ml$/.test(base)) {
+    // Generic yaml — could be an ORM file, k8s manifest, or random config.
+    // Cheap to run databases + configs; if it was infra, the dir-name check
+    // above already added that phase.
+    phases.add('databases')
+    phases.add('configs')
+  }
+
+  return phases
+}
+
+interface RunPhasesResult {
+  phases: ExtractPhase[]
+  nodesAdded: number
+  edgesAdded: number
+  frontiersPromoted: number
+  durationMs: number
+}
+
+export async function runExtractPhases(
+  graph: NeatGraph,
+  scanPath: string,
+  phases: Set<ExtractPhase>,
+): Promise<RunPhasesResult> {
+  const started = Date.now()
+  await ensureCompatLoaded()
+  // Discovery is cheap and every phase needs the same DiscoveredService list,
+  // so we always re-walk. If the user moved a service directory, this is also
+  // the path that picks it up.
+  const services = await discoverServices(scanPath)
+
+  let nodesAdded = 0
+  let edgesAdded = 0
+
+  if (phases.has('services')) {
+    nodesAdded += addServiceNodes(graph, services)
+  }
+  if (phases.has('aliases')) {
+    await addServiceAliases(graph, scanPath, services)
+  }
+  if (phases.has('databases')) {
+    const r = await addDatabasesAndCompat(graph, services)
+    nodesAdded += r.nodesAdded
+    edgesAdded += r.edgesAdded
+  }
+  if (phases.has('configs')) {
+    const r = await addConfigNodes(graph, services, scanPath)
+    nodesAdded += r.nodesAdded
+    edgesAdded += r.edgesAdded
+  }
+  if (phases.has('calls')) {
+    const r = await addCallEdges(graph, services)
+    nodesAdded += r.nodesAdded
+    edgesAdded += r.edgesAdded
+  }
+  if (phases.has('infra')) {
+    const r = await addInfra(graph, scanPath, services)
+    nodesAdded += r.nodesAdded
+    edgesAdded += r.edgesAdded
+  }
+  const frontiersPromoted = promoteFrontierNodes(graph)
+
+  return {
+    phases: ALL_PHASES.filter((p) => phases.has(p)),
+    nodesAdded,
+    edgesAdded,
+    frontiersPromoted,
+    durationMs: Date.now() - started,
+  }
+}
+
+export interface WatchOptions {
+  scanPath: string
+  outPath: string
+  errorsPath: string
+  staleEventsPath: string
+  host?: string
+  port?: number
+  otelPort?: number
+  otelGrpc?: boolean
+  otelGrpcPort?: number
+  debounceMs?: number
+}
+
+export interface WatchHandle {
+  api: FastifyInstance
+  stop: () => Promise<void>
+}
+
+const IGNORED_WATCH_PATHS = [
+  /(?:^|[\\/])node_modules[\\/]/,
+  /(?:^|[\\/])\.git[\\/]/,
+  /(?:^|[\\/])dist[\\/]/,
+  /(?:^|[\\/])build[\\/]/,
+  /(?:^|[\\/])\.turbo[\\/]/,
+  /(?:^|[\\/])\.next[\\/]/,
+  /(?:^|[\\/])neat-out[\\/]/,
+  /[\\/]?\.DS_Store$/,
+]
+
+function shouldIgnore(absPath: string): boolean {
+  return IGNORED_WATCH_PATHS.some((re) => re.test(absPath))
+}
+
+export async function startWatch(
+  graph: NeatGraph,
+  opts: WatchOptions,
+): Promise<WatchHandle> {
+  const debounceMs = opts.debounceMs ?? 1000
+
+  await loadGraphFromDisk(graph, opts.outPath)
+  const initial = await runExtractPhases(graph, opts.scanPath, new Set(ALL_PHASES))
+  console.log(
+    `extract: ${initial.nodesAdded} new nodes, ${initial.edgesAdded} new edges (graph total ${graph.order}/${graph.size})`,
+  )
+
+  const stopPersist = startPersistLoop(graph, opts.outPath)
+  const stopStaleness = startStalenessLoop(graph, { staleEventsPath: opts.staleEventsPath })
+
+  const host = opts.host ?? '0.0.0.0'
+  const port = opts.port ?? 8080
+  const otelPort = opts.otelPort ?? 4318
+
+  const api = await buildApi({
+    graph,
+    scanPath: opts.scanPath,
+    errorsPath: opts.errorsPath,
+    staleEventsPath: opts.staleEventsPath,
+  })
+  await api.listen({ port, host })
+  console.log(`neat-core listening on http://${host}:${port}`)
+  console.log(`  scan path:     ${opts.scanPath} (watching for changes)`)
+  console.log(`  snapshot path: ${opts.outPath}`)
+  console.log(`  errors log:    ${opts.errorsPath}`)
+
+  const onSpan = makeSpanHandler({ graph, errorsPath: opts.errorsPath })
+  const otelHttp = await buildOtelReceiver({ onSpan })
+  await otelHttp.listen({ port: otelPort, host })
+  console.log(`neat-core OTLP receiver on http://${host}:${otelPort}/v1/traces`)
+
+  let grpcReceiver: { stop: () => Promise<void> } | null = null
+  if (opts.otelGrpc) {
+    const grpcPort = opts.otelGrpcPort ?? 4317
+    const r = await startOtelGrpcReceiver({ onSpan, host, port: grpcPort })
+    console.log(`neat-core OTLP/gRPC receiver on ${r.address}`)
+    grpcReceiver = r
+  }
+
+  // Coalesce bursts of changes into a single re-extract. chokidar fires one
+  // event per affected path; an editor save can produce 3+ events on the same
+  // file in <50ms.
+  const pending = new Set<ExtractPhase>()
+  let timer: NodeJS.Timeout | null = null
+  let inflight: Promise<void> | null = null
+
+  const flush = async (): Promise<void> => {
+    if (pending.size === 0) return
+    const phases = new Set(pending)
+    pending.clear()
+    try {
+      const result = await runExtractPhases(graph, opts.scanPath, phases)
+      console.log(
+        `[watch] re-extract phases=${result.phases.join(',')} +${result.nodesAdded}n/+${result.edgesAdded}e in ${result.durationMs}ms`,
+      )
+    } catch (err) {
+      console.error('[watch] re-extract failed', err)
+    }
+  }
+
+  const schedule = (): void => {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => {
+      timer = null
+      // Serialise re-extracts so two flushes can't interleave on the graph.
+      inflight = (inflight ?? Promise.resolve()).then(flush)
+    }, debounceMs)
+  }
+
+  const onPath = (absPath: string): void => {
+    if (shouldIgnore(absPath)) return
+    const rel = path.relative(opts.scanPath, absPath)
+    if (!rel || rel.startsWith('..')) return
+    const phases = classifyChange(rel)
+    if (phases.size === 0) {
+      // Unknown file kind — fall back to full re-extract rather than silently
+      // miss it. Cheaper than the user wondering why their change didn't show.
+      for (const p of ALL_PHASES) pending.add(p)
+    } else {
+      for (const p of phases) pending.add(p)
+    }
+    schedule()
+  }
+
+  const watcher: FSWatcher = chokidar.watch(opts.scanPath, {
+    ignoreInitial: true,
+    ignored: (p) => shouldIgnore(p),
+    persistent: true,
+    awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
+  })
+  watcher.on('add', onPath)
+  watcher.on('change', onPath)
+  watcher.on('unlink', onPath)
+  watcher.on('addDir', onPath)
+  watcher.on('unlinkDir', onPath)
+
+  let stopped = false
+  const stop = async (): Promise<void> => {
+    if (stopped) return
+    stopped = true
+    if (timer) clearTimeout(timer)
+    timer = null
+    if (inflight) {
+      try {
+        await inflight
+      } catch {
+        // surfaced already in flush()
+      }
+    }
+    await watcher.close()
+    stopStaleness()
+    stopPersist()
+    await api.close()
+    await otelHttp.close()
+    if (grpcReceiver) await grpcReceiver.stop()
+  }
+
+  return { api, stop }
+}

--- a/packages/core/test/watch.test.ts
+++ b/packages/core/test/watch.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import path from 'node:path'
+import { classifyChange } from '../src/watch.js'
+
+const sep = path.sep
+
+describe('classifyChange', () => {
+  it('routes package.json to services + aliases + databases', () => {
+    const phases = classifyChange(`packages${sep}service-a${sep}package.json`)
+    expect([...phases].sort()).toEqual(['aliases', 'databases', 'services'])
+  })
+
+  it('routes Python manifests to the same trio', () => {
+    expect([...classifyChange(`svc${sep}requirements.txt`)].sort()).toEqual([
+      'aliases',
+      'databases',
+      'services',
+    ])
+    expect([...classifyChange(`svc${sep}pyproject.toml`)].sort()).toEqual([
+      'aliases',
+      'databases',
+      'services',
+    ])
+  })
+
+  it('routes JS/TS/Python source to calls only', () => {
+    expect([...classifyChange(`src${sep}index.ts`)]).toEqual(['calls'])
+    expect([...classifyChange(`src${sep}index.js`)]).toEqual(['calls'])
+    expect([...classifyChange(`src${sep}page.tsx`)]).toEqual(['calls'])
+    expect([...classifyChange(`app${sep}main.py`)]).toEqual(['calls'])
+  })
+
+  it('routes .env / prisma / knex / ormconfig to databases + configs', () => {
+    expect([...classifyChange(`service-b${sep}.env`)].sort()).toEqual(['configs', 'databases'])
+    expect([...classifyChange(`service-b${sep}.env.production`)].sort()).toEqual([
+      'configs',
+      'databases',
+    ])
+    expect([...classifyChange(`prisma${sep}schema.prisma`)].sort()).toEqual([
+      'configs',
+      'databases',
+    ])
+    // knexfile.ts also looks like JS source — its `calls` phase rerun is a
+    // no-op for the file but cheap, so we accept the overlap.
+    expect([...classifyChange(`knexfile.ts`)].sort()).toEqual([
+      'calls',
+      'configs',
+      'databases',
+    ])
+    expect([...classifyChange(`ormconfig.json`)].sort()).toEqual(['configs', 'databases'])
+  })
+
+  it('routes Dockerfile / compose / Terraform to infra + aliases', () => {
+    expect([...classifyChange('Dockerfile')].sort()).toEqual(['aliases', 'infra'])
+    expect([...classifyChange('docker-compose.yml')].sort()).toEqual([
+      'aliases',
+      'infra',
+    ])
+    expect([...classifyChange('docker-compose.prod.yaml')].sort()).toEqual([
+      'aliases',
+      'infra',
+    ])
+    expect([...classifyChange(`infra${sep}main.tf`)].sort()).toEqual(['aliases', 'infra'])
+  })
+
+  it('routes k8s yaml under k8s/ to infra + aliases + db/configs', () => {
+    // k8s manifests are yaml — we add infra+aliases via the dir hint AND
+    // databases+configs via the generic .yaml fallback. Belt-and-suspenders is
+    // fine; the phases dedupe via Set.
+    const phases = classifyChange(`k8s${sep}deployment.yaml`)
+    expect(phases.has('infra')).toBe(true)
+    expect(phases.has('aliases')).toBe(true)
+  })
+
+  it('returns an empty set for files with no known mapping', () => {
+    expect([...classifyChange(`README.md`)]).toEqual([])
+    expect([...classifyChange(`assets${sep}logo.png`)]).toEqual([])
+  })
+
+  it('case-insensitive for Dockerfile and friends', () => {
+    expect([...classifyChange('dockerfile')].sort()).toEqual(['aliases', 'infra'])
+    expect([...classifyChange('Dockerfile')].sort()).toEqual(['aliases', 'infra'])
+  })
+})


### PR DESCRIPTION
First δ PR. Adds the \`neat watch <path>\` subcommand: boots neat-core, watches the scan path with chokidar, debounces ~1s, re-extracts on file change. Same in-memory graph as the REST API; no new persistence path.

## What's in this PR

- **\`packages/core/src/watch.ts\`** — \`startWatch(graph, opts)\` orchestrates loadSnapshot → initial full extract → API + OTel HTTP/gRPC + persist + staleness loops → chokidar watcher with debounced phase-aware re-extract. Returns a \`stop()\` that closes everything in the right order.
- **\`packages/core/src/cli.ts\`** — wires the \`watch\` subcommand alongside \`init\`. SIGTERM/SIGINT trigger \`stop()\` ahead of \`startPersistLoop\`'s existing \`process.exit(0)\` handler, so the watcher closes cleanly first.
- **\`packages/core/src/extract/databases/index.ts\`** — bring-along bug fix. \`attachIncompatibilities\` only writes the field when non-empty, and the existing writeback spread preserved whatever was on the node, so a re-extract after fixing a dep version wouldn't clear the stale incompat. The verification gate (\"the previously-flagged incompatibility on service-b drops off after the dep edit\") couldn't pass without it. \`POST /graph/scan\` had the same bug; \`watch\` is just where it became visible.
- **\`packages/core/test/watch.test.ts\`** — unit tests for the path classifier.
- **chokidar ^4.0.0** added as a direct dep (was already present transitively via tsup/tailwind).

## Phase mapping

| File pattern | Phases re-run |
|---|---|
| \`package.json\`, \`requirements.txt\`, \`pyproject.toml\`, \`setup.py\` | services + aliases + databases |
| \`.env\`, \`.env.*\`, \`schema.prisma\`, \`knexfile.*\`, \`ormconfig.*\` | databases + configs |
| \`Dockerfile\`, \`docker-compose*.yml\`, \`*.tf\`, dirs named \`k8s\`/\`kustomize\`/\`manifests\` | infra + aliases |
| \`*.js/*.jsx/*.mjs/*.cjs/*.ts/*.tsx/*.py\` | calls |
| any other \`*.yaml/*.yml\` | databases + configs (fallback) |
| anything else | full re-extract |

\`promoteFrontierNodes\` runs after every re-extract regardless.

## Test plan

- [x] \`npx turbo build test lint\` clean (187 core / 30 types / 24 mcp; +1 watch test file with 8 cases)
- [x] Manual smoke: \`PORT=8765 OTEL_PORT=4765 node packages/core/dist/cli.cjs watch /tmp/fixture\` against a temp service with \`pg: 7.4.0\` / postgresql 15. Initial \`/graph\` shows the driver-engine incompat. Editing \`package.json\` to \`pg: 8.0.0\` triggers a phases=services,aliases,databases re-extract within ~50ms; next \`/graph\` shows new deps and no incompatibilities. SIGTERM closes the port cleanly with no orphaned watchers.
- [x] Demo extraction smoke (\`extractFromDirectory(g, './demo')\`) still produces the expected 5 nodes / 5 edges / 0 frontiers.

Refs #79