### PR TITLE
v0.2.0 Sunrise prep: audits + renumbered milestones + tomorrow tracker

### DIFF
--- a/docs/audits/NEAT-audit-graph.md
+++ b/docs/audits/NEAT-audit-graph.md
@@ -1,0 +1,162 @@
+# NEAT Graph Audit — MVP (TypeScript v0.1.x)
+## Load this before touching any graph-related code.
+
+**Scope:** This audit covers the TypeScript MVP only — `packages/core` in the monorepo at `github.com/NEAT-Technologies/Neat`. It does not apply to the Rust v1.0. Items marked `[v1.0]` are noted for awareness only — do not build them here and do not let the agent drift toward them.
+
+**Stack:** graphology DirectedGraph, native tree-sitter bindings, OpenTelemetry Node.js SDK, Fastify REST API, pnpm monorepo.
+
+**What is not in scope for this audit:**
+- Memgraph, Neo4j, or any external graph database — v1.0 only
+- NeatScript VM or query language — v1.0 only
+- Salsa incremental computation — v1.0 only
+- CRDT cloud sync — v1.0 only
+- Firecracker sandbox — v1.0 only
+- Autonomous remediation pipeline — v1.0 only
+
+---
+
+## What the graph must be — MVP
+
+The graph is a live, continuously mutating, in-memory semantic model of a software system. It is not a file. It is not a snapshot. It is not a cache of graph.json. It is a graphology DirectedGraph instance that is the single source of truth for the entire platform at runtime.
+
+Every other component in the MVP — the Fastify REST API, the MCP server, the traversal functions in traverse.ts — must query this live instance directly. Nothing reads graph.json at query time except on startup load.
+
+MVP persistence is graph.json only. Written on shutdown and every 60 seconds as a background interval. Loaded on startup if it exists. That is the complete persistence story for the MVP.
+
+---
+
+## The contract
+
+### 1. Singleton — MVP
+
+There must be exactly one graphology DirectedGraph instance per project scope. Created once at startup. Mutated in place. Never replaced.
+
+**Verify:**
+- Is the graph exported as a module-level singleton from `graph.ts`?
+- Is `new DirectedGraph()` called anywhere except the singleton initialisation? If yes, this is a critical gap.
+- Is the graph ever reassigned or replaced mid-session rather than mutated?
+
+### 2. Node types — MVP
+
+The MVP graph must support these node types:
+
+- `ServiceNode` — a running service
+- `DatabaseNode` — a database. Has: name, engine, engineVersion, compatibleDrivers
+- `ConfigNode` — a config file. Has: name, path, fileType
+- `InfraNode` — infrastructure node derived from docker-compose, k8s, Terraform
+
+`[v1.0]` UserNode, PolicyNode, AgentNode are not MVP scope.
+
+**Verify:**
+- Are all node types validated against a shared enum or Zod schema from `@neat/types` on insertion?
+- Is `pgDriverVersion` still present on ServiceNode and still being read by traversal code? It was marked deprecated. If traversal or root cause logic still special-cases it, that is debt.
+- Are there any node types in the codebase not in this list?
+
+### 3. Edge types — MVP
+
+- `CALLS` — service A calls service B
+- `DEPENDS_ON` — static import or package dependency
+- `CONNECTS_TO` — service connects to a database
+- `CONFIGURED_BY` — service reads from a config node
+
+**Verify:**
+- Is edge type validated on insertion?
+- Are there any edge type strings in the codebase not from a shared const?
+- Are there edges being created without a type field?
+
+### 4. Provenance — the most important contract in the MVP
+
+Every edge must carry a `provenance` field. This is non-negotiable. The valid values are:
+
+```
+EXTRACTED | INFERRED | OBSERVED | STALE | FRONTIER
+```
+
+**EXTRACTED** — found by tree-sitter in source code or config. No timestamp. Does not decay.
+
+**INFERRED** — derived by the trace stitcher. Must carry `confidence: number` between 0.0 and 1.0. Must never be created from traversal depth greater than 2 hops from the originating error span. The 0.6 default documented in PROVENANCE.md must match what the code produces.
+
+**OBSERVED** — directly measured from a live OTel span. Must carry `lastObserved: string` (ISO8601) and `callCount: number`. Never created without both fields.
+
+**STALE** — transitioned from OBSERVED only, never created directly. Carries the `lastObserved` timestamp of the final observation.
+
+**FRONTIER** — MVP: acceptable as a provenance value on edges. `[v1.0]` Full FrontierNode type is Rust v1.0.
+
+**Verify:**
+- Is `Provenance` a shared const or enum in `@neat/types` or are raw strings used?
+- Is there any code path that creates an edge without a `provenance` field?
+- Does every INFERRED edge have a `confidence` field?
+- Does every OBSERVED edge have `lastObserved` and `callCount`?
+- Is STALE ever created directly rather than transitioned from OBSERVED?
+- Does the trace stitcher enforce the depth-2 limit? Find the actual depth check in the code.
+
+### 5. Staleness — MVP
+
+OBSERVED edges decay to STALE when not seen within 24 hours. This must be a background process, not a read-time computation.
+
+`[v1.0]` Per-edge-type staleness thresholds are v1.0 even if mentioned in release notes.
+
+**Verify:**
+- Is there a `setInterval` or equivalent background job that transitions OBSERVED → STALE?
+- Or is staleness computed at read time in the REST API or MCP tools? If yes, this is a gap.
+- When an edge transitions to STALE, is `lastObserved` preserved?
+- Is the 24-hour threshold hardcoded or configurable?
+
+### 6. Persistence — MVP
+
+**Verify:**
+- On startup: does the code load graph.json into the live graphology instance before serving requests?
+- On shutdown: does the code serialise the live instance to graph.json?
+- Is there a background serialisation interval?
+- Does `GET /graph` return data from the live graphology instance or from graph.json? Must be live.
+- Is `readFileSync('graph.json')` called anywhere except the startup load? If yes, critical gap.
+
+### 7. Edge upsert semantics — MVP
+
+One edge between any pair of nodes with one edge type. When OTel confirms a relationship already in the graph as EXTRACTED, upgrade the edge — do not duplicate it.
+
+**Verify:**
+- Is there an upsert function in `ingest.ts` that checks for an existing edge before creating?
+- If EXTRACTED exists and OTel confirms the same relationship, does the code upgrade to OBSERVED or create a duplicate?
+- What is the traversal priority rule when multiple edges exist? OBSERVED must beat EXTRACTED must beat INFERRED.
+
+### 8. Multi-project scoping — MVP
+
+**Verify:**
+- Is there a project registry mapping project names to graph instances?
+- Can a query without a project argument contaminate another project's graph?
+- Does `neat init` for a new project create an isolated graphology instance?
+
+### 9. Concurrent access — MVP
+
+**Verify:**
+- Is graph mutation in `ingest.ts` synchronous within each span processing call?
+- Is there any async gap during mutation where a concurrent read could see partial state?
+
+---
+
+## Red flags
+
+- `new DirectedGraph()` called anywhere except singleton init in `graph.ts`
+- `readFileSync('graph.json')` anywhere except startup load
+- Raw strings like `'OBSERVED'` instead of `Provenance.OBSERVED` from `@neat/types`
+- Edge creation without a `provenance` field
+- INFERRED edges without `confidence`
+- OBSERVED edges without `lastObserved` or `callCount`
+- Staleness computed in the REST API handler rather than as a background transition
+- Two edges between the same pair of nodes with the same edge type
+- `pgDriverVersion` still special-cased in traversal or root cause logic
+
+---
+
+## Five questions — answer these before closing the audit
+
+1. Is `new DirectedGraph()` called only once per project scope?
+2. Does `GET /graph` read from the live graphology instance or from graph.json?
+3. Is staleness a background transition or a read-time computation?
+4. When an EXTRACTED edge is later confirmed by OTel, does the code upgrade or duplicate?
+5. Does every INFERRED edge have a `confidence` field between 0.0 and 1.0?
+
+---
+
+*MVP only. Do not build Memgraph, NeatScript, Salsa, CRDT, or Firecracker. Those are Rust v1.0.*

