### PR TITLE
Sync audit text to shipped ADRs (AUDIT-DRIFT resolution)

### DIFF
--- a/docs/audits/NEAT-audit-graph.md
+++ b/docs/audits/NEAT-audit-graph.md
@@ -44,6 +44,7 @@ The MVP graph must support these node types:
 - `DatabaseNode` — a database. Has: name, engine, engineVersion, compatibleDrivers
 - `ConfigNode` — a config file. Has: name, path, fileType
 - `InfraNode` — infrastructure node derived from docker-compose, k8s, Terraform
+- `FrontierNode` — unresolved span peer (host:port not yet matched to a known node). Promoted to a typed node once an alias matches. See ADR-023.
 
 `[v1.0]` UserNode, PolicyNode, AgentNode are not MVP scope.
 
@@ -58,6 +59,8 @@ The MVP graph must support these node types:
 - `DEPENDS_ON` — static import or package dependency
 - `CONNECTS_TO` — service connects to a database
 - `CONFIGURED_BY` — service reads from a config node
+- `RUNS_ON` — service runs on infra (compose, k8s, Terraform)
+- `PUBLISHES_TO` / `CONSUMES_FROM` — service ↔ message broker (Kafka/Redis/etc.)
 
 **Verify:**
 - Is edge type validated on insertion?
@@ -92,15 +95,16 @@ EXTRACTED | INFERRED | OBSERVED | STALE | FRONTIER
 
 ### 5. Staleness — MVP
 
-OBSERVED edges decay to STALE when not seen within 24 hours. This must be a background process, not a read-time computation.
+OBSERVED edges decay to STALE when not seen within a configured threshold. This must be a background process, not a read-time computation.
 
-`[v1.0]` Per-edge-type staleness thresholds are v1.0 even if mentioned in release notes.
+**Per-edge-type thresholds (ratified in ADR-024):** different edge types decay at different rates. Defaults: CALLS = 1h, CONNECTS_TO = 4h, DEPENDS_ON / CONFIGURED_BY / RUNS_ON = 24h. Overridable via `NEAT_STALE_THRESHOLDS` env. Transitions are appended to `stale-events.ndjson`.
 
 **Verify:**
 - Is there a `setInterval` or equivalent background job that transitions OBSERVED → STALE?
 - Or is staleness computed at read time in the REST API or MCP tools? If yes, this is a gap.
 - When an edge transitions to STALE, is `lastObserved` preserved?
-- Is the 24-hour threshold hardcoded or configurable?
+- Are per-edge-type thresholds enforced (CALLS=1h, CONNECTS_TO=4h, others=24h) and overridable via env?
+- Is each transition appended to `stale-events.ndjson`?
 
 ### 6. Persistence — MVP
 
@@ -113,12 +117,14 @@ OBSERVED edges decay to STALE when not seen within 24 hours. This must be a back
 
 ### 7. Edge upsert semantics — MVP
 
-One edge between any pair of nodes with one edge type. When OTel confirms a relationship already in the graph as EXTRACTED, upgrade the edge — do not duplicate it.
+OBSERVED and EXTRACTED edges **coexist** between the same node pair under distinct edge ids. This is intentional (see `packages/core/src/ingest.ts:15-17`): the OBSERVED layer must remain visible alongside the EXTRACTED layer so divergence between declared intent and observed reality stays load-bearing — it is the gap ADR-027 names as NEAT's value. Upsert is per-(source, target, type, provenance) tuple, not per-(source, target, type).
+
+Edge id pattern: EXTRACTED edges use `${type}:${source}->${target}`; OBSERVED edges use `${type}:OBSERVED:${source}->${target}`; INFERRED and FRONTIER follow the same pattern with their own provenance prefix. Traversal selects the highest-priority edge per pair via `PROV_RANK` (OBSERVED > INFERRED > EXTRACTED > STALE/FRONTIER).
 
 **Verify:**
-- Is there an upsert function in `ingest.ts` that checks for an existing edge before creating?
-- If EXTRACTED exists and OTel confirms the same relationship, does the code upgrade to OBSERVED or create a duplicate?
-- What is the traversal priority rule when multiple edges exist? OBSERVED must beat EXTRACTED must beat INFERRED.
+- Is there an upsert function in `ingest.ts` that checks for an existing edge of the same provenance before creating?
+- Do OBSERVED and EXTRACTED edges coexist with distinct ids when both apply to the same node pair?
+- What is the traversal priority rule when multiple edges exist? OBSERVED must beat INFERRED must beat EXTRACTED must beat STALE.
 
 ### 8. Multi-project scoping — MVP
 
@@ -146,6 +152,7 @@ One edge between any pair of nodes with one edge type. When OTel confirms a rela
 - Staleness computed in the REST API handler rather than as a background transition
 - Two edges between the same pair of nodes with the same edge type
 - `pgDriverVersion` still special-cased in traversal or root cause logic
