### PR TITLE
semantic_search: real embeddings with three-tier fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ Run **after δ merges**, not before. Stand up Railway per `docs/railway.md` → 
 - `infra:<kind>:<name>` id format; one `InfraNode` type, free-string `kind` for sub-typing (ADR-022)
 - `FrontierNode` is a fifth node type for unresolved span peers; promoted away once an alias matches (ADR-023)
 - Per-edge-type stale thresholds + `stale-events.ndjson` transition log (ADR-024)
+- `semantic_search` uses an Ollama → Transformers.js → substring fallback chain; flat in-memory cosine, sidecar `embeddings.json` cache (ADR-025)
 
 ## Conventions
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -305,16 +305,11 @@ v0.1.2-β #73 populated `InfraNode` from docker-compose, Dockerfile, Terraform, 
 
 ---
 
-<<<<<<< HEAD
 ## ADR-023 — `FrontierNode` as a fifth top-level node type
-=======
-## ADR-024 — Per-edge-type stale thresholds
->>>>>>> 959e891 (Per-edge-type stale thresholds + stale-events log (#78))
 
 **Date:** 2026-05-02
 **Status:** Active.
 
-<<<<<<< HEAD
 v0.1.2-γ #75 added a fifth member to `GraphNodeSchema`: `FrontierNode`. A frontier node is the placeholder ingest writes when an OTel span peer (`server.address`, `net.peer.name`, etc.) doesn't resolve to any known service. The id format is `frontier:<host>`. A later extraction round picks up the host as an alias on a real service, `promoteFrontierNodes` re-links the edges, and the placeholder goes away.
 
 **Why a new node type, not an `InfraNode` kind.** ADR-022 deliberately kept the discriminated union at four. Frontier nodes broke that ceiling because they aren't classified by *what they are* — they're classified by *what they don't yet know*. They have a distinct lifecycle (placeholder → promoted → deleted), they carry temporal fields (`firstObserved`, `lastObserved`) that don't make sense on infra catalog entries, and a frontier node is supposed to disappear once extraction catches up. Cramming that into `InfraNode.kind = "frontier"` would have meant teaching every consumer of `InfraNode` to filter out a special case, and would have leaked frontier semantics into a node type whose whole job is to be permanent.
@@ -328,7 +323,14 @@ v0.1.2-γ #75 added a fifth member to `GraphNodeSchema`: `FrontierNode`. A front
 **Where promotion runs.** At the end of every `extractFromDirectory` pass, after services + databases + configs + calls + infra. Promotion needs the full alias state from the latest extraction round, so it has to run last. Re-running ingest doesn't trigger promotion directly — it just keeps pinning frontier `lastObserved` — which is fine because the next extraction round will sweep them up.
 
 **When to revisit.** If frontier nodes start sticking around (a host that never resolves no matter how many rounds pass), they become a UX signal: "you have unknown peers." That's a γ #76 concern (per-edge confidence) or δ ergonomics, not this ADR. The placeholder will continue to do its job until then.
-=======
+
+---
+
+## ADR-024 — Per-edge-type stale thresholds
+
+**Date:** 2026-05-02
+**Status:** Active.
+
 A single 24h `STALE_THRESHOLD_MS` doesn't survive contact with diverse traffic. HTTP `CALLS` recur in seconds — 24h means a service could go down for the whole afternoon and the graph would still claim everything was fine. Infra `DEPENDS_ON` is the opposite — a docker-compose service idle overnight isn't a problem. v0.1.2-γ #78 splits the threshold per edge type: `CALLS` go stale at 1h, `CONNECTS_TO` / `PUBLISHES_TO` / `CONSUMES_FROM` at 4h, infra `DEPENDS_ON` / `CONFIGURED_BY` / `RUNS_ON` at 24h.
 
 **Why a hardcoded default map, not a single tunable.** The defaults encode operational knowledge — "HTTP traffic is chatty, infra dependencies aren't" — and shouldn't have to be rediscovered per deployment. The map lives next to `markStaleEdges` in `ingest.ts`; new edge types fall back to 24h via a single sentinel constant, so adding to `EdgeType` doesn't silently bypass staleness sweeps.
@@ -342,4 +344,38 @@ A single 24h `STALE_THRESHOLD_MS` doesn't survive contact with diverse traffic. 
 **Where this could go wrong.** A flapping integration that calls every 65 minutes will oscillate between OBSERVED and STALE under the 1h `CALLS` default. The fix is to nudge the threshold (`NEAT_STALE_THRESHOLDS={"CALLS":7200000}`); the ndjson log will record both transitions so the oscillation itself is observable.
 
 **When to revisit.** When δ #79's `neat watch` daemon runs continuously, the stale-events log will grow unbounded. Rotation / TTL belongs there, not here — this ADR's job is to define the shape; that one will define the lifecycle.
->>>>>>> 959e891 (Per-edge-type stale thresholds + stale-events log (#78))
+
+---
+
+## ADR-025 — `semantic_search` embedding model: Ollama → Transformers.js → substring fallback chain
+
+**Date:** 2026-05-03
+**Status:** Active.
+
+`semantic_search` shipped in M4 as a substring match over `id` and `name`. It works for "show me the payments service" — but loses to "what handles checkout payments?" because the literal token doesn't appear. v0.1.2-δ #82 replaces the keyword path with real embeddings while keeping the substring path as the lowest-tier fallback so the tool never disappears even on minimal hosts.
+
+The embedding choice is the load-bearing decision in this work. We pick *one* default model and a fallback chain rather than a configurable provider matrix.
+
+**The chain.** First match wins:
+
+1. **Ollama** with `nomic-embed-text`, when `OLLAMA_HOST` is set (or `http://localhost:11434` is reachable on first use). 768-dim, 8K context, MIT-licensed, designed for retrieval. The user already pays the Ollama install cost; we just embed.
+2. **Transformers.js** running `Xenova/all-MiniLM-L6-v2` in-process, when Ollama isn't around. 384-dim, ~25MB on-disk, fully offline, no model server needed. Cold-start cost is the model download (~25MB once, cached in `~/.neat/models/`) plus ~1s of WASM init.
+3. **Substring fallback** — the existing M4 implementation, kept verbatim. Whatever was returned before still gets returned when neither embedder is available.
+
+Every tier returns the same MCP-shaped response, so consumers don't branch on which one ran.
+
+**Why Ollama as the default top tier.** It's the path of least resistance for users who already have it. Local, private, free, and the API surface (`POST /api/embeddings`) is small enough that we don't need an SDK dependency. `nomic-embed-text` consistently wins on retrieval benchmarks at its size class, and 768-dim cosine over a ≤10K-node graph is ~30ms — graph scale isn't the bottleneck.
+
+**Why Transformers.js as the in-process fallback, not a server-side embed.** The fallback exists for the case "the user hasn't installed Ollama and we don't want to make them." Anything that requires a separate process or network call would just become the new "you have to install X" friction. Transformers.js runs inside Node via WASM/ONNX with no external server. The chosen model (`all-MiniLM-L6-v2`) is the de facto default for "I need embeddings, I don't have infrastructure." It's smaller and weaker than nomic, which is exactly why we order Ollama first.
+
+**Why not OpenAI / Voyage / Cohere as defaults.** A hosted API would be the easiest to integrate but introduces an outbound network dependency and a credit cost on a tool that should "just work" against a local repo. NEAT runs against private codebases — sending node names to a third-party embedding endpoint is a category of decision a project should opt into, not inherit. Hosted providers can land later as a fourth tier (`NEAT_EMBED_PROVIDER=openai`) without changing the default.
+
+**Why a flat in-memory cosine, not a vector DB.** The graph caps out at ~10K nodes for any realistic repo. A `Float32Array` per node and a linear scan is ~3ms at 10K × 768. Indexing structures (HNSW, IVF) are faster only above ~100K vectors and add a dependency that has to compile native bindings. ADR-002 already paid that price for tree-sitter; we don't pay it twice.
+
+**What gets embedded.** Per node: `id + name + (description fragments — `language` for services, `engine`/`engineVersion` for databases, `kind` for infra)`. Edges are not embedded. Frontier nodes are not embedded — they're noise by design. The embed input is deterministic from node attrs so re-extracts hash-identical, and we use that hash to skip re-embedding nodes whose attrs didn't change.
+
+**Cache shape.** A sidecar cache at `<scanPath>/neat-out/embeddings.json` keyed by `{ provider, model, dim }` plus per-entry `{ nodeId, attrsHash, vector }`. On startup the search index loads the cache, drops entries whose `attrsHash` doesn't match the current node, and embeds anything new. The cache is regenerable, gitignore-friendly (lives under `neat-out/` with the snapshot), and never touches the snapshot's `schemaVersion: 2` envelope.
+
+**What this ADR isn't deciding.** Whether the substring tier should compute Jaro-Winkler or BM25 — the existing M4 substring code stays as-is. Whether the cache should be sqlite — JSON is fine at 10K vectors and the diff against an existing snapshot pattern works the same way. Whether `semantic_search` should accept a `provider` arg — let environment config drive the choice; the tool surface stays a one-arg `query`.
+
+**When to revisit.** When (a) graph scale exceeds ~50K nodes (then the linear scan becomes the bottleneck and a vector index earns its complexity), (b) a hosted embedding provider lands as a tier (then the chain extends), or (c) the embed input materially changes (e.g. embedding evidence snippets from γ #71's edge metadata — a different decision than node-only embeddings).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1500,6 +1500,16 @@
         "hono": "^4"
       }
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.2.2.tgz",
+      "integrity": "sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -3988,6 +3998,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/memcached": {
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.10.tgz",
@@ -4445,6 +4462,21 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xenova/transformers": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/@xenova/transformers/-/transformers-2.17.2.tgz",
+      "integrity": "sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@huggingface/jinja": "^0.2.2",
+        "onnxruntime-web": "1.14.0",
+        "sharp": "^0.32.0"
+      },
+      "optionalDependencies": {
+        "onnxruntime-node": "1.14.0"
+      }
+    },
     "node_modules/@yomguithereal/helpers": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@yomguithereal/helpers/-/helpers-1.1.1.tgz",
@@ -4709,6 +4741,124 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
+      "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -4729,6 +4879,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -4778,6 +4940,31 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-writer": {
@@ -4960,6 +5147,13 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
@@ -4986,6 +5180,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5003,6 +5211,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -5162,6 +5381,22 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -5170,6 +5405,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -5214,6 +5459,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/didyoumean": {
@@ -5263,6 +5518,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -5636,6 +5901,16 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -5655,6 +5930,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/expect-type": {
@@ -5754,6 +6039,13 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -6050,6 +6342,13 @@
         "node": ">=16"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true
+    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -6131,6 +6430,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -6244,6 +6550,13 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -6386,6 +6699,13 @@
         "graphology-types": ">=0.23.0"
       }
     },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -6493,6 +6813,27 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -6547,6 +6888,13 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/ip-address": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
@@ -6564,6 +6912,13 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -7038,6 +7393,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -7052,6 +7420,23 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/mlly": {
       "version": "1.8.2",
@@ -7116,6 +7501,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -7209,6 +7601,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.90.0.tgz",
+      "integrity": "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-addon-api": {
@@ -7327,6 +7732,94 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/onnx-proto": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/onnx-proto/-/onnx-proto-4.0.4.tgz",
+      "integrity": "sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "protobufjs": "^6.8.8"
+      }
+    },
+    "node_modules/onnx-proto/node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/onnx-proto/node_modules/protobufjs": {
+      "version": "6.11.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.5.tgz",
+      "integrity": "sha512-OKjVH3hDoXdIZ/s5MLv8O2X0s+wOxGfV7ar6WFSKGaSAxi/6gYn3px5POS4vi+mc/0zCOdL7Jkwrj0oT1Yst2A==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.14.0.tgz",
+      "integrity": "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.14.0.tgz",
+      "integrity": "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "onnxruntime-common": "~1.14.0"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.14.0.tgz",
+      "integrity": "sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "flatbuffers": "^1.12.0",
+        "guid-typescript": "^1.0.9",
+        "long": "^4.0.0",
+        "onnx-proto": "^4.0.4",
+        "onnxruntime-common": "~1.14.0",
+        "platform": "^1.3.6"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -7659,6 +8152,13 @@
         "pathe": "^2.0.1"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/postcss": {
       "version": "8.5.13",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
@@ -7861,6 +8361,64 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7958,6 +8516,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8034,6 +8603,32 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -8067,6 +8662,21 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -8433,6 +9043,37 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/sharp": {
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.5.4",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^3.0.4",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/sharp/node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -8539,6 +9180,63 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -8617,6 +9315,28 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -8829,6 +9549,84 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/thenify": {
@@ -9157,6 +9955,19 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/turbo": {
       "version": "2.9.6",
       "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.6.tgz",
@@ -9252,7 +10063,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -10086,6 +10897,9 @@
         "tsx": "^4.19.0",
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"
+      },
+      "optionalDependencies": {
+        "@xenova/transformers": "^2.17.2"
       }
     },
     "packages/mcp": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,5 +58,8 @@
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"
+  },
+  "optionalDependencies": {
+    "@xenova/transformers": "^2.17.2"
   }
 }

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -6,6 +6,7 @@ import { extractFromDirectory } from './extract.js'
 import { readErrorEvents, readStaleEvents } from './ingest.js'
 import { getBlastRadius, getRootCause } from './traverse.js'
 import { computeGraphDiff, loadSnapshotForDiff } from './diff.js'
