### PR TITLE
Fix graphology ESM import under strict Node ESM (tsx, Node 22+)

### DIFF
--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -1,9 +1,21 @@
-import { MultiDirectedGraph } from 'graphology'
+import GraphDefault from 'graphology'
+import type { MultiDirectedGraph as MDGType } from 'graphology'
 import type { GraphEdge, GraphNode } from '@neat/types'
+
+// graphology ships as a CJS bundle that does `module.exports = Graph` with
+// the other constructors attached as properties (`Graph.MultiDirectedGraph =
+// ...`). cjs-module-lexer can't see through that attachment, so a named
+// import like `import { MultiDirectedGraph } from 'graphology'` fails under
+// strict Node ESM (Node 22+ via tsx in particular). Pull the constructor off
+// the default export instead — same shape under tsx and tsup-bundled output.
+type MultiDirectedGraphCtor = typeof MDGType
+const MultiDirectedGraph: MultiDirectedGraphCtor = (
+  GraphDefault as unknown as { MultiDirectedGraph: MultiDirectedGraphCtor }
+).MultiDirectedGraph
 
 // Multi because two nodes can have edges of different types simultaneously
 // (e.g. CALLS and DEPENDS_ON between the same pair of services).
-export type NeatGraph = MultiDirectedGraph<GraphNode, GraphEdge>
+export type NeatGraph = MDGType<GraphNode, GraphEdge>
 
 export const DEFAULT_PROJECT = 'default'
 


### PR DESCRIPTION
\`npm run dev --workspace @neat/core\` was failing on Node 25:

\`\`\`
SyntaxError: The requested module 'graphology' does not provide an
export named 'MultiDirectedGraph'
\`\`\`

graphology's CJS bundle exports the default \`Graph\` constructor and attaches the other classes as properties (\`Graph.MultiDirectedGraph = ...\`). cjs-module-lexer can't see through that attachment, so the named import works under bundlers (which see the .esm.js / .d.ts) but breaks under strict Node ESM. tsx runs the TS source directly through Node's ESM loader, so dev mode hits this; \`packages/core/dist/server.cjs\` was unaffected because tsup transforms the import at build time.

Fix: take \`MultiDirectedGraph\` off the default export at runtime, keep the named-type import for the type position. No behaviour change.

## Test plan

- [x] \`npx turbo build test lint\` clean (214 core / 30 types / 35 mcp; cached)
- [x] Smoke under Node 25 via \`npm run dev --workspace @neat/core\` — server boots, /health and /graph respond with the demo's 5n/5e
- [x] Smoke under the bundled path (\`node packages/core/dist/server.cjs\`) still works — same node/edge counts