--- a/docs/audits/NEAT-audit-init.md
+++ b/docs/audits/NEAT-audit-init.md
@@ -1,0 +1,267 @@
+# NEAT neat-init Audit — MVP (TypeScript v0.3.1)
+## Prospective ADR. Load this before writing a single line of neat init.
+
+**Scope:** Prospective audit — issue #119 has no implementation yet. Output is design decisions the implementer will face, the recommended position on each, and alternatives rejected with reasons. Do not write code until section 1 is read in full and every missing-decision finding in section 2 is resolved.
+
+**Frame:** The NEAT manifesto promises "live" and "ambient." Every decision is tested against those two words. Where a design choice makes NEAT less live or less ambient, that is a finding.
+
+**What this audit does not do:**
+- Propose features not in issue #119
+- Audit the manifesto itself
+- Litigate Rust vs TypeScript — prototype scope, ship fast
+- Design the zero-touch instrumentation strategy (P-001) — treat it as a callable, not a design point
+- Over-engineer for Rust v1.0 forward compatibility
+
+---
+
+## Section 1 — Design Decisions
+
+### Decision 1: Where on the ambient ladder does v0.3.1 sit?
+
+The ambient ladder:
+- **(a)** Per-codebase — user types `neat init` every time
+- **(b)** One-shot per machine — user runs `neat init` once, NEAT auto-discovers after that
+- **(c)** Daemon mode — no init ever, NEAT is always present
+
+**Recommended: (a) for v0.3.1, but designed for (b).**
+
+`neat init .` is the right MVP default. Explicit, auditable, recoverable. User knows exactly which codebases NEAT knows about.
+
+Critical constraint: the design must not require a rewrite to reach (b). This means project registration must write to a machine-level registry (`~/.neat/projects.json`) not only to a local config in the project directory. Auto-discovery in (b) is then a daemon that walks a configured root and calls the same registration function that `neat init` calls. The registration function must be pure and callable from either CLI or daemon.
+
+**Rejected: starting at (b).** Auto-discovery requires validated heuristics for what constitutes a recognisable project. False positives on first run will damage trust. User should opt in per-project until heuristics are proven.
+
+**Rejected: starting at (c).** Daemon mode requires launchd/systemd integration, auto-instrumentation, and push-based graph deltas. All v1.0.
+
+---
+
+### Decision 2: Should `neat init` and `neat install` be the same command?
+
+`neat init` does two things: bootstraps a codebase for NEAT, and registers a Claude Code skill. These are different in scope, failure mode, and lifecycle.
+
+| | neat init | neat install |
+|---|---|---|
+| Scope | Codebase-level | Machine-level |
+| Failure mode | Breaks one repo | Breaks all Claude sessions |
+| Lifecycle | Runs once per project | Runs once per machine |
+| Reversibility | `rm .neat/` | Claude Code skill uninstall |
+
+**Recommended: separate commands.**
+
+`neat init .` — bootstraps the codebase. Writes `.neat/config.json`, registers the project in `~/.neat/projects.json`, optionally instruments services.
+
+`neat install` — registers the Claude Code skill machine-wide. Can be run independently of any project. Idempotent.
+
+**Rejected: one command.** The failure blast radius is different. Conflating them means a broken codebase init can corrupt the Claude Code skill registration. They should fail and recover independently.
+
+---
+
+### Decision 3: What is the trust ladder for the codemod?
+
+`neat init --apply` mutates user code to add OTel instrumentation. Ranked by reversibility:
+
+- **(a)** Read-only — prints a plan, never touches code
+- **(b)** Emits a `.patch` file the user applies manually with `git apply`
+- **(c)** `--apply` writes files, produces `NEAT_INSTRUMENT.md` documenting what changed
+- **(d)** Auto-applies on detection, no flag needed
+
+**Recommended: (b) as default, (c) as opt-in.**
+
+The default `neat init .` emits `neat.patch` to the project root. The user reviews it, runs `git apply neat.patch`, and owns the change. NEAT never writes to the user's files without an explicit flag.
+
+`neat init . --apply` writes directly and produces `NEAT_INSTRUMENT.md`. For users who trust the output and want the faster path.
+
+For the PR goal specifically — NEAT submitting PRs to open source repos — the patch file is the only acceptable default. Maintainers will scrutinise any automated code change. The patch must be reviewable as a clean git diff before submission.
+
+**Rejected: (a) read-only only.** The PR goal requires actual code changes. Read-only is useful for auditing but not for the PR workflow.
+
+**Rejected: (d) auto-apply.** Never writes to user files without explicit consent. Non-negotiable.
+
+---
+
+### Decision 4: What does `neat init` discover and how?
+
+The discovery step walks the project directory and identifies:
+- Services — directories with `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `requirements.txt`
+- Databases — `docker-compose.yml` services using known database images, `.env` DATABASE_URL patterns, ORM config files
+- Infrastructure — `docker-compose.yml`, `*.tf` Terraform files, k8s manifests
+- Config — `.env`, `*.yaml` relevant to services
+
+**Recommended discovery strategy:**
+
+Walk from the provided path. Respect a configurable depth limit (default: 4). Honour `.neatignore` (same syntax as `.gitignore`). Stop recursing into `node_modules`, `.git`, `dist`, `build`, `.next`, `__pycache__`, `vendor`.
+
+Produce a discovery report before any instrumentation. The user must see what NEAT found before anything is changed.
+
+**Verify in implementation:**
+- Is there a depth limit on directory walking?
+- Is `.neatignore` supported?
+- Are `node_modules` and build directories excluded?
+- Does a discovery report print before any file mutation?
+
+---
+
+### Decision 5: What does `neat init` do with monorepos vs polyrepos?
+
+**Recommended: monorepo-aware, polyrepo-agnostic.**
+
+If the init path contains a root `package.json` with a `workspaces` field, or a `pnpm-workspace.yaml`, or a `turbo.json`, treat it as a monorepo. Register each workspace as a separate ServiceNode with the monorepo root as an InfraNode that owns them.
+
+If the init path is a single-service repo, register one ServiceNode.
+
+If the init path is a directory containing multiple unrelated repos (rare but possible), register each sub-repo that has a manifest as a separate project in `~/.neat/projects.json`.
+
+**Polyrepo** — running `neat init` in each repo independently is correct. There is no automatic cross-repo linking at init time. Cross-repo graph connections come from OTel observed traffic, not from init heuristics.
+
+**Missing decision: does `neat init` at a monorepo root instrument all workspaces or only the root?** This must be decided before implementation. Recommended: instrument all workspaces, prompt the user to confirm which ones.
+
+---
+
+### Decision 6: What does `neat init` emit?
+
+**Files written to the project:**
+- `.neat/config.json` — project config: name, scan paths, OTel collector endpoint, instrumentation strategy
+- `neat.patch` — the instrumentation patch (if default mode)
+- `NEAT_INSTRUMENT.md` — documentation of what was instrumented (if `--apply`)
+- `.neatignore` — if not present, create with sensible defaults
+
+**Files written to the machine:**
+- `~/.neat/projects.json` — machine-level project registry, appended with this project
+
+**Files that must not be modified:**
+- `package.json` — no dependencies added without explicit user confirmation
+- `package-lock.json` or `pnpm-lock.yaml` — never touched
+- Any file outside the init path
+- Any file matched by `.gitignore`
+
+**Verify in implementation:**
+- Is there an explicit list of files that `neat init` will never touch?
+- Is `package.json` modification gated behind explicit confirmation?
+- Are lockfiles excluded unconditionally?
+
+---
+
+### Decision 7: Docker, WSL, and dev containers
+
+**Recommended positions:**
+
+Docker — `neat init` works on the source tree on the host. It does not need to run inside Docker. OTel instrumentation targets the Node.js/Python process inside the container, but the codemod runs on the host files. The patch applies to the source, which is then mounted into the container.
+
+WSL — `neat init` runs natively inside WSL. The `~/.neat/` registry lives in the WSL home directory. No special handling needed if the user runs everything in WSL.
+
+Dev containers — known gap. If the user's editor and terminal are inside a dev container, `neat init` must run inside the container too. The machine-level `~/.neat/` registry will be container-scoped, not machine-scoped. This is a missing decision — decide before implementation.
+
+**Recommended for dev containers:** document as unsupported in v0.3.1. Add to backlog. Do not attempt to solve it in the MVP.
+
+---
+
+## Section 2 — Findings
+
+**[missing-decision] The success paragraph does not exist in issue #119.**
+Severity: gap
+
+Issue #119 describes what `neat init` does mechanically but not what success looks like end-to-end from the user's point of view. Without it, every other decision floats. Write the success paragraph before implementation starts. See Section 3 of this audit for a draft.
+
+---
+
+**[missing-decision] Monorepo instrumentation scope is undefined.**
+Severity: gap
+
+Decision 5 identifies this. When `neat init` runs at a monorepo root, it is not defined whether it instruments all workspaces, prompts for selection, or only instruments the root. This will be resolved by the implementer at 2am in whatever direction makes the first test pass. Resolve it now.
+
+Recommended: prompt the user with a checklist of discovered workspaces and instrument the selected ones.
+
+---
+
+**[missing-decision] Dev container behaviour is undefined.**
+Severity: gap
+
+Decision 7 identifies this. Do not leave it to the implementer. Recommended resolution: document as unsupported in v0.3.1, add to backlog.
+
+---
+
+**[missing-decision] Lockfile behaviour is undefined.**
+Severity: gap
+
+Decision 6 recommends lockfiles are never touched. This must be made explicit in the implementation, not assumed. If the instrumentation codemod adds a dependency, it must add it to `package.json` only and instruct the user to run `pnpm install` manually. The lockfile change is the user's responsibility.
+
+---
+
+**[framing] `neat init` is at rung (a) of the ambient ladder but nothing prevents it from being rewritten for (b).**
+Severity: framing
+
+The design must write to `~/.neat/projects.json` on every init. If it only writes to `.neat/config.json` locally, reaching rung (b) requires rewriting the registration logic. Verify the implementation writes to the machine-level registry from day one.
+
+---
+
+**[gap] `neat init` and `neat install` are the same command in issue #119.**
+Severity: gap
+
+Decision 2 identifies this as wrong. The blast radius of the two operations is different. They must be separate commands. This is a design change from issue #119 that must be confirmed before implementation starts.
+
+---
+
+**[gap] The default codemod mode in issue #119 is `--apply` not patch file.**
+Severity: gap
+
+Decision 3 recommends the patch file as the safer MVP default. Issue #119 has `--apply` as the default. This matters for the PR goal — any PR NEAT submits to an open source repo will be reviewed by maintainers who will scrutinise automated code changes. The patch file gives the human the final apply step. Confirm the default before implementation starts.
+
+---
+
+**[scope-creep] Running processes, CI registration, hosted core, and closed-source binaries are not in scope.**
+Severity: scope-creep guard
+
+Explicit non-goals for v0.3.1. The implementation must not attempt any of these:
+- Instrumenting running processes (that is P-001 / v1.0)
+- Registering with CI pipelines
+- Setting up a remote or hosted neat-core
+- Analysing closed-source binaries
+
+If the agent proposes any of these during implementation, reject it.
+
+---
+
+**[bug risk] Discovery without a depth limit will walk the entire filesystem on `/`.**
+Severity: bug
+
+Decision 4 specifies a depth limit of 4. Without it, `neat init /` or `neat init ~/` will walk indefinitely. The depth limit must be implemented and tested against a deeply nested fixture.
+
+---
+
+**[framing] The ambient and live stress test.**
+Severity: framing
+
+The manifesto promises ambient and live. `neat init` at rung (a) is neither ambient nor live — it is explicit and one-shot. This is acceptable for v0.3.1 only if:
+
+- The registration function is designed to be called by a daemon (rung b/c) without modification
+- The graph begins updating live immediately after init completes — not after the user manually starts neat-core
+- The Claude Code skill is available immediately after `neat install` without requiring a session restart
+
+If any of these three are false, `neat init` makes NEAT less ambient and less live than the manifesto claims. Flag each one as a verification point in the implementation.
+
+---
+
+## Section 3 — The Success Paragraph
+
+Cem clones a FastAPI repository on a clean machine. He runs `curl https://neat.is/install | sh` which installs neat-core as a background daemon and the neat CLI. He runs `neat init .` in the cloned directory. NEAT walks the repo, finds the FastAPI service and its SQLAlchemy database connection, prints a discovery report, and emits `neat.patch`. Cem reviews the patch — it adds three lines of OTel instrumentation to the FastAPI startup — runs `git apply neat.patch` and starts the service. He runs `neat install` once to register the Claude Code skill. He opens Claude Code, types "why is this endpoint slow," and receives an answer that names a specific database query pattern visible in the OBSERVED edges — something the static analysis alone would not have found because it only manifests under real traffic. The answer includes the traversal path, the confidence score, and a suggested fix. Cem opens a PR.
+
+This paragraph is the gravity for every other decision in this audit. If a design choice does not serve this paragraph, it does not belong in v0.3.1.
+
+---
+
+## Verification checklist — answer before closing implementation
+
+1. Does `neat init` write to `~/.neat/projects.json` in addition to `.neat/config.json`?
+2. Are `neat init` and `neat install` separate commands with separate failure modes?
+3. Is the default codemod output a patch file, not a direct file write?
+4. Is there a depth limit on directory discovery?
+5. Are lockfiles unconditionally excluded from modification?
+6. Is monorepo workspace instrumentation scope defined and prompted to the user?
+7. Does the graph begin updating live immediately after init — not after a manual neat-core start?
+8. Is dev container behaviour explicitly documented as unsupported in v0.3.1?
+9. Is `--apply` an explicit opt-in flag, not the default?
+10. Can the registration function be called by a future daemon without modification?
+
+---
+
+*v0.3.1 prototype only. Daemon mode, auto-discovery, push-based graph deltas, launchd/systemd integration, and P-001 zero-touch instrumentation are v1.0.*

