### PR TITLE
ADR-027 + parallel-tracks reframe of CLAUDE.md and milestones.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,22 @@ This is the agent guide for the NEAT repo. If you're a fresh Claude session (or 
 
 NEAT keeps a live semantic graph of a software system — code, infrastructure, runtime — and exposes it to AI agents over MCP. The core demo: a service running `pg` 7.4.0 against PostgreSQL 15 fails at runtime, and NEAT traces that failure back to the version mismatch two hops away through the graph. The extraction pipeline reads static code (tree-sitter) and live OTel traces to build and maintain that graph.
 
+## What success looks like (read this first)
+
+**MVP success = closing a real PR on an open-source codebase NEAT was not engineered for.** Not running the pg demo. The demo proves the stack works in a controlled environment; the MVP earns its keep when NEAT finds a real bug in a real repo, where the OBSERVED layer was load-bearing — not just static analysis a Graphify fork could match.
+
+ADR-027 records this reframe. The trace stitcher (INFERRED edges bridging missing OTel coverage) is evidence the gap between declared intent and observed reality is the load-bearing problem NEAT addresses; policies are the formalization of that gap.
+
 ## Where you are in the build
 
-**v0.1.2 "Ubiquity" is shipped and tagged.** Release: https://github.com/NEAT-Technologies/Neat/releases/tag/v0.1.2. The MVP sprint (M0–M6) before it is also complete. Active work is the **v0.2.0 frontend release**.
+**v0.1.2 "Ubiquity" is shipped and tagged.** Release: https://github.com/NEAT-Technologies/Neat/releases/tag/v0.1.2. v0.1.3 (basic Cytoscape viewer) shipped on top. The MVP sprint (M0–M6) before all of that is also complete.
+
+**Two parallel tracks now share `main`:**
+
+- **Track 1 — v0.2.0 Frontend.** Jed's track. Builds against the stable v0.1.2 API. Doesn't gate the MVP success criterion; this track delivers investor-legibility. Issues #28-#31 + #106-#108.
+- **Track 2 — v0.3.0 Policies → v0.3.1 `neat init` + Claude skill.** Engineering track (Cem + Kurt). v0.3.0 closes the four-feature gap — OTel + graph + MCP + **policies** — and gives NEAT the data model where declared intent and observed reality can diverge in a first-class way. v0.3.1 makes NEAT installable on any codebase with one command. Together they unlock the MVP-success PR experiment. Issues #115-#118 (v0.3.0 α/β/γ/δ) and #119 (v0.3.1).
+
+The two tracks ship independently. v0.2.0 might land before v0.3.0 or after; either is fine.
 
 Sub-milestones in v0.1.2, all merged on `main`:
 
@@ -21,9 +34,11 @@ A generic `Dockerfile` at the repo root builds the demo-free image. Mount your c
 
 `docs/milestones.md` has the full verification gates. Always check it before starting any work — it's still the source of truth for what's done and what's next.
 
-## What's next: v0.2.0 — Frontend
+## What's next on each track
 
-`packages/web/` was a shell through v0.1.2 (ADR-004). v0.2.0 fills it in. The core API is stable, project-aware, and exhaustively tested; this release is greenfield UI on top of it.
+### Track 1 — v0.2.0 Frontend (Jed)
+
+`packages/web/` was a shell through v0.1.2 (ADR-004). v0.1.3 added a basic Cytoscape canvas. v0.2.0 fills the rest in. Builds against the stable v0.1.2 API.
 
 Open issues on the v0.2.0 milestone:
 
@@ -37,9 +52,24 @@ Open issues on the v0.2.0 milestone:
 
 Suggested order: #31 (branding shapes the rest of the visual decisions) → #28 (graph explorer) → #29 (inspector) → #106 (project switcher) → #107 (search bar) → #30 (incident log) → #108 (live updates — depends on a stable explorer to render the deltas into).
 
-### Closing gate — M6 manual verification
+### Track 2 — v0.3.0 Policies, then v0.3.1 distribution (Cem + Kurt)
 
