### PR TITLE
Documentation refresh: agents land grounded in current state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,21 +38,29 @@ A generic `Dockerfile` at the repo root builds the demo-free image. Mount your c
 
 ### Track 2 — v0.2.x Engineering
 
-**v0.2.0 — Sunrise.** Audit-driven cleanup. Seven contract documents (`docs/audits/`) define what NEAT v0.1.x must redeem itself against. The first concrete deliverable is **issue #126** — a verification pass that grades every `Verify:` checkbox across all seven audits with file-and-line citations and outputs `docs/audits/verification.md`. Findings only — no code changes in the verification pass itself. After it lands, the user sorts findings into three piles (open as issues / amend existing / defer), and the cleanup work begins from there.
+**The v0.2.x sequence is rebuild-against-locked-contract.** Each minor version owns one layer: it opens with the contract batch that governs that layer (ADRs + per-topic markdown under `docs/contracts/` + regression tests), then the rebuild + cleanup against the locked contract. **Don't ship cleanup work against an unlocked contract** — that's what produced the v0.1.x drift the verification pass surfaced.
 
-**v0.2.1 — Policies.** Closes the four-feature gap (OTel + graph + MCP + policies). α/β/γ/δ pattern mirroring v0.1.2:
+The full per-milestone breakdown lives in `docs/plans/2026-05-04-v0.2.x-sequencing.md`. Current state lives in `docs/plans/<date>-v0.2.0-status.md` (the most recent file in `docs/plans/`).
 
-- **#115 — α** — Policy schema + YAML parser in `@neat/types`
-- **#116 — β** — Evaluation engine + `policy-violations.ndjson`
-- **#117 — γ** — REST + MCP surface (`/policies`, `check_policies` tool, `neat://policies/violations`)
-- **#118 — δ** — Real-world policy library exercising OBSERVED-vs-EXTRACTED divergence
-- **#123** — generalize `getRootCause` beyond DatabaseNode origins (follow-on after #116 + #118 expose `PolicyViolation` as a node-shaped concept)
+**v0.2.0 — Sunrise (data-layer foundation).** Closes when:
+- Audit verification pass is shipped (`docs/audits/verification.md`) ✅
+- AUDIT-DRIFT amendments are applied to audit text ✅
+- Data-layer contracts are locked: ADR-028 (node identity), ADR-029 (edge identity + provenance), ADR-030 (lifecycle), ADR-031 (schema growth vs shape) ✅
+- Contract framework is live: index, per-topic files, PreToolUse hook, regression tests, schema-snapshot guard ✅
 