--- a/docs/audits/NEAT-audit-mcp.md
+++ b/docs/audits/NEAT-audit-mcp.md
@@ -1,0 +1,368 @@
+# NEAT MCP Tools Audit — MVP (TypeScript v0.1.x)
+## Load this before touching any MCP-related code.
+
+**Scope:** This audit covers `packages/mcp` in the TypeScript MVP monorepo at `github.com/NEAT-Technologies/Neat`. It covers the MCP server setup, all tool implementations, tool response format, and the CLAUDE.md skill registration.
+
+**Stack:** `@modelcontextprotocol/sdk` TypeScript SDK, stdio transport for local Claude Code, HTTP transport for remote connection, Fastify REST API in neat-core as the data source.
+
+**The goal this audit serves:** The MCP tools are the interface between NEAT and Claude Code. They are what makes the PR goal possible. A tool that returns correct data in the wrong format, or returns stale data, or does not communicate provenance, fails the PR goal even if the graph behind it is perfect.
+
+**What is not in scope for this audit:**
+- NeatScript tool surface — v1.0 only
+- Autonomous remediation MCP tools — v1.0 only
+- Multi-agent orchestration — v1.0 only
+
+---
+
+## What the MCP tools must do — MVP
+
+The MCP tools expose the live graph to Claude Code and any other MCP-compatible agent. They must answer real questions about real systems, not just the demo environment. Every tool must:
+
+1. Query the live neat-core REST API — not graph.json, not a local cache
+2. Return provenance information in the response so Claude Code can reason about trust
+3. Communicate confidence scores when traversal is involved
+4. Work on any system NEAT has modelled — not just the demo services
+5. Return natural language responses that Claude Code can act on without further translation
+
+---
+
+## The contract
+
+### 1. Server setup — MVP
+
+The MCP server must be registered with the name `neat` and expose tools over stdio for local Claude Code connection.
+
+**Verify:**
+- Is the server name `neat` — exactly this, not `neat-mcp` or `neat-core`?
+- Is stdio transport the primary transport?
+- Is HTTP transport also supported for remote connection?
+- Does the server start cleanly with `node packages/mcp/src/index.ts` or equivalent?
+- Does Claude Code's `/list_tools` return all tools without error?
+- Is the `NEAT_CORE_URL` environment variable read correctly (default: `http://localhost:8080`)?
+
+### 2. CLAUDE.md — MVP
+
+The CLAUDE.md in `packages/mcp` tells Claude Code when to use NEAT tools. It is the instruction set that makes NEAT's tools feel like ambient intelligence rather than tools the user has to remember to call.
+
+**Verify:**
+- Does CLAUDE.md exist at `packages/mcp/CLAUDE.md`?
+- Does it instruct Claude Code to call `get_root_cause` before reading source files when asked about production failures?
+- Does it instruct Claude Code to call `get_blast_radius` before suggesting changes to any service?
+- Does it instruct Claude Code to call `get_observed_dependencies` to confirm what is actually running before making architectural assumptions?
+- Does it state explicitly: "never assume the static code reflects production reality — use get_observed_dependencies to confirm"?
+- Does it give example prompts that map to specific tools?
+
+### 3. Response format contract — MVP
+
+Every tool must follow the same response format. This is the contract between NEAT and Claude Code. Breaking it for one tool breaks Claude Code's ability to reason consistently across tools.
+
+Format:
+1. Natural language answer in plain English — one paragraph, directly answers the question
+2. Structured data block — node names, paths, timestamps, confidence scores
+3. Final line: `confidence: [score] · provenance: [edge provenances in path]`
+
+**Verify:**
+- Does every tool follow this three-part format?
+- Is confidence always expressed as a decimal between 0.0 and 1.0?
+- Is provenance always named — OBSERVED, EXTRACTED, INFERRED, STALE — not as a numeric code?
+- Is the natural language paragraph written for Claude Code to act on — specific, not vague?
+- Does the response fail gracefully when the graph has no data — clear message, not an empty response or a raw JSON error?
+
+### 4. get_root_cause — MVP
+
+The most important tool. This is what closes PRs.
+
+Input schema:
+```typescript
+{
+  errorNode: string  // name of the node where the error surfaced
+  errorId?: string   // optional — specific error event ID from incidents
+}
+```
+
+Calls: `GET ${NEAT_CORE_URL}/traverse/root-cause?node={errorNode}&errorId={errorId}`
+
+Expected response for the demo scenario:
+```
+Root cause identified: pg driver 7.4.0 on service-b is incompatible 
+with PostgreSQL 15 on payments-db. PostgreSQL 15 requires scram-sha-256 
+authentication which pg < 8.0.0 does not support.
+
+Traversal path: payments-db ← service-b ← service-a
+Fix: upgrade pg to ^8.0.0 in service-b/package.json
+
+confidence: 1.0 · provenance: OBSERVED, OBSERVED
+```
+
+**Verify:**
+- Is `errorNode` validated as a non-empty string?
+- Does the tool handle the case where the node does not exist in the graph — clear message, not a 404 propagated raw?
+- Does the tool handle the case where no root cause is found — "no root cause identified in graph" — not null or undefined?
+- Is the traversal path displayed as a chain (A ← B ← C) not as a flat list?
+- Is the fix recommendation derived from the compatibility matrix result, not hardcoded?
+- Does the fix recommendation work for any driver/engine incompatibility — not just pg/PostgreSQL?
+- Is provenance listed for each edge in the traversal path — not just the overall confidence?
+
+### 5. get_blast_radius — MVP
+
+Input schema:
+```typescript
+{
+  node: string  // name of the node to analyse
+}
+```
+
+Calls: `GET ${NEAT_CORE_URL}/traverse/blast-radius?node={node}`
+
+Expected response:
+```
+Blast radius of service-a: 2 nodes affected.
+
+  service-b (distance: 1) — OBSERVED edge, confidence: 1.0
+  payments-db (distance: 2) — OBSERVED edge via service-b, confidence: 1.0
+
+Deploying or modifying service-a will directly impact service-b and 
+indirectly impact payments-db.
+
+confidence: 1.0 · provenance: OBSERVED, OBSERVED
+```
+
+**Verify:**
+- Does the response list each affected node with its distance and provenance?
+- Does it distinguish between direct (distance: 1) and indirect (distance: 2+) impact?
+- Does it produce a human-readable summary of what the blast radius means — not just a list?
+- Does it handle a node with zero blast radius — "no downstream dependencies found"?
+- Does it surface STALE edges differently from OBSERVED edges in the response?
+
+### 6. get_dependencies — MVP
+
+Returns all direct and transitive dependencies of a service — combining EXTRACTED and OBSERVED edges.
+
+Input schema:
+```typescript
+{
+  service: string  // service name
+}
+```
+
+Calls: `GET ${NEAT_CORE_URL}/graph/edges/{service}`
+
+**Verify:**
+- Does the response clearly separate OBSERVED dependencies from EXTRACTED-only dependencies?
+- Does it communicate which dependencies are confirmed by live traffic and which are only declared in code?
+- Does it handle transitive dependencies — not just direct edges?
+- Is the response useful without further explanation — can Claude Code read it and immediately understand the dependency structure?
+
+### 7. get_observed_dependencies — MVP
+
+Returns only OBSERVED edges — dependencies confirmed by live OTel traffic. This is the tool that tells Claude Code what is actually running, not what the code says should be running.
+
+Input schema:
+```typescript
+{
+  service: string  // service name
+}
+```
+
+Calls: `GET ${NEAT_CORE_URL}/graph/edges/{service}` filtered to OBSERVED provenance
+
+Expected response:
+```
+Observed dependencies for service-b (confirmed by live traffic):
+
+  → payments-db via CONNECTS_TO — last seen 8s ago, 312 calls
+  ← service-a via CALLS — last seen 8s ago, 312 calls
+
+No EXTRACTED-only dependencies exist for service-b that are not 
+confirmed by observed traffic.
+
+confidence: 1.0 · provenance: OBSERVED
+```
+
+**Verify:**
+- Does the tool filter to OBSERVED edges only — not EXTRACTED or INFERRED?
+- Does it include `lastObserved` timestamps in the response?
+- Does it include `callCount` in the response?
+- Does it handle STALE edges — does it include them or exclude them? Must be explicit either way.
+- When no OBSERVED edges exist, does it say so clearly — "no live traffic observed for this service"?
+- Is this tool the one Claude Code should call first when asked about what a service is actually doing in production?
+
+### 8. get_incident_history — MVP
+
+Returns error events linked to a specific node.
+
+Input schema:
+```typescript
+{
+  node: string    // node name
+  limit?: number  // default 10
+}
+```
+
+Calls: `GET ${NEAT_CORE_URL}/incidents/{node}?limit={limit}`
+
+**Verify:**
+- Is the response sorted newest first?
+- Does it include timestamp, error type, error message, and trace ID for each event?
+- Does it handle the case where no incidents exist — "no incidents recorded for this node"?
+- Is the limit parameter respected?
+- Does the response include enough context for Claude Code to connect an incident to a potential root cause without calling get_root_cause separately?
+
+### 9. semantic_search — MVP
+
+MVP implementation: keyword search over node names, node properties, and error messages. Not vector search — that is v1.0.
+
+Input schema:
+```typescript
+{
+  query: string  // search terms
+}
+```
+
+Calls: `GET ${NEAT_CORE_URL}/search?q={query}`
+
+**Verify:**
+- Is the tool documented in CLAUDE.md as keyword search, not semantic vector search?
+- Does it search across node names, node properties (including driver versions), and error messages?
+- Does it return results with enough context for Claude Code to understand why each result matched?
+- Is the v1.0 vector search upgrade noted in a comment so it is not accidentally implemented now?
+
+### 10. get_policy_violations — MVP
+
+Returns active policy violations. This tool does not exist in v0.1.2 — it is part of the policy layer being built. Include it here so the MCP audit covers the complete tool surface.
+
+Input schema:
+```typescript
+{
+  severity?: 'critical' | 'warning' | 'info' | 'all'  // default: all
+}
+```
+
+Calls: `GET ${NEAT_CORE_URL}/policy/violations?severity={severity}`
+
+Expected response:
+```
+2 active policy violations:
+
+[CRITICAL] payments-isolation
+  service-x has direct access to payments-db. Only payment-service 
+  is permitted.
+  Nodes: service-x, payments-db
+  Action: alert
+
+[WARNING] all-services-must-have-owner  
+  service-y is missing required property: owner
+  Nodes: service-y
+  Action: alert
+
+confidence: 1.0 · provenance: OBSERVED, EXTRACTED
+```
+
+**Verify:**
+- Does the tool exist? If not, it must be created when the policy layer is built.
+- Is severity filtering passed through as a query parameter?
+- Does the response communicate what action was taken (alert/block/log)?
+- Does it handle zero violations — "no active policy violations"?
+
+### 11. evaluate_policy — MVP
+
+Pre-flight check for autonomous agent actions. Allows Claude Code to ask "would this action violate any policies?" before taking it.
+
+Input schema:
+```typescript
+{
+  action: string       // description of the proposed action
+  affectedNodes: string[]  // nodes that would be affected
+}
+```
+
+Calls: `POST ${NEAT_CORE_URL}/policy/evaluate`
+
+Expected response:
+```
+Policy evaluation: BLOCKED
+
+Proposed action would violate 1 policy:
+
+[CRITICAL] payments-isolation — block
+  Adding service-x → payments-db CONNECTS_TO edge would violate 
+  exclusive access policy. Only payment-service may connect to payments-db.
+
+Do not proceed with this action.
+
+confidence: 1.0 · provenance: OBSERVED
+```
+
+Or if no violations:
+```
+Policy evaluation: ALLOWED
+
+No active policies would be violated by this action.
+Proceed with confidence.
+```
+
+**Verify:**
+- Does this tool exist? It is the enforcement gate for autonomous agent actions.
+- Is the response unambiguous — BLOCKED or ALLOWED — not a list of potential issues?
+- Does BLOCKED include the specific policy that would be violated and why?
+- Does ALLOWED include a confidence indicator rather than a blank pass?
+
+### 12. Tool count and completeness — MVP
+
+The complete tool surface for the MVP is:
+
+| Tool | Status in v0.1.2 |
+|------|-----------------|
+| get_root_cause | Shipped |
+| get_blast_radius | Shipped |
+| get_dependencies | Shipped |
+| get_observed_dependencies | Shipped |
+| get_incident_history | Shipped |
+| semantic_search | Shipped (keyword stub) |
+| get_policy_violations | Not yet — needs policy layer |
+| evaluate_policy | Not yet — needs policy layer |
+
+**Verify:**
+- Does `/list_tools` in Claude Code return all 8 tools after the policy layer is built?
+- Are get_policy_violations and evaluate_policy added when the policy layer ships — not deferred to a later release?
+
+---
+
+## General-purpose requirement
+
+Every tool must work on any codebase NEAT has modelled. Not just the demo.
+
+**Verify for each tool:**
+- Is there any hardcoded reference to `service-a`, `service-b`, `payments-db`, or any demo-specific name in the tool implementation?
+- Does the tool handle node names it has never seen before without throwing?
+- Does the tool produce useful responses for graphs with only EXTRACTED edges — no OTel data yet?
+- Does the tool produce useful responses for graphs with hundreds of nodes — not just the 3-node demo graph?
+
+---
+
+## Red flags
+
+- Tools reading graph.json directly instead of calling the neat-core REST API
+- Tools returning raw JSON from the API without formatting into natural language
+- Confidence scores missing from traversal tool responses
+- Provenance not communicated in tool responses
+- Hardcoded demo service names in any tool implementation
+- `get_policy_violations` or `evaluate_policy` missing after policy layer ships
+- CLAUDE.md missing or not instructing Claude Code to use NEAT tools proactively
+- Tool responses that return empty strings or null when no data is found — must return a clear message
+- Tools that throw unhandled errors when neat-core is unreachable — must return a graceful error message
+- semantic_search implemented as vector search in the MVP — it must be keyword search only
+
+---
+
+## Five questions — answer these before closing the audit
+
+1. Does every tool call the neat-core REST API — not graph.json directly?
+2. Does every tool response include provenance and confidence?
+3. Is there any hardcoded demo service name in any tool implementation?
+4. Do get_policy_violations and evaluate_policy exist after the policy layer ships?
+5. Does CLAUDE.md instruct Claude Code to use NEAT tools proactively rather than reading files?
+
+---
+
+*MVP only. NeatScript tool surface, autonomous remediation tools, and multi-agent orchestration are v1.0.*

--- a/docs/audits/NEAT-audit-otel.md
+++ b/docs/audits/NEAT-audit-otel.md
@@ -1,0 +1,226 @@
+# NEAT OTel Audit — MVP (TypeScript v0.1.x)
+## Load this before touching any ingestion-related code.
+
+**Scope:** This audit covers `packages/core/src/otel.ts`, `packages/core/src/ingest.ts`, and the trace stitcher logic in the TypeScript MVP monorepo at `github.com/NEAT-Technologies/Neat`. It does not apply to the Rust v1.0 OTel ingestion pipeline.
+
+**Stack:** `@opentelemetry/sdk-node`, `@opentelemetry/auto-instrumentations-node`, `@opentelemetry/exporter-trace-otlp-http`, Fastify OTLP HTTP receiver on port 4318, optional gRPC receiver on port 4317 (added in v0.1.2 α).
+
+**The goal this audit serves:** NEAT must be able to ingest OTel spans from any codebase with standard instrumentation — not just the pg 7.4.0 demo environment — and surface real anomalies that static analysis alone would not find. The demo was a controlled proof. The product must work on unknown systems.
+
+**What is not in scope for this audit:**
+- Qdrant vector DB or semantic memory — v1.0 only
+- Autonomous remediation pipeline — v1.0 only
+- Firecracker sandbox — v1.0 only
+- eBPF-based instrumentation — v1.0 only
+- Custom OTel collector distribution — v1.0 only
+
+---
+
+## What OTel ingestion must do — MVP
+
+OTel watches a running system and produces OBSERVED edges in the graph. It answers the question: what is the system actually doing right now?
+
+The output is always tagged OBSERVED with a `lastObserved` timestamp and a `callCount`. It represents ground truth — something that actually happened, measured directly, not inferred from code.
+
+The critical requirement for the general-purpose goal: the OTel layer must be able to ingest spans from any system that emits standard OpenTelemetry semconv attributes. It must not be coupled to the demo environment's specific service names, port numbers, or instrumentation choices.
+
+The trace stitcher exists to bridge gaps where auto-instrumentation is patchy. It is a bounded workaround. It must not grow beyond its stated scope.
+
+---
+
+## The contract
+
+### 1. Receiver — MVP
+
+The OTLP HTTP receiver listens on port 4318. The optional gRPC receiver listens on port 4317.
+
+**Verify:**
+- Is the receiver implemented as a Fastify route or a standalone HTTP server?
+- Does it accept both `application/x-protobuf` and `application/json` OTLP payloads?
+- Does it respond with the correct OTLP success response immediately — before processing the span — so the sending service is not blocked?
+- Is there a health check at `/health` that confirms the receiver is accepting spans?
+- If the gRPC receiver was added in v0.1.2 α, is it actually wired up or just scaffolded?
+
+### 2. Span parsing — MVP
+
+Each incoming span must be parsed for these fields before any graph mutation occurs. These are standard OTel semconv attributes that any compliant instrumentation library emits. The parser must not hardcode service names, hostnames, or port numbers from the demo.
+
+Fields to parse:
+- `resource.attributes['service.name']` — the service that produced the span
+- `span.parentSpanId` — if present and from a different service, this is a cross-service call
+- `span.traceId`
+- `span.spanId`
+- `span.attributes['db.system']` — if present, this span involves a database call
+- `span.attributes['db.name']` — the database name
+- `span.attributes['server.address']` or `span.attributes['net.peer.name']` — target host
+- `span.attributes['http.url']` or `span.attributes['url.full']` — for HTTP calls
+- `span.attributes['http.method']` or `span.attributes['http.request.method']`
+- `span.status.code` — 2 means ERROR
+- `span.startTimeUnixNano` — converted to ISO8601 for `lastObserved`
+
+**Verify:**
+- Is parsing done before any graph mutation?
+- Are both old semconv (`http.url`, `net.peer.name`) and new semconv (`url.full`, `server.address`) supported? Real codebases use both depending on SDK version.
+- Is `span.startTimeUnixNano` correctly converted from nanoseconds? A common mistake is treating it as milliseconds — off by a factor of 1,000,000.
+- If a required field is missing from a span, does the parser skip the span cleanly or throw?
+- Are there any hardcoded strings in the parser that reference `service-a`, `service-b`, `payments-db`, or any demo-specific name? If yes, this is a critical gap — the parser must be general.
+
+### 3. Service identity — MVP
+
+Service identity must be derived entirely from `resource.attributes['service.name']`. Nothing else.
+
+Not from hostname. Not from port. Not from a hardcoded map. Any service that emits spans with a `service.name` attribute is a valid service for NEAT to model.
+
+**Verify:**
+- Is service identity derived exclusively from `service.name`?
+- Is there any code that maps known service names to nodes via a hardcoded list? If yes, this breaks the general-purpose goal.
+- If a span arrives from a service that does not yet have a node in the graph, is a new ServiceNode created automatically?
+- Is the ServiceNode creation from span data distinct from the ServiceNode creation from tree-sitter extraction? They must be reconcilable — the same service appearing in both OTel and static analysis must produce one node, not two.
+
+### 4. Cross-service CALLS edge — MVP
+
+When a span has a `parentSpanId` from a different service, a `CALLS` edge must be created or updated.
+
+**Verify:**
+- Is there a span cache or trace buffer that holds recent spans long enough to correlate parent-child across service boundaries? Without this, cross-service CALLS edges cannot be derived.
+- What is the TTL on the span cache? Spans from the same trace can arrive out of order.
+- If the parent span has not been seen when the child arrives, does the system wait, retry, or drop the cross-service edge?
+- Is the span cache bounded in size? An unbounded cache will grow without limit on a busy production system.
+
+### 5. Database CONNECTS_TO edge — MVP
+
+When a span carries `db.system` and `db.name`, a `CONNECTS_TO` edge must be created or updated.
+
+The database engine is derived from `db.system`. Valid values from OTel semconv: `postgresql`, `mysql`, `mongodb`, `redis`, `sqlite`, `mssql`, `cassandra`, `elasticsearch`. The parser must handle all of these, not just `postgresql`.
+
+**Verify:**
+- Is there a DatabaseNode lookup or creation when a `db.system` span arrives?
+- Is `db.system` mapped to the DatabaseNode's `engine` field correctly for all major database types?
+- Is there any hardcoded check for `postgresql` specifically that would prevent other databases from creating DatabaseNodes? If yes, this breaks the general-purpose goal.
+- When a new DatabaseNode is created from OTel data, is the compatibility matrix checked against the connecting service's driver version (if known from static extraction)?
+
+### 6. ERROR span handling — MVP
+
+When a span carries `status.code === 2`, an ErrorEvent must be created.
+
+**Verify:**
+- Is `status.code === 2` the correct check? Verify integer comparison not string comparison.
+- Is the ErrorEvent written to `neat-out/errors.ndjson` as a complete JSON object per line?
+- Is `affectedEdge` populated when the error occurred on a known CALLS or CONNECTS_TO edge?
+- Are exception attributes read from span events named `exception` — not from top-level span attributes? OTel records exceptions as span events, not attributes.
+- Is the ErrorEvent schema from `@neat/types` used or is there a local ad-hoc schema?
+
+### 7. The trace stitcher — MVP
+
+The trace stitcher exists because some auto-instrumentation does not capture all hops. It infers missing edges from the static graph when an error span is received.
+
+**This is a bounded workaround. It must not expand.**
+
+Stitcher rules — non-negotiable:
+- Only activates when `status.code === 2` (ERROR span)
+- Only walks EXTRACTED edges from the erroring service's node
+- Maximum depth: 2 hops from the erroring service node
+- Produces INFERRED edges with `confidence: 0.6` only
+- Never produces OBSERVED edges
+- Does not activate for non-error spans
+- Does not create INFERRED edges for hops where an OBSERVED edge already exists
+
+**For the general-purpose goal:** the stitcher must work on any erroring service, not just service-b. The erroring service is identified by `service.name` from the span. The stitcher then walks the static graph from that node regardless of what service it is.
+
+**Verify:**
+- Is the stitcher only triggered by ERROR spans?
+- Is the depth limit enforced? Find the actual depth counter in the code.
+- Does the stitcher produce INFERRED edges or OBSERVED edges? OBSERVED is a critical gap.
+- Is `confidence: 0.6` what the code actually writes?
+- Is the stitcher general — does it work from any erroring service node — or does it hardcode service-b as the starting point?
+- Does the stitcher skip hops where OBSERVED edges already exist?
+
+### 8. OBSERVED edge upsert — MVP
+
+When an OTel span confirms a relationship already in the graph, upgrade the edge — do not duplicate it.
+
+Update rules:
+- `lastObserved` → set to the span's timestamp
+- `callCount` → increment by 1
+- `provenance` → upgrade from EXTRACTED or INFERRED to OBSERVED if currently lower trust
+- `confidence` → remove from the edge (not applicable to OBSERVED)
+
+**Verify:**
+- Is there an upsert function that finds an existing edge before creating a new one?
+- Is `callCount` incremented or reset on each span?
+- Is `provenance` upgraded when OTel confirms a relationship previously only known via EXTRACTED or INFERRED?
+- Is the upsert logic general — does it work for any service pair — or is it coupled to the demo service names?
+
+### 9. Staleness transition — MVP
+
+OBSERVED edges must become STALE when `lastObserved` exceeds 24 hours. Background process, not read-time computation.
+
+**Verify:**
+- Is `lastObserved` stored as ISO8601 from the span's `startTimeUnixNano`, not from `Date.now()`?
+- Is there a background `setInterval` that transitions OBSERVED → STALE?
+- Is staleness computed at read time in the REST API handler instead? If yes, this is a gap.
+- When an edge transitions to STALE, is `lastObserved` preserved?
+
+### 10. Non-blocking ingestion — MVP
+
+Spans arrive continuously. The receiver must respond to the sender before graph mutations complete.
+
+**Verify:**
+- Does the Fastify OTLP route respond before awaiting graph mutations?
+- Is there a queue between the receiver and the mutation? Or does mutation happen in the request handler?
+- Is the mutation `await` inside or outside the response send? If inside, the sending service is blocked.
+
+### 11. OTel collector config — MVP
+
+**Verify:**
+- Is the collector config in `demo/collector/config.yaml` general enough to work with any service, not just the demo services?
+- Is the exporter pointing to `http://neat-core:4318` via environment variable, not hardcoded?
+- Is the batch timeout short (200ms or less) so spans arrive quickly?
+- Is there a `logging` exporter for debugging?
+
+---
+
+## What general-purpose OTel ingestion looks like
+
+For NEAT to open a PR on any repo, the OTel layer must be able to:
+
+1. Accept spans from any service with any `service.name`
+2. Create ServiceNodes automatically for services seen in spans but not yet in the static graph
+3. Create DatabaseNodes automatically for any `db.system` type, not just postgresql
+4. Produce CALLS edges for any cross-service span pair
+5. Produce CONNECTS_TO edges for any database span
+6. Run the trace stitcher from any erroring service node, not just the demo services
+7. Surface ErrorEvents for any ERROR span regardless of which service produced it
+
+If any of these seven are scoped to the demo environment specifically, the general-purpose goal is blocked.
+
+---
+
+## Red flags
+
+- Any hardcoded reference to `service-a`, `service-b`, `payments-db`, or any demo-specific name in the OTel parsing or ingestion code
+- The OTLP receiver awaiting graph mutations before sending the success response
+- `Date.now()` used as `lastObserved` instead of the span's `startTimeUnixNano`
+- `startTimeUnixNano` treated as milliseconds
+- The trace stitcher producing OBSERVED edges instead of INFERRED
+- The trace stitcher depth exceeding 2 hops
+- The trace stitcher hardcoded to start from service-b rather than any erroring service
+- `db.system` handling only `postgresql` — other databases create no DatabaseNode
+- Exception data read from span attributes instead of span events named `exception`
+- `status.code === 2` compared against string `'2'` rather than integer `2`
+- OBSERVED edges created alongside existing EXTRACTED edges rather than upgrading them
+- Unbounded span cache with no TTL or size limit
+
+---
+
+## Five questions — answer these before closing the audit
+
+1. Is there any hardcoded demo service name (`service-a`, `service-b`, `payments-db`) in the OTel ingestion code?
+2. Does the trace stitcher start from any erroring service node or only from service-b?
+3. Does the trace stitcher produce INFERRED edges (correct) or OBSERVED edges (critical gap)?
+4. Is a new ServiceNode created automatically when a span arrives from a service not yet in the graph?
+5. Does the `db.system` handler create DatabaseNodes for all major database types or only postgresql?
+
+---
+
+*MVP only. eBPF instrumentation, Qdrant semantic memory, autonomous remediation, and Firecracker sandboxing are v1.0.*

