### PR TITLE
MCP Resources for graph nodes and the incident stream

### DIFF
--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -1,6 +1,6 @@
 # @neat/mcp
 
-The NEAT MCP server. Stdio JSON-RPC, eight tools, talks to a running `@neat/core` instance over HTTP.
+The NEAT MCP server. Stdio JSON-RPC, eight tools and two resources, talks to a running `@neat/core` instance over HTTP.
 
 ## When to use these tools
 
@@ -21,9 +21,18 @@ Rule of thumb: if the question would take more than two file reads to answer fro
 
 If a tool returns "not found" or empty, check that core is running (`curl $NEAT_CORE_URL/health`) before falling back to source reads.
 
+## Resources
+
+Two MCP resources sit alongside the tools — same data, different access pattern:
+
+- **`neat://node/<id>`** (templated) — one resource per graph node. Read returns `{ node, outboundEdges }` as JSON. Listing enumerates every node currently in the graph. Use it when you want the raw attributes rather than a formatted answer.
+- **`neat://incidents/recent`** (static) — most recent error events as JSON `{ count, total, events[] }`. Subscribe to be notified (`notifications/resources/updated`) when new incidents land. The server polls `/incidents` every 5s by default; override with `NEAT_RESOURCE_POLL_MS` (set to `0` to disable polling).
+
 ## Configuration
 
 `NEAT_CORE_URL` — base URL for the core REST API. Default `http://localhost:8080`.
+
+`NEAT_RESOURCE_POLL_MS` — interval in ms for the `neat://incidents/recent` change-detection poll. Default `5000`. `0` disables it.
 
 ## Smoke-test the handshake
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -4,6 +4,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
 import { createHttpClient } from './client.js'
