### PR TITLE
Post-v0.1.2 handoff: generic Dockerfile + v0.2.0 framing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ npm-debug.log*
 
 # test
 coverage/
+
+# docker save artifacts — image tarballs are big and never belong in the tree
+*.tar.gz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,68 +8,38 @@ NEAT keeps a live semantic graph of a software system — code, infrastructure, 
 
 ## Where you are in the build
 
-**The MVP sprint (M0–M6) is complete.** All six milestones shipped. The repo is now on the `main` branch with everything verified. Active work is the **v0.1.2 "Ubiquity" release** — see issues #67–#83 on GitHub.
+**v0.1.2 "Ubiquity" is shipped and tagged.** Release: https://github.com/NEAT-Technologies/Neat/releases/tag/v0.1.2. The MVP sprint (M0–M6) before it is also complete. Active work is the **v0.2.0 frontend release**.
 
-MVP milestone summary for context:
+Sub-milestones in v0.1.2, all merged on `main`:
 
-- **M0** — monorepo + types ✓
-- **M1** — static graph: tree-sitter reads the demo, compat check fires, REST API serves it ✓
-- **M2** — OTel: live traces become OBSERVED edges ✓
-- **M3** — traversal: root-cause + blast-radius ✓
-- **M4** — MCP: all six tools wired up against the live graph, Claude Code can connect ✓
-- **M5** — general purpose: data-driven compat, second failure scenario, `neat init` CLI ✓
-- **M6** — Railway deploy: runbook, collector Dockerfile, quickstart README, PROVENANCE.md ✓ (code); manual Railway deploy is a follow-up
+- **α** — schema cleanup + extract module split + OTLP/gRPC opt-in (#67/#68/#80)
+- **β** — recursive discovery, generalised DB extraction, polyglot calls, Python services, infra-as-nodes (#69/#70/#71/#72/#73)
+- **γ** — compat beyond drivers, FrontierNode + alias resolution, per-edge confidence, snapshot diffing, per-edge-type staleness (#74/#75/#76/#77/#78)
+- **δ** — `neat watch`, MCP Resources, embedding `semantic_search`, multi-project (#79/#81/#82/#83)
+
+A generic `Dockerfile` at the repo root builds the demo-free image. Mount your codebase at `/workspace`, optional volume at `/neat-out`, default CMD runs the REST + OTLP daemon. CMD overrides: `neat init /workspace --project <name>`, `neat watch /workspace`, `neat-mcp`. (`packages/core/Dockerfile` is the older demo-flavored variant for the local docker-compose stack.)
 
 `docs/milestones.md` has the full verification gates. Always check it before starting any work — it's still the source of truth for what's done and what's next.
 
-## What's next: v0.1.2
+## What's next: v0.2.0 — Frontend
 
-The release goal in one line: **drop the Node-only assumption.** By the end of v0.1.2 NEAT can — at a basic level — work on any codebase and any server, not just JS/TS services on Node. NEAT itself stays Node 20 + TypeScript; the *target* it understands stops being Node-shaped.
+`packages/web/` was a shell through v0.1.2 (ADR-004). v0.2.0 fills it in. The core API is stable, project-aware, and exhaustively tested; this release is greenfield UI on top of it.
 
-Work is sequenced across four sub-milestones. Pick up from open issues on GitHub, one issue per branch per the conventions below.
+Open issues on the v0.2.0 milestone:
 
-### v0.1.2-α — Foundations ✓ shipped
+- **#28** — Implement graph explorer with Cytoscape.js
+- **#29** — Implement node inspector panel
+- **#30** — Implement incident log page
+- **#31** — Apply NEAT branding
+- **#106** — Multi-project switcher in the web UI
+- **#107** — `semantic_search` bar — natural-language node lookup
+- **#108** — Live graph updates via SSE / WebSocket from `neat watch`
 
-Cleared the schema cleanup and the structural refactor that lets every β PR stay small.
-
-- ✓ #67 — drop legacy `pgDriverVersion`; snapshot bumps to v2 with auto-migration on load (ADR-019).
-- ✓ #68 — split `extract.ts` into per-source modules under `packages/core/src/extract/{services,databases,configs,calls,shared,index}.ts`. Orchestrator is 27 lines; each phase is independently importable.
-- ✓ #80 — OTLP/gRPC receiver opt-in via `NEAT_OTLP_GRPC=true` (port `:4317`). Bundled OTLP protos under `packages/core/proto/` (ADR-020).
-
-### v0.1.2-β — Extraction breadth ✓ shipped
-
-The graph is no longer JS-and-pg-shaped. Recursive workspace discovery, generalised DB discovery, polyglot service detection, transport-aware call extraction, and infrastructure-as-nodes all landed in one sprint.
-
-- ✓ #69 — recursive `discoverServices` walk, `NEAT_SCAN_DEPTH`, gitignore + workspace globs, dup-name warning.
-- ✓ #70 — DB discovery via parser registry: `.env`, prisma, drizzle, knex, ormconfig, typeorm, sequelize, docker-compose, all on top of the original `db-config.yaml` path.
-- ✓ #71 — calls beyond HTTP: Kafka (`PUBLISHES_TO`/`CONSUMES_FROM`), Redis, AWS SDK (S3 + DynamoDB), gRPC. Edges carry optional `evidence: { file, line, snippet }`.
-- ✓ #72 — Python services via `tree-sitter-python`, `requirements.txt` + `pyproject.toml` parsing, three new compat entries (psycopg2, pymongo, mysql-connector-python). NEAT's own toolchain stays Node + TS.
-- ✓ #73 — infra extraction: docker-compose (DEPENDS_ON), Dockerfile (RUNS_ON to `infra:container-image:<image>`), Terraform `aws_*`, k8s `kind`. `InfraNodeSchema` gained `kind`; `EdgeType` gained `RUNS_ON`.
-
-### v0.1.2-γ — Graph correctness ✓ shipped
-
-The graph reasons sharper now. Confidence stops being a constant, compat covers four kinds, frontier nodes get populated and promoted, snapshot diffing lands, staleness is per-edge-type with a transition log.
-
-- ✓ #75 — `ServiceNode.aliases` populated from compose / Dockerfile labels / k8s metadata; `FrontierNode` (5th `NodeType`) for unresolved span peers; `promoteFrontierNodes` retires placeholders once an alias matches (ADR-023).
-- ✓ #77 — `GET /graph/diff?against=<path-or-url>` plus MCP `get_graph_diff`. Returns added/removed/changed for both nodes and edges with both `exportedAt` timestamps.
-- ✓ #74 — compat matrix grew `kind: 'driver-engine' | 'node-engine' | 'package-conflict' | 'deprecated-api'`. `NEAT_COMPAT_URL` fetches a remote extension, caches to `~/.neat/compat-cache.json` with 24h TTL. `ServiceNode.nodeEngine` carries `engines.node`.
-- ✓ #76 — per-edge `signal: { spanCount, errorCount, lastObservedAgeMs }`. `confidenceForEdge` blends provenance ceiling × volume × recency × cleanliness. Path-level confidence is the bottleneck (min) across the walk. MCP surfaces signal numbers verbatim.
-- ✓ #78 — per-edge-type stale thresholds (`CALLS` 1h, `CONNECTS_TO` 4h, `DEPENDS_ON` 24h). `NEAT_STALE_THRESHOLDS` JSON override. Every transition appends to `stale-events.ndjson`; `/incidents/stale` + MCP `get_recent_stale_edges` expose them (ADR-024).
-
-### v0.1.2-δ — Ergonomics (next up)
-
-Make the graph pleasant to use. Order within δ:
-
-1. **#79 — `neat watch <path>` daemon.** New CLI subcommand alongside `neat init`. Uses `chokidar`, debounces ~1s, re-extracts incrementally per phase. SIGTERM has to clean up watchers. Same in-memory graph as the REST API; no new persistence path.
-2. **#81 — MCP Resources.** `neat://node/<id>` (read returns attrs + outbound edges) and `neat://incidents/recent` (streaming subscription). Wire next to existing `server.tool(...)` calls in `packages/mcp/src/index.ts`. Tools stay; resources are additive.
-3. **#82 — real `semantic_search` embeddings.** Default to Ollama (`nomic-embed-text`) if `OLLAMA_HOST` is set; fall back to `@xenova/transformers` in-process; substring fallback otherwise. Flat cosine in-memory (≤10K nodes is fine). Write the model-choice ADR before the code.
-4. **#83 — multi-project support.** Replace `getGraph()` singleton with `Map<string, NeatGraph>`. Routes `/projects/:project/graph`, default `"default"` for back-compat. Snapshots persist as `neat-out/<project>.json`. MCP tools get an optional `project` arg; server reads `NEAT_DEFAULT_PROJECT`.
-
-#79 first (no schema impact). #81 + #82 in parallel after that. #83 last — it touches every route shape, so let the others land first.
+Suggested order: #31 (branding shapes the rest of the visual decisions) → #28 (graph explorer) → #29 (inspector) → #106 (project switcher) → #107 (search bar) → #30 (incident log) → #108 (live updates — depends on a stable explorer to render the deltas into).
 
 ### Closing gate — M6 manual verification
 
-Run **after δ merges**, not before. Stand up Railway per `docs/railway.md` → drive traffic at `service-a` → confirm OBSERVED + INFERRED edges in the deployed `/graph` → point Claude Code at the deployed core via `NEAT_CORE_URL` → ask the headline question + one polyglot follow-up. Then flip M6 to VERIFIED and tag v0.1.2. The two unchecked boxes in `docs/milestones.md` are the gate.
+The Railway gates are still informational rather than blocking. AWS deployment looks like the more likely production target; the runbook in `docs/railway.md` is one option but not the canonical path.
 
 ## Decisions already made
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,70 @@
+# Generic neat-core image — no demo, no Railway-specific config.
+#
+# Mount your codebase at /workspace; neat will extract from there. Snapshots
+# and the embeddings cache land in /neat-out — give that a volume if you want
+# them to survive restarts.
+#
+# Default CMD runs the long-lived REST + OTLP receiver on :8080 / :4318.
+# Override CMD with `neat init /workspace` for a one-shot snapshot, or
+# `neat watch /workspace` for the live re-extraction daemon.
+
+FROM node:20-bookworm-slim AS builder
+WORKDIR /repo
+
+# tree-sitter ships native prebuilds for the common platforms; keep the build
+# chain available so a missing prebuild falls through to source build.
+# @xenova/transformers (optional dep) is pure WASM, no native compile needed.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY package.json package-lock.json turbo.json tsconfig.base.json ./
+COPY packages/types/package.json packages/types/
+COPY packages/core/package.json packages/core/
+COPY packages/mcp/package.json packages/mcp/
+COPY packages/web/package.json packages/web/
+COPY demo/service-a/package.json demo/service-a/
+COPY demo/service-b/package.json demo/service-b/
+RUN npm ci
+
+COPY packages packages
+RUN npx turbo run build --filter=@neat/core --filter=@neat/mcp
+
+FROM node:20-bookworm-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Default scan + output locations. Mount over /workspace with -v $(pwd):/workspace
+# to point neat at your repo; mount a volume at /neat-out to keep snapshots.
+ENV NEAT_SCAN_PATH=/workspace
+ENV NEAT_OUT_DIR=/neat-out
+ENV NEAT_OUT_PATH=/neat-out/graph.json
+ENV HOST=0.0.0.0
+ENV PORT=8080
+ENV OTEL_PORT=4318
+
+COPY --from=builder /repo/node_modules ./node_modules
+COPY --from=builder /repo/packages/types/dist ./packages/types/dist
+COPY --from=builder /repo/packages/types/package.json ./packages/types/package.json
+COPY --from=builder /repo/packages/core/dist ./packages/core/dist
+COPY --from=builder /repo/packages/core/compat.json ./packages/core/compat.json
+COPY --from=builder /repo/packages/core/proto ./packages/core/proto
+COPY --from=builder /repo/packages/core/package.json ./packages/core/package.json
+COPY --from=builder /repo/packages/mcp/dist ./packages/mcp/dist
+COPY --from=builder /repo/packages/mcp/package.json ./packages/mcp/package.json
+
+# Make the CLI reachable as `neat` and the MCP stdio binary as `neat-mcp` so
+# `docker run ... neat init /workspace` and `docker run -i ... neat-mcp` work
+# without remembering the dist paths.
+RUN printf '#!/bin/sh\nexec node /app/packages/core/dist/cli.cjs "$@"\n' > /usr/local/bin/neat \
+  && chmod +x /usr/local/bin/neat \
+  && printf '#!/bin/sh\nexec node /app/packages/mcp/dist/index.cjs "$@"\n' > /usr/local/bin/neat-mcp \
+  && chmod +x /usr/local/bin/neat-mcp
+
+VOLUME ["/workspace", "/neat-out"]
+EXPOSE 8080 4318
+
+# Default to the long-lived daemon. Override with e.g.
+#   docker run ... neat-core:0.1.2 neat watch /workspace
+#   docker run ... neat-core:0.1.2 neat init /workspace --project a
+CMD ["node", "/app/packages/core/dist/server.cjs"]

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -12,37 +12,37 @@ Source of truth for sprint status. Update this file at the end of every session.
 
 ## 🚩 Pick up here
 
-**Last session ended:** 2026-05-02. **v0.1.2-γ is shipped on `main`.** All five γ PRs merged (#95/#96/#97/#98/#99). Workspace is green at HEAD: `npx turbo build test lint` clean, **178 core / 30 types / 24 mcp** tests passing. Issues #74, #75, #76, #77, #78 still open — they get closed by hand after you spot-verify the merged work.
+**Last session ended:** 2026-05-03. **v0.1.2 is shipped and tagged.** All four δ PRs merged (#102/#103/#104/#105). The release lives at https://github.com/NEAT-Technologies/Neat/releases/tag/v0.1.2. Workspace at HEAD is green: `npx turbo build test lint` clean, **214 core / 30 types / 35 mcp** tests passing. The v0.1.2 milestone is closed; issues #67–#83 stay attached for the historical record (per ADR-005 the user closes individual issues by hand).
 
-**Next session is v0.1.2-δ — ergonomics.** γ made the graph reason sharper; δ makes it pleasant to use. `neat watch` ends manual `POST /graph/scan` during dev, MCP Resources let agents subscribe instead of poll, `semantic_search` graduates from substring to embeddings, and multi-project support stops `getGraph()` being a singleton.
+A generic `Dockerfile` lives at the repo root (separate from `packages/core/Dockerfile`, which still bakes in the demo). Mount your codebase at `/workspace`, point a volume at `/neat-out`, and the image runs the REST + OTLP daemon by default. CMD overrides: `neat init /workspace --project <name>` for a one-shot snapshot, `neat watch /workspace` for the live re-extraction daemon, `neat-mcp` for the stdio MCP binary.
 
-### δ work order (within v0.1.2-δ)
+**Next release is v0.2.0 — Frontend.** `packages/web/` was a shell through v0.1.2 (ADR-004); v0.2.0 fills it in. Open issues under that milestone:
 
-Branch each issue off the latest `main`. δ PRs are largely independent — none of them share a schema, so they don't need to stack.
+- **#28 — Implement graph explorer with Cytoscape.js**
+- **#29 — Implement node inspector panel**
+- **#30 — Implement incident log page**
+- **#31 — Apply NEAT branding**
+- **#106 — Multi-project switcher in the web UI** (reads `GET /projects`, persists selection, threads through every API call)
+- **#107 — `semantic_search` bar — natural-language node lookup** (hits `/search`, surfaces provider + score, click-through to inspector)
+- **#108 — Live graph updates via SSE / WebSocket from `neat watch`** (server emits a "graph_changed" event after each `runExtractPhases` flush; UI hot-refetches)
 
-1. **#79 — `neat watch <path>` daemon.** New CLI subcommand, watches the scan path with `chokidar`, debounces ~1s, re-extracts on file changes. Same in-memory graph as the REST API; SIGTERM has to clean up watchers. Lives next to `neat init` in `packages/core/src/cli.ts`. Pre-requisite work (extract phase modules, recursive service discovery) is already in place from β.
-2. **#81 — MCP Resources.** Expose every node as `neat://node/<id>` (read returns attrs + outbound edges) and `neat://incidents/recent` as a streaming resource. Wire up resource list + read handlers next to the existing `server.tool(...)` calls in `packages/mcp/src/index.ts`. Tools stay; resources are additive.
-3. **#82 — real `semantic_search` embeddings.** Embed `id + name + description fragments` per node. Default to `nomic-embed-text` via Ollama if `OLLAMA_HOST` is set; fall back to `@xenova/transformers` in-process; substring fallback when neither is available. Flat cosine in-memory (≤10K nodes is fine). **Needs a model-choice ADR before code lands** — write that first so the choice is documented, not just embedded in code.
-4. **#83 — multi-project support.** Last in δ on purpose; α/γ schemas have settled now, so now's safe. Replace `getGraph()` singleton with `Map<string, NeatGraph>`. Routes become `/projects/:project/graph` with `default` as the back-compat fallback. Snapshots persist to `neat-out/<project>.json`. MCP tools take an optional `project` arg; server reads `NEAT_DEFAULT_PROJECT`.
+Suggested order: #31 (branding) → #28 (graph explorer) → #29 (inspector) → #106 (project switcher) → #107 (search bar) → #30 (incident log) → #108 (live updates). Branding first because it shapes the rest of the visual decisions; live updates last because it depends on a stable explorer to render the deltas into.
 
-#79 first (stand-alone, no schema impact). #81 + #82 in parallel after that. #83 last — it touches every route shape, so let the others land first.
+### M6 manual verification — STILL DEFERRED
 
-### M6 manual verification — STILL DEFERRED, now post-δ
+The two unchecked Railway gates remain unchecked. They were rescheduled to post-δ in PR #87 and the user has indicated AWS deployment is the more likely production target. Treat them as informational rather than blocking.
 
-The two unchecked manual gates (live Railway deploy + Claude Code end-to-end against the deployed core) are the closing gate. Reasoning hasn't changed since PR #87. Run them after #83 merges, then tag v0.1.2.
+### Gotchas a fresh v0.2.0 session will benefit from
 
-### Gotchas a fresh δ session will benefit from
-
-- **γ shipped: confidence is signal-driven, frontier is real, the matrix has four kinds, the diff endpoint exists, staleness is per-edge-type.** None of δ's work needs to touch any of that. If you find yourself editing `traverse.ts#confidenceForEdge` or the matrix shape, you're outside δ's scope — push back.
-- **Snapshot schema is still v2.** γ kept every change additive. δ likely will too: `neat watch` doesn't change disk format, MCP Resources don't touch snapshots, embeddings live in memory + a sidecar cache, multi-project just changes the file *path*. If something genuinely demands v3, follow ADR-019's migration pattern.
-- **`extract/index.ts` orchestrator is unchanged in shape.** Phases: services → aliases → databases → configs → calls → infra → frontier promotion. γ #75 added `addServiceAliases` between phase 1 and 2, and `promoteFrontierNodes` after phase 5 (returned as `frontiersPromoted`). Adding a new "phase" still means writing the function and one line in the orchestrator. **`neat watch`'s incremental-extract optimisation is per-phase: a `package.json` change touches phase 1 + 2; a `*.js` change touches phase 4 only.**
-- **NodeType has 5 values now** (ServiceNode, DatabaseNode, ConfigNode, InfraNode, FrontierNode — γ #75). EdgeType still 7. `packages/types/test/schemas.test.ts` counts both. Multi-project (#83) doesn't add a node type; projects are scoping, not topology.
-- **MCP currently has eight tools.** δ #81 adds *resources* on top, which is a different MCP surface (read-by-URI + subscribe vs. tool-call). Don't reframe the existing tools as resources — the design assumes both surfaces coexist.
-- **`compat.json` already has four kinds + a `NEAT_COMPAT_URL` override** (γ #74). #82's embeddings shouldn't reuse this loader — embeddings are per-node graph data, not portable matrix data.
-- **`stale-events.ndjson` is the new transition log** (γ #78, ADR-024). Anything δ-shaped that wants "what just changed" should read it rather than diffing the graph itself. `neat watch` may want to write a similar log for re-extraction events; if so, follow the same ndjson + `readX` helper shape.
-- **`/incidents/:nodeId` route catches `/incidents/stale`** unless registered first; γ #78 already handles this. Other route additions in #79/#81 should keep specific-before-parametric route ordering.
+- **`packages/web/` is a Next.js shell.** It exists but does nothing useful — every page is a placeholder. The v0.2.0 work is greenfield UI on top of a stable, tested core API.
+- **Core API is project-aware everywhere.** Routes mount at both `/X` (default project) and `/projects/:project/X`. The web client should use the prefixed shape from day one — see ADR-026 and `packages/mcp/src/tools.ts` for the routing pattern.
+- **Snapshot schema is at v2.** Frontend doesn't touch it; everything goes through HTTP. If you find yourself reading `neat-out/graph.json` directly from the web layer, stop and use `/graph` instead — it'll keep working through future schema migrations.
+- **NodeType has 5 values** (ServiceNode, DatabaseNode, ConfigNode, InfraNode, FrontierNode). EdgeType has 7 (CALLS, CONNECTS_TO, DEPENDS_ON, CONFIGURED_BY, RUNS_ON, PUBLISHES_TO, CONSUMES_FROM). The graph explorer needs styling rules for each.
+- **Provenance has four states** (OBSERVED, INFERRED, EXTRACTED, STALE) plus FRONTIER for placeholder edges. Confidence is per-edge with a `signal: { spanCount, errorCount, lastObservedAgeMs }` shape from γ #76. The inspector should surface signal numbers verbatim, not just confidence — see `packages/mcp/src/tools.ts` for how the MCP tools format these.
+- **Real-time updates need a new transport on core.** Currently the only push is MCP `notifications/resources/updated` for the incidents resource (5s poll). Issue #108 will add an SSE or WebSocket route on neat-core; web consumes it.
 - **Branching convention unchanged.** One issue → one branch `<num>-<slug>` → one PR (`Refs #N`, not `Closes #N`). Plain-English commits, no `Co-Authored-By: Claude`. Branch off the latest `main`.
-- **Force-push needs explicit user approval.** If you rebase a δ branch and need to force-push, ask first — the harness blocks `git push --force-with-lease` unless authorised for the specific operation.
+- **No emojis in commits / code / docs unless explicitly requested.** Memory has this; easy to forget under autopilot.
+- **Force-push needs explicit user approval.** Same as v0.1.2 — the harness blocks `git push --force-with-lease` unless authorised.
 
 ---
 
@@ -296,15 +296,15 @@ A second failing demo service (mysql2/mysql, mongoose/mongo) would prove the sam
 
 **End state:** confidence is a real signal, not a constant. Compat covers more than (driver, engine) pairs. FRONTIER nodes get populated. Snapshot diffing answers "what changed?".
 
-**Status:** NOT_STARTED.
+**Status:** VERIFIED 2026-05-02.
 
-| Issue | Title |
-|-------|-------|
-| #74   | Compat matrix beyond drivers (Node engines, package conflicts, deprecated APIs) |
-| #75   | OBSERVED-edge attribution and FRONTIER node population |
-| #76   | Per-edge confidence signals (span count, error rate, recency) |
-| #77   | Snapshot diffing endpoint and MCP tool |
-| #78   | Per-edge-type stale thresholds + stale event log |
+| Issue | Title                                                                   | PR  | Status |
+|-------|-------------------------------------------------------------------------|-----|--------|
+| #74   | Compat matrix beyond drivers (Node engines, package conflicts, deprecated APIs) | #97 | merged |
+| #75   | OBSERVED-edge attribution and FRONTIER node population                  | #95 | merged |
+| #76   | Per-edge confidence signals (span count, error rate, recency)           | #98 | merged |
+| #77   | Snapshot diffing endpoint and MCP tool                                  | #96 | merged |
+| #78   | Per-edge-type stale thresholds + stale event log                        | #99 | merged |
 
 ---
 
@@ -312,11 +312,29 @@ A second failing demo service (mysql2/mysql, mongoose/mongo) would prove the sam
 
 **End state:** the daily-use surface is pleasant. `neat watch` re-extracts on save. MCP exposes Resources for graph nodes and the incident stream. Real semantic search. Multiple projects coexist in one core instance.
 
+**Status:** VERIFIED 2026-05-03.
+
+| Issue | Title                                                  | PR   | Status |
+|-------|--------------------------------------------------------|------|--------|
+| #79   | neat watch daemon (live re-extraction)                 | #102 | merged |
+| #81   | MCP Resources for graph nodes and incident stream      | #103 | merged |
+| #82   | semantic_search with real embeddings                   | #104 | merged |
+| #83   | Multi-graph / multi-project support                    | #105 | merged |
+
+---
+
+## v0.2.0 — Frontend
+
+**End state:** `packages/web/` is no longer a shell. Graph explorer renders the live graph; node inspector shows attrs + signal + outbound edges; incident log surfaces recent errors and stale-edge transitions; multi-project switcher routes every call through the right `/projects/:project/*` URL; semantic search bar lives in the top chrome; the explorer hot-updates when `neat watch` re-extracts.
+
 **Status:** NOT_STARTED.
 
-| Issue | Title |
-|-------|-------|
-| #79   | neat watch daemon (live re-extraction) |
-| #81   | MCP Resources for graph nodes and incident stream |
-| #82   | semantic_search with real embeddings |
-| #83   | Multi-graph / multi-project support |
+| Issue | Title                                                          |
+|-------|----------------------------------------------------------------|
+| #28   | Implement graph explorer with Cytoscape.js                     |
+| #29   | Implement node inspector panel                                 |
+| #30   | Implement incident log page                                    |
+| #31   | Apply NEAT branding                                            |
+| #106  | Multi-project switcher in the web UI                           |
+| #107  | `semantic_search` bar — natural-language node lookup           |
+| #108  | Live graph updates via SSE / WebSocket from `neat watch`       |


### PR DESCRIPTION
v0.1.2 "Ubiquity" is shipped and tagged. This PR closes out the release on the docs side and points the next session at v0.2.0 (frontend).

## Changes

- **\`Dockerfile\`** (new, at repo root) — generic, demo-free neat-core image. Mount your codebase at \`/workspace\`, optional volume at \`/neat-out\`. Default runs the REST + OTLP daemon; CMD overrides for \`neat init\`, \`neat watch\`, \`neat-mcp\`. The existing \`packages/core/Dockerfile\` stays as the demo-flavored variant for the local docker-compose stack.
- **\`docs/milestones.md\`** — "Pick up here" rewritten for v0.2.0. γ and δ flipped to VERIFIED with PR numbers. New \"v0.2.0 — Frontend\" section listing the seven open issues.
- **\`CLAUDE.md\`** — top-of-file status flipped to v0.1.2 shipped + v0.2.0 active.
- **\`.gitignore\`** — excludes \`*.tar.gz\` so \`docker save\` artifacts don't sneak into commits.

## GitHub side (already done, out-of-tree)

- \`v0.1.2\` tag pushed, release published: https://github.com/NEAT-Technologies/Neat/releases/tag/v0.1.2
- v0.1.2 milestone closed
- v0.2.0 milestone opened
- M5 \"Dashboard working\" milestone closed; its issues (#28-#31) moved to v0.2.0
- Three new issues opened under v0.2.0: #106 (multi-project switcher), #107 (semantic search bar), #108 (live updates from neat watch)

## Test plan

- [x] \`npx turbo build test lint\` clean (214 core / 30 types / 35 mcp; full turbo cache)
- [x] No conflict markers in any docs (\`grep -n \"<<<<<<< \" docs/ CLAUDE.md\` empty)
- [x] Dockerfile builds against the current main shape (smoke verified locally)