--- a/docs/audits/NEAT-audit-policies.md
+++ b/docs/audits/NEAT-audit-policies.md
@@ -1,0 +1,352 @@
+# NEAT Policy Audit — MVP (TypeScript v0.1.x)
+## Load this before building the policy layer.
+
+**Scope:** This audit defines what the policy layer must be in `packages/core` of the TypeScript MVP monorepo at `github.com/NEAT-Technologies/Neat`. The policy layer does not exist yet. This document is a build contract, not a drift check.
+
+**Stack:** policy.json file, Zod schemas in `@neat/types`, evaluation engine in `packages/core/src/policy.ts`, violations.ndjson output, REST API endpoints, MCP tool `get_policy_violations`.
+
+**The goal this audit serves:** Policies must enforce architectural law continuously against the live graph. They must block autonomous agent actions before they violate declared constraints. They are not scan-time validators. They are not alerting rules. They are enforcement.
+
+**What is not in scope for this audit:**
+- NeatScript policy DSL — v1.0 only
+- OPA/Rego integration — v1.0 only
+- Policy UI in neat-web — Jed's concern
+- Autonomous remediation pipeline — v1.0 only
+
+---
+
+## What the policy layer must be — MVP
+
+A policy is a persistent assertion evaluated against the live graph on every mutation. When the graph diverges from the policy, a PolicyViolationEvent is created immediately — not the next time someone queries, not the next time neat init runs, immediately.
+
+The policy layer has three parts:
+
+**Definition** — `policy.json` checked into the repo. Human-readable, no TypeScript required to add a policy.
+
+**Evaluation** — `packages/core/src/policy.ts`. Reads the live graphology instance. Runs on every graph mutation. Writes violations to `neat-out/violations.ndjson`.
+
+**Enforcement** — the `block` onViolation type must prevent FRONTIER node promotion and autonomous agent actions before they execute. Not after.
+
+---
+
+## The contract
+
+### 1. policy.json schema — MVP
+
+The policy definition file lives at the repo root alongside `compat.json`. It must be valid JSON parseable by the Zod schema in `@neat/types`.
+
+Minimum required schema:
+
+```json
+{
+  "version": 1,
+  "policies": [
+    {
+      "id": "string — unique, kebab-case",
+      "description": "string — human readable",
+      "enabled": true,
+      "severity": "critical | warning | info",
+      "type": "structural | compatibility | provenance | ownership | blast_radius",
+      "rule": { ... },
+      "onViolation": "alert | block | log"
+    }
+  ]
+}
+```
+
+**Verify:**
+- Is `policy.json` validated against a Zod schema from `@neat/types` on startup?
+- If `policy.json` is malformed, does neat-core fail to start with a clear error or silently ignore the file?
+- Is the schema versioned — does `version: 1` exist so future schema changes can be migrated?
+- Is `id` enforced as unique? Duplicate policy IDs must be a startup error.
+
+### 2. Policy types — MVP
+
+The MVP must support these five policy types. No others.
+
+**structural** — asserts topology constraints. Who may connect to what.
+```json
+{
+  "type": "structural",
+  "rule": {
+    "targetNode": "payments-db",
+    "targetType": "DatabaseNode",
+    "allowedSources": ["payment-service"],
+    "constraint": "exclusive_access"
+  }
+}
+```
+
+**compatibility** — asserts version compatibility. Extends the compat.json check as a continuous policy rather than a one-time extraction annotation.
+```json
+{
+  "type": "compatibility",
+  "rule": {
+    "driver": "pg",
+    "engine": "postgresql",
+    "minDriverVersion": "8.0.0"
+  }
+}
+```
+
+**provenance** — asserts provenance requirements on edges in specific paths.
+```json
+{
+  "type": "provenance",
+  "rule": {
+    "pathTo": "payments-db",
+    "requiredProvenance": "OBSERVED"
+  }
+}
+```
+
+**ownership** — asserts that nodes carry required properties.
+```json
+{
+  "type": "ownership",
+  "rule": {
+    "nodeType": "ServiceNode",
+    "requiredProperty": "owner"
+  }
+}
+```
+
+**blast_radius** — asserts acceptable blast radius limits.
+```json
+{
+  "type": "blast_radius",
+  "rule": {
+    "targetNode": "payments-db",
+    "maxBlastRadius": 3
+  }
+}
+```
+
+**Verify:**
+- Is there a type dispatch in the evaluator — one evaluator function per policy type?
+- Does an unknown policy type fail loudly or silently skip?
+- Is the `compatibility` type genuinely continuous — re-evaluated when a new ServiceNode arrives with a driver version — or does it only run at scan time?
+
+### 3. Evaluation timing — the most important contract
+
+**Policies must evaluate on every graph mutation. Not at scan time. Not at query time. On every mutation.**
+
+A graph mutation is any of:
+- A new node added to the graph
+- A new edge added to the graph
+- An existing edge's provenance upgraded (EXTRACTED → OBSERVED)
+- An existing edge transitioned to STALE
+- A FRONTIER node created
+
+Every one of these events must trigger policy evaluation.
+
+**Verify:**
+- Is `evaluateAllPolicies()` called from `ingest.ts` after every span-driven graph mutation?
+- Is `evaluateAllPolicies()` called from `extract.ts` after every extraction-driven graph mutation?
+- Is it called after STALE transitions in the background staleness job?
+- Is it called after FRONTIER node creation?
+- Or is policy evaluation only called on REST API requests or on `neat init`? If yes, this is a critical gap — the layer is a validator, not an enforcer.
+
+### 4. PolicyViolationEvent schema — MVP
+
+Every violation must produce a typed event written to `neat-out/violations.ndjson`. The schema must be in `@neat/types`.
+
+```typescript
+PolicyViolationEvent {
+  id: string          // uuid
+  timestamp: string   // ISO8601
+  policyId: string    // matches policy.json id
+  policyDescription: string
+  severity: 'critical' | 'warning' | 'info'
+  violatingNodes: string[]  // node IDs involved in the violation
+  reason: string      // human readable — what the violation is
+  onViolation: 'alert' | 'block' | 'log'
+  resolved: boolean   // false on creation
+}
+```
+
+**Verify:**
+- Is the PolicyViolationEvent schema in `@neat/types` as a Zod schema?
+- Is it exported alongside ErrorEvent so both can be imported from the same package?
+- Is `violations.ndjson` append-only — one JSON object per line — matching the pattern of `errors.ndjson`?
+- Is `resolved: false` set on creation? Is there a mechanism to mark violations as resolved when the graph mutation that caused them is reversed?
+
+### 5. onViolation: alert — MVP
+
+When `onViolation` is `alert`, the violation is written to violations.ndjson and logged. Nothing else blocks. The system continues operating.
+
+**Verify:**
+- Is `alert` the default behaviour when no onViolation is specified?
+- Is the violation written to violations.ndjson synchronously before the function returns?
+- Is there a console.warn or structured log output for `critical` severity alerts?
+
+### 6. onViolation: block — MVP
+
+When `onViolation` is `block`, the violation must prevent the triggering action from completing.
+
+In the MVP, `block` applies to two specific scenarios:
+
+**FRONTIER node promotion** — when the agent attempts to graduate a FRONTIER node to OBSERVED, `evaluatePolicy(action)` must be called first. If any `block` policy would be violated by the promotion, it must not proceed.
+
+**Autonomous agent actions via MCP** — when `evaluate_policy` is called by an agent before taking an action, a `block` result must be communicated clearly so the agent does not proceed.
+
+**Verify:**
+- Is there a `canPromoteFrontier(nodeId)` function that runs block policies before promotion?
+- Does it return `{ allowed: boolean, violations: PolicyViolationEvent[] }` so the caller has full context?
+- Is there an `evaluate_policy` MCP tool that agents can call before taking action?
+- Does `block` actually prevent the action or does it only log that it would have been blocked?
+- Is `block` only relevant for FRONTIER promotion and agent actions in the MVP, not for all graph mutations? Clarify the scope.
+
+### 7. onViolation: log — MVP
+
+`log` is the lowest severity. Write to violations.ndjson, no console output, no blocking.
+
+**Verify:**
+- Is `log` distinct from `alert` in implementation — specifically, no console.warn for `log` severity?
+
+### 8. Structural policy evaluator — MVP
+
+The structural evaluator checks topology constraints. It must query the live graph.
+
+For `constraint: exclusive_access` on a DatabaseNode:
+1. Get all incoming edges to the target node
+2. Filter to edges of type `CALLS` or `CONNECTS_TO`
+3. Check that all source nodes are in `allowedSources`
+4. Any source not in `allowedSources` is a violation
+
+**Verify:**
+- Does the evaluator use `graph.inNeighbors(targetNodeId)` on the live graphology instance — not graph.json?
+- Is the result a list of violating source node IDs?
+- Does it handle the case where the target node does not yet exist in the graph? It must skip cleanly.
+- Is `allowedSources` matched by node ID or node name? Must be consistent with how nodes are identified throughout the system.
+
+### 9. Compatibility policy evaluator — MVP
+
+The compatibility evaluator is the policy-layer version of what `compat.json` already does at extraction time. The difference is timing — the compat.json check runs once at scan time. The policy evaluator runs continuously.
+
+For a compatibility policy on `pg/postgresql`:
+1. Find all ServiceNodes with a `pg` driver version property
+2. Find all DatabaseNodes they connect to with `engine: postgresql`
+3. For each pair, check the driver version against the policy's `minDriverVersion`
+4. Any pair below `minDriverVersion` is a violation
+
+**Verify:**
+- Is the compatibility policy evaluator distinct from the compat.json check in extract.ts?
+- Does it re-evaluate when a new CONNECTS_TO OBSERVED edge appears between a service and a database?
+- Does it use `semver.lt()` for version comparison — not string comparison?
+- Does it handle services where the driver version is not yet known (not extracted)? It must skip those, not throw.
+
+### 10. Provenance policy evaluator — MVP
+
+The provenance evaluator asserts provenance requirements on edges in a path.
+
+For `requiredProvenance: OBSERVED` on `pathTo: payments-db`:
+1. Find all incoming edges to `payments-db`
+2. Check each edge's provenance
+3. Any edge that is not OBSERVED is a violation
+
+**Verify:**
+- Does the evaluator traverse all incoming edges to the target node?
+- Does it handle multi-hop paths or only direct edges? For MVP, direct edges only is acceptable — note it as v1.0 debt if multi-hop is skipped.
+- Does it handle STALE edges? An edge that was OBSERVED but is now STALE may still be a violation depending on policy intent.
+
+### 11. Ownership policy evaluator — MVP
+
+The ownership evaluator checks that nodes carry required properties.
+
+For `requiredProperty: owner` on `nodeType: ServiceNode`:
+1. Iterate all nodes in the graph
+2. Filter to the specified node type
+3. Check each node for the required property
+4. Any node missing the property is a violation
+
+**Verify:**
+- Does the evaluator use `graph.forEachNode()` on the live graphology instance?
+- Does it handle the case where no nodes of the specified type exist? It must return no violations, not throw.
+
+### 12. Blast radius policy evaluator — MVP
+
+The blast radius evaluator uses the existing `getBlastRadius()` function from traverse.ts.
+
+**Verify:**
+- Does the policy evaluator call `getBlastRadius(targetNode)` from traverse.ts — not reimplement the traversal?
+- Does it compare `result.totalAffected` against `maxBlastRadius`?
+- Is this re-evaluated when new edges are added to the graph that might increase the blast radius of a monitored node?
+
+### 13. REST API endpoints — MVP
+
+Two new endpoints must be added to the Fastify API in api.ts:
+
+```
+GET /policy/violations                    — all active violations, newest first
+GET /policy/violations?severity=critical  — filtered by severity
+GET /policy/violations/:policyId          — violations for a specific policy
+POST /policy/evaluate                     — dry-run evaluation against a proposed action
+```
+
+**Verify:**
+- Do the violation endpoints read from violations.ndjson or from an in-memory violation store?
+- If from violations.ndjson, is there pagination? A busy system could produce many violations.
+- Is `POST /policy/evaluate` implemented for the dry-run use case?
+
+### 14. MCP tool — MVP
+
+One new MCP tool must be added in packages/mcp:
+
+`get_policy_violations(severity?: 'critical' | 'warning' | 'info' | 'all')`
+
+Response format — same contract as all other MCP tools:
+1. Natural language summary of active violations
+2. Structured list: policy ID, reason, violating nodes, severity
+3. Final line: `total violations: N · critical: N · warning: N`
+
+**Verify:**
+- Does the tool call `GET ${NEAT_CORE_URL}/policy/violations` on the neat-core REST API?
+- Does it format the response in natural language suitable for Claude Code to reason about?
+- Is severity filtering passed through as a query parameter?
+
+---
+
+## What continuous enforcement looks like
+
+When a new CONNECTS_TO OBSERVED edge arrives between service-x and payments-db, this sequence must occur automatically:
+
+1. `ingest.ts` upserts the edge into the live graph
+2. `ingest.ts` calls `evaluateAllPolicies()`
+3. The structural evaluator checks whether service-x is in `allowedSources` for payments-db
+4. It is not — violation created
+5. PolicyViolationEvent written to violations.ndjson
+6. `console.warn` if severity is critical
+7. The next call to `GET /policy/violations` returns the new violation
+8. The next call to the `get_policy_violations` MCP tool surfaces it to Claude Code
+
+This entire sequence must complete within the same event loop cycle as the edge upsert. No deferred evaluation.
+
+---
+
+## Red flags
+
+- `evaluateAllPolicies()` called only from REST API handlers or `neat init` — not from graph mutation points
+- `onViolation: block` logging the violation but not actually preventing the action
+- Policy evaluation reading graph.json instead of the live graphology instance
+- `canPromoteFrontier()` not existing — FRONTIER promotion has no policy gate
+- Compatibility policy using string comparison instead of `semver.lt()`
+- PolicyViolationEvent schema defined locally rather than in `@neat/types`
+- violations.ndjson not existing or not being written to
+- `evaluate_policy` MCP tool missing — agents have no way to pre-flight check actions
+- Policy types beyond the five listed being added — scope creep
+- NeatScript policy syntax appearing anywhere in the MVP — it is v1.0 only
+
+---
+
+## Five questions — answer these before closing the audit
+
+1. Is `evaluateAllPolicies()` called from both `ingest.ts` and `extract.ts` after every graph mutation?
+2. Does `onViolation: block` actually prevent FRONTIER promotion or does it only log?
+3. Does the compatibility policy evaluator use `semver.lt()` for version comparison?
+4. Is PolicyViolationEvent defined in `@neat/types` as a Zod schema?
+5. Is there a `get_policy_violations` MCP tool that surfaces active violations to Claude Code?
+
+---
+
+*MVP only. NeatScript policy DSL, OPA/Rego integration, and the full enforcement surface for autonomous remediation are v1.0.*

