### PR TITLE
Contract #5: Static-extraction contract (ADR-032) — opens v0.2.1

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -14,14 +14,14 @@ This file is the index. Each rule has a short summary and a link to its full per
 | 2 | Edge identity + provenance | [`contracts/provenance.md`](./contracts/provenance.md) | Edge id wire format per provenance, `PROV_RANK` ordering, coexistence, confidence semantics (ADR-029) | ✅ landed |
 | 3 | Node + edge lifecycle | [`contracts/lifecycle.md`](./contracts/lifecycle.md) | Creation, transition, retirement. Mutation authority locked to `ingest.ts` and `extract/*` (ADR-030) | ✅ landed |
 | 4 | Schema growth vs shape | [`contracts/schema.md`](./contracts/schema.md) | Growth = commit-and-go (snapshot diff). Shape change = ADR + `persist.ts` migration (ADR-031) | ✅ landed |
+| 5 | Static extraction | [`contracts/static-extraction.md`](./contracts/static-extraction.md) | Producer interface, evidence on every EXTRACTED edge, ghost-edge cleanup keyed on `evidence.file`, language dispatch, idempotency (ADR-032) | ✅ landed (v0.2.1 opens) |
 
 ### Future contracts — opened at the start of each milestone
 
-The data-layer foundation (1-4) is shared across all producers and consumers. Producer-, consumer-, surface-, policy-, and distribution-layer contracts open at the start of the milestone where their layer gets rebuilt.
+Producer-, consumer-, surface-, policy-, and distribution-layer contracts open at the start of the milestone where their layer gets rebuilt.
 
 | # | Contract | Milestone | Governs (target) |
 |---|----------|-----------|------------------|
-| 5 | Static extraction (tree-sitter) | v0.2.1 | What edges static extraction produces, evidence shape, language dispatch, depth limits, ghost-edge cleanup (`packages/core/src/extract/**`) |
 | 6 | OTel ingest | v0.2.2 | Span-time `lastObserved`, parent-span correlation, exception-event parsing, auto-creation, non-blocking ingest (`ingest.ts` ingest path) |
 | 7 | Trace stitcher | v0.2.2 | When INFERRED fires, depth limit, OBSERVED-twin-skip rule (`stitchTrace`) |
 | 8 | FrontierNode promotion | v0.2.2 | When promotion fires, alias-match precedence, attribute merge (`promoteFrontierNodes`) |

