### PR TITLE
Add docs/v0.x-proposals.md — zero-touch instrumentation design space

### DIFF
--- a/docs/v0.x-proposals.md
+++ b/docs/v0.x-proposals.md
@@ -1,0 +1,212 @@
+# v0.x Proposals
+
+Working notes for changes the user is ruminating on. Not committed work — this is the *design space*, the trade-offs, the debates, and the rejected alternatives. ADRs cover decisions that have been made; this file covers decisions that haven't.
+
+Each section is self-contained. When a proposal hardens into a milestone, it leaves here and becomes an issue + ADR + PR series.
+
+---
+
+## P-001 — Zero-touch instrumentation of target codebases
+
+**Status:** Open, ruminating. No code, no milestone slot yet.
+**Owner:** user
+**Last touched:** 2026-05-04
+
+### The framing
+
+NEAT today extracts a static graph from any codebase pointed at via `NEAT_SCAN_PATH`. That's the EXTRACTED layer (tree-sitter + manifest parsing + Dockerfile/compose/Terraform). The **live** layers (OBSERVED, INFERRED, STALE) require OTel spans to flow into neat-core's `:4318` receiver — which means the target has to be instrumented.
+
+The question on the table: **how does NEAT help users instrument target codebases without making them learn OTel themselves?**
+
+The user's stated requirement: **anything that needs to know which query failed, or anything where the target talks over a non-eBPF-visible transport (in-process events, encrypted connections to non-OpenSSL libs) is non-negotiable**, and ideally **without modifying the target's source code**.
+
+### The honest framing the agent pushed back with
+
+There is no single tool that delivers full visibility (HTTP + SQL statement + cross-async context + in-process events + non-OpenSSL TLS) on every target on every OS without any cooperation from the target. Datadog, Honeycomb, NewRelic have spent a decade on this and still ship SDKs. **In-process events specifically cannot be observed from outside the process address space without code/SDK/runtime injection — that's a physical constraint, not a tooling gap.**
+
+The realistic path for NEAT isn't "find the magic tool"; it's "compose the right approaches per visibility class, be honest about what each delivers, and accept that the deepest visibility tier (function-level in-process tracing) requires an SDK."
+
+### The option space
+
+#### Option 1 — `neat instrument` codemod (mutates target source)
+
+A new subcommand parallel to `neat init` that detects the target's languages, adds OTel auto-instrumentation deps, wraps the run command, and sets env vars. Defaults to dry-run; `--apply` writes changes; emits a `NEAT_INSTRUMENT.md` explaining what changed and how to revert.
+
+| Language | Adds | Wraps | Env vars |
+|---|---|---|---|
+| Node | `@opentelemetry/auto-instrumentations-node`, `@opentelemetry/sdk-node` | `node --require @opentelemetry/auto-instrumentations-node/register` on the start script | `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT` |
+| Python | `opentelemetry-distro`, `opentelemetry-exporter-otlp` | `opentelemetry-instrument` prefix on entrypoint | same |
+| Java | downloads agent jar to `vendor/` | adds `-javaagent:vendor/opentelemetry-javaagent.jar` to JVM args | same |
+| Dockerfile | modifies in place | adds `RUN` for SDK install + `CMD` wrap | adds `ENV` lines |
+
+Pros: covers everything an SDK can — query-level SQL, full distributed trace context, async propagation, function-level spans where the SDK supports it.
+
+Cons: **mutates user code**. Different category from anything NEAT does today (init is read-only). Needs an ADR. Different deployment shapes (docker, k8s, raw process, lambda) each want slightly different changes. The user explicitly raised this as the blast-radius concern that prompted the rest of the conversation.
+
+#### Option 2 — eBPF (Grafana Beyla / OpenTelemetry OBI)
+
+Single Go binary, runs as a sidecar on the host, watches kernel syscalls + SSL/TLS hooks, reconstructs HTTP / gRPC / SQL / Redis traffic per process, exports OTLP. **Zero source / SDK / run-command touch on the target.**
+
+```bash
+sudo beyla --config <(cat <<EOF
+discovery:
+  services:
+    - exe_path_regex: "node|python|java"
+otel_traces_export:
+  endpoint: "http://localhost:4318"
+EOF
+)
+```
+
+| | eBPF (Beyla) | SDK auto-instrumentation |
+|---|---|---|
+| Source / run-command change | None | Install dep + `--require` / `opentelemetry-instrument` |
+| Linux-only | **Yes** | No (any host) |
+| Privileged (CAP_SYS_ADMIN) | **Yes** | No |
+| HTTP / gRPC traffic | ✅ | ✅ |
+| SQL queries | Partial — sees the wire, often misses statement text | ✅ statement + parameters |
+| Redis / Kafka / AWS SDK | Partial (TCP shape only) | ✅ |
+| Trace context propagation across async / queues | Limited | Full |
+| Per-function spans | Impossible | Limited but possible |
+
+Where Beyla **is** enough: NEAT's headline value ("service-b → payments-db is broken because of pg 7.4.0 vs PG 15"). It sees the connection attempts, errors, and resolves the peer; NEAT's compat matrix does the version-vs-engine reasoning from the static graph. Statement-level SQL isn't required for that.
+
+Where Beyla **isn't** enough — the user's "non-negotiable" set:
+
+- **Knowing which query failed** — Beyla sees the wire shape (Postgres bind/exec, MySQL COM_QUERY) but its statement extraction is shallow today. Improving in OBI.
+- **Encrypted non-OpenSSL traffic** — Go's `crypto/tls`, Rustls, BoringSSL outside OpenSSL all require per-library probes. Some are landed; not all.
+- **In-process events** — physically impossible from outside the process. eBPF can hook JVM via USDT, .NET via ETW; Node and Python in-process events are out of reach.
+
+Constraint: **Linux-only, privileged.** macOS / Windows users need a Linux container or VM. Three workarounds discussed:
+
+1. Run target inside a Linux container, run Beyla in another container with `--privileged --pid=host`. Standard Docker Desktop pattern.
+2. Spin up a tiny Linux EC2 / Lightsail box, run target + Beyla there, point Beyla at neat-core via tunnel.
+3. Use SDK auto-instrumentation on the laptop, eBPF on Linux production. Most teams end up here.
+
+#### Option 3 — Service mesh / Envoy sidecar (Istio Ambient)
+
+Envoy understands HTTP/gRPC + Postgres/MySQL/Mongo/Redis/Kafka wire protocols natively at L7. Istio Ambient Mesh's ztunnel + waypoint pattern transparently MITMs encrypted traffic with the cluster's CA, so non-OpenSSL TLS is decrypted at the sidecar.
+
+| Feature | Covered by Envoy? |
+|---|---|
+| HTTP / gRPC traces | ✅ native |
+| SQL statement | ✅ via `network.postgres_proxy` / `mysql_proxy` filters |
+| Encrypted non-OpenSSL traffic | ✅ — TLS terminated at the sidecar with a mesh-issued cert |
+| In-process events | ❌ still impossible |
+
+Pros: production-grade, fully zero-touch on the target binary, no kernel privileges needed.
+
+Cons: target must run in a Kubernetes pod (or be reachable via iptables redirection). Big infra commitment for the user. Not laptop-friendly. The user's mental model of "test on AWS instance / on a laptop" doesn't fit this neatly.
+
+NEAT integration shape: `neat mesh-config <path>` — emits the Istio config + Envoy filter chains tailored to the discovered services. NEAT doesn't run Istio; just configures it.
+
+#### Option 4 — L7 protocol-aware proxies in front of databases
+
+Wire-aware proxies that already exist for each DB protocol. Drop the proxy in front of the database; route the target's connection string through it; the proxy logs queries and emits OTLP.
+
+| DB | Proxy | Statement-level visibility | OTLP today? |
+|---|---|---|---|
+| Postgres | PgBouncer / Pgpool-II / cnpg pgproxy | Partial → full depending on tool | Plugin-emit; we'd wrap |
+| MySQL | ProxySQL / Vitess vtgate | Full | Yes via metrics → OTLP bridge |
+| MongoDB | Mongos itself, custom Envoy filter | Full | Envoy: yes |
+| Redis | Twemproxy (limited) / Envoy redis filter | Partial | Envoy: yes |
+| Kafka | Envoy kafka_broker filter | Full | Yes |
+
+Pros: rock solid, query-level visibility for free, **the user only changes one env var (`DATABASE_URL`)** — no source diff, no SDK install, no run-command wrap. "Soft touch" config change, not code mutation.
+
+Cons: doesn't help with non-DB observability (HTTP, in-process events). Pairs naturally with Option 2 (eBPF for HTTP/gRPC topology + L7 proxy for DB statements).
+
+NEAT integration shape: `neat db-proxy <path>` — reads the extracted graph, sees `service-b → database:payments-db (postgres)`, generates a PgBouncer/ProxySQL config and prints the modified connection strings the user puts in their `.env`.
+
+#### Option 5 — Fork or contribute to Beyla / OBI
+
+The OTel community is explicitly working on the SQL-statement / non-OpenSSL-TLS / broader-runtime gaps. The OBI project (OpenTelemetry eBPF Instrumentation) is essentially merging Beyla's work into OTel core.
+
+Forking is duplicating effort that already has a community of contributors. **Upstreaming patches NEAT specifically needs is more leverage per dollar.** Fork only makes sense if NEAT needs a feature OBI explicitly rejects. None identified yet.
+
+Per-feature contribution effort: weeks. Maintaining a fork: forever, multiplied by every Beyla release.
+
+#### Option 6 — Process-attach agents (ptrace / dlopen / runtime hot-patch)
+
+Attach to running process, inject instrumentation library into address space, hook function symbols.
+
+Pros: no restart, no source edit, can do anything an SDK can.
+
+Cons: **brittle as hell**. Symbol mangling differs per language. Stripped binaries break it. Triggers anti-debugging in some runtimes. macOS SIP blocks ptrace by default. Linux YAMA hardening too. The big APM vendors (Datadog, Dynatrace, NewRelic) burned years on this for Java/.NET specifically and still ship SDKs as the recommended path.
+
+**Not a credible build for a small team.** Documented here as explicitly rejected.
+
+#### Option 7 — "Containerize the SDK" (the user's instinctive idea)
+
+The user asked: can we containerize the OTel SDK so it works globally without target modification?
+
+Honest answer: **no, not in the shape the question implies.** SDK auto-instrumentation patches at module load time inside the target process. Putting the SDK in a container next to the target doesn't help — the SDK would be in a different process address space.
+
+The closest existing pattern is the Kubernetes init-container shape that Datadog / Dynatrace / NewRelic ship: an admission webhook that auto-injects the SDK install + `--require` into the target pod's container at deploy time. **This is still SDK auto-instrumentation, just delivered through a different surface.** It's a real pattern, but it's not "global" in any sense beyond "every k8s pod the webhook intercepts."
+
+NEAT could build this. It's substantial — admission webhook + per-language injectors + cluster RBAC. Multi-week effort. Documented here as a possibility, not a current proposal.
+
+### The composition the agent recommended
+
+No single tool answers "everything." The realistic shape:
+
+| Visibility class | Best tool | Cost to user |
+|---|---|---|
+| Service topology + HTTP/gRPC | eBPF (Beyla / OBI) | Linux + privileged sidecar |
+| SQL statement-level | L7 proxy + connection string rewrite | One env var change |
+| Non-OpenSSL TLS | Service mesh sidecar (Envoy) | Container/k8s deployment |
+| In-process events | OTel SDK auto-instrumentation | Install dep + wrap run cmd |
+
+NEAT's role becomes "compose these for the user based on the graph it already extracted":
+
+1. **`neat sidecar`** — emits a Beyla config matched to discovered services. ~1 week of work. Covers 80% of headline use cases on Linux. Zero target touch.
+2. **`neat db-proxy`** — emits PgBouncer/ProxySQL/Twemproxy configs + the rewritten connection strings the user puts in their `.env`. ~2 weeks. Closes the "which query failed" gap. Soft config touch only.
+3. **`neat mesh-config`** — emits Istio Ambient config + Envoy filter chains. ~3 weeks. Production-grade zero-touch path for k8s targets.
+4. **`neat instrument` (codemod)** — opt-in, dry-run-default, mutates target source. The "I need function-level spans" escape hatch. Needs its own ADR because it's the only path here that touches user code.
+
+### What was rejected and why
+
+- **Forking Beyla** — duplicates community work; contribute upstream instead.
+- **Building a ptrace-based agent** — graveyard of failed APM products. Big vendors with ten years of investment haven't made it work cleanly. Not a credible greenfield build.
+- **Promising in-process events without an SDK** — physically impossible from outside the process for most runtimes. Honesty in docs ("if you need function-level traces, use the OTel SDK") beats overpromising.
+- **Single-tool framing** — "find the magic zero-touch tool" is a wrong question; composition is the answer.
+
+### The debate
+
+The user's instinctive position was that the missing capabilities (SQL statement-level, non-OpenSSL TLS, in-process events) are **non-negotiable**, and asked whether forking Beyla or "containerizing an SDK to work globally" was the path.
+
+The agent's pushback:
+
+1. **In-process events are not negotiable through any external tool** — that's a physical constraint, not a tooling gap. If they're truly required, an SDK is required. Period.
+2. **"Containerized SDK" doesn't work** in the literal sense — SDKs patch in-process. The k8s init-container injection pattern is the closest shape but it's still SDK delivery, just at deploy time.
+3. **Forking Beyla is high cost, low leverage** — OBI is the upstream future; contribute there.
+4. **The right framing is composition, not a single tool** — Beyla for topology, L7 proxy for SQL, mesh for non-OpenSSL TLS, SDK for in-process. NEAT's value-add is auto-configuring the composition based on the graph it already extracted.
+
+The user said the agent should write up the research, the debate, and the proposed shape into a v0.x doc — this section. No commitment to a milestone slot yet. The user wants more time to ruminate on which of these (or which combination) belongs in which release.
+
+### Open questions for the user
+
+1. **Which target shape is the priority — laptop testing, single-server (e.g. EC2), or k8s production?** Laptop testing pulls toward Option 1 (codemod); single-server pulls toward Options 2 + 4 (eBPF + DB proxy); k8s pulls toward Option 3 (mesh).
+2. **How important is genuinely zero-touch?** If a one-line env var change is acceptable, Option 4 unlocks SQL visibility on any OS. If even that's too much, the answer narrows to Linux-only Beyla.
+3. **Is the in-process / function-level use case real today, or aspirational?** If it's real, an SDK is unavoidable and `neat instrument` (Option 1) needs to be on the roadmap. If it's aspirational, NEAT can ship the composition path first and add the SDK route later.
+4. **Where does this work slot relative to v0.2.0 frontend?** The frontend is independent — it just visualizes whatever the graph contains. Instrumentation work could land before, after, or in parallel with v0.2.0.
+
+### Effort table
+
+| Proposal | Estimated effort | Blast radius | Reversible? |
+|---|---|---|---|
+| `neat sidecar` (Beyla config) | ~1 week | Config file in NEAT's working dir | Trivial |
+| `neat db-proxy` (L7 proxy config) | ~2 weeks | One env var per DB on the user's side | Trivial — revert env var |
+| `neat mesh-config` (Istio) | ~3 weeks | Istio install + sidecar injection | Tear down mesh |
+| `neat instrument` (codemod, dry-run-default) | ~3 weeks | Modifies target source; revert via `git` | Yes, via `git` |
+| Forking Beyla | Multi-quarter | Maintenance forever | No |
+| Custom ptrace agent | Multi-quarter, brittle | High | Hard |
+| Admission webhook (k8s SDK injection) | ~4 weeks | Cluster-wide | Yes, uninstall webhook |
+
+---
+
+## How to use this file
+
+- When the user wants to start a proposal, branch off main and execute. Move the proposal section out of this file and into `docs/decisions.md` as an ADR (for the decision) and `docs/milestones.md` (for the work).
+- When the user wants to add a new proposal, append a new `## P-NNN — <title>` section.
+- Keep the open questions list honest. If the agent and user genuinely disagree on something, write the disagreement down here rather than pretending consensus exists.