+import { registerResources } from './resources.js'
 import {
   getBlastRadius,
   getDependencies,
@@ -117,10 +118,27 @@ server.tool(
   async (input) => getRecentStaleEdges(client, input),
 )
 
+// Resources sit alongside tools — same data, different access pattern. Read
+// the per-node resource for raw attrs+edges JSON; subscribe to the incidents
+// resource to be notified when new errors land. The eight tools above are
+// unchanged.
+const incidentsPollMs = process.env.NEAT_RESOURCE_POLL_MS
+  ? Number(process.env.NEAT_RESOURCE_POLL_MS)
+  : undefined
+const resourceRegistration = registerResources(server, client, {
+  ...(incidentsPollMs !== undefined ? { incidentsPollMs } : {}),
+})
+
 async function main(): Promise<void> {
   const transport = new StdioServerTransport()
   await server.connect(transport)
 }
+
+const stopPolling = (): void => {
+  resourceRegistration.stop()
+}
+process.on('SIGTERM', stopPolling)
+process.on('SIGINT', stopPolling)
 
 main().catch((err) => {
   console.error(err)

--- a/packages/mcp/src/resources.ts
+++ b/packages/mcp/src/resources.ts
@@ -1,0 +1,236 @@
+// MCP Resources — additive surface alongside the eight tools. Two resources:
+//
+//   neat://node/<id>          — one resource per graph node. Read returns the
+//                                node attributes plus its outbound edges.
+//   neat://incidents/recent   — most recent error events. Pollable by the SDK
+//                                via subscribe; we send `notifications/resources/
+//                                updated` when /incidents grows.
+//
+// Pure read helpers are exported so tests can exercise them without spinning up
+// an MCP transport. `registerResources()` does the SDK wiring + the poll loop.
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import {
+  ResourceTemplate,
+} from '@modelcontextprotocol/sdk/server/mcp.js'
+import type {
+  ListResourcesResult,
+  ReadResourceResult,
+} from '@modelcontextprotocol/sdk/types.js'
+import type { ErrorEvent, GraphEdge, GraphNode } from '@neat/types'
+import { HttpError, type HttpClient } from './client.js'
+
+interface EdgesResponse {
+  inbound: GraphEdge[]
+  outbound: GraphEdge[]
+}
+
+interface SerializedGraph {
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+}
+
+const NODE_RESOURCE_MIME = 'application/json'
+const INCIDENTS_URI = 'neat://incidents/recent'
+const INCIDENTS_DEFAULT_LIMIT = 50
+
+function nodeUri(id: string): string {
+  // Node ids contain `:` which RFC 6570 percent-encodes; doing it explicitly
+  // here keeps the URI we hand the SDK identical to what `list` produces.
+  return `neat://node/${encodeURIComponent(id)}`
+}
+
+function nameFromAttrs(attrs: GraphNode): string {
+  return (attrs as { name?: string }).name ?? attrs.id
+}
+
+export async function listNodeResources(client: HttpClient): Promise<ListResourcesResult> {
+  const graph = await client.get<SerializedGraph>('/graph')
+  return {
+    resources: graph.nodes.map((n) => ({
+      uri: nodeUri(n.id),
+      name: nameFromAttrs(n),
+      description: `${n.type} — ${nameFromAttrs(n)}`,
+      mimeType: NODE_RESOURCE_MIME,
+    })),
+  }
+}
+
+export async function readNodeResource(
+  client: HttpClient,
+  id: string,
+): Promise<ReadResourceResult> {
+  const uri = nodeUri(id)
+  try {
+    const [attrs, edges] = await Promise.all([
+      client.get<GraphNode>(`/graph/node/${encodeURIComponent(id)}`),
+      client.get<EdgesResponse>(`/graph/edges/${encodeURIComponent(id)}`),
+    ])
+    const body = {
+      node: attrs,
+      // Outbound only — the issue spec says "attrs + outbound edges". Inbound
+      // edges are still reachable via the other endpoint and would double the
+      // payload for hub nodes (e.g. a shared database).
+      outboundEdges: edges.outbound,
+    }
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: NODE_RESOURCE_MIME,
+          text: JSON.stringify(body, null, 2),
+        },
+      ],
+    }
+  } catch (err) {
+    if (err instanceof HttpError && err.status === 404) {
+      return {
+        contents: [
+          {
+            uri,
+            mimeType: NODE_RESOURCE_MIME,
+            text: JSON.stringify({ error: 'node not found', id }),
+          },
+        ],
+      }
+    }
+    throw err
+  }
+}
+
+export async function readRecentIncidentsResource(
+  client: HttpClient,
+  limit: number = INCIDENTS_DEFAULT_LIMIT,
+): Promise<ReadResourceResult> {
+  const events = await client.get<ErrorEvent[]>('/incidents')
+  // ndjson order is append-time = oldest first. Reverse so most-recent leads.
+  const ordered = [...events].reverse().slice(0, limit)
+  return {
+    contents: [
+      {
+        uri: INCIDENTS_URI,
+        mimeType: NODE_RESOURCE_MIME,
+        text: JSON.stringify(
+          { count: ordered.length, total: events.length, events: ordered },
+          null,
+          2,
+        ),
+      },
+    ],
+  }
+}
+
+// Pure helper so the poll loop can be tested without timers. Returns true when
+// the visible state of /incidents has changed in a way subscribers should hear
+// about. Compares total count + the id of the newest event — either is enough
+// on its own, but the pair makes deletes (if they ever happen) survive a
+// missed update.
+export function incidentsChanged(
+  prev: { total: number; lastId?: string } | null,
+  next: { total: number; lastId?: string },
+): boolean {
+  if (!prev) return false // first observation seeds, doesn't notify
+  if (prev.total !== next.total) return true
+  if (prev.lastId !== next.lastId) return true
+  return false
+}
+
+export interface RegisterResourcesOptions {
+  // Poll interval for /incidents in ms. 5s by default; 0 disables polling.
+  incidentsPollMs?: number
+}
+
+export interface ResourceRegistration {
+  // Stops the poll loop. The SDK keeps the registered resources around as
+  // long as the server is alive — calling stop() doesn't unregister them.
+  stop: () => void
+}
+
+export function registerResources(
+  server: McpServer,
+  client: HttpClient,
+  options: RegisterResourcesOptions = {},
+): ResourceRegistration {
+  const pollMs = options.incidentsPollMs ?? 5000
+
+  // neat://node/<id> — templated. The list callback enumerates current nodes;
+  // the read callback resolves a specific id.
+  server.registerResource(
+    'graph-node',
+    new ResourceTemplate('neat://node/{id}', {
+      list: async () => listNodeResources(client),
+    }),
+    {
+      description:
+        'A single graph node by id. Reading returns the node attributes plus its outbound edges as JSON.',
+      mimeType: NODE_RESOURCE_MIME,
+    },
+    async (_uri, variables) => {
+      const raw = variables.id
+      const id = Array.isArray(raw) ? raw[0] : raw
+      if (typeof id !== 'string' || id.length === 0) {
+        throw new Error('neat://node/{id} requires an id')
+      }
+      // RFC 6570 hands us a percent-decoded value, but be defensive in case a
+      // client double-encoded the colon.
+      const decoded = id.includes('%') ? decodeURIComponent(id) : id
+      return readNodeResource(client, decoded)
+    },
+  )
+
+  // neat://incidents/recent — static. Subscribers get notifications/resources/
+  // updated on each tick where /incidents has changed.
+  server.registerResource(
+    'incidents-recent',
+    INCIDENTS_URI,
+    {
+      description:
+        'Most recent error events recorded by neat-core, newest first. JSON: { count, total, events[] }.',
+      mimeType: NODE_RESOURCE_MIME,
+    },
+    async () => readRecentIncidentsResource(client),
+  )
+
+  let stopped = false
+  let timer: NodeJS.Timeout | null = null
+  let last: { total: number; lastId?: string } | null = null
+
+  const tick = async (): Promise<void> => {
+    if (stopped) return
+    try {
+      const events = await client.get<ErrorEvent[]>('/incidents')
+      const next = {
+        total: events.length,
+        lastId: events.length > 0 ? events[events.length - 1].id : undefined,
+      }
+      if (incidentsChanged(last, next)) {
+        // Underlying low-level Server has the notification senders. The
+        // McpServer high-level wrapper exposes it via .server.
+        await server.server.sendResourceUpdated({ uri: INCIDENTS_URI }).catch(() => {
+          // No transport connected yet, or the client dropped — either way we
+          // just skip this notification rather than crashing the poll loop.
+        })
+      }
+      last = next
+    } catch {
+      // Core down or not reachable — keep polling, the next tick will catch up.
+    }
+  }
+
+  if (pollMs > 0) {
+    // Seed `last` on first tick so we don't fire an "updated" notification
+    // when the server first comes up.
+    timer = setInterval(() => {
+      void tick()
+    }, pollMs)
+    if (typeof timer.unref === 'function') timer.unref()
+  }
+
+  return {
+    stop: (): void => {
+      stopped = true
+      if (timer) clearInterval(timer)
+      timer = null
+    },
+  }
+}

