### PR TITLE
Basic Cytoscape.js graph viewer (v0.1.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3984,6 +3984,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cytoscape": {
+      "version": "3.21.9",
+      "resolved": "https://registry.npmjs.org/@types/cytoscape/-/cytoscape-3.21.9.tgz",
+      "integrity": "sha512-JyrG4tllI6jvuISPjHK9j2Xv/LTbnLekLke5otGStjFluIyA9JjgnvgZrSBsp8cEDpiTjwgZUZwpPv8TSBcoLw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5363,6 +5370,15 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
+      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -10938,11 +10954,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@neat/types": "*",
+        "cytoscape": "^3.33.3",
         "next": "14.2.35",
         "react": "^18",
         "react-dom": "^18"
       },
       "devDependencies": {
+        "@types/cytoscape": "^3.21.9",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",

--- a/packages/web/app/api/graph/route.ts
+++ b/packages/web/app/api/graph/route.ts
@@ -1,0 +1,32 @@
+// Proxies the core /graph endpoint so the browser hits the web app's own
+// origin (avoids needing CORS configuration on neat-core for local dev) and
+// so a future deployment can route the call through whichever core URL the
+// web app is configured against.
+//
+// v0.1.3 stays single-project: hits the default project's /graph route. The
+// project-aware path (/projects/:project/graph) lands with the v0.2.0
+// project switcher (#106).
+
+const CORE_URL = process.env.NEAT_CORE_URL ?? 'http://localhost:8080'
+
+export async function GET(): Promise<Response> {
+  try {
+    const upstream = await fetch(`${CORE_URL}/graph`, { cache: 'no-store' })
+    const body = await upstream.text()
+    return new Response(body, {
+      status: upstream.status,
+      headers: {
+        'content-type': upstream.headers.get('content-type') ?? 'application/json',
+      },
+    })
+  } catch (err) {
+    return Response.json(
+      {
+        error: 'failed to reach neat-core',
+        coreUrl: CORE_URL,
+        detail: err instanceof Error ? err.message : 'unknown',
+      },
+      { status: 502 },
+    )
+  }
+}

--- a/packages/web/app/components/GraphView.tsx
+++ b/packages/web/app/components/GraphView.tsx
@@ -1,0 +1,210 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import cytoscape, { type Core, type ElementDefinition, type StylesheetStyle } from 'cytoscape'
+import type { GraphEdge, GraphNode } from '@neat/types'
+
+interface GraphResponse {
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+}
+
+const NODE_COLOURS: Record<string, string> = {
+  ServiceNode: '#3b82f6', // blue
+  DatabaseNode: '#10b981', // emerald
+  ConfigNode: '#f59e0b', // amber
+  InfraNode: '#a855f7', // purple
+  FrontierNode: '#6b7280', // grey — placeholder shape
+}
+
+const EDGE_COLOURS: Record<string, string> = {
+  OBSERVED: '#10b981', // green — runtime, trustworthy
+  INFERRED: '#3b82f6', // blue — derived
+  EXTRACTED: '#9ca3af', // grey — static
+  STALE: '#f59e0b', // amber — was OBSERVED, gone quiet
+  FRONTIER: '#6b7280', // dark grey — placeholder
+}
+
+// Cytoscape's TypeScript types are strict about px-flavoured values being
+// strings while the runtime accepts numbers happily. Cast at the boundary
+// rather than strewing string conversions through the style block.
+const STYLES = [
+  {
+    selector: 'node',
+    style: {
+      'background-color': (node: cytoscape.NodeSingular) =>
+        NODE_COLOURS[node.data('type') as string] ?? '#9ca3af',
+      label: 'data(label)',
+      color: '#111827',
+      'font-size': 11,
+      'text-valign': 'bottom',
+      'text-halign': 'center',
+      'text-margin-y': 6,
+      'text-background-color': '#ffffff',
+      'text-background-opacity': 0.85,
+      'text-background-padding': 2,
+      width: 32,
+      height: 32,
+      'border-width': 1,
+      'border-color': '#1f2937',
+    },
+  },
+  {
+    selector: 'edge',
+    style: {
+      'curve-style': 'bezier',
+      'target-arrow-shape': 'triangle',
+      'line-color': (edge: cytoscape.EdgeSingular) =>
+        EDGE_COLOURS[edge.data('provenance') as string] ?? '#9ca3af',
+      'target-arrow-color': (edge: cytoscape.EdgeSingular) =>
+        EDGE_COLOURS[edge.data('provenance') as string] ?? '#9ca3af',
+      width: 2,
+      label: 'data(type)',
+      'font-size': 9,
+      color: '#374151',
+      'text-rotation': 'autorotate',
+      'text-background-color': '#ffffff',
+      'text-background-opacity': 0.85,
+      'text-background-padding': 2,
+    },
+  },
+  {
+    selector: 'edge[provenance = "STALE"], edge[provenance = "FRONTIER"]',
+    style: { 'line-style': 'dashed' },
+  },
+] as unknown as StylesheetStyle[]
+
+function toElements(graph: GraphResponse): ElementDefinition[] {
+  const nodes = graph.nodes.map((n) => ({
+    data: {
+      id: n.id,
+      label: (n as { name?: string }).name ?? n.id,
+      type: n.type,
+    },
+  }))
+  const edges = graph.edges.map((e) => ({
+    data: {
+      id: e.id,
+      source: e.source,
+      target: e.target,
+      type: e.type,
+      provenance: e.provenance,
+    },
+  }))
+  return [...nodes, ...edges]
+}
+
+export function GraphView(): JSX.Element {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const cyRef = useRef<Core | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [meta, setMeta] = useState<{ nodes: number; edges: number } | null>(null)
+  const [loading, setLoading] = useState<boolean>(true)
+
+  const fetchGraph = async (): Promise<void> => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/graph', { cache: 'no-store' })
+      if (!res.ok) {
+        const detail = await res.text().catch(() => '')
+        throw new Error(`HTTP ${res.status}${detail ? `: ${detail}` : ''}`)
+      }
+      const graph = (await res.json()) as GraphResponse
+      setMeta({ nodes: graph.nodes.length, edges: graph.edges.length })
+      const cy = cyRef.current
+      if (!cy) return
+      cy.elements().remove()
+      cy.add(toElements(graph))
+      cy.layout({ name: 'cose', animate: false, padding: 30 }).run()
+      cy.fit(undefined, 30)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!containerRef.current) return
+    const cy = cytoscape({
+      container: containerRef.current,
+      elements: [],
+      style: STYLES,
+      wheelSensitivity: 0.2,
+    })
+    cyRef.current = cy
+    void fetchGraph()
+    return () => {
+      cy.destroy()
+      cyRef.current = null
+    }
+  }, [])
+
+  return (
+    <div className="relative h-screen w-screen">
+      <div ref={containerRef} className="h-full w-full bg-slate-50" />
+      <div className="pointer-events-none absolute left-4 top-4 flex flex-col gap-2">
+        <div className="pointer-events-auto rounded bg-white/90 px-3 py-2 shadow-sm">
+          <div className="text-sm font-semibold text-slate-900">NEAT graph</div>
+          <div className="mt-1 text-xs text-slate-600">
+            {loading
+              ? 'loading…'
+              : meta
+                ? `${meta.nodes} nodes, ${meta.edges} edges`
+                : '—'}
+          </div>
+          {error ? (
+            <div className="mt-1 max-w-xs text-xs text-red-600">{error}</div>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => {
+              void fetchGraph()
+            }}
+            className="mt-2 rounded bg-slate-900 px-2 py-1 text-xs font-medium text-white hover:bg-slate-700"
+          >
+            refresh
+          </button>
+        </div>
+        <Legend />
+      </div>
+    </div>
+  )
+}
+
+function Legend(): JSX.Element {
+  return (
+    <div className="pointer-events-auto rounded bg-white/90 px-3 py-2 text-xs shadow-sm">
+      <div className="font-semibold text-slate-900">Nodes</div>
+      <ul className="mt-1 space-y-1">
+        {Object.entries(NODE_COLOURS).map(([k, c]) => (
+          <li key={k} className="flex items-center gap-2">
+            <span
+              className="inline-block h-3 w-3 rounded-full border border-slate-700"
+              style={{ backgroundColor: c }}
+            />
+            <span className="text-slate-700">{k}</span>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-2 font-semibold text-slate-900">Edges</div>
+      <ul className="mt-1 space-y-1">
+        {Object.entries(EDGE_COLOURS).map(([k, c]) => (
+          <li key={k} className="flex items-center gap-2">
+            <span
+              className="inline-block h-[2px] w-5"
+              style={{
+                backgroundColor: c,
+                ...(k === 'STALE' || k === 'FRONTIER'
+                  ? { backgroundImage: `linear-gradient(90deg, ${c} 50%, transparent 50%)`, backgroundSize: '6px 2px' }
+                  : {}),
+              }}
+            />
+            <span className="text-slate-700">{k}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,7 +1,5 @@
-export default function Home() {
-  return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-6xl font-semibold tracking-tight">NEAT</h1>
-    </main>
-  )
+import { GraphView } from './components/GraphView'
+
+export default function Home(): JSX.Element {
+  return <GraphView />
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,11 +13,13 @@
   },
   "dependencies": {
     "@neat/types": "*",
+    "cytoscape": "^3.33.3",
     "next": "14.2.35",
     "react": "^18",
     "react-dom": "^18"
   },
   "devDependencies": {
+    "@types/cytoscape": "^3.21.9",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",


### PR DESCRIPTION
v0.1.3 sub-release before the full v0.2.0 frontend work. Bare-minimum useful frontend: run the core, run the web app, see the graph.

## What's in

- **Cytoscape.js** as the graph library on \`@neat/web\`. Default \`cose\` layout — no plugin dep for v0.1.3's small-graph case.
- **\`/api/graph\` proxy route** in the web app, same shape as the existing \`/api/health\`. Browser hits its own origin so no CORS config is needed on neat-core.
- **\`GraphView\` component** — full-viewport canvas + legend + refresh button + loading/error card.
- **Node colours by \`NodeType\`** (5 buckets: ServiceNode / DatabaseNode / ConfigNode / InfraNode / FrontierNode).
- **Edge colours by \`Provenance\`** (OBSERVED / INFERRED / EXTRACTED / STALE / FRONTIER). STALE and FRONTIER also dashed.

## What's not in (lives in v0.2.0)

- Click-through to a node inspector (#29)
- Incident log page (#30)
- NEAT branding / chrome (#31)
- Multi-project switcher (#106)
- Semantic search bar (#107)
- Live updates from \`neat watch\` (#108)

## Test plan

- [x] \`npx turbo build test lint\` clean (214 core / 30 types / 35 mcp; web build + lint pass)
- [x] Live smoke against the demo: \`PORT=8765 NEAT_SCAN_PATH=./demo node packages/core/dist/server.cjs\` then \`NEAT_CORE_URL=http://localhost:8765 npm run dev --workspace @neat/web -- --port 3010\`. \`/\` returns 200 with the GraphView markup, \`/api/graph\` proxies the 5n/5e demo response, page hydrates and renders the graph with distinct node colours.

## How to run it

\`\`\`bash
# terminal 1 — core
NEAT_SCAN_PATH=./demo npm run dev --workspace @neat/core

# terminal 2 — web
npm run dev --workspace @neat/web
# open http://localhost:3000
\`\`\`

Refs #110