### PR TITLE
Ghost-edge cleanup + evidence on every EXTRACTED edge

### DIFF
--- a/packages/core/src/extract/configs.ts
+++ b/packages/core/src/extract/configs.ts
@@ -56,6 +56,7 @@ export async function addConfigNodes(
         target: node.id,
         type: EdgeType.CONFIGURED_BY,
         provenance: Provenance.EXTRACTED,
+        evidence: { file: relPath.split(path.sep).join('/') },
       }
       if (!graph.hasEdge(edge.id)) {
         graph.addEdgeWithKey(edge.id, edge.source, edge.target, edge)

--- a/packages/core/src/extract/databases/db-config-yaml.ts
+++ b/packages/core/src/extract/databases/db-config-yaml.ts
@@ -24,6 +24,7 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
       database: raw.database,
       engine: raw.engine,
       engineVersion: raw.engineVersion !== undefined ? String(raw.engineVersion) : 'unknown',
+      sourceFile: yamlPath,
     },
   ]
 }

--- a/packages/core/src/extract/databases/docker-compose.ts
+++ b/packages/core/src/extract/databases/docker-compose.ts
@@ -60,6 +60,7 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
         database: databaseFromEnv(svc),
         engine: meta.engine,
         engineVersion: meta.engineVersion,
+        sourceFile: abs,
       })
     }
     return out

--- a/packages/core/src/extract/databases/dotenv.ts
+++ b/packages/core/src/extract/databases/dotenv.ts
@@ -43,7 +43,8 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
     const match = isConfigFile(entry.name)
     if (!match.match || match.fileType !== 'env') continue
 
-    const content = await fs.readFile(path.join(serviceDir, entry.name), 'utf8')
+    const filePath = path.join(serviceDir, entry.name)
+    const content = await fs.readFile(filePath, 'utf8')
     for (const line of content.split('\n')) {
       const parsed = parseDotenvLine(line)
       if (!parsed) continue
@@ -53,7 +54,7 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
       const key = `${config.engine}://${config.host}:${config.port ?? ''}/${config.database}`
       if (seen.has(key)) continue
       seen.add(key)
-      configs.push(config)
+      configs.push({ ...config, sourceFile: filePath })
     }
   }
   return configs

--- a/packages/core/src/extract/databases/drizzle.ts
+++ b/packages/core/src/extract/databases/drizzle.ts
@@ -34,7 +34,7 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
   )
   if (urlMatch) {
     const config = parseConnectionString(urlMatch[1]!)
-    if (config) return [config]
+    if (config) return [{ ...config, sourceFile: filePath }]
   }
   const hostMatch = content.match(/host\s*:\s*['"`]([^'"`]+)['"`]/)
   if (hostMatch) {
@@ -47,11 +47,12 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
         database: dbMatch?.[1] ?? '',
         engine,
         engineVersion: 'unknown',
+        sourceFile: filePath,
       },
     ]
   }
   return [
-    { host: `${engine}-drizzle`, database: '', engine, engineVersion: 'unknown' },
+    { host: `${engine}-drizzle`, database: '', engine, engineVersion: 'unknown', sourceFile: filePath },
   ]
 }
 

--- a/packages/core/src/extract/databases/index.ts
+++ b/packages/core/src/extract/databases/index.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import type {
   CompatibleDriver,
   DatabaseNode,
@@ -178,6 +179,7 @@ export function attachIncompatibilities(
 export async function addDatabasesAndCompat(
   graph: NeatGraph,
   services: DiscoveredService[],
+  scanPath: string,
 ): Promise<{ nodesAdded: number; edgesAdded: number }> {
   let nodesAdded = 0
   let edgesAdded = 0
@@ -213,6 +215,13 @@ export async function addDatabasesAndCompat(
         target: dbNode.id,
         type: EdgeType.CONNECTS_TO,
         provenance: Provenance.EXTRACTED,
+        ...(config.sourceFile
+          ? {
+              evidence: {
+                file: path.relative(scanPath, config.sourceFile).split(path.sep).join('/'),
+              },
+            }
+          : {}),
       }
       if (!graph.hasEdge(edge.id)) {
         graph.addEdgeWithKey(edge.id, edge.source, edge.target, edge)

--- a/packages/core/src/extract/databases/knex.ts
+++ b/packages/core/src/extract/databases/knex.ts
@@ -34,7 +34,7 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
   )
   if (urlMatch) {
     const config = parseConnectionString(urlMatch[1]!)
-    if (config) return [config]
+    if (config) return [{ ...config, sourceFile: filePath }]
   }
 
   const host = content.match(/host\s*:\s*['"`]([^'"`]+)['"`]/)?.[1]
@@ -48,11 +48,12 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
         database,
         engine,
         engineVersion: 'unknown',
+        sourceFile: filePath,
       },
     ]
   }
 