+import type { SearchIndex } from './search.js'
 
 export interface BuildApiOptions {
   graph: NeatGraph
@@ -16,6 +17,9 @@ export interface BuildApiOptions {
   errorsPath?: string
   // ndjson path /incidents/stale reads from. Optional for tests.
   staleEventsPath?: string
+  // Optional embedding-backed search index. When absent, /search falls back
+  // to the substring path inline so the route always works.
+  searchIndex?: SearchIndex
 }
 
 interface SerializedGraph {
@@ -133,17 +137,33 @@ export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> 
     },
   )
 
-  app.get<{ Querystring: { q?: string } }>('/search', async (req, reply) => {
-    const q = (req.query.q ?? '').trim().toLowerCase()
-    if (!q) return reply.code(400).send({ error: 'query parameter `q` is required' })
-    const matches: GraphNode[] = []
+  app.get<{ Querystring: { q?: string; limit?: string } }>('/search', async (req, reply) => {
+    const raw = (req.query.q ?? '').trim()
+    if (!raw) return reply.code(400).send({ error: 'query parameter `q` is required' })
+    const limit = req.query.limit ? Number(req.query.limit) : undefined
+    const safeLimit = limit !== undefined && Number.isFinite(limit) && limit > 0 ? limit : undefined
+
+    if (opts.searchIndex) {
+      const result = await opts.searchIndex.search(raw, safeLimit)
+      return {
+        query: result.query,
+        provider: result.provider,
+        matches: result.matches.map((m) => ({ ...m.node, score: m.score })),
+      }
+    }
+
+    // Substring fallback for callers (mainly tests) that build the API
+    // without an attached index. Same shape as the index path so consumers
+    // don't branch.
+    const q = raw.toLowerCase()
+    const matches: (GraphNode & { score: number })[] = []
     graph.forEachNode((id, attrs) => {
       const name = (attrs as { name?: string }).name ?? ''
       if (id.toLowerCase().includes(q) || name.toLowerCase().includes(q)) {
-        matches.push(attrs)
+        matches.push({ ...(attrs as GraphNode), score: 1 })
       }
     })
-    return { query: q, matches }
+    return { query: q, provider: 'substring' as const, matches: matches.slice(0, safeLimit) }
   })
 
   app.get<{ Querystring: { against?: string } }>('/graph/diff', async (req, reply) => {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -147,11 +147,16 @@ async function main(): Promise<void> {
         path.join(path.dirname(outPath), 'stale-events.ndjson'),
     )
 
+    const embeddingsCachePath = process.env.NEAT_EMBEDDINGS_CACHE_PATH
+      ? path.resolve(process.env.NEAT_EMBEDDINGS_CACHE_PATH)
+      : undefined
+
     const handle: WatchHandle = await startWatch(getGraph(), {
       scanPath,
       outPath,
       errorsPath,
       staleEventsPath,
+      ...(embeddingsCachePath ? { embeddingsCachePath } : {}),
       host: process.env.HOST ?? '0.0.0.0',
       port: Number(process.env.PORT ?? 8080),
       otelPort: Number(process.env.OTEL_PORT ?? 4318),

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -1,0 +1,415 @@
+// semantic_search — embedding-based node retrieval with a three-tier
+// fallback chain. The chain is settled in ADR-025; this file is the
+// implementation. Public API:
+//
+//   buildSearchIndex(graph, opts) → SearchIndex
+//   SearchIndex.search(query, limit) → { provider, matches }
+//   SearchIndex.refresh(graph)      → re-embeds new/changed nodes,
+//                                     drops vanished ones
+//
+// The `/search` route in api.ts holds a single SearchIndex, refreshing it
+// after any extraction. MCP's `semantic_search` tool reads the same shape.
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { createHash } from 'node:crypto'
+import type { GraphNode } from '@neat/types'
+import type { NeatGraph } from './graph.js'
+
+export interface ScoredNode {
+  node: GraphNode
+  score: number
+}
+
+export interface SearchResponse {
+  query: string
+  provider: 'ollama' | 'transformers' | 'substring'
+  matches: ScoredNode[]
+}
+
+export interface SearchIndex {
+  readonly provider: SearchResponse['provider']
+  search(query: string, limit?: number): Promise<SearchResponse>
+  refresh(graph: NeatGraph): Promise<void>
+}
+
+interface Embedder {
+  provider: 'ollama' | 'transformers'
+  model: string
+  dim: number
+  embed(texts: string[]): Promise<Float32Array[]>
+}
+
+const DEFAULT_LIMIT = 10
+const NOMIC_DIM = 768
+const MINI_LM_DIM = 384
+
+// FrontierNodes are noise by design (placeholders that should disappear).
+// Embedding them would just clutter results.
+function shouldEmbed(node: GraphNode): boolean {
+  return node.type !== 'FrontierNode'
+}
+
+// Deterministic per-node text. Stable keys let the cache hit across
+// extractions when nothing material changed.
+export function embedText(node: GraphNode): string {
+  const parts: string[] = [node.id]
+  const name = (node as { name?: string }).name
+  if (name) parts.push(name)
+  switch (node.type) {
+    case 'ServiceNode': {
+      const lang = (node as { language?: string }).language
+      if (lang) parts.push(`language=${lang}`)
+      break
+    }
+    case 'DatabaseNode': {
+      const eng = (node as { engine?: string }).engine
+      const ver = (node as { engineVersion?: string }).engineVersion
+      if (eng) parts.push(`engine=${eng}`)
+      if (ver) parts.push(`engineVersion=${ver}`)
+      break
+    }
+    case 'InfraNode': {
+      const kind = (node as { kind?: string }).kind
+      if (kind) parts.push(`kind=${kind}`)
+      break
+    }
+    case 'ConfigNode': {
+      const filePath = (node as { path?: string }).path
+      if (filePath) parts.push(`path=${filePath}`)
+      break
+    }
+    default:
+      break
+  }
+  return parts.join(' ')
+}
+
+function attrsHash(node: GraphNode): string {
+  return createHash('sha1').update(embedText(node)).digest('hex').slice(0, 16)
+}
+
+export function cosine(a: Float32Array, b: Float32Array): number {
+  if (a.length !== b.length) return 0
+  let dot = 0
+  let na = 0
+  let nb = 0
+  for (let i = 0; i < a.length; i++) {
+    const ai = a[i] ?? 0
+    const bi = b[i] ?? 0
+    dot += ai * bi
+    na += ai * ai
+    nb += bi * bi
+  }
+  if (na === 0 || nb === 0) return 0
+  return dot / (Math.sqrt(na) * Math.sqrt(nb))
+}
+
+// ---------------------------------------------------------------- Embedders
+
+function ollamaHost(): string | null {
+  return process.env.OLLAMA_HOST ?? null
+}
+
+async function ollamaReachable(host: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${host.replace(/\/$/, '')}/api/tags`, {
+      signal: AbortSignal.timeout(500),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+function makeOllamaEmbedder(host: string, model = 'nomic-embed-text'): Embedder {
+  const root = host.replace(/\/$/, '')
+  return {
+    provider: 'ollama',
+    model,
+    dim: NOMIC_DIM,
+    async embed(texts: string[]): Promise<Float32Array[]> {
+      const out: Float32Array[] = []
+      // Ollama's /api/embeddings is one-text-per-request. ≤10K nodes × ~30ms
+      // each is fine for a one-shot index build; if it ever isn't, the API
+      // also accepts batched input on /api/embed (newer routes).
+      for (const text of texts) {
+        const res = await fetch(`${root}/api/embeddings`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ model, prompt: text }),
+        })
+        if (!res.ok) {
+          throw new Error(`ollama embeddings: ${res.status} ${res.statusText}`)
+        }
+        const data = (await res.json()) as { embedding: number[] }
+        out.push(Float32Array.from(data.embedding))
+      }
+      return out
+    },
+  }
+}
+
+interface XenovaPipeline {
+  (text: string | string[], options?: { pooling?: string; normalize?: boolean }): Promise<{
+    data: Float32Array
+  }>
+}
+
+async function makeTransformersEmbedder(): Promise<Embedder | null> {
+  let pipelineFn: ((task: string, model: string) => Promise<XenovaPipeline>) | null = null
+  try {
+    // Lazy require so server.ts boot doesn't pay the WASM init cost when
+    // Ollama is available. The package is heavy — only load it on demand.
+    // The package is optional so its types may not be installed in every
+    // environment. Use a dynamic specifier so tsc keeps the import dynamic
+    // and doesn't try to resolve types at build time.
+    const specifier = '@xenova/transformers'
+    const mod = (await import(specifier)) as unknown as {
+      pipeline: (task: string, model: string) => Promise<XenovaPipeline>
+    }
+    pipelineFn = mod.pipeline
+  } catch {
+    return null
+  }
+  if (!pipelineFn) return null
+  const model = 'Xenova/all-MiniLM-L6-v2'
+  const extractor = await pipelineFn('feature-extraction', model)
+  return {
+    provider: 'transformers',
+    model,
+    dim: MINI_LM_DIM,
+    async embed(texts: string[]): Promise<Float32Array[]> {
+      const out: Float32Array[] = []
+      for (const text of texts) {
+        // Mean-pooled, L2-normalized → cosine reduces to dot product but
+        // we keep the explicit cosine() for clarity.
+        const result = await extractor(text, { pooling: 'mean', normalize: true })
+        out.push(Float32Array.from(result.data))
+      }
+      return out
+    },
+  }
+}
+
+// Picks the highest-tier embedder available. Returns null when only
+// substring is available (caller decides what to build).
+export async function pickEmbedder(): Promise<Embedder | null> {
+  const host = ollamaHost()
+  if (host && (await ollamaReachable(host))) {
+    return makeOllamaEmbedder(host)
+  }
+  return makeTransformersEmbedder()
+}
+
+// ------------------------------------------------------------------ Cache
+
+interface CacheEntry {
+  nodeId: string
+  attrsHash: string
+  vector: number[]
+}
+
+interface CacheFile {
+  version: 1
+  provider: 'ollama' | 'transformers'
+  model: string
+  dim: number
+  entries: CacheEntry[]
+}
+
+async function readCache(cachePath: string): Promise<CacheFile | null> {
+  try {
+    const raw = await fs.readFile(cachePath, 'utf8')
+    const parsed = JSON.parse(raw) as CacheFile
+    if (parsed.version !== 1) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+async function writeCache(cachePath: string, cache: CacheFile): Promise<void> {
+  await fs.mkdir(path.dirname(cachePath), { recursive: true })
+  await fs.writeFile(cachePath, JSON.stringify(cache))
+}
+
+// ----------------------------------------------------------------- Indexes
+
+class VectorIndex implements SearchIndex {
+  readonly provider: 'ollama' | 'transformers'
+  private vectors = new Map<string, { node: GraphNode; vector: Float32Array; hash: string }>()
+
+  constructor(
+    private embedder: Embedder,
+    private cachePath: string | null,
+  ) {
+    this.provider = embedder.provider
+  }
+
+  async search(query: string, limit = DEFAULT_LIMIT): Promise<SearchResponse> {
+    const trimmed = query.trim()
+    if (!trimmed || this.vectors.size === 0) {
+      return { query: trimmed, provider: this.provider, matches: [] }
+    }
+    const embedded = await this.embedder.embed([trimmed])
+    const qv = embedded[0]
+    if (!qv) {
+      return { query: trimmed, provider: this.provider, matches: [] }
+    }
+    const scored: ScoredNode[] = []
+    for (const { node, vector } of this.vectors.values()) {
+      const score = cosine(qv, vector)
+      scored.push({ node, score })
+    }
+    scored.sort((a, b) => b.score - a.score)
+    return { query: trimmed, provider: this.provider, matches: scored.slice(0, limit) }
+  }
+
+  async refresh(graph: NeatGraph): Promise<void> {
+    const present = new Set<string>()
+    const toEmbed: { id: string; node: GraphNode; hash: string; text: string }[] = []
+
+    graph.forEachNode((id, attrs) => {
+      const node = attrs as GraphNode
+      if (!shouldEmbed(node)) return
+      present.add(id)
+      const hash = attrsHash(node)
+      const cached = this.vectors.get(id)
+      if (cached && cached.hash === hash) {
+        cached.node = node
+        return
+      }
+      toEmbed.push({ id, node, hash, text: embedText(node) })
+    })
+
+    // Drop vanished nodes
+    for (const id of [...this.vectors.keys()]) {
+      if (!present.has(id)) this.vectors.delete(id)
+    }
+
+    if (toEmbed.length > 0) {
+      const vectors = await this.embedder.embed(toEmbed.map((e) => e.text))
+      toEmbed.forEach((entry, i) => {
+        const v = vectors[i]
+        if (!v) return
+        this.vectors.set(entry.id, { node: entry.node, vector: v, hash: entry.hash })
+      })
+    }
+
+    if (this.cachePath) {
+      const entries: CacheEntry[] = []
+      for (const [id, { vector, hash }] of this.vectors) {
+        entries.push({ nodeId: id, attrsHash: hash, vector: Array.from(vector) })
+      }
+      await writeCache(this.cachePath, {
+        version: 1,
+        provider: this.embedder.provider,
+        model: this.embedder.model,
+        dim: this.embedder.dim,
+        entries,
+      })
+    }
+  }
+
+  // Hydrate the in-memory map from a previously-written cache. Validates
+  // shape against the current embedder; mismatch → empty start.
+  loadFromCache(cache: CacheFile, graph: NeatGraph): void {
+    if (
+      cache.provider !== this.embedder.provider ||
+      cache.model !== this.embedder.model ||
+      cache.dim !== this.embedder.dim
+    ) {
+      return
+    }
+    const present = new Map<string, GraphNode>()
+    graph.forEachNode((id, attrs) => {
+      const node = attrs as GraphNode
+      if (shouldEmbed(node)) present.set(id, node)
+    })
+    for (const entry of cache.entries) {
+      const node = present.get(entry.nodeId)
+      if (!node) continue
+      // Skip cache entries whose attrs no longer match — they'll be
+      // re-embedded by the next refresh().
+      if (attrsHash(node) !== entry.attrsHash) continue
+      if (entry.vector.length !== this.embedder.dim) continue
+      this.vectors.set(entry.nodeId, {
+        node,
+        hash: entry.attrsHash,
+        vector: Float32Array.from(entry.vector),
+      })
+    }
+  }
+}
+
+class SubstringIndex implements SearchIndex {
+  readonly provider = 'substring' as const
+  private graph: NeatGraph | null = null
+
+  async search(query: string, limit = DEFAULT_LIMIT): Promise<SearchResponse> {
+    const q = query.trim().toLowerCase()
+    const out: ScoredNode[] = []
+    if (!q || !this.graph) {
+      return { query: q, provider: 'substring', matches: [] }
+    }
+    this.graph.forEachNode((id, attrs) => {
+      const node = attrs as GraphNode
+      const name = (node as { name?: string }).name ?? ''
+      if (id.toLowerCase().includes(q) || name.toLowerCase().includes(q)) {
+        out.push({ node, score: 1 })
+      }
+    })
+    return { query: q, provider: 'substring', matches: out.slice(0, limit) }
+  }
+
+  async refresh(graph: NeatGraph): Promise<void> {
+    this.graph = graph
+  }
+}
+
+// ------------------------------------------------------------ Public factory
+
+export interface BuildSearchIndexOptions {
+  // Where to read/write the embedding cache. Falls back to in-memory only
+  // if not provided. Pass `null` to explicitly disable caching.
+  cachePath?: string | null
+  // Override the embedder selection. Useful for tests (substring-only mode
+  // skips the Ollama probe + the Transformers.js download).
+  forceProvider?: 'ollama' | 'transformers' | 'substring'
+  // Pre-built embedder (test injection). Wins over forceProvider.
+  embedder?: Embedder
+}
+
+export async function buildSearchIndex(
+  graph: NeatGraph,
+  options: BuildSearchIndexOptions = {},
+): Promise<SearchIndex> {
+  let embedder: Embedder | null = null
+  if (options.embedder) {
+    embedder = options.embedder
+  } else if (options.forceProvider !== 'substring') {
+    embedder = await pickEmbedder()
+    if (options.forceProvider === 'ollama' && embedder?.provider !== 'ollama') {
+      embedder = null
+    }
+    if (options.forceProvider === 'transformers' && embedder?.provider !== 'transformers') {
+      embedder = null
+    }
+  }
+
+  if (!embedder) {
+    const idx = new SubstringIndex()
+    await idx.refresh(graph)
+    return idx
+  }
+
+  const cachePath = options.cachePath === undefined ? null : options.cachePath
+  const idx = new VectorIndex(embedder, cachePath)
+  if (cachePath) {
+    const cache = await readCache(cachePath)
+    if (cache) idx.loadFromCache(cache, graph)
+  }
+  await idx.refresh(graph)
+  return idx
+}

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -6,6 +6,7 @@ import { loadGraphFromDisk, startPersistLoop } from './persist.js'
 import { buildOtelReceiver } from './otel.js'
 import { startOtelGrpcReceiver } from './otel-grpc.js'
 import { makeSpanHandler, startStalenessLoop } from './ingest.js'
+import { buildSearchIndex } from './search.js'
 
 async function main(): Promise<void> {
   const graph = getGraph()
@@ -37,7 +38,19 @@ async function main(): Promise<void> {
   const port = Number(process.env.PORT ?? 8080)
   const otelPort = Number(process.env.OTEL_PORT ?? 4318)
 
-  const app = await buildApi({ graph, scanPath, errorsPath, staleEventsPath })
+  const cachePath = path.resolve(
+    process.env.NEAT_EMBEDDINGS_CACHE_PATH ??
+      path.join(path.dirname(outPath), 'embeddings.json'),
+  )
+  const searchIndex = await buildSearchIndex(graph, { cachePath }).catch((err) => {
+    console.warn(`semantic_search: index build failed (${(err as Error).message}); falling back to inline substring`)
+    return undefined
+  })
+  if (searchIndex) {
+    console.log(`semantic_search: ${searchIndex.provider} provider`)
+  }
+
+  const app = await buildApi({ graph, scanPath, errorsPath, staleEventsPath, searchIndex })
   await app.listen({ port, host })
   console.log(`neat-core listening on http://${host}:${port}`)
   console.log(`  scan path:     ${scanPath}`)

--- a/packages/core/src/watch.ts
+++ b/packages/core/src/watch.ts
@@ -14,6 +14,7 @@ import { makeSpanHandler, promoteFrontierNodes, startStalenessLoop } from './ing
 import { buildOtelReceiver } from './otel.js'
 import { startOtelGrpcReceiver } from './otel-grpc.js'
 import { loadGraphFromDisk, startPersistLoop } from './persist.js'
+import { buildSearchIndex, type SearchIndex } from './search.js'
 
 export type ExtractPhase =
   | 'services'
@@ -163,6 +164,7 @@ export interface WatchOptions {
   outPath: string
   errorsPath: string
   staleEventsPath: string
+  embeddingsCachePath?: string
   host?: string
   port?: number
   otelPort?: number
@@ -210,11 +212,24 @@ export async function startWatch(
   const port = opts.port ?? 8080
   const otelPort = opts.otelPort ?? 4318
 
+  const cachePath =
+    opts.embeddingsCachePath ?? path.join(path.dirname(opts.outPath), 'embeddings.json')
+  let searchIndex: SearchIndex | undefined
+  try {
+    searchIndex = await buildSearchIndex(graph, { cachePath })
+    console.log(`semantic_search: ${searchIndex.provider} provider`)
+  } catch (err) {
+    console.warn(
+      `semantic_search: index build failed (${(err as Error).message}); falling back to inline substring`,
+    )
+  }
+
   const api = await buildApi({
     graph,
     scanPath: opts.scanPath,
     errorsPath: opts.errorsPath,
     staleEventsPath: opts.staleEventsPath,
+    searchIndex,
   })
   await api.listen({ port, host })
   console.log(`neat-core listening on http://${host}:${port}`)
@@ -251,6 +266,13 @@ export async function startWatch(
       console.log(
         `[watch] re-extract phases=${result.phases.join(',')} +${result.nodesAdded}n/+${result.edgesAdded}e in ${result.durationMs}ms`,
       )
+      if (searchIndex) {
+        try {
+          await searchIndex.refresh(graph)
+        } catch (err) {
+          console.warn('[watch] semantic_search refresh failed', err)
+        }
+      }
     } catch (err) {
       console.error('[watch] re-extract failed', err)
     }

--- a/packages/core/test/search.test.ts
+++ b/packages/core/test/search.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { EdgeType, NodeType, Provenance } from '@neat/types'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { buildSearchIndex, cosine, embedText } from '../src/search.js'
+
+let tmpDir: string
+
+beforeEach(async () => {
+  resetGraph()
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-search-'))
+})
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true })
+})
+
+function seedGraph(): ReturnType<typeof getGraph> {
+  const graph = getGraph()
+  graph.addNode('service:checkout', {
+    id: 'service:checkout',
+    type: NodeType.ServiceNode,
+    name: 'checkout',
+    language: 'javascript',
+  })
+  graph.addNode('service:payments', {
+    id: 'service:payments',
+    type: NodeType.ServiceNode,
+    name: 'payments',
+    language: 'javascript',
+  })
+  graph.addNode('database:payments-db', {
+    id: 'database:payments-db',
+    type: NodeType.DatabaseNode,
+    name: 'payments-db',
+    engine: 'postgresql',
+    engineVersion: '15',
+  })
+  graph.addEdgeWithKey(
+    'CONNECTS_TO:service:payments->database:payments-db',
+    'service:payments',
+    'database:payments-db',
+    {
+      id: 'CONNECTS_TO:service:payments->database:payments-db',
+      source: 'service:payments',
+      target: 'database:payments-db',
+      type: EdgeType.CONNECTS_TO,
+      provenance: Provenance.EXTRACTED,
+    },
+  )
+  return graph
+}
+
+describe('embedText', () => {
+  it('joins id, name, and type-specific fragments', () => {
+    const txt = embedText({
+      id: 'service:checkout',
+      type: NodeType.ServiceNode,
+      name: 'checkout',
+      language: 'javascript',
+    })
+    expect(txt).toBe('service:checkout checkout language=javascript')
+  })
+
+  it('emits engine + engineVersion for databases', () => {
+    const txt = embedText({
+      id: 'database:payments-db',
+      type: NodeType.DatabaseNode,
+      name: 'payments-db',
+      engine: 'postgresql',
+      engineVersion: '15',
+    })
+    expect(txt).toBe('database:payments-db payments-db engine=postgresql engineVersion=15')
+  })
+
+  it('emits kind for infra nodes', () => {
+    const txt = embedText({
+      id: 'infra:postgres:payments',
+      type: NodeType.InfraNode,
+      name: 'payments',
+      kind: 'postgres',
+    })
+    expect(txt).toBe('infra:postgres:payments payments kind=postgres')
+  })
+})
+
+describe('cosine', () => {
+  it('returns 1 for identical vectors', () => {
+    const v = new Float32Array([1, 2, 3])
+    expect(cosine(v, v)).toBeCloseTo(1, 6)
+  })
+
+  it('returns 0 when one vector is zero', () => {
+    expect(cosine(new Float32Array([0, 0]), new Float32Array([1, 1]))).toBe(0)
+  })
+
+  it('returns 0 on length mismatch', () => {
+    expect(cosine(new Float32Array([1]), new Float32Array([1, 1]))).toBe(0)
+  })
+})
+
+describe('buildSearchIndex with substring provider', () => {
+  it('falls back to substring when no embedder is available', async () => {
+    seedGraph()
+    const idx = await buildSearchIndex(getGraph(), { forceProvider: 'substring' })
+    expect(idx.provider).toBe('substring')
+    const result = await idx.search('payments')
+    expect(result.provider).toBe('substring')
+    const ids = result.matches.map((m) => m.node.id).sort()
+    expect(ids).toEqual(['database:payments-db', 'service:payments'])
+  })
+})
+
+describe('buildSearchIndex with an injected embedder', () => {
+  // Tiny deterministic embedder: hashes the text into two dimensions so two
+  // nodes whose text shares prefixes are closer than nodes that don't.
+  function fakeEmbedder() {
+    const dim = 8
+    const embed = (text: string): Float32Array => {
+      const v = new Float32Array(dim)
+      for (let i = 0; i < text.length; i++) {
+        v[text.charCodeAt(i) % dim] += 1
+      }
+      // L2 normalise
+      let n = 0
+      for (let i = 0; i < dim; i++) n += v[i] * v[i]
+      n = Math.sqrt(n)
+      if (n > 0) for (let i = 0; i < dim; i++) v[i] /= n
+      return v
+    }
+    return {
+      provider: 'transformers' as const,
+      model: 'fake-test-model',
+      dim,
+      async embed(texts: string[]): Promise<Float32Array[]> {
+        return texts.map(embed)
+      },
+    }
+  }
+
+  it('returns scored matches sorted by cosine similarity', async () => {
+    seedGraph()
+    const idx = await buildSearchIndex(getGraph(), {
+      embedder: fakeEmbedder(),
+      cachePath: null,
+    })
+    expect(idx.provider).toBe('transformers')
+    const result = await idx.search('payments database', 5)
+    expect(result.provider).toBe('transformers')
+    expect(result.matches.length).toBeGreaterThan(0)
+    // Scores are descending.
+    const scores = result.matches.map((m) => m.score)
+    for (let i = 1; i < scores.length; i++) {
+      expect(scores[i - 1]).toBeGreaterThanOrEqual(scores[i])
+    }
+  })
+
+  it('persists vectors to a cache and skips re-embed when attrs unchanged', async () => {
+    seedGraph()
+    const cachePath = path.join(tmpDir, 'embeddings.json')
+    const calls: string[][] = []
+    const inner = fakeEmbedder()
+    const counting = {
+      ...inner,
+      async embed(texts: string[]): Promise<Float32Array[]> {
+        calls.push(texts)
+        return inner.embed(texts)
+      },
+    }
+    const first = await buildSearchIndex(getGraph(), {
+      embedder: counting,
+      cachePath,
+    })
+    expect(calls.flat().length).toBeGreaterThan(0)
+    void first
+
+    const cache = JSON.parse(await fs.readFile(cachePath, 'utf8'))
+    expect(cache.version).toBe(1)
+    expect(cache.provider).toBe('transformers')
+    expect(cache.entries.length).toBeGreaterThan(0)
+
+    // Second build with the same graph + same cache should not call embed.
+    const callsAfter: string[][] = []
+    const recheck = {
+      ...inner,
+      async embed(texts: string[]): Promise<Float32Array[]> {
+        callsAfter.push(texts)
+        return inner.embed(texts)
+      },
+    }
+    const second = await buildSearchIndex(getGraph(), {
+      embedder: recheck,
+      cachePath,
+    })
+    expect(callsAfter.flat()).toEqual([])
+    void second
+  })
+
+  it('drops cache entries whose attrs hash no longer matches', async () => {
+    seedGraph()
+    const cachePath = path.join(tmpDir, 'embeddings.json')
+    const inner = fakeEmbedder()
+    await buildSearchIndex(getGraph(), { embedder: inner, cachePath })
+
+    // Mutate the service: changing name → changes embedText → changes hash.
+    const graph = getGraph()
+    graph.replaceNodeAttributes('service:payments', {
+      id: 'service:payments',
+      type: NodeType.ServiceNode,
+      name: 'payments-renamed',
+      language: 'javascript',
+    })
+
+    const calls: string[][] = []
+    const counting = {
+      ...inner,
+      async embed(texts: string[]): Promise<Float32Array[]> {
+        calls.push(texts)
+        return inner.embed(texts)
+      },
+    }
+    await buildSearchIndex(getGraph(), { embedder: counting, cachePath })
+    // Should have re-embedded exactly the renamed node, not all three.
+    expect(calls.flat()).toEqual([
+      embedText({
+        id: 'service:payments',
+        type: NodeType.ServiceNode,
+        name: 'payments-renamed',
+        language: 'javascript',
+      }),
+    ])
+  })
+
+  it('refresh() drops vanished nodes from the index', async () => {
+    seedGraph()
+    const idx = await buildSearchIndex(getGraph(), {
+      embedder: fakeEmbedder(),
+      cachePath: null,
+    })
+    let result = await idx.search('payments')
+    expect(result.matches.map((m) => m.node.id)).toContain('database:payments-db')
+
+    getGraph().dropNode('database:payments-db')
+    await idx.refresh(getGraph())
+    result = await idx.search('payments')
+    expect(result.matches.map((m) => m.node.id)).not.toContain('database:payments-db')
+  })
+
+  it('skips FrontierNodes', async () => {
+    seedGraph()
+    getGraph().addNode('frontier:unknown.host', {
+      id: 'frontier:unknown.host',
+      type: NodeType.FrontierNode,
+      name: 'unknown.host',
+      firstObserved: '2026-05-01T00:00:00Z',
+      lastObserved: '2026-05-01T00:00:00Z',
+    })
+    const idx = await buildSearchIndex(getGraph(), {
+      embedder: fakeEmbedder(),
+      cachePath: null,
+    })
+    const result = await idx.search('unknown')
+    expect(result.matches.map((m) => m.node.id)).not.toContain('frontier:unknown.host')
+  })
+})

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -80,8 +80,8 @@ server.tool(
 
 server.tool(
   'semantic_search',
-  'Search nodes by free-text query. Currently a keyword match over node ids and names; vector search lands post-MVP.',
-  { query: z.string().describe('Search text') },
+  'Search nodes by natural-language query. Uses embedding vectors when an embedder is available (Ollama nomic-embed-text → in-process MiniLM → substring fallback) — phrase the query the way you would describe what you want.',
+  { query: z.string().describe('Free-text query, e.g. "service handling checkout payments"') },
   async (input) => semanticSearch(client, input),
 )
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -247,7 +247,8 @@ export interface SemanticSearchInput {
 
 interface SearchResponse {
   query: string
-  matches: GraphNode[]
+  provider?: 'ollama' | 'transformers' | 'substring'
+  matches: (GraphNode & { score?: number })[]
 }
 
 export async function semanticSearch(
@@ -261,9 +262,19 @@ export async function semanticSearch(
     if (result.matches.length === 0) {
       return text(`No matches for "${input.query}".`)
     }
-    const lines = [`Search results for "${input.query}":`, '']
+    const provider = result.provider ?? 'substring'
+    const lines = [
+      `Search results for "${input.query}" (${provider}):`,
+      '',
+    ]
     for (const n of result.matches) {
-      lines.push(`  • ${n.id} (${n.type}) — ${n.name}`)
+      // Embedding tiers attach a cosine score in [0,1]; substring fallback
+      // doesn't, so we elide the score when it's the placeholder 1.
+      const scoreBit =
+        provider !== 'substring' && typeof n.score === 'number'
+          ? ` [score=${n.score.toFixed(2)}]`
+          : ''
+      lines.push(`  • ${n.id} (${n.type}) — ${(n as { name?: string }).name ?? n.id}${scoreBit}`)
     }
     return text(lines.join('\n'))
   } catch (err) {


### PR DESCRIPTION
Third δ PR. Replaces the M4 keyword stub with embedding-backed search. The model-choice ADR (ADR-025) is included in this PR, written before the code per gamma's note.

## The chain

| Tier | Provider | When |
|---|---|---|
| 1 | Ollama \`nomic-embed-text\` (768d) | \`OLLAMA_HOST\` is set and \`/api/tags\` answers within 500ms |
| 2 | \`@xenova/transformers\` MiniLM-L6-v2 (384d) | optionalDependency loads successfully |
| 3 | substring | the existing M4 path, kept verbatim |

Picked once at startup; the active provider is logged. Vectors live in memory keyed by node id, with a sidecar at \`neat-out/embeddings.json\` keyed by \`{provider, model, dim}\` plus per-entry \`attrsHash\`. A cold start with a matching cache loads zero embeddings; a stale cache (different provider, dim mismatch, or hash mismatch) is dropped silently and entries get re-embedded.

## What's in the changeset

- **\`docs/decisions.md\`** — ADR-025 (model choice + cache shape). **Bring-along:** the file picked up stray conflict markers around ADR-023/ADR-024 from an earlier merge; both bodies were present, just wrapped in \`<<<<<<<\`. Cleaned up so the new ADR reads in order.
- **\`packages/core/src/search.ts\`** — new. Embedder factories (Ollama via fetch, Transformers.js via lazy dynamic import), \`VectorIndex\` + \`SubstringIndex\` behind a common interface, \`buildSearchIndex(graph, opts)\` factory, JSON cache I/O, deterministic \`embedText(node)\`.
- **\`packages/core/src/api.ts\`** — \`/search\` route prefers the attached index, falls back to substring inline. Response shape gains \`provider\` and per-match \`score\`.
- **\`server.ts\` + \`watch.ts\`** — build the index after initial extract, refresh it on every \`neat watch\` re-extract.
- **\`packages/mcp/src/tools.ts\` + \`index.ts\`** — tool description rewritten for natural-language input; output surfaces \`provider\` and \`score\` when present.
- **\`packages/core/package.json\`** — \`@xenova/transformers\` as \`optionalDependencies\` so install never fails for users on minimal hosts. The lazy import gracefully handles absence.

## Test plan

- [x] \`npx turbo build test lint\` clean (198 → 210 core tests, 33 mcp)
- [x] Unit coverage for \`embedText\`, \`cosine\`, substring fallback, vector index with an injected fake embedder, cache hit/miss, attrs-hash invalidation, vanished-node drop, FrontierNode skip
- [x] Live smoke against a temp two-service fixture (Ollama not running, Transformers.js not installed): \`semantic_search: substring provider\` logged, \`/search?q=payments\` returns \`{ provider: 'substring', matches: [3 nodes with score: 1] }\`
- [x] Demo extraction smoke: 5 nodes / 5 edges / 0 frontiers (unchanged)

## What's deferred

- A hosted embedding tier (OpenAI / Voyage / Cohere) lives in ADR-025's "when to revisit" — it can land as a fourth tier without changing the default.
- Vector index swap (HNSW etc.) — deferred until graph scale exceeds ~50K nodes per ADR-025.

Refs #82