-**v0.2.2 — `neat init` + Claude Code skill.** Distribution layer for the MVP-success PR experiment.
+The 15 cleanup issues (#131-#145) are open against this milestone today **but belong to later milestones** — see the status doc for the redistribution.
 
-- **#119** — zero-config init on any codebase, Claude skill packaging
+**v0.2.1 — Tree-sitter rebuild.** Opens with contract #5 (static extraction). Then ships #140 ghost-edge cleanup, #141 source-level DB/import detection, #142 framework field, #145 drop unused graphology deps.
 
-Pulls P-001 (zero-touch instrumentation) out of `docs/v0.x-proposals.md` once #119 starts.
+**v0.2.2 — OTel ingest rebuild.** Opens with contracts #6-#8 (OTel ingest, trace stitcher, FrontierNode promotion). Then ships #131 non-blocking ingest, #132 span-time `lastObserved`, #133 parent-span cache, #134 auto-create services/DBs, #135 exception event parsing.
+
+**v0.2.3 — Traversal rebuild.** Opens with contracts #9-#11 (traversal, getRootCause, getBlastRadius). Then ships #136 FRONTIER exclusion, #137 BlastRadius schema fields, #138 distance positive, #139 schema validation, #123 generalize getRootCause.
+
+**v0.2.4 — Policies + MCP refresh.** Opens with contracts #12-#18 (MCP, REST, persistence, policy schema/eval/actions/tools). Then ships #115-#118 + #143 three-part response, #144 transitive `get_dependencies`.
+
+**v0.2.5 — `neat init` + SDK install + Claude skill.** Opens with contracts #19-#22 (init, SDK install, machine registry, daemon). Then ships #119.
+
+After v0.2.5: the MVP-success PR experiment (ADR-027) — point NEAT at an open-source codebase. Self-hosting on the NEAT codebase activates only after that PR closes.
 
 ### Track 1 — v0.3.0 Frontend (Jed)
 
@@ -97,6 +105,10 @@ The Railway gates from M6 are still informational. AWS is the more likely produc
 - `semantic_search` uses an Ollama → Transformers.js → substring fallback chain; flat in-memory cosine, sidecar `embeddings.json` cache (ADR-025)
 - Multi-project lives behind `Map<string, NeatGraph>`; routes dual-mount at `/X` and `/projects/:project/X`; default project keeps the legacy filenames; OTel ingest stays single-project (ADR-026)
 - MVP success is closing a real PR on an unfamiliar open-source codebase, not running the pg demo; OBSERVED layer must be load-bearing (ADR-027)
+- Node ids come from `@neat/types/identity` helpers (`serviceId`, `databaseId`, `configId`, `infraId`, `frontierId`); hand-rolled template literals are a contract violation (ADR-028)
+- Edge ids per provenance variant come from `@neat/types/identity` helpers (`extractedEdgeId`, `observedEdgeId`, `inferredEdgeId`, `frontierEdgeId`, `parseEdgeId`); `PROV_RANK` lives there too (ADR-029)
+- Mutation authority on the graph is locked to `ingest.ts` and `extract/*`; OBSERVED↔STALE and FRONTIER→OBSERVED transitions are owned by `ingest.ts` (ADR-030)
+- Schema additions in `@neat/types` are growth (snapshot diff is the audit trail); renames/removals/type-changes are shape changes (require ADR + `persist.ts` migration); enforced via `packages/core/test/audits/schema-snapshot.test.ts` (ADR-031)
 
 ## Conventions
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -8,14 +8,39 @@ This file is the index. Each rule has a short summary and a link to its full per
 
 ## Per-topic contracts
 
-| # | Contract | File | Governs |
-|---|----------|------|---------|
-| 16 | Node identity | [`contracts/identity.md`](./contracts/identity.md) | Node ids constructed via `@neat/types/identity` helpers, never literals (ADR-028) |
-| 17 | Edge identity + provenance | [`contracts/provenance.md`](./contracts/provenance.md) | Edge id wire format per provenance, `PROV_RANK` ordering, coexistence rule, confidence semantics (ADR-029) |
-| 18 | Node + edge lifecycle | [`contracts/lifecycle.md`](./contracts/lifecycle.md) | When nodes/edges are created, transition, get rewritten, retire. Mutation authority is locked to ingest.ts and extract/* (ADR-030) |
-| 19 | Schema growth vs shape | [`contracts/schema.md`](./contracts/schema.md) | Schema additions are growth (commit-and-go). Renames, removals, type changes are shape changes (ADR + persist.ts migration). Mechanically enforced via schema-snapshot test (ADR-031) |
+| # | Contract | File | Governs | Status |
+|---|----------|------|---------|--------|
+| 1 | Node identity | [`contracts/identity.md`](./contracts/identity.md) | Node ids constructed via `@neat/types/identity` helpers, never literals (ADR-028) | ✅ landed |
+| 2 | Edge identity + provenance | [`contracts/provenance.md`](./contracts/provenance.md) | Edge id wire format per provenance, `PROV_RANK` ordering, coexistence, confidence semantics (ADR-029) | ✅ landed |
+| 3 | Node + edge lifecycle | [`contracts/lifecycle.md`](./contracts/lifecycle.md) | Creation, transition, retirement. Mutation authority locked to `ingest.ts` and `extract/*` (ADR-030) | ✅ landed |
+| 4 | Schema growth vs shape | [`contracts/schema.md`](./contracts/schema.md) | Growth = commit-and-go (snapshot diff). Shape change = ADR + `persist.ts` migration (ADR-031) | ✅ landed |
 
-*(More land as the v0.2.x sequence progresses: traversal, MCP surface, persistence, policies, init/install. See `docs/milestones.md` for sequencing.)*
+### Future contracts — opened at the start of each milestone
+
+The data-layer foundation (1-4) is shared across all producers and consumers. Producer-, consumer-, surface-, policy-, and distribution-layer contracts open at the start of the milestone where their layer gets rebuilt.
+
+| # | Contract | Milestone | Governs (target) |
+|---|----------|-----------|------------------|
+| 5 | Static extraction (tree-sitter) | v0.2.1 | What edges static extraction produces, evidence shape, language dispatch, depth limits, ghost-edge cleanup (`packages/core/src/extract/**`) |
+| 6 | OTel ingest | v0.2.2 | Span-time `lastObserved`, parent-span correlation, exception-event parsing, auto-creation, non-blocking ingest (`ingest.ts` ingest path) |
+| 7 | Trace stitcher | v0.2.2 | When INFERRED fires, depth limit, OBSERVED-twin-skip rule (`stitchTrace`) |
+| 8 | FrontierNode promotion | v0.2.2 | When promotion fires, alias-match precedence, attribute merge (`promoteFrontierNodes`) |
+| 9 | Traversal | v0.2.3 | Edge priority per hop, FRONTIER exclusion, confidence cascading, schema validation (`traverse.ts`) |
+| 10 | `getRootCause` | v0.2.3 | Incompatibility-check semantics per upstream node type, reason-string format, fix-recommendation derivation |
+| 11 | `getBlastRadius` | v0.2.3 | Outbound semantics, distance positive integer, per-node path and confidence, total-affected count |
+| 12 | MCP tool surface | v0.2.4 | Three-part response, confidence/provenance footer, transitive vs direct, tool count and naming (`packages/mcp/src/`) |
+| 13 | REST API | v0.2.4 | Endpoint shape per resource, project-scoped routing, error response shape (`packages/core/src/api.ts`) |
+| 14 | Persistence | v0.2.4 | Snapshot schema versioning, migration rules, startup-load behavior (`packages/core/src/persist.ts`) |
+| 15 | Policy schema | v0.2.4 | `policy.json` shape, version literal, type dispatch, rule structure |
+| 16 | Policy evaluation | v0.2.4 | When policies evaluate (post-ingest, post-extract, post-stale), evaluator dispatch, violation-event shape |
+| 17 | Policy onViolation actions | v0.2.4 | alert / log / block — what each does, what authority each carries |
+| 18 | Policy tool surface | v0.2.4 | MCP tool naming and shape, REST endpoints |
+| 19 | `neat init` | v0.2.5 | What init does, what it writes, what it doesn't touch, codemod patch-vs-apply semantics |
+| 20 | SDK install | v0.2.5 | Per-language installer module interface, dependency-file edits, entrypoint modifications, opt-in semantics |
+| 21 | Machine-level project registry | v0.2.5 | `~/.neat/projects.json` shape, daemon discovery rules, project lifecycle |
+| 22 | Daemon | v0.2.5 | Continuous extraction triggers (file mtime, OTel arrival), per-project graph isolation, lifecycle |
+
+The full reasoning and per-milestone sequencing live in `docs/plans/2026-05-04-v0.2.x-sequencing.md`. The current state of the active milestone lives in `docs/plans/<latest-date>-v0.2.x-status.md`.
 
 ## Cross-cutting rules (applied everywhere; not yet split out)
 

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -12,37 +12,31 @@ Source of truth for sprint status. Update this file at the end of every session.
 
 ## 🚩 Pick up here
 
-**Last session ended:** 2026-05-04 evening. **v0.1.2 + v0.1.3 shipped.** Workspace at HEAD is green: `npx turbo build test lint` clean, **214 core / 30 types / 35 mcp** tests passing.
+**Last session ended:** 2026-05-05. v0.1.2 + v0.1.3 shipped. v0.2.0 Sunrise nearly closed — three PRs stacked on `main` carry the data-layer foundation (see "Open PRs awaiting merge" below).
+
+**For current operational state of the active milestone, read `docs/plans/2026-05-05-v0.2.0-status.md` first.** That doc is updated per session; this file describes the long-term shape.
 
 **Two parallel tracks share `main`:**
 
-- **Track 1 — v0.3.0 Frontend (Jed).** Renumbered from old v0.2.0 on 2026-05-04. Builds against the stable v0.1.2 API. Issues #28-#31 + #106-#108. Doesn't gate the MVP success criterion; this track delivers investor-legibility.
-- **Track 2 — v0.2.x Engineering (Cem + Kurt).** Three releases:
-  - **v0.2.0 — Sunrise** — audit-driven cleanup. Seven audits (`docs/audits/`) define the contract NEAT v0.1.x grew toward organically; v0.2.0 closes the gap.
-  - **v0.2.1 — Policies.** Renumbered from old v0.3.0. Closes the four-feature gap (OTel + graph + MCP + policies). Issues #115-#118 + #123 follow-on.
-  - **v0.2.2 — `neat init` + Claude Code skill.** Renumbered from old v0.3.1. Distribution layer for the MVP-success PR experiment. Issue #119.
+- **Track 1 — v0.3.0 Frontend (Jed).** Builds against the stable v0.1.2 API. Issues #28-#31 + #106-#108. Doesn't gate the MVP success criterion.
+- **Track 2 — v0.2.x Engineering (Cem + Kurt).** Six releases, sequential. Each milestone owns one layer: it opens with the contract batch that governs that layer, then ships the rebuild + cleanup against the locked contract. **Don't ship cleanup work against an unlocked contract** — that's what produced the v0.1.x drift the verification pass surfaced. Full v0.2.x sequencing in `docs/plans/2026-05-04-v0.2.x-sequencing.md`.
 
-Engineering ships first; that order is what the user named when they renumbered. The two tracks are still independent — v0.2.x and v0.3.0 don't depend on each other — but the engineering numbering communicates priority.
+  - **v0.2.0 — Sunrise** — data-layer foundation. ADRs 028-031 + contract framework + audit verification + AUDIT-DRIFT sync. Pending merge in PRs #146 + #147 + the doc-refresh PR.
+  - **v0.2.1 — Tree-sitter rebuild.** Opens with contract #5 (static extraction). Ships #140, #141, #142, #145.
+  - **v0.2.2 — OTel ingest rebuild.** Opens with contracts #6-#8. Ships #131-#135.
+  - **v0.2.3 — Traversal rebuild.** Opens with contracts #9-#11. Ships #136-#139, #123.
+  - **v0.2.4 — Policies + MCP refresh.** Opens with contracts #12-#18. Ships #115-#118, #143, #144.
+  - **v0.2.5 — `neat init` + SDK install + Claude skill.** Opens with contracts #19-#22. Ships #119.
 
-### Tomorrow's work — start here
+After v0.2.5: the MVP-success PR experiment (ADR-027). Self-hosting on the NEAT codebase activates only after that PR closes — until then NEAT is the target of construction, not the tool.
 
-**Issue [#126](https://github.com/NEAT-Technologies/Neat/issues/126)** — v0.2.0-α audit verification pass. The first concrete deliverable for Sunrise.
+### Active work — start here
 
-The seven audits in `docs/audits/` are interlocking contracts NEAT v0.1.x must redeem itself against. The verification pass produces one document — `docs/audits/verification.md` — grading every `Verify:` checkbox (~150 of them) against the codebase at HEAD with file-and-line citations. **Findings only — no code changes, no issue creation in the same pass.** After the verification doc lands, the user reads it, sorts findings into three piles (open as new v0.2.0 issues / amend existing / defer), and the issue/amendment work happens in a follow-up.
+**Once the three open v0.2.0 PRs (#146, #147, doc refresh) merge:** v0.2.0 closes. Open v0.2.1.
 
-Branch: `v0.2.0-audit-verification`. Open as draft PR for inline review of findings.
+**v0.2.1 first move:** the Contract Author writes contract #5 (static extraction) — ADR + `docs/contracts/static-extraction.md` + regression tests. Then the implementation agent picks up #140 / #141 / #142 / #145 against the locked contract. Each cleanup issue closes when its corresponding `it.todo` in `contracts.test.ts` flips to a live assertion and passes.
 
-**The audits in dependency order** (verify in this order, downstream audits reference upstream findings):
-1. types — `docs/audits/NEAT-audit-types(1).md`
-2. graph — `docs/audits/NEAT-audit-graph.md`
-3. tree-sitter — `docs/audits/NEAT-audit-treesitter.md`
-4. OTel — `docs/audits/NEAT-audit-otel.md`
-5. traversal — `docs/audits/NEAT-audit-traversal.md`
-6. policies (prospective — feature not built) — `docs/audits/NEAT-audit-policies.md`
-7. MCP — `docs/audits/NEAT-audit-mcp.md`
-8. init (prospective — feature not built) — `docs/audits/NEAT-audit-init.md`
-
-Two of the eight (policies, init) are prospective ADRs against unbuilt features — verification translates their `Verify:` checkboxes into spec amendments for issues #115-#119, not code citations. Track those separately in the verification doc.
+The 15 cleanup issues #131-#145 are open against the v0.2.0 milestone today **but belong to v0.2.1-v0.2.4** under the rebuild-contract framing. Migration of issue→milestone on GitHub is pending.
 
 ### Closing gate — the MVP-success PR
 
@@ -66,7 +60,11 @@ The Railway gates from M6 are still informational. AWS is the more likely produc
 
 ### Open PRs awaiting merge
 
-- **#125** — ADR-027 + parallel-tracks reframe of CLAUDE.md and milestones.md. Note: this PR's body still references the old milestone numbering (v0.2.0 = Frontend, v0.3.0 = Policies). The renumbering happened after #125 was opened. The PR's content is still correct in shape; the reviewer should treat the milestone numbers as having shifted by one bucket.
+Three stacked PRs close v0.2.0 Sunrise. Merge in order:
+
+- **#146** — Sync audit text to shipped ADRs (AUDIT-DRIFT resolution). Doc-only. Branch: `audit-drift-sync` → `main`.
+- **#147** — v0.2.0 contract framework + ADRs 028-031. Six commits: contract framework + four data-layer ADRs. Branch: `v0.2.0-contracts-framework` → `audit-drift-sync` (auto-rebases on `main` once #146 merges).
+- **Doc refresh PR** (this one) — CLAUDE.md, milestones.md, contracts.md index, `docs/plans/`. Branched from `v0.2.0-contracts-framework`; auto-rebases on `main` once #147 merges.
 
 ---
 

--- a/docs/plans/2026-05-04-v0.2.x-sequencing.md
+++ b/docs/plans/2026-05-04-v0.2.x-sequencing.md
@@ -1,0 +1,70 @@
+# Temp discussion — 2026-05-04 evening
+
+Stash of the v0.2.x sequencing message so future context doesn't get bloated re-derivation. Keep, delete after the work lands or move into a real ADR / milestones.md update.
+
+---
+
+## Proposed v0.2.x sequence (one session per sub-version)
+
+### v0.2.0 — Graph contract
+Lock the type system, provenance contract, and node/edge lifecycle in ADRs and `@neat/types`. Run the existing 15 cleanup issues against the locked contract; some collapse, some sharpen. Foundation for everything else.
+**Output:** stable schema, locked contract docs, cleanup issues closed, audit text aligned. Verification pass re-runs green.
+
+### v0.2.1 — Tree-sitter / static extraction
+The graph contract specifies what an EXTRACTED edge **is**. The producer that creates them is the first one rebuilt against the locked contract. Big cluster of FAILs — ghost-edge cleanup (#140), source-mtime tracking, source-level DB/import detection (#141), framework field (#142). 7 FAIL + 13 PARTIAL in the verification pass, all in service of the same producer.
+**Output:** EXTRACTED edges are evidence-backed, source-mtime-tracked, ghost-cleanable, framework-aware. Tree-sitter extraction is a stable producer.
+
+### v0.2.2 — OTel ingest / runtime extraction
+The other producer, rebuilt against the locked contract. #131-#135 plus auto-create-services/DBs plus OBSERVED-as-additive contract decision. 8 FAILs in the verification pass — biggest single bucket. Comes after tree-sitter because OTel's auto-create-ServiceNode behavior reconciles against existing service ids — needs tree-sitter as a steady reference first.
+**Output:** OBSERVED edges land non-blocking, span-time accurate, parent-span correlated, auto-creating. Stable producer.
+
+### v0.2.3 — Traversal / consumer surface
+Rebuild traversal against locked contract + now-stable producers. Fixes #136-#139 (FRONTIER exclusion, BlastRadiusAffectedNode schema, distance fix, schema validation) plus generalizing `getRootCause` past DatabaseNode origins (#123). Builds before producers are settled = same trap as v0.1.x.
+**Output:** traversal is contract-validated, schema-locked, FRONTIER-safe, general across origin types.
+
+### v0.2.4 — Policies
+The architecture-first surface from the neat.is manifesto, finally buildable because graph + producers + traversal are stable. Schema (#115), engine (#116), surface (#117), library (#118). First place users experience NEAT as something that asserts intent, not just observes reality.
+**Output:** policies layer live. Architecture-first surface visible.
+
+### v0.2.5 — `neat init` + SDK install + Claude skill
+Distribution layer. Init owns SDK install (Node + Python first), codemod with `--apply` opt-in, machine-level `~/.neat/projects.json` registry, daemon model. Last in v0.2.x because init has to know what NEAT supports — feature set must be frozen first.
+**Output:** `neat install` + `neat init <repo>` + Claude skill. End-to-end usable on an arbitrary codebase.
+
+### v0.3.0 — Frontend + open-source release
+Jed's track. Builds against fully stable v0.2.x API. Repo opens publicly. Engineering pace drops to ambient. Pre-v1.0 product-discovery mode begins — bugs, blog posts, talks, watching real users, letting v1.0 design crystallize from usage not assumption.
+
+---
+
+## Rehearsal of v1.0 features in v0.2.x
+
+- **NeatScript** rehearsed by the policies DSL (v0.2.4)
+- **Time-travel** rehearsed by `errors.ndjson` + trace stitcher (v0.2.2)
+- **IaC generation** not rehearsed; pure v1.0 surface
+- **Agentic remediation** rehearsed by MCP tool surface (v0.2.4 + ongoing)
+
+---
+
+## Why simultaneity was the v0.1.x mistake
+
+α/β/γ/δ shipped four tracks in parallel, all touching the graph layer with no settled contract. Verification pass paid the bill: 35 FAILs, mostly clustered in OTel ingest (8) and tree-sitter (7) — both writing to a layer whose semantics weren't locked. Traversal FAILs (5) the same pattern from the consumer side.
+
+Simultaneity is a **launch concern**, not a build concern. v0.1.x conflated them. v0.2.x decouples — graph contract first, then layers in sequence.
+
+---
+
+## Open product calls still on the table
+
+1. Policies REST path: `/policies` vs `/policy/violations` — recommended `/policies`.
+2. Policies MCP tools: one (`check_policies`) vs two (`check_policies` + `get_policy_violations`) — recommended two.
+3. `drivers` vs `dependencies` — recommended keep `dependencies`, defer `drivers` until a second consumer.
+4. Init audit's 5 questions (depth limit, IGNORED_DIRS extras, ADR-017 vs `.neat/config.json`, init vs install separation, grade-now-vs-defer).
+5. ADR-028 — pre-v1 OBSERVED is single-source App-only via init-time SDK install; eBPF/mesh-Net deferred to v1.0+.
+
+---
+
+## Active branches / PRs
+
+- Branch `v0.2.0-audit-verification` — 2 commits ahead of main: `ea83304` verification, `ca15e69` AUDIT-DRIFT sync.
+- PR #130 — draft, ready for review.
+- Issues open against v0.2.0 Sunrise milestone: #126 (verification tracker), #131-#145 (15 cleanup).
+- v0.2.1 carries #115-#118 + #123. v0.2.2 carries #119.

--- a/docs/plans/2026-05-05-v0.2.0-status.md
+++ b/docs/plans/2026-05-05-v0.2.0-status.md
@@ -1,0 +1,71 @@
+# v0.2.0 Sunrise — current state
+
+**Last updated:** 2026-05-05
+
+This is the "pick up here" doc for v0.2.0 work. If you're a fresh agent or a human picking up cold, read this first. CLAUDE.md tells you the project shape; this tells you the **current operational state** for the active milestone.
+
+## What v0.2.0 is
+
+v0.2.0 Sunrise was originally framed as audit-driven cleanup ("fix the 35 FAILs the verification pass found"). That framing has been **reshaped** during the milestone — see `docs/plans/2026-05-04-v0.2.x-sequencing.md` for the full reasoning. The new framing:
+
+> v0.2.0 closes when the **data-layer contract foundation** is locked. The 15 cleanup issues redistribute to v0.2.1 through v0.2.4 — each milestone owns its layer's contract batch and the cleanup against it.
+
+The reason for the shift: the v0.1.x verification surfaced contract drift (35 FAILs), not just bugs. Producing fixes against an undocumented contract is what produced the drift in the first place. v0.2.0 writes the contract; v0.2.1+ fix the producers and consumers against the locked contract.
+
+## What's done
+
+- **Audit verification pass** — `docs/audits/verification.md` grades all eight audits with file:line citations.
+- **AUDIT-DRIFT amendments** — five places where the audit text contradicted ratified ADRs were synced to the ADRs.
+- **Contract framework** — `docs/contracts.md` index, per-topic contracts under `docs/contracts/`, PreToolUse hook at `docs/contracts/_hook.sh`, regression test suite at `packages/core/test/audits/contracts.test.ts`, schema-snapshot guard at `packages/core/test/audits/schema-snapshot.test.ts`.
+- **Data-layer ADRs (028-031)** — node identity, edge identity + provenance ranking, lifecycle, schema growth vs shape. Helpers in `@neat/types/identity.ts`. Producers refactored. 28 live regression assertions, 19 todos queued for the cleanup issues.
+
+## What's pending merge
+
+- **PR #146** — AUDIT-DRIFT sync (audit text only). Branch: `audit-drift-sync` → `main`.
+- **PR #147** — Contract framework + ADRs 028-031. Branch: `v0.2.0-contracts-framework` → `audit-drift-sync` (stacked).
+- **This doc refresh PR** — branched from `v0.2.0-contracts-framework`, stacks on #147.
+
+**Merge order:** #146 → #147 → doc refresh. Each rebases automatically as the previous one merges.
+
+## What's *not* in v0.2.0 (deliberately)
+
+The 15 cleanup issues (#131-#145) are open against the v0.2.0 milestone today, but they belong to later milestones under the new framing:
+
+| Cleanup issues | Layer | Milestone |
+|----------------|-------|-----------|
+| #140 ghost-edge cleanup, #141 source-level DB/import, #142 framework field, #145 drop unused graphology | Tree-sitter / static extraction | v0.2.1 |
+| #131 non-blocking ingest, #132 span-time `lastObserved`, #133 parent-span cache, #134 auto-create services/DBs, #135 exception event parsing | OTel ingest | v0.2.2 |
+| #136 FRONTIER exclusion, #137 `BlastRadiusAffectedNode` schema, #138 `distance` positive, #139 schema validation, #123 generalize `getRootCause` | Traversal | v0.2.3 |
+| #143 MCP three-part response, #144 transitive `get_dependencies` | MCP surface | v0.2.4 |
+
+**Each milestone opens with its own contract batch, then the rebuild against it.** Don't ship cleanup issues against today's loose contract surface — they'll need redoing when the layer's contract batch lands.
+
+The issue-to-milestone migration on GitHub is pending — see "Open product calls" below.
+
+## Open product calls
+
+These are blocking decisions for v0.2.1+ but not for v0.2.0 closing:
+
+1. **Policies REST path** — `/policies` (recommended) vs `/policy/violations`. Blocks v0.2.4 #117.
+2. **Policies MCP tools** — one (`check_policies`) vs two (`check_policies` + `get_policy_violations`). Blocks v0.2.4 #117.
+3. **`drivers` vs `dependencies` field name** — keep `dependencies` raw, defer `drivers` until a second consumer materializes (recommended; not a v0.2.0 blocker).
+
+## Self-hosting gate
+
+NEAT is **not** self-hosted on the NEAT codebase yet. The gate is the MVP-success PR (ADR-027): NEAT closes a real PR on an open-source codebase it was not engineered for, where the OBSERVED layer was load-bearing. Until that PR closes, agents work on NEAT the same way they work today — read source, query contracts via the PreToolUse hook, no MCP queries against `neat-out/graph.json` for NEAT itself.
+
+After the PR closes: self-hosting flips on. Until then: discipline.
+
+## Where to look next
+
+- `CLAUDE.md` — project shape (target, conventions, decision history).
+- `docs/contracts.md` — binding rules index. Auto-loaded by every session.
+- `docs/contracts/<name>.md` — per-topic binding rules. Auto-surfaced by the PreToolUse hook when you edit a governed file.
+- `docs/decisions.md` — full ADR log with rationale. Read on demand, not auto-loaded.
+- `docs/audits/verification.md` — graded audit findings. Read when working on a layer's cleanup.
+- `docs/plans/2026-05-04-v0.2.x-sequencing.md` — the full v0.2.x roadmap with contract numbering.
+- `docs/milestones.md` — milestone gates and "Pick up here" pointer.
+
+## When this file is wrong
+
+It's a snapshot, not a contract. If `main` has moved since the date at the top, treat the description as historical and check `git log` for the canonical state. New status docs should land as `docs/plans/<date>-<milestone>-status.md` — keep the old ones for context, don't overwrite.


### PR DESCRIPTION
## Summary

Closes the gap that caused a separate session's agent to misread v0.2.0's state. The agent read CLAUDE.md, milestones.md, and `docs/audits/`, and landed at "v0.2.0 = audit-driven cleanup of #131-#145." That was correct three days ago. After the rebuild-contract framing landed in this conversation, v0.2.0's close condition is "data-layer foundation locked," and #131-#145 redistribute to v0.2.1-v0.2.4. The docs hadn't caught up.

This PR catches them up. Stacks on #147; rebases on `main` once #146 + #147 merge.

## What changes

- **CLAUDE.md** — Track 2 section rewritten. v0.2.0's close condition is explicit. v0.2.1-v0.2.5 each name the contract batch they open with and the cleanup issues they ship. Decision list extended to ADRs 028-031.

- **docs/milestones.md** — "Pick up here" rewritten to point at the current plans/ status doc. Six v0.2.x sub-milestones listed in sequence. The three open PRs documented as the close-out of v0.2.0.

- **docs/contracts.md** — index extended with the full 22-contract roadmap. Each future contract names its target milestone and what it governs. Landed four (1-4) marked as such.

- **docs/plans/2026-05-04-v0.2.x-sequencing.md** — promoted from the untracked `temp-discussion-0504-2030.md` scratchpad. Same content; now tracked, dated, agent-discoverable.

- **docs/plans/2026-05-05-v0.2.0-status.md** — new. Per-session "where we are now" doc. Future status docs land as new dated files; old ones stay for context.

## What this does not change

- No source code touched.
- No GitHub issue migration (still pending — #131-#145 are tagged to v0.2.0 today; should move to v0.2.1-v0.2.4 once we're past the merge of these three PRs).
- No GitHub milestone description edits (also pending).
- The haunted branch \`v0.2.0-audit-verification\` still exists on origin — should be deleted post-merge since its work is now in #146/#147.

## Test plan

- [ ] Read \`docs/plans/2026-05-05-v0.2.0-status.md\` end-to-end. Confirm it reflects current reality.
- [ ] Read CLAUDE.md's Track 2 section. Confirm a fresh agent would not jump straight to v0.2.3 cleanup.
- [ ] Spot-check the contracts.md roadmap against the in-conversation list of 22.
- [ ] After merge: delete \`v0.2.0-audit-verification\` on origin. Migrate #131-#145 to their proper milestones on GitHub.

Refs #126