--- a/docs/contracts/static-extraction.md
+++ b/docs/contracts/static-extraction.md
@@ -1,0 +1,134 @@
+---
+name: static-extraction
+description: Producers under packages/core/src/extract/* read source code and config to build the EXTRACTED layer. Every edge carries evidence.file. Ghost-edge cleanup keys on it. All producers are idempotent.
+governs:
+  - "packages/core/src/extract/**"
+  - "packages/core/src/watch.ts"
+adr: [ADR-032, ADR-030, ADR-031, ADR-024]
+---
+
+# Static-extraction contract
+
+The first producer-layer contract. `packages/core/src/extract/**` reads source code and config files to build the EXTRACTED layer of the graph. Mutation authority for static creation is locked here per the lifecycle contract (ADR-030).
+
+## Producer interface
+
+Every producer module exports a single async function with the signature:
+
+```ts
+async function addX(
+  graph: NeatGraph,
+  services: DiscoveredService[],
+  scanPath: string,
+): Promise<{ nodesAdded?: number; edgesAdded?: number }>
+```
+
+Producers are pure with respect to graph state outside their own writes. They:
+
+- read from the filesystem within `scanPath` and each service's `dir`,
+- write nodes and edges via `graph.addNode` / `graph.addEdgeWithKey`,
+- guard every write with `graph.hasNode(id)` / `graph.hasEdge(id)` for idempotency,
+- never read the OBSERVED layer,
+- never trigger REST or MCP,
+- never call `compat.json` outside `compat.ts`.
+
+## Evidence on EXTRACTED edges (binding)
+
+Every EXTRACTED edge carries an `evidence` field:
+
+```ts
+evidence: {
+  file: string         // path relative to scanPath, forward slashes
+  line?: number        // 1-indexed
+  snippet?: string     // small source fragment, max ~120 chars
+}
+```
+
+`file` is required. `line` and `snippet` are optional but strongly preferred when the producer can compute them cheaply.
+
+Today the CALLS-family producers (`calls/http.ts`, `calls/aws.ts`, `calls/kafka.ts`, `calls/grpc.ts`, `calls/redis.ts`) carry evidence. CONNECTS_TO, CONFIGURED_BY, DEPENDS_ON, and RUNS_ON producers do not. Issue #140 closes that gap.
+
+## Ghost-edge cleanup
+
+When a file changes or disappears between extract passes, every EXTRACTED edge whose `evidence.file` matches that path is **dropped before the producer reruns**. Re-extraction recreates the edges that still apply; the deleted code's edges stay deleted.
+
+`watch.ts` owns the cleanup trigger per ADR-030's mutation authority. The order is:
+
+1. `classifyChange` decides which producer phases the changed file belongs to.
+2. For each phase, `watch.ts` calls a `retireEdgesByFile(graph, file)` step that drops every edge in that phase whose `evidence.file` matches.
+3. The producer reruns. Idempotent writes recreate surviving edges.
+
+This is the v0.1.x bug closed by issue #140. Without it, watch-driven re-extraction accumulates stale EXTRACTED edges indefinitely.
+
+## Idempotency
+
+Every producer is idempotent. Running the same producer twice on the same input produces the same graph state. `graph.hasNode(id)` and `graph.hasEdge(id)` guards already enforce this; the contract reaffirms it.
+
+Idempotency is what makes ghost-edge cleanup safe — the path-keyed retire step plus re-extraction always converges on the source's current state, regardless of how many times either fires.
+
+## Language dispatch
+
+Source-file parsing routes by file extension:
+
+| Extension                                | Grammar                          |
+|------------------------------------------|----------------------------------|
+| `.js` `.jsx` `.mjs` `.cjs` `.ts` `.tsx`  | `tree-sitter-javascript`         |
+| `.py`                                    | `tree-sitter-python`             |
+
+`tree-sitter-typescript` is installed but currently unused — `.ts` / `.tsx` fall through to the JS parser. Replacing the JS fallback with the dedicated TS grammar is a future improvement, not in scope for this contract.
+
+Other extensions are skipped silently by `walkSourceFiles` per `IGNORED_DIRS` and `SERVICE_FILE_EXTENSIONS` in `extract/shared.ts`. New language support requires a grammar import and an extension entry in one place.
+
+## Discovery policy
+
+- Recursive directory walk from `scanPath`, bounded by `NEAT_SCAN_DEPTH` (default 5, configurable via env).
+- `.gitignore` honored.
+- `IGNORED_DIRS` skip set: `node_modules`, `.git`, `.turbo`, `dist`, `build`, `.next`. (`__pycache__` and `vendor` are pending — see open-questions list in `docs/audits/verification.md`.)
+- `package.json#workspaces` triggers monorepo expansion. `pnpm-workspace.yaml` and `turbo.json` are not yet read (deferred).
+
+## Producers in scope
+
+| Module               | Produces                                       | Evidence today |
+|----------------------|------------------------------------------------|----------------|
+| `services.ts`        | ServiceNode (npm + Python)                     | n/a (nodes)    |
+| `aliases.ts`         | host:port aliases on existing ServiceNodes     | n/a            |
+| `databases/*`        | DatabaseNode + CONNECTS_TO                     | ❌ — #140      |
+| `configs.ts`         | ConfigNode + CONFIGURED_BY                     | ❌ — #140      |
+| `calls/{aws,grpc,http,kafka,redis}.ts` | CALLS / PUBLISHES_TO / CONSUMES_FROM | ✅          |
+| `infra/{docker-compose,dockerfile,k8s,terraform}.ts` | InfraNode + DEPENDS_ON / RUNS_ON | ❌ — #140 |
+
+New producers under `calls/` for source-level DB connections (`new pg.Pool(...)`) and inter-service imports land under issue #141. They follow the same interface, same evidence shape, same idempotency.
+
+## `framework` on ServiceNode
+
+Issue #142 adds `framework?: string` to `ServiceNodeSchema`. This is **schema growth** governed by ADR-031, not a new field on this contract. The producer (`extract/services.ts`) populates it from `dependencies` and `devDependencies` via a package-name → framework-label table:
+
+| Package                | Framework label  |
+|------------------------|------------------|
+| `express`              | `express`        |
+| `fastify`              | `fastify`        |
+| `@nestjs/core`         | `nestjs`         |
+| `hono`                 | `hono`           |
+| `koa`                  | `koa`            |
+| `next`                 | `next`           |
+| `fastapi` (Python)     | `fastapi`        |
+| `flask` (Python)       | `flask`          |
+| `django` (Python)      | `django`         |
+
+The table lives in `compat.json` or a sibling data file. Population happens at extract time. The snapshot guard catches schema drift.
+
+## Enforcement
+
+`packages/core/test/audits/contracts.test.ts` includes:
+
+- A scan asserting every EXTRACTED-edge construction site in `extract/` includes an `evidence` field with at least `file`. Lands as `it.todo` keyed to #140 and flips when the issue closes.
+- A producer-interface assertion: every `addX` export under `extract/` accepts `(graph, services, scanPath)` (or a strict subset).
+- An idempotency assertion: run a producer twice on the same fixture, expect identical graph state.
+
+The PreToolUse hook surfaces this contract whenever any file under `extract/` or `watch.ts` is edited.
+
+## Rationale
+
+Static extraction was the most-FAIL'd layer in the verification pass — 7 FAILs and 13 PARTIALs across the tree-sitter audit. Most of them clustered around two missing structural rules: evidence shape on every EXTRACTED edge, and a cleanup mechanism keyed to it. Both rules already informally existed (CALLS edges carry evidence; the audit asks for cleanup). This contract makes them universal across producers and ties them to the lifecycle authority that owns retirement.
+
+Full rationale and historical context: [ADR-032](../decisions.md#adr-032--static-extraction-contract).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -704,3 +704,55 @@ Specific schema additions queued for v0.2.x cleanup (`framework`, `evidence.file
 **When to revisit.**
 
 When the snapshot file becomes hard to review — say it grows past 500 lines and a real shape change is hard to spot in the diff. At that point we either split the snapshot per schema or write a smarter diff tool. Today the schema set is small enough that a single JSON file is sufficient.
+
+---
+
+## ADR-032 — Static extraction contract
+
+**Date:** 2026-05-05
+**Status:** Active.
+
+The first producer-layer contract. Static extraction (`packages/core/src/extract/**`) is the producer that reads source code and config files to build the EXTRACTED layer of the graph. Today's producers work but disagree on what evidence they carry, when re-extraction retires old edges, and what counts as a producer at all. v0.2.1's tree-sitter rebuild needs these locked before the cleanup issues (#140, #141, #142, #145) can ship without re-introducing drift.
+
+**Decision.**
+
+1. **Every EXTRACTED edge carries `evidence: { file, line?, snippet? }`.** Today only CALLS-family edges do (`calls/http.ts`, `calls/aws.ts`, `calls/kafka.ts`, `calls/grpc.ts`, `calls/redis.ts`). CONNECTS_TO (databases), CONFIGURED_BY (configs), DEPENDS_ON / RUNS_ON (infra) edges currently have no evidence. The contract growth: every producer that writes an EXTRACTED edge attaches at least `evidence.file` — the source path the edge was derived from, relative to the scan root, forward slashes regardless of platform. `line` and `snippet` are optional but strongly preferred when the producer can compute them cheaply.
+
+2. **Ghost-edge cleanup is keyed on `evidence.file`.** When a file changes or disappears between extract passes, every EXTRACTED edge whose `evidence.file` matches that path is dropped before the producer reruns. Re-extraction recreates the edges that still apply; the deleted code's edges stay deleted. The cleanup is owned by `watch.ts` per ADR-030's lifecycle authority — it fires the producer's path-keyed retire step, then reruns the producer. This closes the v0.1.x bug where re-extraction accumulates stale edges indefinitely (issue #140).
+
+3. **Producer interface.** Every producer module under `extract/` exports a single async function with the signature `(graph: NeatGraph, services: DiscoveredService[], scanPath: string) => Promise<...>`. Producers are pure with respect to graph state outside their own writes — they never read the OBSERVED layer, never call `compat.json` outside `compat.ts`, never trigger MCP or REST. They can read from the filesystem within `scanPath` and from each service's `dir`. They emit nodes and edges via `graph.addNode` / `graph.addEdgeWithKey`, guarded by `hasNode` / `hasEdge` for idempotency.
+
+4. **Language dispatch.** Source-file parsing routes by extension: `.js` / `.jsx` / `.mjs` / `.cjs` / `.ts` / `.tsx` use the `tree-sitter-javascript` grammar (TypeScript falls through; using `tree-sitter-typescript` is a future improvement, not in scope for this contract). `.py` uses `tree-sitter-python`. Other extensions are skipped silently by `walkSourceFiles` per `IGNORED_DIRS` and the `SERVICE_FILE_EXTENSIONS` set in `extract/shared.ts`. New language support requires adding the grammar import and the extension dispatch in one place.
+
+5. **Depth and ignore policy.** Recursive directory walk from `scanPath` is bounded by `NEAT_SCAN_DEPTH` (default 5, configurable). `.gitignore` is honored. `IGNORED_DIRS` (`node_modules`, `.git`, `.turbo`, `dist`, `build`, `.next`, plus `__pycache__` and `vendor` once added — see issue #142's neighborhood) is the canonical skip set. `package.json#workspaces` triggers monorepo expansion; `pnpm-workspace.yaml` and `turbo.json` are not yet read (deferred).
+
+6. **Idempotency under re-extraction.** Every producer is idempotent: re-running the same producer on the same input produces the same graph state. `graph.hasNode(id)` and `graph.hasEdge(id)` guards already enforce this; the contract reaffirms it. Idempotency is what makes ghost-edge cleanup safe — the path-keyed retire step plus re-extraction always converges on the source's current state.
+
+7. **`framework` on ServiceNode is schema growth, not a new contract.** Issue #142's `framework?: string` field is governed by the schema-growth contract (ADR-031) — `ServiceNodeSchema` gains an optional field, the snapshot regenerates, the producer in `extract/services.ts` populates it from a package-name → framework-label table. This contract names the population rule (read from `dependencies` and `devDependencies`) but the schema-snapshot guard handles enforcement.
+
+**Producers in scope (the locked set).**
+
+- `services.ts` — ServiceNode from `package.json` and `pyproject.toml`.
+- `aliases.ts` — host:port aliases for FrontierNode promotion (governed by the lifecycle contract; this contract just confirms it as a producer).
+- `databases/*` — DatabaseNode + CONNECTS_TO from ORM configs, `.env`, docker-compose. Today no evidence; #140 fixes that.
+- `configs.ts` — ConfigNode + CONFIGURED_BY for yaml / yml / `.env` files.
+- `calls/*` — source-level CALLS / PUBLISHES_TO / CONSUMES_FROM edges via HTTP URLs, AWS SDK, gRPC, Kafka, Redis. Today carries evidence — keep.
+- `infra/*` — InfraNode + DEPENDS_ON / RUNS_ON from docker-compose, Dockerfile, k8s, Terraform.
+- New producers under `calls/` for source-level DB connections (`new pg.Pool(...)`) and inter-service imports — issue #141. Same evidence shape, same idempotency, same interface.
+
+**Enforcement.**
+
+`packages/core/test/audits/contracts.test.ts` adds:
+- A scan asserting every EXTRACTED-edge construction site under `packages/core/src/extract/` includes an `evidence` field with at least a `file` key. Currently CALLS-family producers pass; CONNECTS_TO / CONFIGURED_BY / DEPENDS_ON / RUNS_ON producers fail until #140 lands. The assertion lands as `it.todo` keyed to #140 and flips when the issue closes.
+- A producer-interface assertion: every module under `extract/` exporting a function whose name matches `add(Service|Database|Config|Edge|Infra)Nodes?|add\w+Edges?` accepts `(graph, services, scanPath)` (or a strict subset). Catches drift toward producer signatures that diverge.
+- An idempotency test: run a producer twice on the same fixture, assert node/edge count unchanged.
+
+`docs/contracts/static-extraction.md` records the binding rules in short form and is auto-surfaced by the PreToolUse hook whenever any file under `extract/` is edited.
+
+**What this ADR is not deciding.**
+
+The shape of source-level DB-connection detection (issue #141 — that's an implementation choice within the producer interface). Whether `tree-sitter-typescript` should replace the JS-falls-through approach (deferred — TS fallback works, the grammar swap is its own cleanup). The framework-detection package-name table (lives in `compat.json` or a sibling data file, not in the contract). Workspace-scoped service ids (deferred per ADR-028). Dev-container handling (deferred per the init audit's open questions).
+
+**When to revisit.**
+
+When source-level DB-connection detection (#141) lands — that introduces a new producer pattern (`new pg.Pool(...)` etc.) and the contract may need to specify its evidence shape more precisely (e.g. constructor-name in the snippet). When ghost-edge cleanup (#140) ships — the contract's path-keyed retire step becomes load-bearing and might surface edge cases.

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -409,6 +409,90 @@ describe('Lifecycle contract — FRONTIER → OBSERVED on promotion (ADR-030)', 
 })
 
 // ──────────────────────────────────────────────────────────────────────────
+// Static-extraction contract — producer interface, evidence, idempotency (ADR-032)
+// ──────────────────────────────────────────────────────────────────────────
+describe('Static-extraction contract (ADR-032)', () => {
+  // Producer interface: every exported `addX` function under `extract/` accepts
+  // (graph, services, scanPath) — or a strict subset. The scan reads function
+  // signatures syntactically; it's a static check, not a runtime invocation.
+  it('producer entry points accept (graph, services, scanPath) — strict subset allowed', () => {
+    const offenders: string[] = []
+    const EXTRACT_DIR = join(CORE_SRC, 'extract')
+    // Match `export (async)? function add<Word>...(args)` and capture the args.
+    const re = /export\s+(?:async\s+)?function\s+(add[A-Z]\w*)\s*\(([^)]*)\)/g
+    const allowed = ['graph', 'services', 'scanPath', 'service']
+
+    for (const file of walkSrc(EXTRACT_DIR)) {
+      const content = readFileSync(file, 'utf8')
+      let m: RegExpExecArray | null
+      while ((m = re.exec(content)) !== null) {
+        const fnName = m[1]!
+        const argList = m[2]!
+        // Pull parameter names off the type-annotated param list.
+        const paramNames = argList
+          .split(',')
+          .map((p) => p.trim())
+          .filter((p) => p.length > 0)
+          .map((p) => p.split(':')[0]!.trim().replace(/\?$/, ''))
+        for (const name of paramNames) {
+          if (!allowed.includes(name)) {
+            offenders.push(`${file}: ${fnName} has unexpected parameter \`${name}\``)
+          }
+        }
+      }
+    }
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
+
+  it('producers guard every node write with hasNode (idempotency)', () => {
+    // Heuristic: any line that calls graph.addNode(...) should be inside an
+    // `if (!graph.hasNode(...))` guard within the previous 5 lines, or the
+    // addNode call itself is preceded by hasNode in the same expression.
+    const offenders: string[] = []
+    const EXTRACT_DIR = join(CORE_SRC, 'extract')
+    for (const file of walkSrc(EXTRACT_DIR)) {
+      const lines = readFileSync(file, 'utf8').split('\n')
+      lines.forEach((line, i) => {
+        if (!/\bgraph\.addNode\s*\(/.test(line)) return
+        const window = lines.slice(Math.max(0, i - 15), i + 1).join('\n')
+        if (/\bgraph\.hasNode\s*\(/.test(window)) return
+        offenders.push(`${file}:${i + 1}: addNode without hasNode guard`)
+      })
+    }
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
+
+  it('producers guard every edge write with hasEdge (idempotency)', () => {
+    const offenders: string[] = []
+    const EXTRACT_DIR = join(CORE_SRC, 'extract')
+    for (const file of walkSrc(EXTRACT_DIR)) {
+      const lines = readFileSync(file, 'utf8').split('\n')
+      lines.forEach((line, i) => {
+        if (!/\bgraph\.addEdge(WithKey)?\s*\(/.test(line)) return
+        const window = lines.slice(Math.max(0, i - 15), i + 1).join('\n')
+        if (/\bgraph\.hasEdge\s*\(/.test(window)) return
+        offenders.push(`${file}:${i + 1}: addEdge without hasEdge guard`)
+      })
+    }
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
+
+  // The CALLS-family producers carry evidence today; CONNECTS_TO / CONFIGURED_BY /
+  // DEPENDS_ON / RUNS_ON producers do not. Issue #140 closes that gap. Until it
+  // lands, the assertion below is `it.todo` — flip it once #140 is shipped.
+  it.todo(
+    'every EXTRACTED edge construction site under extract/ includes evidence.file (issue #140)',
+  )
+
+  // Issue #142 adds `framework` to ServiceNodeSchema and populates it from
+  // package.json deps. The schema-snapshot guard catches the schema growth;
+  // this test asserts the producer wires it up.
+  it.todo(
+    'extract/services.ts populates ServiceNode.framework from known framework packages (issue #142)',
+  )
+})
+
+// ──────────────────────────────────────────────────────────────────────────
 // Provenance contract — Edge identity helpers + PROV_RANK (ADR-029)
 // ──────────────────────────────────────────────────────────────────────────
 describe('Provenance contract — edge identity (ADR-029)', () => {


### PR DESCRIPTION
## Summary

The first producer-layer contract. Opens v0.2.1's tree-sitter rebuild milestone. Implementation work on #140 / #141 / #142 / #145 lands against this locked contract.

## What's locked

- **Producer interface.** Every \`addX\` export under \`packages/core/src/extract/*\` accepts \`(graph, services, scanPath)\` — strict subset allowed. Producers are pure outside their own writes. Mutation authority stays locked to \`ingest.ts\` and \`extract/*\` per ADR-030.

- **Evidence on every EXTRACTED edge.** \`evidence: { file, line?, snippet? }\` on every edge. \`file\` is required, the rest preferred. CALLS-family producers carry it today; #140 extends it across CONNECTS_TO, CONFIGURED_BY, DEPENDS_ON, RUNS_ON.

- **Ghost-edge cleanup keys on \`evidence.file\`.** \`watch.ts\` retires edges whose \`evidence.file\` matches the changed path before rerunning the producer. Re-extraction recreates survivors. Closes the v0.1.x bug where re-extraction accumulates stale edges.

- **Idempotency.** Every producer guards \`addNode\`/\`addEdgeWithKey\` with \`hasNode\`/\`hasEdge\`. Two new live regression scans enforce this.

- **Language dispatch.** \`.js\`/\`.jsx\`/\`.mjs\`/\`.cjs\`/\`.ts\`/\`.tsx\` → tree-sitter-javascript; \`.py\` → tree-sitter-python. Replacing the JS fallback with tree-sitter-typescript is a future improvement.

- **\`framework\` on ServiceNode** is schema growth governed by ADR-031, not new contract surface. Population rules table lives in this contract.

## What this PR contains

- \`docs/decisions.md\` — ADR-032 appended.
- \`docs/contracts/static-extraction.md\` — per-topic contract with frontmatter \`governs:\` covering \`packages/core/src/extract/**\` and \`watch.ts\`.
- \`docs/contracts.md\` — index updated; #5 marked landed.
- \`packages/core/test/audits/contracts.test.ts\` — three new live assertions (producer signature scan, \`hasNode\`/\`hasEdge\` guards) plus two new \`it.todo\` items keyed to #140 and #142.

## Test totals

246 passing across @neat/core (up from 243), 21 todo, 0 fail.

## What this PR doesn't do

- No source code in \`extract/\` is modified.
- No GitHub issue closures — #140 / #141 / #142 / #145 stay open and ship under v0.2.1's implementation work.
- The PreToolUse hook will surface this contract automatically once merged; no settings changes needed.

## Test plan

- [ ] \`npx turbo build test lint\` clean
- [ ] Verify the hook surfaces the new contract:
  \`\`\`bash
  CLAUDE_PROJECT_DIR=\"\$PWD\" bash docs/contracts/_hook.sh \\
    < <(echo '{\"tool_input\":{\"file_path\":\"'\"\$PWD\"'/packages/core/src/extract/services.ts\"}}') \\
    | jq -r '.hookSpecificOutput.additionalContext' | grep '^name: '
  \`\`\`
  Should print \`identity\`, \`provenance\`, \`static-extraction\`.
- [ ] Read \`docs/contracts/static-extraction.md\` end to end. Confirm the locked rules match v0.2.1's intended cleanup work.
- [ ] After merge: implementation agent picks up v0.2.1 cleanup against this contract.

Refs #126