--- a/packages/mcp/test/resources.test.ts
+++ b/packages/mcp/test/resources.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest'
+import { EdgeType, NodeType, Provenance } from '@neat/types'
+import type { HttpClient } from '../src/client.js'
+import { HttpError } from '../src/client.js'
+import {
+  incidentsChanged,
+  listNodeResources,
+  readNodeResource,
+  readRecentIncidentsResource,
+} from '../src/resources.js'
+
+interface Capture {
+  paths: string[]
+}
+
+function clientFor(map: Record<string, unknown>, capture: Capture = { paths: [] }): {
+  client: HttpClient
+  capture: Capture
+} {
+  return {
+    capture,
+    client: {
+      async get<T>(path: string): Promise<T> {
+        capture.paths.push(path)
+        const decoded = decodeURIComponent(path.split('?')[0])
+        if (decoded in map) return map[decoded] as T
+        if (path in map) return map[path] as T
+        throw new HttpError(404, `404 on ${path}`)
+      },
+    },
+  }
+}
+
+describe('listNodeResources', () => {
+  it('returns one resource per graph node with neat://node/<id> URIs', async () => {
+    const { client } = clientFor({
+      '/graph': {
+        nodes: [
+          {
+            id: 'service:service-a',
+            type: NodeType.ServiceNode,
+            name: 'service-a',
+            language: 'javascript',
+          },
+          {
+            id: 'database:payments-db',
+            type: NodeType.DatabaseNode,
+            name: 'payments-db',
+            engine: 'postgresql',
+            engineVersion: '15',
+          },
+        ],
+        edges: [],
+      },
+    })
+    const result = await listNodeResources(client)
+    expect(result.resources).toHaveLength(2)
+    expect(result.resources[0].uri).toBe('neat://node/service%3Aservice-a')
+    expect(result.resources[0].name).toBe('service-a')
+    expect(result.resources[0].mimeType).toBe('application/json')
+    expect(result.resources[1].uri).toBe('neat://node/database%3Apayments-db')
+  })
+})
+
+describe('readNodeResource', () => {
+  it('returns node attrs and outbound edges as JSON', async () => {
+    const { client, capture } = clientFor({
+      '/graph/node/service:service-b': {
+        id: 'service:service-b',
+        type: NodeType.ServiceNode,
+        name: 'service-b',
+        language: 'javascript',
+        dependencies: { pg: '7.4.0' },
+      },
+      '/graph/edges/service:service-b': {
+        inbound: [],
+        outbound: [
+          {
+            id: 'CONNECTS_TO:EXTRACTED:service:service-b->database:payments-db',
+            source: 'service:service-b',
+            target: 'database:payments-db',
+            type: EdgeType.CONNECTS_TO,
+            provenance: Provenance.EXTRACTED,
+          },
+        ],
+      },
+    })
+    const result = await readNodeResource(client, 'service:service-b')
+    expect(result.contents).toHaveLength(1)
+    const c = result.contents[0]
+    expect(c.uri).toBe('neat://node/service%3Aservice-b')
+    expect(c.mimeType).toBe('application/json')
+    const body = JSON.parse(c.text as string)
+    expect(body.node.id).toBe('service:service-b')
+    expect(body.node.dependencies.pg).toBe('7.4.0')
+    expect(body.outboundEdges).toHaveLength(1)
+    expect(body.outboundEdges[0].target).toBe('database:payments-db')
+    expect(capture.paths).toContain('/graph/node/service%3Aservice-b')
+    expect(capture.paths).toContain('/graph/edges/service%3Aservice-b')
+  })
+
+  it('returns a JSON error body when the node is missing instead of throwing', async () => {
+    const { client } = clientFor({})
+    const result = await readNodeResource(client, 'service:missing')
+    const body = JSON.parse(result.contents[0].text as string)
+    expect(body.error).toBe('node not found')
+    expect(body.id).toBe('service:missing')
+  })
+})
+
+describe('readRecentIncidentsResource', () => {
+  it('returns events newest-first with count and total', async () => {
+    const events = [
+      {
+        id: 'e1',
+        timestamp: '2026-05-01T10:00:00Z',
+        service: 'service-b',
+        traceId: 't1',
+        spanId: 's1',
+        errorMessage: 'timeout',
+      },
+      {
+        id: 'e2',
+        timestamp: '2026-05-01T11:00:00Z',
+        service: 'service-b',
+        traceId: 't2',
+        spanId: 's2',
+        errorMessage: 'scram failure',
+      },
+    ]
+    const { client } = clientFor({ '/incidents': events })
+    const result = await readRecentIncidentsResource(client)
+    expect(result.contents).toHaveLength(1)
+    const body = JSON.parse(result.contents[0].text as string)
+    expect(body.total).toBe(2)
+    expect(body.count).toBe(2)
+    // Reversed → newest leads.
+    expect(body.events[0].id).toBe('e2')
+    expect(body.events[1].id).toBe('e1')
+  })
+
+  it('honours the limit', async () => {
+    const events = Array.from({ length: 100 }, (_, i) => ({
+      id: `e${i}`,
+      timestamp: `2026-05-01T${String(i).padStart(2, '0')}:00:00Z`,
+      service: 'svc',
+      traceId: 't',
+      spanId: 's',
+      errorMessage: 'boom',
+    }))
+    const { client } = clientFor({ '/incidents': events })
+    const result = await readRecentIncidentsResource(client, 5)
+    const body = JSON.parse(result.contents[0].text as string)
+    expect(body.count).toBe(5)
+    expect(body.total).toBe(100)
+    expect(body.events[0].id).toBe('e99')
+  })
+})
+
+describe('incidentsChanged', () => {
+  it('returns false on the first observation (seeds, does not notify)', () => {
+    expect(incidentsChanged(null, { total: 5, lastId: 'e5' })).toBe(false)
+  })
+
+  it('detects total count change', () => {
+    expect(
+      incidentsChanged({ total: 5, lastId: 'e5' }, { total: 6, lastId: 'e6' }),
+    ).toBe(true)
+  })
+
+  it('detects last-id change even when total is unchanged', () => {
+    // Same total but a different newest event — could happen if a delete +
+    // insert raced. Rare but cheap to handle.
+    expect(
+      incidentsChanged({ total: 5, lastId: 'e5' }, { total: 5, lastId: 'e6' }),
+    ).toBe(true)
+  })
+
+  it('returns false when nothing changed', () => {
+    expect(
+      incidentsChanged({ total: 5, lastId: 'e5' }, { total: 5, lastId: 'e5' }),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
Second δ PR. Adds the MCP resource surface alongside the existing eight tools.

## What's exposed

| URI | Shape | Notes |
|---|---|---|
| \`neat://node/<id>\` | Templated, one per graph node | Read → JSON \`{ node, outboundEdges }\`. List enumerates current nodes — useful for browsing without round-tripping through \`semantic_search\`. |
| \`neat://incidents/recent\` | Static | Read → JSON \`{ count, total, events[] }\` newest-first. Poll loop hits \`/incidents\` every 5s and fires \`notifications/resources/updated\` when the count or newest event changes. |

## Implementation notes

- Tools are untouched. Resource registration sits after the eight \`server.tool(...)\` calls in \`packages/mcp/src/index.ts\` so the diff to existing surface is purely additive.
- Pure read helpers (\`listNodeResources\`, \`readNodeResource\`, \`readRecentIncidentsResource\`, \`incidentsChanged\`) are exported from \`resources.ts\` so the test suite can stub the HttpClient — no MCP transport needed.
- Poll cadence is \`NEAT_RESOURCE_POLL_MS\` (default 5000, 0 disables). The first observation seeds the comparator without firing a notification — clients only hear about changes that happen after they connect.
- \`registerResources()\` returns a \`stop()\`. SIGTERM/SIGINT call it so the dev poll interval doesn't keep the process alive after stdio closes.

## Test plan

- [x] \`npx turbo build test lint\` clean (24 → 33 mcp tests)
- [x] Live smoke against a \`neat watch\` core on :8765:
  - \`initialize\` advertises \`capabilities.resources.listChanged: true\`
  - \`resources/list\` returns the incidents resource and one entry per graph node
  - \`resources/templates/list\` returns the \`neat://node/{id}\` template
  - \`resources/read\` on \`neat://node/service%3Asmoke-svc\` returns \`{ node, outboundEdges }\` with two outbound edges
  - \`resources/read\` on \`neat://incidents/recent\` returns \`{ count: 0, total: 0, events: [] }\`
- [x] Demo extraction smoke: 5 nodes / 5 edges / 0 frontiers (unchanged)

Refs #81