-The Railway gates are still informational rather than blocking. AWS deployment looks like the more likely production target; the runbook in `docs/railway.md` is one option but not the canonical path.
+**v0.3.0 (Policies)** closes the four-feature gap. α/β/γ/δ pattern mirroring v0.1.2:
+
+- **#115 — α** — Policy schema + YAML parser in `@neat/types`. Built-in policy library starts here.
+- **#116 — β** — Evaluation engine + `policy-violations.ndjson` transition log mirroring `errors.ndjson` and `stale-events.ndjson`.
+- **#117 — γ** — REST + MCP surface. `GET /policies`, `GET /policies/violations`, `check_policies` MCP tool, `neat://policies/violations` resource. Project-aware via the dual-mount routes from #83.
+- **#118 — δ** — Real-world policy library that exercises the OBSERVED-vs-EXTRACTED divergence — runtime call not declared, declared call never observed, compat-must-not-merge, stale-frontier-must-be-resolved, db-driver-pinned-major. The thing a Graphify fork can't trivially replicate.
+
+**v0.3.1 (`neat init` + Claude skill)** is the sub-release after v0.3.0:
+
+- **#119** — zero-config init on any codebase, auto-instrumentation strategy picker (codemod / Beyla / mesh / DB-proxy from P-001), Claude Code skill packaging that registers the eight tools + the new `check_policies` tool against the running core.
+
+Pulls P-001 (zero-touch instrumentation) out of `docs/v0.x-proposals.md` once v0.3.1 starts.
+
+### Closing gate — the MVP-success PR
+
+After v0.3.0 + v0.3.1 land, point NEAT at an open-source codebase neither we nor anyone else engineered, identify a real bug NEAT alone surfaces (load-bearing OBSERVED signal, not static-only), propose a fix, get the PR merged. That's the bar ADR-027 sets. The Railway / AWS deploy is a means to that end, not the end itself.
 
 ## Decisions already made
 
@@ -61,6 +91,7 @@ The Railway gates are still informational rather than blocking. AWS deployment l
 - Per-edge-type stale thresholds + `stale-events.ndjson` transition log (ADR-024)
 - `semantic_search` uses an Ollama → Transformers.js → substring fallback chain; flat in-memory cosine, sidecar `embeddings.json` cache (ADR-025)
 - Multi-project lives behind `Map<string, NeatGraph>`; routes dual-mount at `/X` and `/projects/:project/X`; default project keeps the legacy filenames; OTel ingest stays single-project (ADR-026)
+- MVP success is closing a real PR on an open-source codebase, not running the pg demo; OBSERVED layer must be load-bearing (ADR-027)
 
 ## Conventions
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -402,3 +402,29 @@ v0.1.2-δ #83 replaces the `getGraph()` singleton with a `Map<string, NeatGraph>
 **MCP tools take an optional `project` arg.** Tools omit it by default, the HTTP client uses the legacy unprefixed URL, and the core resolves that to `default`. When `NEAT_DEFAULT_PROJECT=alpha` is set on the MCP server, every tool call without an explicit `project` routes through `/projects/alpha/...`. The arg can override per-call. Same shape for resources — `neat://node/<id>` always resolves against the configured project, and `neat://incidents/recent` polls `/projects/<project>/incidents` (or `/incidents` when no project is set) for change detection.
 
 **When to revisit.** Per-project OTel ingest (when a real multi-project deployment surfaces and one collector emitting to multiple project graphs becomes a thing). Auto-loading projects from disk (when manual `NEAT_PROJECTS` becomes the source of bug reports). Per-project default thresholds, embedders, or scan depth (when a project actually needs to override these — none does today, so they all stay process-global).