--- a/docs/audits/NEAT-audit-traversal.md
+++ b/docs/audits/NEAT-audit-traversal.md
@@ -1,0 +1,233 @@
+# NEAT Traversal Audit — MVP (TypeScript v0.1.x)
+## Load this before touching traverse.ts or any code that calls getRootCause or getBlastRadius.
+
+**Scope:** This audit covers `packages/core/src/traverse.ts` in the TypeScript MVP monorepo at `github.com/NEAT-Technologies/Neat`. It covers getRootCause, getBlastRadius, edge priority rules, confidence cascading, depth limits, and whether the algorithms work on unknown graphs.
+
+**Stack:** graphology-traversal, graphology-shortest-path, semver, @neat/types schemas for RootCauseResult and BlastRadiusResult.
+
+**The goal this audit serves:** Traversal is the intelligence layer. The graph and OTel give you data. Traversal is what turns that data into an answer. If edge priority is wrong, NEAT will prefer a stale guess over a confirmed observation. If confidence cascading is wrong, a high-confidence answer will be reported with a low score or vice versa. If depth limits are wrong, traversal on a large real-world graph will walk indefinitely. These failures are silent — they produce wrong answers, not errors.
+
+**What is not in scope:**
+- NeatScript traversal API — v1.0 only
+- Differential dataflow — v1.0 only
+- Autonomous remediation traversal — v1.0 only
+
+---
+
+## What traversal must do — MVP
+
+Traversal turns the graph into answers. Two functions. Both must work on any graph NEAT has modelled — not just the 3-node demo graph.
+
+**getRootCause** — given a node where an error surfaced, walk incoming edges to find the upstream cause. Return the cause, the path, and a confidence score that reflects how much of the path was confirmed by live traffic.
+
+**getBlastRadius** — given any node, walk outgoing edges to find everything downstream. Return each affected node with its distance, path, and confidence.
+
+Both functions must prefer OBSERVED edges over INFERRED over EXTRACTED. This is the edge priority rule. It is the most important semantic contract in the entire traversal layer.
+
+---
+
+## The contract
+
+### 1. Edge priority rule — the most important contract
+
+When multiple edges exist between two nodes — for example an EXTRACTED edge and an OBSERVED edge for the same relationship — traversal must always prefer the highest-trust provenance.
+
+Priority order, highest to lowest:
+```
+OBSERVED > INFERRED > EXTRACTED > STALE
+```
+
+FRONTIER edges must not be traversed in getRootCause or getBlastRadius. FRONTIER represents unknown territory. Traversal must stay within the known graph.
+
+**Verify:**
+- Is there an explicit priority function or sort that orders edges by provenance before traversal?
+- If two edges exist between service-b and payments-db — one EXTRACTED, one OBSERVED — does traversal use the OBSERVED edge?
+- Are STALE edges traversed or skipped? They must be traversed (they represent a real relationship that was observed) but flagged in the result as stale.
+- Are FRONTIER edges excluded from traversal?
+- Is the priority rule applied at every hop — not just at the starting node?
+
+### 2. Confidence cascading — MVP
+
+The confidence score of a traversal result must reflect the weakest link in the path.
+
+Rules:
+- A path where all edges are OBSERVED → confidence: 1.0
+- A path where any edge is INFERRED → confidence: min(0.7, inferred_edge.confidence)
+- A path where any edge is EXTRACTED only → confidence: 0.5
+- A path where any edge is STALE → confidence: 0.3
+- A path with mixed provenances → confidence: minimum of all edge confidences in the path
+
+The confidence cascades from the weakest edge in the path. A single INFERRED edge in a five-hop OBSERVED path drops the overall confidence to 0.7 or lower.
+
+**Verify:**
+- Is confidence computed from the weakest edge in the path — not from the final edge only?
+- Is confidence a cascade of minimums — not an average?
+- Does a single STALE edge in the path produce confidence ≤ 0.3?
+- Is confidence included in RootCauseResult and in each node entry of BlastRadiusResult?
+- Is the confidence calculation tested against a fixture graph with mixed provenances?
+
+### 3. getRootCause — MVP
+
+Algorithm:
+1. Start at the error node
+2. Walk incoming edges depth-first
+3. At each upstream node, run `checkCompatibility` from compat.ts
+4. If incompatibility found, return RootCauseResult with the full path and cascaded confidence
+5. If depth limit reached with no incompatibility, return null
+
+**Verify:**
+- Is the traversal direction incoming — not outgoing? getRootCause walks backward through the dependency chain.
+- Is graphology-traversal used or is there a hand-rolled DFS? Either is acceptable but hand-rolled must handle cycles.
+- Is there cycle detection? A graph with a circular dependency will loop indefinitely without it.
+- Is the depth limit enforced? What is it — 5 hops is the recommended default. Find the actual value in the code.
+- When the starting node does not exist in the graph, does the function return null with a clear reason — not throw?
+- Is `checkCompatibility` called at every upstream ServiceNode — not only the direct parent of the error node?
+- Is the traversal general — does it start from any node passed in, not just `payments-db`?
+- Does getRootCause use the live graphology instance or does it read graph.json?
+
+### 4. getRootCause result — MVP
+
+The result must conform to RootCauseResultSchema from @neat/types:
+
+```typescript
+{
+  rootCauseNode:   string        // the node identified as the cause
+  rootCauseReason: string        // human readable — what the incompatibility is
+  traversalPath:   string[]      // array of node IDs from error surface to root cause
+  edgeProvenances: Provenance[]  // one entry per edge in traversalPath
+  confidence:      number        // 0.0-1.0, cascaded from weakest edge
+}
+```
+
+**Verify:**
+- Is `traversalPath` in order from error surface to root cause — not reversed?
+- Is `edgeProvenances` the same length as `traversalPath` minus one (one provenance per edge, not per node)?
+- Is `rootCauseReason` a human-readable string — not a raw compat.json entry?
+- Does `rootCauseReason` include the specific version that is incompatible and why — not just "incompatibility detected"?
+- Is the result validated against RootCauseResultSchema before being returned?
+
+### 5. getBlastRadius — MVP
+
+Algorithm:
+1. Start at the origin node
+2. Walk outgoing edges depth-first
+3. For each downstream node, record its distance from the origin, its path, and the cascaded confidence of the path
+4. Return all downstream nodes with their distances, paths, and confidences
+
+**Verify:**
+- Is the traversal direction outgoing — not incoming?
+- Is there a depth limit? What is it — 10 hops is the recommended default. Find the actual value.
+- Is there cycle detection?
+- Does getBlastRadius use the live graphology instance?
+- Is graphology-shortest-path used for path computation or is path tracking done manually during traversal?
+- Is `totalAffected` the count of unique affected nodes — not the count of edges?
+- Does it handle nodes with zero outgoing edges — returns `totalAffected: 0`, not an error?
+
+### 6. getBlastRadius result — MVP
+
+The result must conform to BlastRadiusResultSchema from @neat/types:
+
+```typescript
+{
+  origin:        string
+  affectedNodes: Array<{
+    node:       string    // node ID
+    distance:   number    // hops from origin, minimum 1
+    path:       string[]  // node IDs from origin to this node
+    confidence: number    // cascaded confidence of this path
+  }>
+  totalAffected: number
+}
+```
+
+**Verify:**
+- Is `distance` minimum 1 — not 0? Distance 0 would mean the origin itself is affected, which is meaningless.
+- Is `path` populated for each affected node — not an empty array?
+- Is `path` in order from origin to the affected node — not reversed?
+- Is `confidence` per affected node — not a single confidence for the entire blast radius?
+- Is `totalAffected` the count of `affectedNodes` — does it match the array length?
+
+### 7. Cycle detection — MVP
+
+Both getRootCause and getBlastRadius can encounter cycles in real production graphs. A service A that depends on service B that depends on service A. Without cycle detection, traversal loops indefinitely.
+
+**Verify:**
+- Is there a `visited` set or equivalent that tracks nodes already in the current traversal path?
+- Does the traversal skip a node that is already in the visited set?
+- Is cycle detection applied in both getRootCause and getBlastRadius?
+- Is cycle detection tested against a fixture graph with a circular dependency?
+
+### 8. General-purpose requirement — MVP
+
+Traversal must work on any graph NEAT has modelled. Not just the demo graph.
+
+The demo graph has 3 nodes and 2 edges. A real production graph might have 50 nodes and 200 edges. Traversal must not have any hardcoded assumptions about the demo graph.
+
+**Verify:**
+- Is there any hardcoded reference to `service-a`, `service-b`, `payments-db`, or any demo-specific name in traverse.ts?
+- Does getRootCause work correctly when called with a node name it has never seen before? It must return null cleanly.
+- Does getBlastRadius work correctly on a node with many outgoing edges — not just one or two?
+- Is traversal tested against a fixture graph that is different from the demo scenario?
+
+### 9. Performance on real graphs — MVP
+
+The demo graph is tiny. A real graph is not. Traversal must not be catastrophically slow on a large graph.
+
+**Verify:**
+- Does getRootCause return in under 500ms on a graph with 100 nodes and 300 edges?
+- Does getBlastRadius return in under 500ms on the same graph?
+- Is graphology-traversal used rather than a hand-rolled BFS/DFS? graphology's built-in traversal is optimised for its internal data structures.
+- Is there any N+1 pattern — fetching node attributes inside a loop that iterates edges? This will be slow on large graphs.
+
+### 10. Integration with compat.ts — MVP
+
+getRootCause depends on `checkCompatibility` from compat.ts. The integration must be correct.
+
+**Verify:**
+- Is `checkCompatibility` imported from compat.ts — not reimplemented in traverse.ts?
+- Is it called with the correct arguments — driver name, driver version, engine name, engine version — not just version strings?
+- Are driver name and engine name derived from node properties — not hardcoded to `pg` and `postgresql`?
+- When `checkCompatibility` returns `{ compatible: false, reason }`, is `reason` used as `rootCauseReason` in the result?
+- When `checkCompatibility` returns `{ compatible: true }`, does the traversal continue to the next upstream node rather than stopping?
+
+### 11. STALE edge handling — MVP
+
+STALE edges represent relationships that were observed but have not been confirmed recently. Traversal must handle them distinctly from OBSERVED edges.
+
+**Verify:**
+- Are STALE edges included in traversal or excluded? They must be included — they represent a real relationship.
+- Does a STALE edge in the traversal path reduce confidence to 0.3 or lower?
+- Is the STALE provenance surfaced in `edgeProvenances` in the traversal result?
+- Does the MCP tool response communicate clearly when a traversal result contains STALE edges?
+
+---
+
+## Red flags
+
+- No cycle detection — traversal will loop indefinitely on circular dependencies
+- Depth limit not enforced or hardcoded to a very large number
+- Confidence computed from the final edge only — not cascaded from the weakest edge
+- getRootCause walking outgoing edges instead of incoming
+- getBlastRadius walking incoming edges instead of outgoing
+- FRONTIER edges included in traversal
+- Hardcoded demo node names in traverse.ts
+- `checkCompatibility` reimplemented in traverse.ts rather than imported from compat.ts
+- `checkCompatibility` called with hardcoded `pg` and `postgresql` rather than reading from node properties
+- graphology not used — hand-rolled DFS without proper cycle detection or performance optimisation
+- RootCauseResult or BlastRadiusResult defined locally rather than from @neat/types
+- `distance: 0` in BlastRadiusResult — minimum distance must be 1
+- `traversalPath` and `edgeProvenances` arrays of mismatched length
+
+---
+
+## Five questions — answer these before closing the audit
+
+1. Is the edge priority rule enforced at every hop — OBSERVED > INFERRED > EXTRACTED > STALE?
+2. Is confidence cascaded from the weakest edge in the path — not averaged and not taken from the final edge?
+3. Is cycle detection implemented in both getRootCause and getBlastRadius?
+4. Is `checkCompatibility` called with general driver and engine names from node properties — not hardcoded to pg/postgresql?
+5. Is there any hardcoded demo node name in traverse.ts?
+
+---
+
+*MVP only. NeatScript traversal API, differential dataflow, and autonomous remediation traversal are v1.0.*