### PR DESCRIPTION
Captures the research and debate from this session about how NEAT helps users instrument target codebases without making them learn OTel.

P-001 in the doc walks through seven options:

1. \`neat instrument\` codemod (mutates target source) — opt-in, dry-run-default
2. eBPF (Beyla / OBI) — zero target touch, Linux + privileged, no statement-level SQL today
3. Service mesh / Envoy sidecar (Istio Ambient) — full L7 visibility, k8s-only
4. L7 DB protocol proxies (PgBouncer / ProxySQL / Twemproxy / Envoy filters) — soft env-var change, full SQL visibility
5. Fork or contribute to Beyla / OBI — recommended: contribute, don't fork
6. Process-attach agents (ptrace) — explicitly rejected
7. \"Containerize the SDK\" — physical constraint: doesn't work in the literal sense; closest shape is k8s admission webhook

The recommended composition: Beyla for topology + L7 proxy for SQL + mesh for non-OpenSSL TLS + SDK as the function-level escape hatch. NEAT's value-add is auto-configuring the composition based on the graph it already extracted.

The doc captures:
- What each option delivers and costs
- What's rejected and why (forking Beyla, ptrace agents, in-process events without an SDK)
- The disagreement points (the user's \"non-negotiable\" framing vs. the agent's \"physically constrained\" pushback)
- Open questions for the user to ruminate on (target priority, zero-touch tolerance, in-process need, ordering vs. v0.2.0 frontend)
- Effort + blast-radius table per option

Format is append-only — new proposals get \`## P-NNN — <title>\` sections; hardened proposals move out into ADRs + milestone slots.

No code changes. No issue or milestone created — that comes when a proposal hardens.

## Test plan

- [x] Doc renders cleanly on GitHub (markdown valid)
- [x] No conflict markers, no broken links, no claims of decisions that haven't been made