+
+---
+
+## ADR-027 — MVP success is closing a real PR on an unfamiliar open-source codebase, not running the pg demo
+
+**Date:** 2026-05-04
+**Status:** Active.
+
+The pg demo (a service running pg 7.4.0 against PostgreSQL 15) was stood up to prove the graph + provenance + traversal stack works end to end. It does. But the demo was scaffolded against a failure mode we engineered ourselves, in a controlled environment we built to fail in a specific shape. Closing a real PR on a codebase we did not engineer — where the bug is not pre-staged, the maintainers do not know about it, and the fix has to be correct enough to merge — is a different and much higher bar.
+
+This ADR records that the second bar is the actual MVP success criterion. The pg demo was a stepping stone that became the destination by accident of incremental delivery.
+
+**Why this is the right bar.** A static-only find on a real repo (e.g. the FastAPI lexicographic-version-comparison shape — `"3.10" < "3.9"` because string compare) is reproducible by any tree-sitter-based tool. Graphify in particular already does this category of thing for ~39K users. A NEAT PR that closes a static-shaped bug doesn't differentiate the product; it confirms a Graphify fork could match it. The PR that earns NEAT its category is one where the OBSERVED layer was load-bearing — runtime signal that tree-sitter alone could not have predicted, connected back to a code decision through the graph.
+
+**The trace stitcher is evidence, not a workaround.** PROVENANCE.md records that pg 7.4.0 is too old for `@opentelemetry/instrumentation-pg`, so the demo's own database spans never emit; the INFERRED layer was added to bridge the gap. We had been treating that as a demo-environment compromise. It is in fact a small instance of the load-bearing fact NEAT exists to surface: in real systems, OBSERVED ground truth requires instrumentation that does not always exist, and the gap between what you can see and what you must infer is not a clean line. Every real codebase has a much larger version of this gap. NEAT's job is to make that gap navigable.
+
+**What follows for the roadmap.** Two parallel tracks share `main`:
+
+- **Track 1 — v0.2.0 (frontend).** Investor-legibility. Jed's work, against the stable v0.1.2 API. Doesn't gate the MVP success criterion; the headline metric is "PR merged on a repo we didn't engineer," not "graph renders pretty."
+- **Track 2 — v0.3.0 (policies) → v0.3.1 (`neat init` + Claude skill).** Engineering work. v0.3.0 closes the four-feature gap (OTel + graph + MCP + policies) and gives NEAT the data model that makes intent-vs-observed-reality first class. v0.3.1 collapses NEAT's installation to one command + a Claude skill so it can be pointed at any codebase. Together they are what makes the MVP-success PR experiment runnable.
+
+**What's deferred until after the MVP-success PR.** Auto-PR generation (NEAT writes the patch, not just identifies the divergence). Hosted MCP. Multi-tenant policy stores. None of these change whether NEAT can find a real bug; they only matter once it can.
+
+**What this ADR is not deciding.** Which open-source repo we point NEAT at first; that's a product call once the platform is in shape. Whether the codemod or eBPF route is the v0.3.1 default; that's ADR-029's call when v0.3.1 starts. Whether v0.2.0 frontend ships before or after v0.3.0 platform; the tracks are independent.
+
+**When to revisit.** When the first real PR closes — flip the framing from "can NEAT do this" to "what's the next bar." Until then this ADR stays the active project gravity.

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -12,37 +12,61 @@ Source of truth for sprint status. Update this file at the end of every session.
 
 ## 🚩 Pick up here
 