--- a/docs/audits/NEAT-audit-treesitter.md
+++ b/docs/audits/NEAT-audit-treesitter.md
@@ -1,0 +1,198 @@
+# NEAT Tree-sitter Audit — MVP (TypeScript v0.1.x)
+## Load this before touching any extraction-related code.
+
+**Scope:** This audit covers `packages/core/src/extract.ts` and its sub-modules in the TypeScript MVP monorepo at `github.com/NEAT-Technologies/Neat`. It does not apply to the Rust v1.0 tree-sitter native bindings.
+
+**Stack:** Native tree-sitter Node.js bindings (`tree-sitter` + language grammars), not web-tree-sitter WASM. This was an explicit decision — neat-core is a Node.js server process only, never a browser, so WASM overhead is unnecessary.
+
+**What is not in scope for this audit:**
+- web-tree-sitter WASM bindings — if these appear in packages/core, remove them
+- Semantic analysis beyond what tree-sitter's query API can express — LLM-assisted extraction is v1.0
+- Salsa incremental computation — v1.0 only
+- Cross-language semantic unification at scale — MVP supports JS/TS/Python, that is enough
+
+---
+
+## What tree-sitter extraction must do — MVP
+
+tree-sitter reads your source files and config and produces EXTRACTED nodes and edges in the graph. It answers the question: what does the code say this system looks like?
+
+The output is always tagged EXTRACTED. It is always a snapshot accurate at the time of the last scan. It never claims more than what it found in the files.
+
+The extraction pipeline must be modular — one extractor per source type. A monolithic extract.ts that handles all file types in one function is debt. The v0.1.2 β release noted this split was made. Verify it held.
+
+---
+
+## The contract
+
+### 1. Module structure — MVP
+
+Extraction must be split by source type. Not one 300-line function.
+
+Expected modules or clear logical separation:
+- Service extraction — reads package.json, source files, finds service definitions
+- Database extraction — reads db config, ORM config, connection strings
+- Call extraction — reads source files, finds HTTP calls, gRPC, message queue producers/consumers
+- Config extraction — reads yaml, env, Dockerfile
+- Infra extraction — reads docker-compose.yml, basic Terraform, k8s manifests
+
+**Verify:**
+- Is extract.ts split into per-source-type functions or is it still one large function?
+- If it is one function, does it have clear phase boundaries or is it genuinely tangled?
+- Are the extractors independently testable — can you run database extraction against a fixture without running service extraction?
+
+### 2. Language support — MVP
+
+The MVP must support at minimum:
+
+- JavaScript (`.js`, `.mjs`, `.cjs`)
+- TypeScript (`.ts`, `.tsx`)
+- Python (`.py`) — added in v0.1.2 β
+- JSON (`package.json`, `*.json` config files)
+- YAML (`*.yaml`, `*.yml` — docker-compose, k8s, ORM config)
+- `.env` files
+
+`[v1.0]` Go, Rust, Java, Ruby, and other languages. Do not add new language grammars to the MVP unless a specific demo scenario requires it.
+
+**Verify:**
+- Which tree-sitter grammars are installed as dependencies in `packages/core/package.json`?
+- Is there a language dispatch table — a map from file extension to grammar — or is it hardcoded conditionals?
+- If a file extension is not recognised, does extraction skip it cleanly or does it throw?
+
+### 3. Service discovery — MVP
+
+From v0.1.2 β, recursive service discovery was added. It must honour workspace conventions.
+
+**Verify:**
+- Does `neat init /path` discover services recursively, not just direct children of the scan path?
+- Does it honour `package.json#workspaces` — if a monorepo declares workspaces, are those the service roots?
+- Does it recognise `apps/`, `services/`, `packages/` as conventional service directories?
+- Is there a depth limit on recursion? Without one, scanning `/` would be catastrophic.
+- What is the depth limit and is it configurable?
+
+### 4. What must be extracted from package.json — MVP
+
+For each `package.json` found, the extractor must produce:
+
+- `ServiceNode.name` — from `name` field
+- `ServiceNode.version` — from `version` field
+- `ServiceNode.language` — `node` or `javascript` or `typescript` depending on presence of TypeScript in devDependencies
+- Driver versions — from `dependencies` and `devDependencies`: specifically `pg`, `mysql2`, `mongoose`, `redis`, `@prisma/client`, `drizzle-orm`, `sequelize` — each maps to a property on the ServiceNode for compatibility checking
+- Framework detection — `express`, `fastapi` (Python), `hono`, `fastify`, `nestjs` — stored as `ServiceNode.framework`
+
+**Verify:**
+- Is driver version extraction general or hardcoded to `pg` only? The `pgDriverVersion` deprecation in the CLAUDE.md suggests it was special-cased. Is it now replaced by a general driver extraction mechanism?
+- Is framework detection present? If not, the FastAPI audit scenario cannot work.
+- Are dependency versions stripped of semver range prefixes (`^`, `~`, `>=`) before being stored? A version stored as `^7.4.0` will not match correctly against the compatibility matrix.
+
+### 5. What must be extracted from source files — MVP
+
+**From JavaScript and TypeScript:**
+
+HTTP calls — find `fetch`, `axios.get/post/put/delete`, `got`, `superagent`, `node-fetch` calls with URL arguments. Extract the target URL. Map it to a known ServiceNode if the hostname matches. Create a `CALLS` EXTRACTED edge.
+
+Database connections — find `new pg.Pool`, `new pg.Client`, `mongoose.connect`, `mysql.createConnection`, `new PrismaClient`, `drizzle(...)`, `new Sequelize`. Create a `CONNECTS_TO` EXTRACTED edge to the appropriate DatabaseNode.
+
+Imports — find `import` and `require` statements. Create `DEPENDS_ON` EXTRACTED edges for inter-service dependencies where the import path resolves to another service in the graph.
+
+**From Python:**
+`requests.get/post`, `httpx.get/post` → CALLS edges
+`psycopg2.connect`, `sqlalchemy.create_engine`, `motor.AsyncIOMotorClient` → CONNECTS_TO edges
+`import` statements → DEPENDS_ON edges
+
+**Verify:**
+- Are the tree-sitter queries for HTTP call detection tested against fixture files?
+- Does URL-literal matching work for `http://service-b:3001/query` style URLs? This is what the demo uses.
+- Does URL-literal matching fail gracefully for dynamic URLs like `` `http://${host}/path` ``? It must not crash — it should skip or create a FRONTIER edge.
+- Is database connection detection general (checking for multiple ORMs) or only `pg`?
+
+### 6. What must be extracted from config files — MVP
+
+**docker-compose.yml:**
+- Each `services` entry → `ServiceNode` or `InfraNode` depending on whether it is a first-party service or an image pull
+- `depends_on` → `DEPENDS_ON` EXTRACTED edge
+- Port mappings and environment variables → stored as node properties
+- Named volumes → `ConfigNode`
+
+**`.env` files:**
+- `DATABASE_URL` → parse the connection string, create `DatabaseNode` and `CONNECTS_TO` edge
+- `*_HOST`, `*_PORT` patterns → infer database or service targets
+
+**YAML ORM config:**
+- `drizzle.config.ts` — extract connection target
+- `prisma/schema.prisma` — extract datasource url
+- `ormconfig.json` — extract connection details
+- `knexfile.js` — extract connection details
+
+**Verify:**
+- Is docker-compose parsing present? It was listed as part of v0.1.2 β infra extraction.
+- Is `.env` DATABASE_URL parsing present?
+- Is there a `ConfigNode` being created for these files or are they only used to populate other node properties?
+- Are ORM config files parsed or only `package.json`?
+
+### 7. Compatibility matrix integration — MVP
+
+After extraction, every ServiceNode with a driver version must be checked against `compat.json`. Any incompatibility found at extraction time must be annotated on the ServiceNode as a property — not stored as a separate event, not written to errors.ndjson, not computed at traversal time.
+
+The annotation is: `compatibilityWarnings: Array<{ driver, engine, reason }>` on the ServiceNode.
+
+**Verify:**
+- Is `checkCompatibility` called from within the extraction pipeline after a driver version is extracted?
+- Is the result stored on the node or only computed at root cause traversal time?
+- If stored on the node, is it visible in `GET /graph/node/:id`?
+- Is the compat.json check general — does it handle mysql2/mysql and mongoose/mongodb entries in addition to pg/postgresql?
+
+### 8. Incremental extraction and watch mode — MVP
+
+From v0.1.2 δ, `neat watch` was added. Watch mode must re-extract only the changed file, not the entire codebase.
+
+**Verify:**
+- Is there a file watcher (chokidar or Node.js `fs.watch`) in the watch mode implementation?
+- When a file changes, does the extractor re-scan only that file and update only the affected nodes and edges?
+- Or does it re-scan the entire directory on every file change? If yes, this is acceptable for MVP but note it as a performance debt item.
+- When a file is re-scanned, are the old EXTRACTED edges from that file removed before new ones are written? Without this, deleted code paths will leave ghost edges in the graph.
+
+### 9. Ghost edge cleanup — MVP
+
+When a file is deleted or a dependency is removed from package.json, the EXTRACTED edges derived from it must be removed from the graph.
+
+**Verify:**
+- Is there a mechanism to identify which edges were derived from a specific file?
+- Are EXTRACTED edges tagged with their source file path so they can be cleaned up when that file changes or is deleted?
+- Is ghost edge cleanup implemented or is it a known gap?
+
+### 10. Idempotency — MVP
+
+Running extraction twice against the same unchanged codebase must produce the same graph. The documented behaviour from PROVENANCE.md is: `extractFromDirectory` is idempotent — same source, same nodes, same edge ids.
+
+**Verify:**
+- Are node IDs deterministically generated from the node's content — service name, file path — rather than from UUIDs or timestamps?
+- Are edge IDs deterministically generated from source node ID + target node ID + edge type?
+- If the same extraction runs twice, does the graph end up with duplicate nodes or duplicate edges?
+
+---
+
+## Red flags
+
+- `require('web-tree-sitter')` or `import ... from 'web-tree-sitter'` anywhere in packages/core — wrong binding, remove it
+- `pgDriverVersion` still being special-cased instead of going through the general driver extraction mechanism
+- Semver ranges stored with `^` or `~` prefix — these will break compatibility matrix checks
+- No depth limit on recursive service discovery
+- HTTP call detection only working for URL literals — dynamic URLs must fail gracefully, not crash
+- EXTRACTED edges not tagged with source file path — ghost edge cleanup is impossible without this
+- Re-scanning the entire codebase on every file change in watch mode — acceptable for MVP but must be noted as debt
+- `new tree_sitter.Parser()` instantiated once globally or instantiated fresh on every file — parser instantiation is expensive, it should be instantiated once per language grammar and reused
+
+---
+
+## Five questions — answer these before closing the audit
+
+1. Is driver version extraction general (multiple ORMs and drivers) or still special-cased to `pg`?
+2. Are semver range prefixes stripped from dependency versions before storage?
+3. When a file changes in watch mode, are ghost EXTRACTED edges from the previous scan removed?
+4. Are node and edge IDs deterministic so that re-extraction does not create duplicates?
+5. Is `checkCompatibility` called during extraction and the result stored on the node, or is compatibility only checked at traversal time?
+
+---
+
+*MVP only. web-tree-sitter WASM, LLM-assisted extraction, and additional language grammars beyond JS/TS/Python are v1.0.*