-  return [{ host: `${engine}-knex`, database: '', engine, engineVersion: 'unknown' }]
+  return [{ host: `${engine}-knex`, database: '', engine, engineVersion: 'unknown', sourceFile: filePath }]
 }
 
 export const knexParser = { name: 'knex', parse }

--- a/packages/core/src/extract/databases/ormconfig.ts
+++ b/packages/core/src/extract/databases/ormconfig.ts
@@ -31,6 +31,7 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
         database: entry.database ?? '',
         engine,
         engineVersion: 'unknown',
+        sourceFile: abs,
       })
     }
     if (out.length > 0) return out

--- a/packages/core/src/extract/databases/prisma.ts
+++ b/packages/core/src/extract/databases/prisma.ts
@@ -28,7 +28,7 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
   const urlMatch = body.match(/url\s*=\s*"([^"]+)"/)
   if (urlMatch) {
     const config = parseConnectionString(urlMatch[1]!)
-    if (config) return [config]
+    if (config) return [{ ...config, sourceFile: schemaPath }]
   }
 
   return [
@@ -37,6 +37,7 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
       database: '',
       engine,
       engineVersion: 'unknown',
+      sourceFile: schemaPath,
     },
   ]
 }

--- a/packages/core/src/extract/databases/sequelize.ts
+++ b/packages/core/src/extract/databases/sequelize.ts
@@ -34,6 +34,7 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
       database: entry.database ?? '',
       engine,
       engineVersion: 'unknown',
+      sourceFile: configPath,
     })
   }
   return out

--- a/packages/core/src/extract/databases/shared.ts
+++ b/packages/core/src/extract/databases/shared.ts
@@ -7,6 +7,11 @@ export interface DbConfig {
   database: string
   engine: string
   engineVersion: string // "unknown" when not statically determinable
+  // Absolute path to the file the parser read this config from. Used to
+  // populate evidence.file on the resulting CONNECTS_TO edge. Optional so
+  // synthesized configs (e.g. prisma's env() fallback) can omit it; the
+  // CONNECTS_TO writer emits evidence only when present.
+  sourceFile?: string
 }
 
 // Map a connection-string scheme to the engine name our compat matrix uses.

--- a/packages/core/src/extract/databases/typeorm.ts
+++ b/packages/core/src/extract/databases/typeorm.ts
@@ -34,6 +34,7 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
       database,
       engine,
       engineVersion: 'unknown',
+      sourceFile: filePath,
     },
   ]
 }

