### PR TITLE
Set up the ADR process: docs/adr/README.md + template.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ The Railway gates are still informational rather than blocking. AWS deployment l
 
 ## Decisions already made
 
-`docs/decisions.md` is the ADR log. Read it before reopening any of these:
+`docs/decisions.md` is the ADR log. `docs/adr/README.md` is the process — when to write one, the template, supersession, ratification. Read decisions.md before reopening any of these:
 
 - pnpm → npm (ADR-007)
 - `tree-sitter` native bindings, not `web-tree-sitter` (ADR-002)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,92 @@
+# Architecture Decision Records
+
+Decisions that change a long-lived contract or trade-off in NEAT live here as ADRs. Bug fixes, scoped refactors, and code-style choices do not.
+
+## Where ADRs live
+
+- **`docs/decisions.md`** is the canonical, single-file ledger. Every ADR through ADR-NNN is appended in order. Read it top-to-bottom and you have the full architectural history of the project.
+- **`docs/adr/template.md`** is the format new ADRs follow.
+- **`docs/adr/README.md`** (this file) is the process — when to write one, who ratifies, lifecycle states, supersession.
+
+The single-file ledger is deliberate. Splitting into one-file-per-ADR is a future refactor we may do once `decisions.md` becomes too long to skim cleanly; today it's still the easiest shape to grep, link to anchors, and read in order. ADR-008's "commits and PRs read like a colleague wrote them" applies here — we want the ledger to read like a logbook, not a folder.
+
+## When to write an ADR
+
+Write one when **a future agent (human or otherwise) reading the code six months from now would benefit from knowing why we picked X and not Y, and the answer isn't obvious from the diff.**
+
+Concrete triggers:
+
+- A choice that changes a long-lived contract (snapshot schema, route shape, MCP tool surface, file layout, dep registry).
+- A choice between two technologies, libraries, or approaches that both work — and a future contributor might re-litigate without context.
+- A scoping call that defers something on purpose (e.g. ADR-004: `packages/web/` is a shell). Future readers need to know the deferral was intentional.
+- A reframe of project goals or success criteria (ADR-027: MVP success isn't running the demo).
+- A constraint that came from outside the codebase (license, business decision, partner agreement) and now shapes the code.
+
+If you're about to write a comment longer than three lines explaining *why* something is the way it is, that's usually an ADR signal — write it down where the next agent will find it.
+
+## When NOT to write an ADR
+
+- Bug fixes. Commit messages are enough.
+- Scoped refactors that don't change a long-lived contract.
+- Code style, formatting, naming conventions inside a file.
+- Anything already covered by an existing ADR — update the existing one or write a superseding ADR if the original is wrong now.
+- Personal preference about which package to use when there's no real trade-off. Pick one, move on.
+
+## Numbering
+
+- Monotonic, zero-padded to three digits in references: `ADR-001`, `ADR-026`, `ADR-027`.
+- Never reused. If an ADR is wrong, a later ADR supersedes it; the original stays in the ledger as historical record.
+- The next free number is `(highest existing ADR + 1)`. Check `docs/decisions.md` before writing.
+
+## Lifecycle
+
+Every ADR has a `**Status:**` line. The states:
+
+- **Active** — the decision is in force.
+- **Superseded by ADR-NNN** — the decision was reversed or refined; ADR-NNN replaces it. Add this line at the top of the original ADR; keep the body intact for historical record.
+- **Deprecated** — the decision is no longer relevant (the system it described was removed) but no replacement was needed. Rare.
+
+State changes get committed via a small focused PR — don't bury them in unrelated work.
+
+## Voice
+
+Plain English. Same convention as commits and PRs (ADR-008). Lead with the *why*. Avoid release-notes-y bullet lists. Avoid emojis (memory has this, easy to forget under autopilot).
+
+A good ADR captures:
+
+1. **The context** — what's the actual question, what was previously assumed.
+2. **The decision** — what we picked.
+3. **Why this and not the alternatives** — the rejected paths matter as much as the chosen one. Future agents need to know we considered Y before they propose Y.
+4. **What this is not deciding** — useful boundary marking when the problem space is broader than the call you're making.
+5. **When to revisit** — the conditions under which this decision should be reopened.
+
+Use `docs/adr/template.md` as the starting shape.
+
+## Who ratifies
+
+The user merging the PR that introduces the ADR ratifies it. Per ADR-005, branch-per-issue, manual close after verification — same shape applies to ADRs:
+
+1. Author drafts the ADR on a branch (often the same branch as the code change it documents).
+2. PR includes the ADR addition + the code change together.
+3. User reviews. If the user pushes back on the decision, the ADR gets revised before merge.
+4. Merge ratifies. The ADR is now `**Status:** Active`.
+
+ADRs are not retroactive justification. They're the gate the decision passes through.
+
+## Supersession
+
+When a later decision overturns or refines an earlier one:
+
+1. Write the new ADR in the standard shape, with `**Supersedes:** ADR-NNN` near the top.
+2. Edit the original ADR's status line: `**Status:** Superseded by ADR-MMM (date)`.
+3. Both stay in the ledger. The original's body is not deleted — that history is what makes the ledger useful.
+
+## Where the existing ADRs live today
+
+ADR-001 through ADR-026 (and onward) live in `docs/decisions.md`, in numerical order. The "Decisions already made" section at the top of `CLAUDE.md` keeps a one-line summary per ADR for quick reference; the full bodies live in `decisions.md`.
+
+When you write a new ADR:
+
+1. Append it to the bottom of `docs/decisions.md` (use `template.md` as the starting shape).
+2. Add the one-line summary to the bullet list under "Decisions already made" in `CLAUDE.md`.
+3. Reference the ADR number from any commit, PR description, or other ADR that depends on it.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,25 @@
+<!--
+Copy this file's body into docs/decisions.md as the next ADR. Number it
+(highest existing ADR + 1). Date it with today's date in YYYY-MM-DD form.
+Replace this comment block before committing.
+
+The five-section shape below is the minimum useful ADR. Sections can be
+longer or shorter than the examples; what matters is that a fresh reader
+six months from now understands the decision without re-running the
+debate that produced it. See docs/adr/README.md for when to write one.
+-->
+
+## ADR-NNN — One-line title that names the decision, not the topic
+
+**Date:** YYYY-MM-DD
+**Status:** Active.
+
+One or two paragraphs of context. What's the actual question. What was previously assumed. Why this came up now. Lead with the *why* — the reader knows what the diff is; they're here to understand the motivation.
+
+**The decision.** State it plainly in one sentence or two. What we picked. The body of the paragraph explains the consequences — what changes in the code, what callers can rely on, what the new contract is.
+
+**Why this and not the alternatives.** List the paths we considered and why each one lost. Be specific about the trade-offs — "X was rejected because Y" not "X seemed worse." Future agents will propose the rejected paths again unless they can read why.
+
+**What this is not deciding.** Useful boundary marking when the problem space is broader than the call. List the related questions this ADR explicitly leaves open.
+
+**When to revisit.** The conditions under which this decision should be reopened — a metric crossing a threshold, a downstream system changing shape, a constraint going away.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2,6 +2,8 @@
 
 Append-only ADR log. Each entry: what was decided, why, and the date. New decisions go to the bottom.
 
+For the process — when to write an ADR, what shape, how supersession works, who ratifies — see [`docs/adr/README.md`](./adr/README.md). The starting shape for a new ADR is [`docs/adr/template.md`](./adr/template.md).
+
 ---
 
 ## ADR-001 — Monorepo with pnpm + Turborepo


### PR DESCRIPTION
ADRs were already living in \`docs/decisions.md\` (27 of them). What was missing was the documented process — when to write one, what shape, who ratifies, how supersession works. The repo had grown past \"everyone knows the convention\" as a workable substitute.

## What's in

- **\`docs/adr/README.md\`** — the process doc. When to write an ADR vs. when not to. Numbering rules. Lifecycle states (Active / Superseded / Deprecated). The voice. Who ratifies. How supersession works.
- **\`docs/adr/template.md\`** — the standard five-section shape: context, decision, why-not-the-alternatives, what-this-is-not-deciding, when-to-revisit.
- **\`docs/decisions.md\`** — top-of-file note pointing at the process doc and template.
- **\`CLAUDE.md\`** — one-line reference so a fresh agent finds the process before writing a new ADR.

## What's not in

Splitting the existing 27 ADRs out of \`decisions.md\` into one-file-per-ADR form. The single-file ledger stays deliberate for now — easier to skim, grep, and read in order. The README documents that \"we may split later\" is a future call.

## Test plan

- [x] \`npx turbo lint\` clean (no code changes — docs-only)
- [x] No conflict markers in any of the touched files
- [x] Process doc's \"where the existing ADRs live today\" section accurately describes the current state