--- a/docs/audits/NEAT-audit-types(1).md
+++ b/docs/audits/NEAT-audit-types(1).md
@@ -1,0 +1,367 @@
+# NEAT Types Package Audit — MVP (TypeScript v0.1.x)
+## Load this before touching @neat/types or any code that imports from it.
+
+**Scope:** This audit covers `packages/types` in the TypeScript MVP monorepo at `github.com/NEAT-Technologies/Neat`. It covers Zod schemas, TypeScript type exports, shared constants, and whether the package is actually used by the other packages or shadowed by local ad-hoc definitions.
+
+**Stack:** Zod for runtime validation and TypeScript type inference. No runtime dependencies on other `@neat/*` packages — types is the root of the dependency tree.
+
+**The goal this audit serves:** `@neat/types` is the contract between all packages. If it drifts — if `packages/core` defines its own local GraphEdge type, if `packages/mcp` has its own ad-hoc ErrorEvent schema, if the Zod schemas do not match what the code actually produces — the entire system breaks silently. Type errors at compile time. Wrong data at runtime. Mismatched responses between tools and the graph.
+
+**What is not in scope:**
+- NeatScript type system — v1.0 only
+- Rust type definitions — v1.0 only
+- Any type that is not currently used in the MVP codebase
+
+---
+
+## What @neat/types must be — MVP
+
+A single source of truth. Every schema, every type, every shared constant that crosses a package boundary must live here and only here. If a type is defined in more than one place in the monorepo, that is a critical gap.
+
+The package has no runtime logic. It exports Zod schemas, their inferred TypeScript types, and const objects for provenance and edge type values. Nothing else.
+
+---
+
+## The contract
+
+### 1. Package structure — MVP
+
+```
+packages/types/
+  src/
+    nodes.ts       — ServiceNode, DatabaseNode, ConfigNode, InfraNode schemas
+    edges.ts       — GraphEdge schema, EdgeType const
+    provenance.ts  — Provenance schema, Provenance const
+    events.ts      — ErrorEvent, PolicyViolationEvent schemas
+    traversal.ts   — RootCauseResult, BlastRadiusResult schemas
+    policy.ts      — Policy, PolicyFile schemas
+    index.ts       — re-exports everything
+  package.json
+  tsconfig.json
+```
+
+**Verify:**
+- Does this structure exist or is everything in one flat file?
+- Is `index.ts` a clean re-export of all schemas and types?
+- Does the package build cleanly with `pnpm --filter @neat/types build`?
+- Is the package listed as a workspace dependency in `packages/core/package.json`, `packages/mcp/package.json`, and `packages/web/package.json`?
+
+### 2. Provenance — MVP
+
+The provenance system is the most critical shared type. It must be defined exactly once.
+
+```typescript
+export const Provenance = {
+  EXTRACTED: 'EXTRACTED',
+  INFERRED:  'INFERRED',
+  OBSERVED:  'OBSERVED',
+  STALE:     'STALE',
+  FRONTIER:  'FRONTIER',
+} as const
+
+export type Provenance = typeof Provenance[keyof typeof Provenance]
+
+export const ProvenanceSchema = z.enum([
+  'EXTRACTED',
+  'INFERRED',
+  'OBSERVED',
+  'STALE',
+  'FRONTIER',
+])
+```
+
+**Verify:**
+- Is `Provenance` defined as a const object (for value access at runtime) AND as a Zod enum (for schema validation)?
+- Is `Provenance.OBSERVED` used throughout the codebase or is the raw string `'OBSERVED'` used? Grep for `'OBSERVED'`, `'EXTRACTED'`, `'INFERRED'`, `'STALE'`, `'FRONTIER'` as raw strings in packages/core and packages/mcp. Any occurrence outside of the types package itself is a gap.
+- Is FRONTIER present? It was added in v0.1.2 γ. Verify it is in the enum.
+
+### 3. EdgeType — MVP
+
+```typescript
+export const EdgeType = {
+  CALLS:         'CALLS',
+  DEPENDS_ON:    'DEPENDS_ON',
+  CONNECTS_TO:   'CONNECTS_TO',
+  CONFIGURED_BY: 'CONFIGURED_BY',
+} as const
+
+export type EdgeType = typeof EdgeType[keyof typeof EdgeType]
+
+export const EdgeTypeSchema = z.enum([
+  'CALLS',
+  'DEPENDS_ON',
+  'CONNECTS_TO',
+  'CONFIGURED_BY',
+])
+```
+
+**Verify:**
+- Is EdgeType defined as both a const object and a Zod enum?
+- Are raw edge type strings used anywhere outside the types package? Grep for `'CALLS'`, `'DEPENDS_ON'`, `'CONNECTS_TO'`, `'CONFIGURED_BY'` in packages/core and packages/mcp.
+- Are there any edge types in the codebase not in this enum?
+
+### 4. Node schemas — MVP
+
+Each node schema must have a discriminated `type` field that uniquely identifies the node type.
+
+**ServiceNode:**
+```typescript
+export const ServiceNodeSchema = z.object({
+  id:                   z.string(),
+  type:                 z.literal('ServiceNode'),
+  name:                 z.string(),
+  language:             z.string(),
+  version:              z.string().optional(),
+  framework:            z.string().optional(),
+  repoPath:             z.string().optional(),
+  dbConnectionTarget:   z.string().optional(),
+  drivers:              z.record(z.string()).optional(), // { pg: '7.4.0', mysql2: '2.1.0' }
+  compatibilityWarnings: z.array(z.object({
+    driver:  z.string(),
+    engine:  z.string(),
+    reason:  z.string(),
+  })).optional(),
+  owner:                z.string().optional(),
+})
+```
+
+Note: `pgDriverVersion` must NOT be in this schema. It was deprecated and should have been replaced by the general `drivers` map. If it is still present, this is technical debt that will produce incorrect compatibility checks for non-pg drivers.
+
+**DatabaseNode:**
+```typescript
+export const DatabaseNodeSchema = z.object({
+  id:                z.string(),
+  type:              z.literal('DatabaseNode'),
+  name:              z.string(),
+  engine:            z.string(),       // 'postgresql', 'mysql', 'mongodb', 'redis'
+  engineVersion:     z.string().optional(),
+  compatibleDrivers: z.array(z.object({
+    name:           z.string(),
+    minVersion:     z.string(),
+  })),
+})
+```
+
+**ConfigNode:**
+```typescript
+export const ConfigNodeSchema = z.object({
+  id:       z.string(),
+  type:     z.literal('ConfigNode'),
+  name:     z.string(),
+  path:     z.string(),
+  fileType: z.string(),
+})
+```
+
+**InfraNode:**
+```typescript
+export const InfraNodeSchema = z.object({
+  id:       z.string(),
+  type:     z.literal('InfraNode'),
+  name:     z.string(),
+  provider: z.string().optional(),
+  region:   z.string().optional(),
+})
+```
+
+**Verify:**
+- Is `pgDriverVersion` absent from ServiceNodeSchema? If present, this is debt.
+- Is `drivers` a general map rather than named driver fields?
+- Is `framework` present on ServiceNode? Required for FastAPI detection.
+- Is `owner` present on ServiceNode? Required for ownership policies.
+- Is `compatibilityWarnings` present? Required for pre-computing compat checks at extraction time.
+- Does each node schema use `z.literal()` for the `type` field enabling discriminated union?
+- Is there a `GraphNodeSchema` union of all four node types?
+
+### 5. GraphEdge schema — MVP
+
+```typescript
+export const GraphEdgeSchema = z.object({
+  id:            z.string(),
+  source:        z.string(),      // node id
+  target:        z.string(),      // node id
+  type:          EdgeTypeSchema,
+  provenance:    ProvenanceSchema,
+  confidence:    z.number().min(0).max(1).optional(),  // INFERRED only
+  lastObserved:  z.string().datetime().optional(),     // OBSERVED only
+  callCount:     z.number().int().min(0).optional(),   // OBSERVED only
+  sourceFile:    z.string().optional(),                // EXTRACTED only — for ghost edge cleanup
+})
+```
+
+**Verify:**
+- Is `confidence` optional and constrained to 0.0-1.0?
+- Is `lastObserved` an ISO8601 datetime string — not a Unix timestamp?
+- Is `callCount` an integer — not a float?
+- Is `sourceFile` present? Required for ghost edge cleanup when files change.
+- Are `confidence`, `lastObserved`, and `callCount` all optional — they only apply to specific provenance values?
+- Is there any field on GraphEdge that is not in this schema?
+
+### 6. ErrorEvent schema — MVP
+
+```typescript
+export const ErrorEventSchema = z.object({
+  id:            z.string().uuid(),
+  timestamp:     z.string().datetime(),
+  service:       z.string(),
+  traceId:       z.string(),
+  spanId:        z.string(),
+  errorType:     z.string().optional(),
+  errorMessage:  z.string(),
+  affectedEdge:  z.string().optional(),
+  affectedNode:  z.string(),
+})
+```
+
+**Verify:**
+- Is this schema in `@neat/types` and not redefined locally in packages/core?
+- Is `id` validated as a UUID?
+- Is `timestamp` validated as an ISO8601 datetime?
+- Is the schema used when writing to `errors.ndjson`? Is it used when reading incidents via the REST API?
+
+### 7. PolicyViolationEvent schema — MVP
+
+This schema does not exist in v0.1.2 — it must be added when the policy layer is built. Including it here so it is defined before the policy layer agent starts building.
+
+```typescript
+export const PolicyViolationEventSchema = z.object({
+  id:                  z.string().uuid(),
+  timestamp:           z.string().datetime(),
+  policyId:            z.string(),
+  policyDescription:   z.string(),
+  severity:            z.enum(['critical', 'warning', 'info']),
+  violatingNodes:      z.array(z.string()),
+  reason:              z.string(),
+  onViolation:         z.enum(['alert', 'block', 'log']),
+  resolved:            z.boolean(),
+})
+```
+
+**Verify:**
+- Does this schema exist? If not, add it before building the policy layer.
+- Is it exported from `packages/types/src/index.ts`?
+- Is it distinct from ErrorEvent — a policy violation is not the same as a runtime error?
+
+### 8. Traversal result schemas — MVP
+
+```typescript
+export const RootCauseResultSchema = z.object({
+  rootCauseNode:    z.string(),
+  rootCauseReason:  z.string(),
+  traversalPath:    z.array(z.string()),
+  edgeProvenances:  z.array(ProvenanceSchema),
+  confidence:       z.number().min(0).max(1),
+})
+
+export const BlastRadiusResultSchema = z.object({
+  origin:        z.string(),
+  affectedNodes: z.array(z.object({
+    node:       z.string(),
+    distance:   z.number().int().min(1),
+    path:       z.array(z.string()),
+    confidence: z.number().min(0).max(1),
+  })),
+  totalAffected: z.number().int().min(0),
+})
+```
+
+**Verify:**
+- Are these schemas in `@neat/types` and not defined locally in packages/core/traverse.ts?
+- Is `edgeProvenances` an array matching the length of `traversalPath`? Each edge in the path has a provenance.
+- Is `confidence` on the root cause result a cascade of the individual edge confidences — not just the final edge's confidence?
+- Is `distance` an integer starting from 1 — not 0?
+
+### 9. Policy schemas — MVP
+
+```typescript
+export const PolicyRuleSchema = z.object({
+  targetNode:          z.string().optional(),
+  targetType:          z.string().optional(),
+  allowedSources:      z.array(z.string()).optional(),
+  constraint:          z.string().optional(),
+  forbiddenProvenance: z.string().optional(),
+  requiredProvenance:  z.string().optional(),
+  inBlastRadiusOf:     z.string().optional(),
+  pathTo:              z.string().optional(),
+  nodeType:            z.string().optional(),
+  requiredProperty:    z.string().optional(),
+  maxBlastRadius:      z.number().int().min(1).optional(),
+  driver:              z.string().optional(),
+  engine:              z.string().optional(),
+  minDriverVersion:    z.string().optional(),
+})
+
+export const PolicySchema = z.object({
+  id:          z.string(),
+  description: z.string(),
+  enabled:     z.boolean(),
+  severity:    z.enum(['critical', 'warning', 'info']),
+  type:        z.enum(['structural', 'compatibility', 'provenance', 'ownership', 'blast_radius']),
+  rule:        PolicyRuleSchema,
+  onViolation: z.enum(['alert', 'block', 'log']),
+})
+
+export const PolicyFileSchema = z.object({
+  version:  z.literal(1),
+  policies: z.array(PolicySchema),
+})
+```
+
+**Verify:**
+- Do these schemas exist? They must be added before the policy layer is built.
+- Is `PolicyFileSchema` used to validate `policy.json` on startup?
+- Is `version: z.literal(1)` present so future schema changes can be detected?
+
+### 10. Import audit — the most revealing check
+
+The purpose of `@neat/types` is that nothing else defines these types. If any package defines its own version of a type that should be in `@neat/types`, the contract is broken.
+
+**Run these checks:**
+
+Grep for local type or interface definitions in packages/core and packages/mcp:
+
+```bash
+grep -r "interface ServiceNode" packages/core packages/mcp
+grep -r "interface DatabaseNode" packages/core packages/mcp
+grep -r "interface GraphEdge" packages/core packages/mcp
+grep -r "interface ErrorEvent" packages/core packages/mcp
+grep -r "type Provenance" packages/core packages/mcp
+grep -r "z.object" packages/core/src packages/mcp/src
+```
+
+Any `z.object` call in packages/core or packages/mcp that defines a type that should be in `@neat/types` is a gap. The only `z.object` calls permitted in packages/core and packages/mcp are for request/response validation that is specific to that package and not shared.
+
+**Verify:**
+- Are there any locally defined schemas in packages/core or packages/mcp that duplicate types from `@neat/types`?
+- Does every import of a shared type come from `@neat/types` — not from a relative path within the same package?
+
+---
+
+## Red flags
+
+- `pgDriverVersion` still present on ServiceNodeSchema
+- Raw provenance strings (`'OBSERVED'`, `'EXTRACTED'`) used outside packages/types
+- Raw edge type strings (`'CALLS'`, `'CONNECTS_TO'`) used outside packages/types
+- Local type definitions in packages/core or packages/mcp that duplicate @neat/types schemas
+- `z.object` calls in packages/core or packages/mcp defining types that cross package boundaries
+- `ErrorEventSchema` defined locally in packages/core instead of imported from @neat/types
+- `PolicyViolationEventSchema` missing — must exist before policy layer is built
+- `lastObserved` typed as a number (Unix timestamp) instead of ISO8601 string
+- `confidence` typed as an integer instead of a float between 0.0 and 1.0
+- `sourceFile` missing from GraphEdgeSchema — ghost edge cleanup is impossible without it
+- `framework` missing from ServiceNodeSchema — FastAPI detection is impossible without it
+- `drivers` map missing — general driver version tracking requires it
+
+---
+
+## Five questions — answer these before closing the audit
+
+1. Is `pgDriverVersion` absent from ServiceNodeSchema and replaced by a general `drivers` map?
+2. Are raw provenance and edge type strings used anywhere outside packages/types?
+3. Does PolicyViolationEventSchema exist in @neat/types?
+4. Is `sourceFile` present on GraphEdgeSchema for ghost edge cleanup?
+5. Does every shared type import come from `@neat/types` — with no local duplicates in other packages?
+
+---
+
+*MVP only. NeatScript type system and Rust type definitions are v1.0.*

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -12,37 +12,61 @@ Source of truth for sprint status. Update this file at the end of every session.
 
 ## 🚩 Pick up here
 