-**Last session ended:** 2026-05-03. **v0.1.2 is shipped and tagged.** All four δ PRs merged (#102/#103/#104/#105). The release lives at https://github.com/NEAT-Technologies/Neat/releases/tag/v0.1.2. Workspace at HEAD is green: `npx turbo build test lint` clean, **214 core / 30 types / 35 mcp** tests passing. The v0.1.2 milestone is closed; issues #67–#83 stay attached for the historical record (per ADR-005 the user closes individual issues by hand).
+**Last session ended:** 2026-05-04. **v0.1.2 + v0.1.3 shipped.** Workspace at HEAD is green: `npx turbo build test lint` clean, **214 core / 30 types / 35 mcp** tests passing.
 
-A generic `Dockerfile` lives at the repo root (separate from `packages/core/Dockerfile`, which still bakes in the demo). Mount your codebase at `/workspace`, point a volume at `/neat-out`, and the image runs the REST + OTLP daemon by default. CMD overrides: `neat init /workspace --project <name>` for a one-shot snapshot, `neat watch /workspace` for the live re-extraction daemon, `neat-mcp` for the stdio MCP binary.
+**The MVP success criterion has been reframed (ADR-027).** Headline metric is now: **closing a real PR on an open-source codebase NEAT was not engineered for, where the OBSERVED layer was load-bearing.** Not running the pg demo. Static-only finds (FastAPI #12901-shaped) don't earn NEAT its category — a Graphify fork could match them. The PR has to be one where the gap between declared intent and observed reality is the load-bearing fact.
 
-**Next release is v0.2.0 — Frontend.** `packages/web/` was a shell through v0.1.2 (ADR-004); v0.2.0 fills it in. Open issues under that milestone:
+**Two parallel tracks share `main`. They don't depend on each other.**
 
-- **#28 — Implement graph explorer with Cytoscape.js**
-- **#29 — Implement node inspector panel**
-- **#30 — Implement incident log page**
-- **#31 — Apply NEAT branding**
-- **#106 — Multi-project switcher in the web UI** (reads `GET /projects`, persists selection, threads through every API call)
-- **#107 — `semantic_search` bar — natural-language node lookup** (hits `/search`, surfaces provider + score, click-through to inspector)
-- **#108 — Live graph updates via SSE / WebSocket from `neat watch`** (server emits a "graph_changed" event after each `runExtractPhases` flush; UI hot-refetches)
+### Track 1 — v0.2.0 Frontend (Jed)
 
-Suggested order: #31 (branding) → #28 (graph explorer) → #29 (inspector) → #106 (project switcher) → #107 (search bar) → #30 (incident log) → #108 (live updates). Branding first because it shapes the rest of the visual decisions; live updates last because it depends on a stable explorer to render the deltas into.
+Builds against the stable v0.1.2 API. v0.1.3 already shipped a basic Cytoscape canvas; v0.2.0 fills the rest in. Open issues:
 
-### M6 manual verification — STILL DEFERRED
+- **#31** — Apply NEAT branding (recommended first — shapes visual decisions)
+- **#28** — Graph explorer (richer than the v0.1.3 viewer)
+- **#29** — Node inspector panel
+- **#106** — Multi-project switcher
+- **#107** — `semantic_search` bar
+- **#30** — Incident log page
+- **#108** — Live graph updates via SSE / WebSocket from `neat watch`
 
-The two unchecked Railway gates remain unchecked. They were rescheduled to post-δ in PR #87 and the user has indicated AWS deployment is the more likely production target. Treat them as informational rather than blocking.
+This track is independent — Jed should not block on Track 2.
 
-### Gotchas a fresh v0.2.0 session will benefit from
+### Track 2 — v0.3.0 Policies → v0.3.1 distribution (Cem + Kurt)
 
-- **`packages/web/` is a Next.js shell.** It exists but does nothing useful — every page is a placeholder. The v0.2.0 work is greenfield UI on top of a stable, tested core API.
-- **Core API is project-aware everywhere.** Routes mount at both `/X` (default project) and `/projects/:project/X`. The web client should use the prefixed shape from day one — see ADR-026 and `packages/mcp/src/tools.ts` for the routing pattern.
-- **Snapshot schema is at v2.** Frontend doesn't touch it; everything goes through HTTP. If you find yourself reading `neat-out/graph.json` directly from the web layer, stop and use `/graph` instead — it'll keep working through future schema migrations.
-- **NodeType has 5 values** (ServiceNode, DatabaseNode, ConfigNode, InfraNode, FrontierNode). EdgeType has 7 (CALLS, CONNECTS_TO, DEPENDS_ON, CONFIGURED_BY, RUNS_ON, PUBLISHES_TO, CONSUMES_FROM). The graph explorer needs styling rules for each.
-- **Provenance has four states** (OBSERVED, INFERRED, EXTRACTED, STALE) plus FRONTIER for placeholder edges. Confidence is per-edge with a `signal: { spanCount, errorCount, lastObservedAgeMs }` shape from γ #76. The inspector should surface signal numbers verbatim, not just confidence — see `packages/mcp/src/tools.ts` for how the MCP tools format these.
-- **Real-time updates need a new transport on core.** Currently the only push is MCP `notifications/resources/updated` for the incidents resource (5s poll). Issue #108 will add an SSE or WebSocket route on neat-core; web consumes it.
+**v0.3.0 — Policies.** Closes the four-feature gap (OTel + graph + MCP + **policies**). The data model where declared intent and observed reality diverge in a first-class way. α/β/γ/δ pattern mirroring v0.1.2:
+
+1. **#115 — α** — Policy schema + YAML parser in `@neat/types`. Built-in policy library starts here.
+2. **#116 — β** — Evaluation engine + `policy-violations.ndjson` transition log mirroring `errors.ndjson` + `stale-events.ndjson`.
+3. **#117 — γ** — REST + MCP surface. `GET /policies`, `GET /policies/violations`, `check_policies` MCP tool, `neat://policies/violations` resource. Project-aware via dual-mount.
+4. **#118 — δ** — Real-world policies that surface OBSERVED-vs-EXTRACTED divergences. Runtime call not declared, declared call never observed, compat-must-not-merge, stale-frontier, db-driver-pinned-major.
+
+α first (no schema impact). β depends on α. γ + δ can run in parallel after β.
+
+**v0.3.1 — `neat init` for arbitrary codebases + Claude Code skill.** Sub-release after v0.3.0:
+
+- **#119** — zero-config init that detects the target's language, picks the right instrumentation strategy from P-001 (codemod / Beyla / mesh / DB-proxy), defaults to dry-run, writes `NEAT_INSTRUMENT.md` on `--apply`. Claude Code skill packaging registers the eight tools + `check_policies` against the running core.
+
+Pulls P-001 out of `docs/v0.x-proposals.md` once #119 starts.
+
+### Closing gate — the MVP-success PR
+
+After v0.3.0 + v0.3.1 land: point NEAT at an open-source codebase, identify a real divergence-shaped bug, propose a fix, get the PR merged. That's the bar from ADR-027.
+
+The Railway gates from M6 are still informational. AWS is the more likely production target; `docs/railway.md` is one option, not canonical.
+
+### Gotchas a fresh agent will benefit from (either track)
+
+- **`packages/web/` already has a basic Cytoscape viewer (v0.1.3).** v0.2.0 builds on it, doesn't replace it. Track 1 work is incremental over `packages/web/app/components/GraphView.tsx`.
+- **Core API is project-aware everywhere.** Routes mount at both `/X` (default project) and `/projects/:project/X`. New work should use the prefixed shape from day one — see ADR-026 and `packages/mcp/src/tools.ts` for the routing pattern.
+- **Snapshot schema is at v2.** v0.3.0 policies live in `policies/*.yaml` separate from the graph file; no schema bump expected. Policy violations append to ndjson, not the snapshot.
+- **NodeType has 5 values** (ServiceNode, DatabaseNode, ConfigNode, InfraNode, FrontierNode). EdgeType has 7 (CALLS, CONNECTS_TO, DEPENDS_ON, CONFIGURED_BY, RUNS_ON, PUBLISHES_TO, CONSUMES_FROM). Both tracks reference these.
+- **Provenance has four states** (OBSERVED, INFERRED, EXTRACTED, STALE) plus FRONTIER for placeholder edges. Confidence is per-edge with `signal: { spanCount, errorCount, lastObservedAgeMs }` from γ #76. Track 1 inspector + Track 2 policies both consume these.
+- **The trace stitcher (INFERRED) is load-bearing, not a workaround.** PROVENANCE.md + ADR-027 explain why. Track 2 policies should treat the OBSERVED-vs-INFERRED-vs-EXTRACTED gap as the data model's central fact, not an edge case.
+- **Real-time updates** are still TODO. Currently the only push is MCP `notifications/resources/updated` for incidents (5s poll). #108 (Track 1) will add SSE/WebSocket on neat-core; v0.3.0-γ (Track 2) can subscribe to the same channel for `policies/violations`.
 - **Branching convention unchanged.** One issue → one branch `<num>-<slug>` → one PR (`Refs #N`, not `Closes #N`). Plain-English commits, no `Co-Authored-By: Claude`. Branch off the latest `main`.
-- **No emojis in commits / code / docs unless explicitly requested.** Memory has this; easy to forget under autopilot.
-- **Force-push needs explicit user approval.** Same as v0.1.2 — the harness blocks `git push --force-with-lease` unless authorised.
+- **No emojis in commits / code / docs unless explicitly requested.**
+- **Force-push needs explicit user approval.** Harness blocks `git push --force-with-lease` unless authorised.
 
 ---
 
@@ -338,3 +362,49 @@ A second failing demo service (mysql2/mysql, mongoose/mongo) would prove the sam
 | #106  | Multi-project switcher in the web UI                           |
 | #107  | `semantic_search` bar — natural-language node lookup           |
 | #108  | Live graph updates via SSE / WebSocket from `neat watch`       |
+
+---
+
+## v0.3.0 — Policies (engineering track)
+
+**End state:** NEAT carries declared intent as data, not as ad-hoc code. A user-defined policy library is evaluated against the live graph; violations land in `policy-violations.ndjson` like errors and stale events; the REST + MCP surface lets agents and CI ask "what's wrong" against typed expectations rather than reading the graph and guessing. Closes the four-feature gap (OTel + graph + MCP + **policies**) and gives NEAT a data model where declared intent and observed reality diverge first-class.
+
+**Status:** NOT_STARTED.
+
+| Issue | Title                                                                                    | Sub |
+|-------|------------------------------------------------------------------------------------------|-----|
+| #115  | Policy schema + YAML parser in `@neat/types`; built-in policy library                    | α   |
+| #116  | Evaluation engine + `policy-violations.ndjson` transition log                            | β   |
+| #117  | REST + MCP surface (`/policies`, `/policies/violations`, `check_policies` tool, `neat://policies/violations` resource) | γ   |
+| #118  | Real-world policy library that exercises OBSERVED-vs-EXTRACTED divergence                | δ   |
+| #123  | Generalize `getRootCause` beyond DatabaseNode origins (lands once #116 + #118 expose `PolicyViolation` as a node-shaped concept) | follow-on |
+
+α first (no schema impact). β depends on α. γ + δ can run in parallel after β.
+
+ADR-027 records the reframe that puts this milestone where it is: MVP success = closing a real PR on an unfamiliar codebase, not running the pg demo. Policies are the data primitive that makes the OBSERVED-vs-EXTRACTED divergence — the gap PROVENANCE.md and the trace stitcher already encode — first-class for downstream consumers (agents, CI, the eventual UI).
+
+---
+
+## v0.3.1 — `neat init` for arbitrary codebases + Claude Code skill (sub-release)
+
+**End state:** `neat init <path>` on any codebase auto-detects language, picks the right instrumentation strategy (codemod / Beyla / mesh / DB-proxy from P-001), defaults to dry-run, and on `--apply` writes a `NEAT_INSTRUMENT.md` explaining what changed and how to revert. The Claude Code skill registers the eight tools + `check_policies` against the running core. Together this is the distribution layer that makes the MVP-success PR experiment runnable on a repo neither we nor anyone else engineered.
+
+**Status:** NOT_STARTED.
+
+| Issue | Title                                                                       |
+|-------|-----------------------------------------------------------------------------|
+| #119  | `neat init` for arbitrary codebases + Claude Code skill                     |
+
+When this milestone starts, `docs/v0.x-proposals.md` P-001 (zero-touch instrumentation) graduates out of the proposals doc into ADRs sized to the strategy adapters that ship.
+
+---
+
+## Cross-track follow-ups (no milestone yet)
+
+| Issue | Title                                                                                 | Kind |
+|-------|---------------------------------------------------------------------------------------|------|
+| #120  | Edge id encodes provenance; `markStaleEdges` mutates the attribute but leaves the id stale | bug |
+| #121  | Collapse legacy `callCount` into `signal.spanCount`                                   | architecture cleanup |
+| #122  | Migrate api tests to projects-aware `buildApi` shape; drop `buildLegacyRegistry`      | dx cleanup |
+
+These came out of an architecture audit. #120 is a real correctness gap in `get_graph_diff`. #121 and #122 are cleanup work to bundle with whatever next change is adjacent to the affected lines.


### PR DESCRIPTION
Records the reframe captured in a separate conversation: **MVP success is closing a real PR on an open-source codebase NEAT was not engineered for, not running the pg demo.**

## What's in

- **ADR-027** in \`docs/decisions.md\`. The trace stitcher (γ #75 INFERRED edges that bridge missing OTel coverage for pg 7.4.0) reframes from \"demo workaround\" to \"evidence the gap between declared intent and observed reality is the load-bearing problem NEAT addresses.\" Policies are the formalisation of that gap. Static-only finds (FastAPI #12901-shaped) don't earn NEAT its category — a Graphify fork could match them.

- **\`CLAUDE.md\`** rewrite of the \"Where you are\" + \"What's next\" sections. Two parallel tracks share \`main\`:
  - Track 1 (Jed) — v0.2.0 frontend, against the stable v0.1.2 API.
  - Track 2 (Cem + Kurt) — v0.3.0 policies → v0.3.1 \`neat init\` + Claude skill.
  ADR-027 added to the \"Decisions already made\" bullet list.

- **\`docs/milestones.md\`** — \"Pick up here\" rewritten for the parallel tracks; v0.3.0 + v0.3.1 + cross-track follow-up sections appended at the bottom.

## What's not in

- Any code change. This is a docs-only PR.
- Any work on the v0.3.0 / v0.3.1 issues themselves (#115-#119) — those are open on GitHub awaiting design ratification with Kurt.
- The \"NEAT gives coding agents eyes\" framing from a later conversation. ADR-027's body holds the divergence-shaped framing; the agents-as-perception framing is true at a higher level and can land in a follow-up ADR or as a body update once the framing settles. Not gated on it.

## Test plan

- [x] \`npx turbo lint\` clean (docs-only)
- [x] No conflict markers (\`grep -n \"<<<<<<< \" docs/ CLAUDE.md\` empty)
- [x] All issue references in the docs (#115-#119, #28-#31, #106-#108, #120-#123) resolve to live issues on GitHub