+- A second OBSERVED-layer edge written under the EXTRACTED id (clobbering the static layer) — OBSERVED must use its own id pattern
 
 ---
 
@@ -154,7 +161,7 @@ One edge between any pair of nodes with one edge type. When OTel confirms a rela
 1. Is `new DirectedGraph()` called only once per project scope?
 2. Does `GET /graph` read from the live graphology instance or from graph.json?
 3. Is staleness a background transition or a read-time computation?
-4. When an EXTRACTED edge is later confirmed by OTel, does the code upgrade or duplicate?
+4. When an EXTRACTED edge is later confirmed by OTel, does the OBSERVED edge land under its own distinct id pattern (`${type}:OBSERVED:src->tgt`) so both layers remain visible?
 5. Does every INFERRED edge have a `confidence` field between 0.0 and 1.0?
 
 ---

--- a/docs/audits/NEAT-audit-mcp.md
+++ b/docs/audits/NEAT-audit-mcp.md
@@ -210,7 +210,7 @@ Calls: `GET ${NEAT_CORE_URL}/incidents/{node}?limit={limit}`
 
 ### 9. semantic_search — MVP
 
-MVP implementation: keyword search over node names, node properties, and error messages. Not vector search — that is v1.0.
+MVP implementation per ADR-025: a tiered embedder chain — Ollama (`nomic-embed-text`, 768d) → Transformers.js (`all-MiniLM-L6-v2`, 384d) → substring fallback. Flat in-memory cosine search; sidecar `embeddings.json` cache so a cold start does not re-embed every node. Vector search **is** part of the MVP — pivoted from the original keyword-only stub once the local embedder chain proved cheap enough.
 
 Input schema:
 ```typescript
@@ -222,10 +222,11 @@ Input schema:
 Calls: `GET ${NEAT_CORE_URL}/search?q={query}`
 
 **Verify:**
-- Is the tool documented in CLAUDE.md as keyword search, not semantic vector search?
+- Does the tool description note the embedder chain and graceful degradation to substring fallback?
 - Does it search across node names, node properties (including driver versions), and error messages?
-- Does it return results with enough context for Claude Code to understand why each result matched?
-- Is the v1.0 vector search upgrade noted in a comment so it is not accidentally implemented now?
+- Does it return results with enough context for Claude Code to understand why each result matched (id, type, name, score)?
+- Does the substring fallback engage cleanly when no embedder is available?
+- Is the sidecar `embeddings.json` cache used so cold start is fast?
 
 ### 10. get_policy_violations — MVP
 
@@ -318,7 +319,7 @@ The complete tool surface for the MVP is:
 | get_dependencies | Shipped |
 | get_observed_dependencies | Shipped |
 | get_incident_history | Shipped |
-| semantic_search | Shipped (keyword stub) |
+| semantic_search | Shipped (Ollama → MiniLM → substring chain per ADR-025) |
 | get_policy_violations | Not yet — needs policy layer |
 | evaluate_policy | Not yet — needs policy layer |
 
@@ -351,7 +352,7 @@ Every tool must work on any codebase NEAT has modelled. Not just the demo.
 - CLAUDE.md missing or not instructing Claude Code to use NEAT tools proactively
 - Tool responses that return empty strings or null when no data is found — must return a clear message
 - Tools that throw unhandled errors when neat-core is unreachable — must return a graceful error message
-- semantic_search implemented as vector search in the MVP — it must be keyword search only
+- semantic_search regressed to substring-only when Ollama and MiniLM are both reachable — the embedder chain must engage when available (per ADR-025)
 
 ---
 

--- a/docs/audits/NEAT-audit-otel.md
+++ b/docs/audits/NEAT-audit-otel.md
@@ -137,23 +137,26 @@ Stitcher rules — non-negotiable:
 
 ### 8. OBSERVED edge upsert — MVP
 
-When an OTel span confirms a relationship already in the graph, upgrade the edge — do not duplicate it.
+When an OTel span confirms a relationship already in the graph, an OBSERVED edge is written **alongside** the EXTRACTED edge under a distinct id pattern, not in place of it. The two layers coexist so the gap between declared intent and observed reality stays visible (see `packages/core/src/ingest.ts:15-17` and graph audit §7). Traversal selects the highest-priority edge per pair via `PROV_RANK`.
 
-Update rules:
-- `lastObserved` → set to the span's timestamp
-- `callCount` → increment by 1
-- `provenance` → upgrade from EXTRACTED or INFERRED to OBSERVED if currently lower trust
-- `confidence` → remove from the edge (not applicable to OBSERVED)
+Edge id pattern for OBSERVED: `${type}:OBSERVED:${source}->${target}`.
+
+Update rules for the OBSERVED edge:
+- `lastObserved` → set to the span's timestamp (ISO8601 from `startTimeUnixNano`)
+- `callCount` → increment by 1 on each span
+- `provenance` → `OBSERVED`
+- `confidence` → `1.0` (OBSERVED is direct measurement; the constant is a max-trust marker, not a guess)
 
 **Verify:**
-- Is there an upsert function that finds an existing edge before creating a new one?
-- Is `callCount` incremented or reset on each span?
-- Is `provenance` upgraded when OTel confirms a relationship previously only known via EXTRACTED or INFERRED?
+- Is there an upsert function that finds an existing OBSERVED edge by its distinct id before creating a new one?
+- Does the OBSERVED edge live under its own id pattern (`${type}:OBSERVED:src->tgt`), not under the EXTRACTED id?
+- Is `callCount` incremented (not reset) on each span?
+- Is `confidence: 1.0` set on OBSERVED edges?
 - Is the upsert logic general — does it work for any service pair — or is it coupled to the demo service names?
 
 ### 9. Staleness transition — MVP
 
-OBSERVED edges must become STALE when `lastObserved` exceeds 24 hours. Background process, not read-time computation.
+OBSERVED edges must become STALE when `lastObserved` exceeds the per-edge-type threshold (CALLS=1h, CONNECTS_TO=4h, others=24h per ADR-024; overridable via `NEAT_STALE_THRESHOLDS`). Background process, not read-time computation.
 
 **Verify:**
 - Is `lastObserved` stored as ISO8601 from the span's `startTimeUnixNano`, not from `Date.now()`?

--- a/docs/audits/verification.md
+++ b/docs/audits/verification.md
@@ -687,4 +687,18 @@ A short list of items most likely to deserve v0.2.0 cleanup issues, not deferral
 
 ---
 
-*End of verification pass. Findings only — no code changes in this pass. User triage opens v0.2.0 issues, amendments to existing #115-#119, and audit-text amendments based on the AUDIT-DRIFT roll-up above.*
+*End of verification pass. Findings only — no code changes in this pass.*
+
+---
+
+## Addendum — audit-drift amendments (applied)
+
+The five AUDIT-DRIFT items in the cross-cutting roll-up have been resolved by amending the audit text to match shipped ADRs. Source code unchanged.
+
+- **Graph audit §2** — added `FrontierNode` to the MVP node-types list (ADR-023).
+- **Graph audit §3** — added `RUNS_ON`, `PUBLISHES_TO`, `CONSUMES_FROM` to the MVP edge-types list (matches `packages/types/src/constants.ts`).
+- **Graph audit §5 + OTel audit §9** — replaced flat 24h staleness with per-edge-type thresholds (ADR-024). Added `stale-events.ndjson` to the verify list.
+- **Graph audit §7 + OTel audit §8** — replaced "upgrade in place" contract with the coexistence contract (`ingest.ts:15-17`, ADR-027). Both audits now describe the distinct OBSERVED edge id pattern and the `PROV_RANK` selection rule. OTel §8 also corrects `confidence` expectation: OBSERVED edges carry `confidence: 1.0` as a max-trust marker, not removed.
+- **MCP audit §9** — replaced "keyword only in MVP" with the ADR-025 embedder chain (Ollama → MiniLM → substring). Updated tool-status table and red-flag entry.
+
+The two policies-naming clashes and the `drivers` vs `dependencies` field-name disagreement remain open — they need product calls before any audit edit.


### PR DESCRIPTION
## Summary

Five places where the audit documents in \`docs/audits/\` contradict ratified ADRs and would have graded correct code as failing on the next verification pass. Amend the audits, leave the code.

- **Graph §2** — add \`FrontierNode\` to the MVP node-types list (ADR-023).
- **Graph §3** — add \`RUNS_ON\`, \`PUBLISHES_TO\`, \`CONSUMES_FROM\` to the MVP edge-types list (matches \`packages/types/src/constants.ts\`).
- **Graph §5 + OTel §9** — flat 24h staleness replaced with per-edge-type thresholds (ADR-024: CALLS=1h, CONNECTS_TO=4h, others=24h, env-overridable).
- **Graph §7 + OTel §8** — "upgrade in place" replaced with the coexistence contract (\`ingest.ts:15-17\`, ADR-027). OBSERVED edges live under a distinct id pattern alongside EXTRACTED so the divergence stays load-bearing. OTel §8 also corrects \`confidence\`: OBSERVED carries \`confidence: 1.0\` as a max-trust marker, not removed.
- **MCP §9** — "keyword only" replaced with the ADR-025 embedder chain (Ollama → MiniLM → substring). Tool-status table and red-flag updated.

\`docs/audits/verification.md\` gets an addendum recording these amendments.

## Test plan

- [ ] Read each diffed audit section; confirm wording matches the ratified ADR
- [ ] Spot-check that no source code is touched (audit text only)

Refs #126