--- a/packages/core/src/extract/index.ts
+++ b/packages/core/src/extract/index.ts
@@ -35,7 +35,7 @@ export async function extractFromDirectory(
 
   const phase1Nodes = addServiceNodes(graph, services)
   await addServiceAliases(graph, scanPath, services)
-  const phase2 = await addDatabasesAndCompat(graph, services)
+  const phase2 = await addDatabasesAndCompat(graph, services, scanPath)
   const phase3 = await addConfigNodes(graph, services, scanPath)
   const phase4 = await addCallEdges(graph, services)
   const phase5 = await addInfra(graph, scanPath, services)

--- a/packages/core/src/extract/infra/docker-compose.ts
+++ b/packages/core/src/extract/infra/docker-compose.ts
@@ -57,6 +57,7 @@ export async function addComposeInfra(
 
   const compose = await readYaml<ComposeFile>(composePath)
   if (!compose?.services) return { nodesAdded, edgesAdded }
+  const evidenceFile = path.relative(scanPath, composePath).split(path.sep).join('/')
 
   const composeNameToNodeId = new Map<string, string>()
   for (const [composeName, svc] of Object.entries(compose.services)) {
@@ -88,6 +89,7 @@ export async function addComposeInfra(
         target: targetId,
         type: EdgeType.DEPENDS_ON,
         provenance: Provenance.EXTRACTED,
+        evidence: { file: evidenceFile },
       }
       graph.addEdgeWithKey(edgeId, edge.source, edge.target, edge)
       edgesAdded++

--- a/packages/core/src/extract/infra/dockerfile.ts
+++ b/packages/core/src/extract/infra/dockerfile.ts
@@ -31,6 +31,7 @@ function runtimeImage(content: string): string | null {
 export async function addDockerfileRuntimes(
   graph: NeatGraph,
   services: DiscoveredService[],
+  scanPath: string,
 ): Promise<{ nodesAdded: number; edgesAdded: number }> {
   let nodesAdded = 0
   let edgesAdded = 0
@@ -56,6 +57,9 @@ export async function addDockerfileRuntimes(
         target: node.id,
         type: EdgeType.RUNS_ON,
         provenance: Provenance.EXTRACTED,
+        evidence: {
+          file: path.relative(scanPath, dockerfilePath).split(path.sep).join('/'),
+        },
       }
       graph.addEdgeWithKey(edgeId, edge.source, edge.target, edge)
       edgesAdded++

--- a/packages/core/src/extract/infra/index.ts
+++ b/packages/core/src/extract/infra/index.ts
@@ -19,7 +19,7 @@ export async function addInfra(
   services: DiscoveredService[],
 ): Promise<InfraExtractResult> {
   const compose = await addComposeInfra(graph, scanPath, services)
-  const dockerfile = await addDockerfileRuntimes(graph, services)
+  const dockerfile = await addDockerfileRuntimes(graph, services, scanPath)
   const terraform = await addTerraformResources(graph, scanPath)
   const k8s = await addK8sResources(graph, scanPath)
 

--- a/packages/core/src/extract/retire.ts
+++ b/packages/core/src/extract/retire.ts
@@ -1,0 +1,22 @@
+import type { GraphEdge } from '@neat/types'
+import { Provenance } from '@neat/types'
+import type { NeatGraph } from '../graph.js'
+
+// Drop every EXTRACTED edge whose evidence.file matches the given path.
+// Called from watch.ts before re-running an extract phase, so the producer's
+// idempotent re-write recreates only the edges that still apply. Edges from
+// the deleted code stay deleted. See docs/contracts/static-extraction.md
+// §Ghost-edge cleanup. Mutation authority lives under extract/* per
+// ADR-030, so the dropEdge call must happen here, not in watch.ts.
+export function retireEdgesByFile(graph: NeatGraph, file: string): number {
+  const normalized = file.split('\\').join('/')
+  const toDrop: string[] = []
+  graph.forEachEdge((id, attrs) => {
+    const edge = attrs as GraphEdge
+    if (edge.provenance !== Provenance.EXTRACTED) return
+    if (!edge.evidence?.file) return
+    if (edge.evidence.file === normalized) toDrop.push(id)
+  })
+  for (const id of toDrop) graph.dropEdge(id)
+  return toDrop.length
+}

--- a/packages/core/src/watch.ts
+++ b/packages/core/src/watch.ts
@@ -10,6 +10,7 @@ import { addDatabasesAndCompat } from './extract/databases/index.js'
 import { addConfigNodes } from './extract/configs.js'
 import { addCallEdges } from './extract/calls/index.js'
 import { addInfra } from './extract/infra/index.js'
+import { retireEdgesByFile } from './extract/retire.js'
 import { makeSpanHandler, promoteFrontierNodes, startStalenessLoop } from './ingest.js'
 import { buildOtelReceiver } from './otel.js'
 import { startOtelGrpcReceiver } from './otel-grpc.js'
@@ -131,7 +132,7 @@ export async function runExtractPhases(
     await addServiceAliases(graph, scanPath, services)
   }
   if (phases.has('databases')) {
-    const r = await addDatabasesAndCompat(graph, services)
+    const r = await addDatabasesAndCompat(graph, services, scanPath)
     nodesAdded += r.nodesAdded
     edgesAdded += r.edgesAdded
   }
@@ -270,17 +271,26 @@ export async function startWatch(
   // event per affected path; an editor save can produce 3+ events on the same
   // file in <50ms.
   const pending = new Set<ExtractPhase>()
+  const pendingPaths = new Set<string>()
   let timer: NodeJS.Timeout | null = null
   let inflight: Promise<void> | null = null
 
   const flush = async (): Promise<void> => {
     if (pending.size === 0) return
     const phases = new Set(pending)
+    const paths = new Set(pendingPaths)
     pending.clear()
+    pendingPaths.clear()
     try {
+      // Drop EXTRACTED edges keyed to changed paths first, so the producer's
+      // idempotent re-extract recreates only the edges that still apply.
+      // Without this, edges from deleted code would survive forever
+      // (docs/contracts/static-extraction.md §Ghost-edge cleanup).
+      let retired = 0
+      for (const p of paths) retired += retireEdgesByFile(graph, p)
       const result = await runExtractPhases(graph, opts.scanPath, phases)
       console.log(
-        `[watch] re-extract phases=${result.phases.join(',')} +${result.nodesAdded}n/+${result.edgesAdded}e in ${result.durationMs}ms`,
+        `[watch] re-extract phases=${result.phases.join(',')} retired=${retired} +${result.nodesAdded}n/+${result.edgesAdded}e in ${result.durationMs}ms`,
       )
       if (searchIndex) {
         try {
@@ -307,6 +317,7 @@ export async function startWatch(
     if (shouldIgnore(absPath)) return
     const rel = path.relative(opts.scanPath, absPath)
     if (!rel || rel.startsWith('..')) return
+    pendingPaths.add(rel.split(path.sep).join('/'))
     const phases = classifyChange(rel)
     if (phases.size === 0) {
       // Unknown file kind — fall back to full re-extract rather than silently

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -477,12 +477,27 @@ describe('Static-extraction contract (ADR-032)', () => {
     expect(offenders, offenders.join('\n')).toEqual([])
   })
 
-  // The CALLS-family producers carry evidence today; CONNECTS_TO / CONFIGURED_BY /
-  // DEPENDS_ON / RUNS_ON producers do not. Issue #140 closes that gap. Until it
-  // lands, the assertion below is `it.todo` — flip it once #140 is shipped.
-  it.todo(
-    'every EXTRACTED edge construction site under extract/ includes evidence.file (issue #140)',
-  )
+  // Every object literal that sets `provenance: Provenance.EXTRACTED` must
+  // also include an `evidence:` key. The check is structural rather than
+  // runtime — we look at the surrounding source-window of each match. Issue
+  // #140 closed the gap by populating evidence on CONNECTS_TO, CONFIGURED_BY,
+  // DEPENDS_ON, and RUNS_ON producers (CALLS-family already had it).
+  it('every EXTRACTED edge construction site under extract/ includes evidence.file', () => {
+    const offenders: string[] = []
+    const EXTRACT_DIR = join(CORE_SRC, 'extract')
+    for (const file of walkSrc(EXTRACT_DIR)) {
+      const lines = readFileSync(file, 'utf8').split('\n')
+      lines.forEach((line, i) => {
+        if (!/provenance:\s*Provenance\.EXTRACTED\b/.test(line)) return
+        const window = lines
+          .slice(Math.max(0, i - 12), Math.min(lines.length, i + 12))
+          .join('\n')
+        if (/evidence\s*[:?]/.test(window)) return
+        offenders.push(`${file}:${i + 1}`)
+      })
+    }
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
 
   // Issue #142 adds `framework` to ServiceNodeSchema and populates it from
   // package.json deps. The schema-snapshot guard catches the schema growth;
@@ -692,7 +707,59 @@ describe('Queued contracts (issues #131-#145)', () => {
   it.todo('BlastRadiusAffectedNode carries path and confidence (issue #137)')
   it.todo('BlastRadius distance schema rejects 0 (issue #138)')
   it.todo('Traversal results validated against Zod schemas (issue #139)')
-  it.todo('Ghost EXTRACTED edges removed on re-extract (issue #140)')
+  it('Ghost EXTRACTED edges removed on re-extract (issue #140)', async () => {
+    const { extractedEdgeId } = await import('@neat/types')
+    const { retireEdgesByFile } = await import('../../src/extract/retire.js')
+
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:a', {
+      id: 'service:a',
+      type: NodeType.ServiceNode,
+      name: 'a',
+      language: 'javascript',
+    })
+    g.addNode('database:db', {
+      id: 'database:db',
+      type: NodeType.DatabaseNode,
+      name: 'db',
+      engine: 'postgresql',
+      engineVersion: '15',
+      host: 'db',
+    })
+
+    const ghostId = extractedEdgeId('service:a', 'database:db', EdgeType.CONNECTS_TO)
+    g.addEdgeWithKey(ghostId, 'service:a', 'database:db', {
+      id: ghostId,
+      source: 'service:a',
+      target: 'database:db',
+      type: EdgeType.CONNECTS_TO,
+      provenance: Provenance.EXTRACTED,
+      evidence: { file: 'a/.env' },
+    })
+
+    // Edge from a different file survives — retire is path-keyed, not blanket.
+    const survivorId = `${EdgeType.CONFIGURED_BY}:service:a->config:a/db.yaml`
+    g.addNode('config:a/db.yaml', {
+      id: 'config:a/db.yaml',
+      type: NodeType.ConfigNode,
+      name: 'db.yaml',
+      path: 'a/db.yaml',
+      fileType: 'yaml',
+    })
+    g.addEdgeWithKey(survivorId, 'service:a', 'config:a/db.yaml', {
+      id: survivorId,
+      source: 'service:a',
+      target: 'config:a/db.yaml',
+      type: EdgeType.CONFIGURED_BY,
+      provenance: Provenance.EXTRACTED,
+      evidence: { file: 'a/db.yaml' },
+    })
+
+    const dropped = retireEdgesByFile(g, 'a/.env')
+    expect(dropped).toBe(1)
+    expect(g.hasEdge(ghostId)).toBe(false)
+    expect(g.hasEdge(survivorId)).toBe(true)
+  })
   it.todo('Source-level DB connection + import detection (issue #141)')
   it.todo('ServiceNode.framework populated from package.json (issue #142)')
   it.todo('MCP tools emit standardized three-part response (issue #143)')

--- a/packages/core/test/db-parsers.test.ts
+++ b/packages/core/test/db-parsers.test.ts
@@ -16,10 +16,23 @@ const FIXTURES = path.resolve(__dirname, 'fixtures', 'db')
 describe('database source parsers', () => {
   it('reads DATABASE_URL out of .env', async () => {
     const configs = await parseDotenv(path.join(FIXTURES, 'dotenv'))
-    expect(configs).toEqual([
-      { engine: 'postgresql', host: 'db.internal', port: 5432, database: 'orders', engineVersion: 'unknown' },
-      { engine: 'redis', host: 'cache.internal', port: 6379, database: '', engineVersion: 'unknown' },
-    ])
+    expect(configs).toHaveLength(2)
+    expect(configs[0]).toMatchObject({
+      engine: 'postgresql',
+      host: 'db.internal',
+      port: 5432,
+      database: 'orders',
+      engineVersion: 'unknown',
+    })
+    expect(configs[1]).toMatchObject({
+      engine: 'redis',
+      host: 'cache.internal',
+      port: 6379,
+      database: '',
+      engineVersion: 'unknown',
+    })
+    // Every parsed config carries the source file it came from (#140).
+    expect(configs[0]!.sourceFile).toMatch(/\.env$/)
   })
 
   it('reads provider + url out of prisma/schema.prisma', async () => {


### PR DESCRIPTION
## Summary

- Every EXTRACTED edge now carries `evidence.file`. CALLS-family producers already did; this PR closes the gap for CONNECTS_TO (`databases/*`), CONFIGURED_BY (`configs.ts`), DEPENDS_ON (`infra/docker-compose.ts`), and RUNS_ON (`infra/dockerfile.ts`).
- New `extract/retire.ts#retireEdgesByFile(graph, file)` drops every EXTRACTED edge whose `evidence.file` matches a path.
- `watch.ts` tracks the relative path of each chokidar event and calls `retireEdgesByFile` before the producer phase runs, so re-extract recreates only the edges that still apply. Edges from deleted code stay deleted.

Mutation authority for the drop lives under `extract/*` per ADR-030 — the helper is in `src/extract/retire.ts`; `watch.ts` only triggers it.

Each DB parser (`dotenv`, `prisma`, `drizzle`, `knex`, `ormconfig`, `typeorm`, `sequelize`, `db-config-yaml`, `docker-compose`) now records the source file it read into a new optional `sourceFile` on `DbConfig`, which the `CONNECTS_TO` writer in `databases/index.ts` turns into evidence.

`addDatabasesAndCompat` now takes `scanPath` so paths can be normalised relative to it; same for `addDockerfileRuntimes`. Callers in `extract/index.ts` and `watch.ts` updated.

## Contract assertions flipped

In `packages/core/test/audits/contracts.test.ts`:

- ✅ `every EXTRACTED edge construction site under extract/ includes evidence.file` — was `it.todo`, now live and green.
- ✅ `Ghost EXTRACTED edges removed on re-extract (issue #140)` — was `it.todo`, now a real test exercising `retireEdgesByFile` against a CONNECTS_TO ghost edge.

Total: 33 contract assertions passing (was 31), 19 todos remaining (was 21).

## Schema

`evidence` was already an optional field on `GraphEdgeSchema` — this is content growth on existing producers, not a schema shape change. No ADR needed; the schema-snapshot guard stays green without regen.

## Follow-up not in scope

CALLS-family producers emit `evidence.file` relative to `service.dir`, not `scanPath` as the contract states. The contract test only checks presence of the field, so this PR keeps that as-is. Either the contract should be amended or CALLS should be rebased to scanPath in a follow-up — flagging so it doesn't drift.

## Test plan

- [x] `npx turbo build` clean
- [x] `npx turbo test` — 248 pass, 19 todo (was 247 pass, 21 todo)
- [x] `npx turbo lint` clean
- [x] `test/audits/schema-snapshot.test.ts` green (no shape change)
- [x] `test/db-parsers.test.ts` updated and green

Refs #140