-**Last session ended:** 2026-05-03. **v0.1.2 is shipped and tagged.** All four δ PRs merged (#102/#103/#104/#105). The release lives at https://github.com/NEAT-Technologies/Neat/releases/tag/v0.1.2. Workspace at HEAD is green: `npx turbo build test lint` clean, **214 core / 30 types / 35 mcp** tests passing. The v0.1.2 milestone is closed; issues #67–#83 stay attached for the historical record (per ADR-005 the user closes individual issues by hand).
+**Last session ended:** 2026-05-04 evening. **v0.1.2 + v0.1.3 shipped.** Workspace at HEAD is green: `npx turbo build test lint` clean, **214 core / 30 types / 35 mcp** tests passing.
 
-A generic `Dockerfile` lives at the repo root (separate from `packages/core/Dockerfile`, which still bakes in the demo). Mount your codebase at `/workspace`, point a volume at `/neat-out`, and the image runs the REST + OTLP daemon by default. CMD overrides: `neat init /workspace --project <name>` for a one-shot snapshot, `neat watch /workspace` for the live re-extraction daemon, `neat-mcp` for the stdio MCP binary.
+**Two parallel tracks share `main`:**
 
-**Next release is v0.2.0 — Frontend.** `packages/web/` was a shell through v0.1.2 (ADR-004); v0.2.0 fills it in. Open issues under that milestone:
+- **Track 1 — v0.3.0 Frontend (Jed).** Renumbered from old v0.2.0 on 2026-05-04. Builds against the stable v0.1.2 API. Issues #28-#31 + #106-#108. Doesn't gate the MVP success criterion; this track delivers investor-legibility.
+- **Track 2 — v0.2.x Engineering (Cem + Kurt).** Three releases:
+  - **v0.2.0 — Sunrise** — audit-driven cleanup. Seven audits (`docs/audits/`) define the contract NEAT v0.1.x grew toward organically; v0.2.0 closes the gap.
+  - **v0.2.1 — Policies.** Renumbered from old v0.3.0. Closes the four-feature gap (OTel + graph + MCP + policies). Issues #115-#118 + #123 follow-on.
+  - **v0.2.2 — `neat init` + Claude Code skill.** Renumbered from old v0.3.1. Distribution layer for the MVP-success PR experiment. Issue #119.
 
-- **#28 — Implement graph explorer with Cytoscape.js**
-- **#29 — Implement node inspector panel**
-- **#30 — Implement incident log page**
-- **#31 — Apply NEAT branding**
-- **#106 — Multi-project switcher in the web UI** (reads `GET /projects`, persists selection, threads through every API call)
-- **#107 — `semantic_search` bar — natural-language node lookup** (hits `/search`, surfaces provider + score, click-through to inspector)
-- **#108 — Live graph updates via SSE / WebSocket from `neat watch`** (server emits a "graph_changed" event after each `runExtractPhases` flush; UI hot-refetches)
+Engineering ships first; that order is what the user named when they renumbered. The two tracks are still independent — v0.2.x and v0.3.0 don't depend on each other — but the engineering numbering communicates priority.
 
-Suggested order: #31 (branding) → #28 (graph explorer) → #29 (inspector) → #106 (project switcher) → #107 (search bar) → #30 (incident log) → #108 (live updates). Branding first because it shapes the rest of the visual decisions; live updates last because it depends on a stable explorer to render the deltas into.
+### Tomorrow's work — start here
 
-### M6 manual verification — STILL DEFERRED
+**Issue [#126](https://github.com/NEAT-Technologies/Neat/issues/126)** — v0.2.0-α audit verification pass. The first concrete deliverable for Sunrise.
 
-The two unchecked Railway gates remain unchecked. They were rescheduled to post-δ in PR #87 and the user has indicated AWS deployment is the more likely production target. Treat them as informational rather than blocking.
+The seven audits in `docs/audits/` are interlocking contracts NEAT v0.1.x must redeem itself against. The verification pass produces one document — `docs/audits/verification.md` — grading every `Verify:` checkbox (~150 of them) against the codebase at HEAD with file-and-line citations. **Findings only — no code changes, no issue creation in the same pass.** After the verification doc lands, the user reads it, sorts findings into three piles (open as new v0.2.0 issues / amend existing / defer), and the issue/amendment work happens in a follow-up.
 
-### Gotchas a fresh v0.2.0 session will benefit from
+Branch: `v0.2.0-audit-verification`. Open as draft PR for inline review of findings.
 
-- **`packages/web/` is a Next.js shell.** It exists but does nothing useful — every page is a placeholder. The v0.2.0 work is greenfield UI on top of a stable, tested core API.
-- **Core API is project-aware everywhere.** Routes mount at both `/X` (default project) and `/projects/:project/X`. The web client should use the prefixed shape from day one — see ADR-026 and `packages/mcp/src/tools.ts` for the routing pattern.
-- **Snapshot schema is at v2.** Frontend doesn't touch it; everything goes through HTTP. If you find yourself reading `neat-out/graph.json` directly from the web layer, stop and use `/graph` instead — it'll keep working through future schema migrations.
-- **NodeType has 5 values** (ServiceNode, DatabaseNode, ConfigNode, InfraNode, FrontierNode). EdgeType has 7 (CALLS, CONNECTS_TO, DEPENDS_ON, CONFIGURED_BY, RUNS_ON, PUBLISHES_TO, CONSUMES_FROM). The graph explorer needs styling rules for each.
-- **Provenance has four states** (OBSERVED, INFERRED, EXTRACTED, STALE) plus FRONTIER for placeholder edges. Confidence is per-edge with a `signal: { spanCount, errorCount, lastObservedAgeMs }` shape from γ #76. The inspector should surface signal numbers verbatim, not just confidence — see `packages/mcp/src/tools.ts` for how the MCP tools format these.
-- **Real-time updates need a new transport on core.** Currently the only push is MCP `notifications/resources/updated` for the incidents resource (5s poll). Issue #108 will add an SSE or WebSocket route on neat-core; web consumes it.
-- **Branching convention unchanged.** One issue → one branch `<num>-<slug>` → one PR (`Refs #N`, not `Closes #N`). Plain-English commits, no `Co-Authored-By: Claude`. Branch off the latest `main`.
-- **No emojis in commits / code / docs unless explicitly requested.** Memory has this; easy to forget under autopilot.
-- **Force-push needs explicit user approval.** Same as v0.1.2 — the harness blocks `git push --force-with-lease` unless authorised.
+**The audits in dependency order** (verify in this order, downstream audits reference upstream findings):
+1. types — `docs/audits/NEAT-audit-types(1).md`
+2. graph — `docs/audits/NEAT-audit-graph.md`
+3. tree-sitter — `docs/audits/NEAT-audit-treesitter.md`
+4. OTel — `docs/audits/NEAT-audit-otel.md`
+5. traversal — `docs/audits/NEAT-audit-traversal.md`
+6. policies (prospective — feature not built) — `docs/audits/NEAT-audit-policies.md`
+7. MCP — `docs/audits/NEAT-audit-mcp.md`
+8. init (prospective — feature not built) — `docs/audits/NEAT-audit-init.md`
+
+Two of the eight (policies, init) are prospective ADRs against unbuilt features — verification translates their `Verify:` checkboxes into spec amendments for issues #115-#119, not code citations. Track those separately in the verification doc.
+
+### Closing gate — the MVP-success PR
+
+After v0.2.x lands: point NEAT at an open-source codebase, identify a real divergence-shaped bug (OBSERVED layer must be load-bearing), propose a fix, get the PR merged. ADR-027 is the framing. Static-only finds (FastAPI #12901-shaped) don't earn NEAT its category — a Graphify fork could match them.
+
+The Railway gates from M6 are still informational. AWS is the more likely production target.
+
+### Gotchas a fresh agent will benefit from
+
+- **The audits are scope-disciplined.** Every audit has an explicit `[v1.0]` not-in-scope list (NeatScript, Memgraph, Salsa, OPA/Rego, eBPF, Firecracker, Qdrant). Don't drift toward those — they belong to the Rust v1.0, not the TypeScript MVP.
+- **The provenance contract is load-bearing.** Five values (`OBSERVED` / `INFERRED` / `EXTRACTED` / `STALE` / `FRONTIER`), one definition in `@neat/types`, propagated everywhere, never duplicated as raw strings. Three audits independently flag this as "the most important contract in the MVP."
+- **Hardcoded demo names is the recurring red flag.** Four audits explicitly check for `service-a` / `service-b` / `payments-db` references in non-fixture code. Any hit is critical-severity — the MVP success criterion (real PR on unfamiliar codebase) requires these be absent.
+- **`packages/web/` already has a basic Cytoscape viewer (v0.1.3).** Track 1 (v0.3.0) builds on it incrementally over `packages/web/app/components/GraphView.tsx`.
+- **Core API is project-aware everywhere.** Routes mount at both `/X` (default project) and `/projects/:project/X`. New work uses the prefixed shape from day one — see ADR-026 and `packages/mcp/src/tools.ts`.
+- **NodeType has 5 values** (ServiceNode, DatabaseNode, ConfigNode, InfraNode, FrontierNode). EdgeType has 7 (CALLS, CONNECTS_TO, DEPENDS_ON, CONFIGURED_BY, RUNS_ON, PUBLISHES_TO, CONSUMES_FROM).
+- **Provenance has four states** plus FRONTIER for placeholder edges. Confidence is per-edge with `signal: { spanCount, errorCount, lastObservedAgeMs }` from γ #76.
+- **Real-time updates** are still TODO. Currently the only push is MCP `notifications/resources/updated` for incidents (5s poll). #108 will add SSE/WebSocket on neat-core; v0.2.1 policies can subscribe to the same channel.
+- **Branching convention unchanged.** One issue → one branch `<num>-<slug>` → one PR (`Refs #N`, not `Closes #N`). Plain-English commits, no `Co-Authored-By: Claude`. Branch off latest `main`.
+- **No emojis in commits / code / docs unless explicitly requested.**
+- **Force-push needs explicit user approval.** Harness blocks `git push --force-with-lease` unless authorised.
+
+### Open PRs awaiting merge
+
+- **#125** — ADR-027 + parallel-tracks reframe of CLAUDE.md and milestones.md. Note: this PR's body still references the old milestone numbering (v0.2.0 = Frontend, v0.3.0 = Policies). The renumbering happened after #125 was opened. The PR's content is still correct in shape; the reviewer should treat the milestone numbers as having shifted by one bucket.
 
 ---
 


### PR DESCRIPTION
Prep for tomorrow. Milestones renumbered, audits committed, tracker filed. No code change.

## Why this is in tree

The seven audits + one prospective ADR (init) define the contract NEAT v0.1.x grew toward organically. v0.2.0 Sunrise — the new milestone — closes the gap between contract and reality.

## What's in this PR

- **8 audits** under `docs/audits/`. Read order: types → graph → tree-sitter → OTel → traversal → policies → MCP → init. Two of them (policies, init) are prospective ADRs against unbuilt features; the other six grade the existing surface.
- **`docs/milestones.md`** "Pick up here" rewritten for the new state — parallel tracks, audit-driven Sunrise, the eight audits in dependency order, the closing gate (MVP-success PR per ADR-027).

## Milestones renumbered (GitHub side, already done)

| Old | New | Theme |
|---|---|---|
| v0.2.0 | v0.3.0 | Frontend (Jed) |
| v0.3.0 | v0.2.1 | Policies |
| v0.3.1 | v0.2.2 | `neat init` + Claude skill |
| — | **v0.2.0** | **Sunrise** — audit-driven cleanup |

Engineering ships first as v0.2.x. Frontend lands at v0.3.0. Tracks remain independent.

## Tomorrow's tracker

[Issue #126](https://github.com/NEAT-Technologies/Neat/issues/126) — v0.2.0-α audit verification pass. The first concrete deliverable for Sunrise. Branch `v0.2.0-audit-verification` off main; output one document at `docs/audits/verification.md` grading every `Verify:` checkbox with file-and-line citations. **Findings only — no code changes, no issue creation in the same pass.**

## Test plan

- [x] `npx turbo lint` clean (docs-only)
- [x] No conflict markers in any of the touched files
- [x] All eight audit files render cleanly on GitHub
