### PR TITLE
Bump workspace versions to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neat",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neat",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "workspaces": [
         "packages/*",
         "demo/*"
@@ -10881,7 +10881,7 @@
     },
     "packages/core": {
       "name": "@neat/core",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
         "@grpc/grpc-js": "^1.14.3",
@@ -10920,7 +10920,7 @@
     },
     "packages/mcp": {
       "name": "@neat/mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@neat/types": "*",
@@ -10939,7 +10939,7 @@
     },
     "packages/types": {
       "name": "@neat/types",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "zod": "^3.23.8"
       },
@@ -10951,7 +10951,7 @@
     },
     "packages/web": {
       "name": "@neat/web",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@neat/types": "*",
         "cytoscape": "^3.33.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neat",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "NEAT — production intelligence platform with a live semantic graph queryable via MCP",
   "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "NEAT graph engine: tree-sitter extraction, OTel ingest, REST API",
   "type": "module",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat/mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "NEAT MCP server: exposes graph queries to AI agents over stdio",
   "type": "module",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat/types",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Shared Zod schemas, types, and runtime constants for NEAT",
   "type": "module",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat/web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "NEAT web shell — minimal Next.js app fronting the core API",
   "scripts": {


### PR DESCRIPTION
## Summary

Tracks the v0.2.0 Sunrise release. Versions had stayed at 0.1.0 through the entire v0.1.x cycle; bumping now so npm metadata matches the git tag and the GitHub release.

## What changed

- \`package.json\` (root) → 0.2.0
- \`packages/types/package.json\` → 0.2.0
- \`packages/core/package.json\` → 0.2.0
- \`packages/mcp/package.json\` → 0.2.0
- \`packages/web/package.json\` → 0.2.0
- \`package-lock.json\` regenerated to match

## Test plan

- [x] \`npm install\` clean
- [x] \`npx turbo build\` clean
- [x] \`npx turbo test\` clean (243 core / 35 mcp / 30 types / 19 todo)

Refs #126