### PR TITLE
Contracts #6/#7/#8: OTel ingest + trace stitcher + FrontierNode promotion (ADRs 033-035) — opens v0.2.2

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -15,6 +15,9 @@ This file is the index. Each rule has a short summary and a link to its full per
 | 3 | Node + edge lifecycle | [`contracts/lifecycle.md`](./contracts/lifecycle.md) | Creation, transition, retirement. Mutation authority locked to `ingest.ts` and `extract/*` (ADR-030) | ✅ landed |
 | 4 | Schema growth vs shape | [`contracts/schema.md`](./contracts/schema.md) | Growth = commit-and-go (snapshot diff). Shape change = ADR + `persist.ts` migration (ADR-031) | ✅ landed |
 | 5 | Static extraction | [`contracts/static-extraction.md`](./contracts/static-extraction.md) | Producer interface, evidence on every EXTRACTED edge, ghost-edge cleanup keyed on `evidence.file`, language dispatch, idempotency (ADR-032) | ✅ landed (v0.2.1 opens) |
+| 6 | OTel ingest | [`contracts/otel-ingest.md`](./contracts/otel-ingest.md) | Non-blocking receiver, span-time `lastObserved`, parent-span cache, exception-event parsing, auto-creation of unseen services/DBs (ADR-033) | ✅ landed (v0.2.2 opens) |
+| 7 | Trace stitcher | [`contracts/trace-stitcher.md`](./contracts/trace-stitcher.md) | ERROR-only trigger, depth-2 limit, EXTRACTED-only walk, OBSERVED-twin-skip rule, default confidence 0.6 (ADR-034) | ✅ landed (v0.2.2 opens) |
+| 8 | FrontierNode promotion | [`contracts/frontier-promotion.md`](./contracts/frontier-promotion.md) | Post-extract trigger, alias-match precedence, atomic per-node, FRONTIER→OBSERVED upgrade, canonical edge-id helpers required (ADR-035) | ✅ landed (v0.2.2 opens) |
 
 ### Future contracts — opened at the start of each milestone
 
@@ -22,9 +25,6 @@ Producer-, consumer-, surface-, policy-, and distribution-layer contracts open a
 
 | # | Contract | Milestone | Governs (target) |
 |---|----------|-----------|------------------|
-| 6 | OTel ingest | v0.2.2 | Span-time `lastObserved`, parent-span correlation, exception-event parsing, auto-creation, non-blocking ingest (`ingest.ts` ingest path) |
-| 7 | Trace stitcher | v0.2.2 | When INFERRED fires, depth limit, OBSERVED-twin-skip rule (`stitchTrace`) |
-| 8 | FrontierNode promotion | v0.2.2 | When promotion fires, alias-match precedence, attribute merge (`promoteFrontierNodes`) |
 | 9 | Traversal | v0.2.3 | Edge priority per hop, FRONTIER exclusion, confidence cascading, schema validation (`traverse.ts`) |
 | 10 | `getRootCause` | v0.2.3 | Incompatibility-check semantics per upstream node type, reason-string format, fix-recommendation derivation |
 | 11 | `getBlastRadius` | v0.2.3 | Outbound semantics, distance positive integer, per-node path and confidence, total-affected count |

--- a/docs/contracts/frontier-promotion.md
+++ b/docs/contracts/frontier-promotion.md
@@ -1,0 +1,112 @@
+---
+name: frontier-promotion
+description: FrontierNode promotion fires after every extract pass, alias-matches by name then aliases list, atomically rewires incident edges, upgrades FRONTIER to OBSERVED on rebuild. Edge ids during rebuild MUST use canonical helpers.
+governs:
+  - "packages/core/src/ingest.ts"
+  - "packages/core/src/extract/index.ts"
+  - "packages/core/src/extract/aliases.ts"
+  - "packages/core/src/watch.ts"
+adr: [ADR-035, ADR-023, ADR-029, ADR-030]
+---
+
+# FrontierNode promotion contract
+
+The third of three v0.2.2 producer-layer contracts. Governs `promoteFrontierNodes`, `rewireFrontierEdges`, and `rebuildEdge` in `ingest.ts`. Sibling contracts: [otel-ingest.md](./otel-ingest.md), [trace-stitcher.md](./trace-stitcher.md).
+
+FrontierNodes (ADR-023) are placeholders for OTel peers that don't match any known service. Promotion replaces a FrontierNode with a real typed node once an alias resolves the host. This contract locks the trigger conditions, alias-match rules, edge-rewrite semantics, and the FRONTIER → OBSERVED provenance upgrade.
+
+## Trigger
+
+`promoteFrontierNodes(graph)` runs:
+- at the end of `extract/index.ts:extractFromDirectory` (every static-extraction pass),
+- at the end of every watch-driven phase rerun in `watch.ts`.
+
+**Promotion is batched per pass, not per-edge.** The ingest path itself does not trigger promotion — only the static-extraction lifecycle does, because aliases land during static extraction (compose names, k8s metadata.name, Dockerfile labels via `extract/aliases.ts`).
+
+## Alias matching
+
+The function builds a `Map<string, string>` from every ServiceNode's `attrs.name → id` and `attrs.aliases[i] → id`. Then it walks every FrontierNode and looks up `attrs.host` in the map:
+
+- First match wins.
+- If no match, the FrontierNode persists; the next extract pass tries again.
+- A FrontierNode whose host happens to equal a service name is promoted on the spot.
+
+Aliases come from `extract/aliases.ts`, which scans docker-compose, k8s manifests, and Dockerfile labels.
+
+## Atomicity
+
+Promotion is atomic per FrontierNode. When a FrontierNode is selected:
+
+1. All incident edges (inbound + outbound) are rewired to the typed-node id via `rewireFrontierEdges`.
+2. The FrontierNode is dropped via `graph.dropNode(frontierId)`.
+
+There is no point at which a partial state is visible. ADR-030 §9 atomicity applies.
+
+## Edge rewrite
+
+`rewireFrontierEdges` walks `graph.inboundEdges(frontierId)` and `graph.outboundEdges(frontierId)`. For each, `rebuildEdge`:
+
+1. Drops the old edge.
+2. Constructs a new edge id under the typed-node endpoint via the canonical helper.
+3. Adds the new edge with the rebuilt attributes — or merges into the existing edge if one is already present at the new id.
+
+This is the only place in the codebase where an edge id changes — not because the edge content changed, but because one of its endpoints did.
+
+## Provenance upgrade: FRONTIER → OBSERVED
+
+When `rebuildEdge` is rewriting an edge whose provenance was `FRONTIER`, the new edge's provenance is `OBSERVED`. The reasoning: the call certainty was always there (the OTel span was observed), only the target identity was unknown. Now it's known, so the edge graduates from placeholder to direct measurement.
+
+Other provenance values pass through unchanged:
+- EXTRACTED stays EXTRACTED (rare — FrontierNodes typically have only OTel-source edges, but possible in mixed cases).
+- INFERRED stays INFERRED (also rare).
+- FRONTIER → OBSERVED is the load-bearing case.
+
+## Edge id construction (binding — and a current violation)
+
+`rebuildEdge` MUST construct the new edge id via the canonical helpers from `@neat/types/identity` (ADR-029):
+
+```ts
+const newId =
+  promotedProvenance === Provenance.OBSERVED ? observedEdgeId(newSource, newTarget, edge.type) :
+  promotedProvenance === Provenance.INFERRED ? inferredEdgeId(newSource, newTarget, edge.type) :
+  promotedProvenance === Provenance.EXTRACTED ? extractedEdgeId(newSource, newTarget, edge.type) :
+  frontierEdgeId(newSource, newTarget, edge.type)
+```
+
+**Today `ingest.ts:463` hand-rolls the id**:
+
+```ts
+// CURRENT — contract violation
+const newId = `${edge.type}:${promotedProvenance}:${newSource}->${newTarget}`
+```
+
+The contracts.test.ts scan (provenance contract, ADR-029) didn't catch it because the literal interpolates the provenance variable rather than embedding `:OBSERVED:` directly. The scan is extended in this batch to catch the variable-interpolation case. Fix is a v0.2.2 cleanup task: replace the literal with the dispatch above.
+
+## Edge merge on collision
+
+If the rewritten edge id already exists (because an OBSERVED edge between the typed source and target was previously created independently), the rebuilt edge merges into the existing one:
+
+```ts
+{ ...existing,
+  callCount: (existing.callCount ?? 0) + (edge.callCount ?? 0),
+  lastObserved: pickLater(existing.lastObserved, edge.lastObserved) }
+```
+
+No duplicate edge is created.
+
+## No reverse promotion
+
+A typed node never reverts to a FrontierNode. If OTel later observes a peer that matches no known service, a *new* FrontierNode is created at a different host id; the previously-promoted typed node is unaffected.
+
+## Authority
+
+`promoteFrontierNodes` is owned by `ingest.ts` per ADR-030. Triggered by `extract/index.ts` and `watch.ts`. No other module calls it.
+
+## Enforcement
+
+`contracts.test.ts` includes:
+- A live test asserting alias-matched FrontierNode is promoted, edges are rewired, FRONTIER provenance becomes OBSERVED on rebuilt edges (already exists from the lifecycle contract — extended here to also assert id construction routes through the canonical helpers).
+- A new live test scanning for hand-rolled edge id template literals that include a variable-interpolated provenance segment (catches the `${edge.type}:${variable}:...` pattern in `rebuildEdge`).
+- An `it.todo` keyed to the rebuildEdge-uses-canonical-helpers fix.
+
+Full rationale and historical context: [ADR-035](../decisions.md#adr-035--frontiernode-promotion-contract).

--- a/docs/contracts/otel-ingest.md
+++ b/docs/contracts/otel-ingest.md
@@ -1,0 +1,88 @@
+---
+name: otel-ingest
+description: OTel receiver replies before mutation, lastObserved derives from span time, parent-span cache correlates cross-service CALLS, exception data is parsed from span events, unseen services and DBs are auto-created.
+governs:
+  - "packages/core/src/ingest.ts"
+  - "packages/core/src/otel.ts"
+  - "packages/core/src/otel-grpc.ts"
+adr: [ADR-033, ADR-029, ADR-030]
+---
+
+# OTel ingest contract
+
+The first of three v0.2.2 producer-layer contracts. Governs the OTel ingest path: receiver, span parsing, the `handleSpan` mutation function. Sibling contracts: [trace-stitcher.md](./trace-stitcher.md), [frontier-promotion.md](./frontier-promotion.md). Together they lock the OBSERVED layer.
+
+## Non-blocking ingest (binding)
+
+The receiver replies 200 OK immediately on receipt. Mutation runs through a non-blocking handler — either an in-process queue drained on the next tick, or fire-and-forget with bounded concurrency. **The OTel sender is never blocked on graph mutation.** SDK exporters retry on timeout, so blocking ingest produces observable backpressure on the system being observed; ambient observation requires no observable effect.
+
+Today (issue #131) the receiver awaits `opts.onSpan` per-span before sending the 200. The cleanup is to introduce a queue.
+
+## `lastObserved` from span time
+
+Every OBSERVED edge's `lastObserved` field is derived from `span.startTimeUnixNano`, converted to ISO8601. Replayed traces, out-of-order spans, and historical fill-ins must produce a `lastObserved` that reflects when the span actually fired — not when the receiver received it.
+
+The conversion lives in `parseOtlpRequest` so every consumer of `ParsedSpan.startTimeUnixNano` gets a normalized form. `nowIso(ctx)` is for cases where a span timestamp doesn't apply (e.g. ad-hoc test fixtures); production paths use the span time. Issue #132 closes this gap.
+
+## Parent-span cache for cross-service CALLS
+
+Today peer resolution uses `server.address` / `net.peer.name` / `url.full` only. That misses non-HTTP RPCs and any span whose peer is opaque.
+
+The contract adds a bounded TTL cache keyed by `${traceId}:${spanId}` storing each span's service. On span arrival:
+
+1. Address-based resolution runs first (`pickAddress(span)`).
+2. If no peer is found and `parentSpanId` is set, look up the parent in the cache. If the parent's service is known and differs from the current span's service, that's a cross-service CALLS edge.
+
+Cache size and TTL are constants near the other ingest tunables. Out-of-order arrival (child before parent) drops the child; we don't buffer. Issue #133.
+
+## Auto-creation of unseen services and databases
+
+When `handleSpan` resolves a `service.name` not present in the graph, it creates a minimal `ServiceNode` at `serviceId(span.service)` with `language: 'unknown'`, no `version`, no `dependencies`. Same for unseen `db.system` + host — a minimal `DatabaseNode` at `databaseId(host)`.
+
+Auto-created nodes carry `discoveredVia: 'otel'` (schema growth governed by ADR-031 — adds an optional field, snapshot regenerates).
+
+When static extraction later finds the same id, attributes **merge** per ADR-028 §3. Static fields override OTel-derived fields where both exist (because static is more authoritative on declared intent: language, version, dependencies). `discoveredVia` becomes `'merged'` if both layers recorded the node independently. Issue #134.
+
+## Exception data from span events
+
+`OtlpSpan` is extended with `events: Array<{ name, timeUnixNano, attributes }>`. When a span has an `events[]` entry with `name === 'exception'`, the parser extracts `exception.type`, `exception.message`, and `exception.stacktrace` from its attributes.
+
+`handleSpan`'s ErrorEvent path prefers exception data over `status.message`:
+
+```
+exceptionMessage = events.find(e => e.name === 'exception')?.attributes['exception.message']
+                ?? span.status.message
+                ?? span.name
+                ?? 'unknown error'
+```
+
+`exception.type` is added to ErrorEvent as an optional field (schema growth via ADR-031). Issue #135.
+
+## HTTP receiver supports JSON and protobuf
+
+Today the HTTP receiver only accepts `application/json` bodies. The contract: dispatch on `Content-Type`. Protobuf parsing uses the bundled `.proto` definitions (ADR-020). gRPC continues to handle protobuf natively.
+
+## `db.system` is data, not a switch
+
+Engine identification is read from the span attribute as a string and never compared against a hardcoded list. No `if (db.system === 'postgresql')` branches. Engine-specific behavior lives in `compat.json` and is consulted via `compat.ts` per Rule 8 of `docs/contracts.md`.
+
+## Error events
+
+`appendErrorEvent` writes to `errors.ndjson` synchronously after the graph mutation but before the receiver replies. If the file write fails, the receiver returns 500 so the OTel SDK retries.
+
+ErrorEvent shape stays as defined in `@neat/types`. New fields (`exceptionType`, `exceptionStacktrace`) land via the schema-growth contract.
+
+## Authority
+
+Owned by `ingest.ts` per ADR-030. Receiver shape lives in `otel.ts` / `otel-grpc.ts`; mutation logic lives in `ingest.ts`. No other module mutates the graph through the OTel ingest path.
+
+## Enforcement
+
+`packages/core/test/audits/contracts.test.ts` includes `it.todo` items keyed to issues #131-#135. Each flips to a live assertion as the issue ships:
+- non-blocking ingest (timing-based test on the receiver),
+- `lastObserved` from span time (replay-a-backdated-span fixture),
+- parent-span cache correlation (parent-then-child fixture, child-then-parent fixture),
+- auto-creation (span for unseen service produces ServiceNode with `discoveredVia: 'otel'`),
+- exception event parsing (span with `events[]` produces ErrorEvent with `exceptionMessage` from the event).
+
+Full rationale and historical context: [ADR-033](../decisions.md#adr-033--otel-ingest-contract).

--- a/docs/contracts/trace-stitcher.md
+++ b/docs/contracts/trace-stitcher.md
@@ -1,0 +1,70 @@
+---
+name: trace-stitcher
+description: stitchTrace fires only on ERROR spans, walks EXTRACTED outbound edges to depth 2, produces INFERRED edges with confidence 0.6, skips hops where an OBSERVED twin already exists.
+governs:
+  - "packages/core/src/ingest.ts"
+adr: [ADR-034, ADR-027, ADR-029, ADR-030]
+---
+
+# Trace stitcher contract
+
+The second of three v0.2.2 producer-layer contracts. Governs `stitchTrace` and `upsertInferredEdge` in `ingest.ts`. Sibling contracts: [otel-ingest.md](./otel-ingest.md), [frontier-promotion.md](./frontier-promotion.md).
+
+The trace stitcher is the load-bearing concrete example of NEAT's value (ADR-027). When declared intent and observed reality diverge — a service depending on a driver that can't be auto-instrumented (pg 7.4.0 in the demo, PROVENANCE.md) — the stitcher infers the bridge and labels it as inferred. The user sees what NEAT reasoned about, not just what it observed directly.
+
+## Trigger
+
+`stitchTrace` is called by `handleSpan` only when `span.statusCode === 2`. Non-error spans don't trigger inference: if the call succeeded, the OBSERVED layer captured what it could.
+
+## Depth limit
+
+`STITCH_MAX_DEPTH = 2`, hardcoded. Walking deeper produces speculative edges that are too far from the originating error to claim relevance. The constant is a contract value, not a tunable — changing it requires an ADR amendment.
+
+## Walks EXTRACTED outbound only
+
+The BFS walks `graph.outboundEdges(node)` and considers only edges where `provenance === Provenance.EXTRACTED`:
+
+- OBSERVED edges already carry the relationship — no inference needed.
+- INFERRED edges are the stitcher's own output — no recursion.
+- FRONTIER edges represent unknown territory and are excluded per Rule 3 of `docs/contracts.md`.
+- STALE edges represent decayed observation — not inferable from a fresh error.
+
+## OBSERVED-twin skip rule
+
+When the stitcher considers an EXTRACTED edge `(source, target, type)`, it checks whether an OBSERVED edge for the same triplet already exists:
+
+```ts
+if (graph.hasEdge(observedEdgeId(source, target, type))) continue
+```
+
+If so, the OBSERVED edge already provides ground-truth coverage for that hop — the stitcher does **not** produce an INFERRED twin. Today the stitcher writes INFERRED edges regardless of OBSERVED twins; the rule closes that gap (verification.md OTel §7).
+
+## Confidence
+
+Default `0.6`, capped at `0.7`. `INFERRED_CONFIDENCE = 0.6` is applied at edge creation. The stitcher does not produce edges with confidence > 0.7 even if a custom override is added later — INFERRED is by definition less trustworthy than OBSERVED, which carries `1.0`. The cap is a contract value.
+
+## Idempotency
+
+When a second error span produces the same stitched edges, `upsertInferredEdge` updates `lastObserved` on the existing edge — it does not create duplicates, does not increment a confidence score, does not add evidence. The edge id (`inferredEdgeId(source, target, type)`) is the deduplication key.
+
+## Origin generality
+
+`stitchTrace(graph, sourceServiceId, ts)` accepts any `service:*` id as the origin. No special-case for the demo (`service:service-b`); no hardcoded driver (`pg`); no hardcoded engine (`postgresql`). The stitcher walks whatever EXTRACTED edges exist outbound from the erroring service.
+
+## No node creation
+
+The stitcher only writes edges. It never creates nodes; it never modifies existing nodes; it doesn't extend across FrontierNode boundaries.
+
+## Authority
+
+`stitchTrace` is owned by `ingest.ts` per ADR-030. Called only from `handleSpan` (error path). No other module triggers stitching.
+
+## Enforcement
+
+`contracts.test.ts` includes:
+- A live test asserting `stitchTrace` produces no edges when called with a node that has no outbound EXTRACTED edges.
+- A live test asserting `STITCH_MAX_DEPTH` is enforced (depth-3 EXTRACTED chain produces edges only at depth 1 and 2).
+- An `it.todo` keyed to the OBSERVED-twin-skip refinement.
+- An idempotency test (calling `stitchTrace` twice produces identical edge state).
+
+Full rationale and historical context: [ADR-034](../decisions.md#adr-034--trace-stitcher-contract).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -756,3 +756,148 @@ The shape of source-level DB-connection detection (issue #141 — that's an impl
 **When to revisit.**
 
 When source-level DB-connection detection (#141) lands — that introduces a new producer pattern (`new pg.Pool(...)` etc.) and the contract may need to specify its evidence shape more precisely (e.g. constructor-name in the snippet). When ghost-edge cleanup (#140) ships — the contract's path-keyed retire step becomes load-bearing and might surface edge cases.
+
+---
+
+## ADR-033 — OTel ingest contract
+
+**Date:** 2026-05-05
+**Status:** Active.
+
+The first of three v0.2.2 producer-layer contracts. Governs the OTel ingest path in `packages/core/src/ingest.ts` plus the receiver in `otel.ts` and `otel-grpc.ts`. Sibling contracts: ADR-034 (trace stitcher) and ADR-035 (FrontierNode promotion). They share vocabulary and govern overlapping concerns; together they lock the OBSERVED layer.
+
+**Decision.**
+
+1. **Receiver replies before mutation (issue #131).** The OTLP/HTTP receiver in `packages/core/src/otel.ts` and the gRPC receiver in `packages/core/src/otel-grpc.ts` reply 200 OK immediately on receipt. Mutation runs through a non-blocking handler — either an in-process queue drained on the next tick, or a fire-and-forget pattern with bounded concurrency. **The sender is never blocked on graph mutation.** OTel SDK exporters retry on timeout, so blocking ingest causes observable backpressure on the system being observed; ambient observation requires no observable effect.
+
+2. **`lastObserved` is sourced from `span.startTimeUnixNano`, not `Date.now()` (issue #132).** Every OBSERVED edge's `lastObserved` field is derived from the parsed span's start time, converted to ISO8601. Replayed traces, out-of-order spans, and historical fill-ins must produce a `lastObserved` that reflects when the span actually fired — not when the receiver happened to receive it. The ISO8601 conversion lives in `parseOtlpRequest` (otel.ts) so every consumer of `ParsedSpan.startTimeUnixNano` gets a normalized form.
+
+3. **Cross-service CALLS edges correlate via parent-span cache (issue #133).** Today peer resolution uses `server.address` / `net.peer.name` / `url.full` only. That misses non-HTTP RPCs and any span whose peer is opaque. The contract adds a bounded TTL cache keyed by `${traceId}:${spanId}` storing each span's service. On span arrival, peer resolution falls through to a `parentSpanId` lookup in the cache: if the parent's service is known and differs from the current service, that's a cross-service CALLS edge. Cache size and TTL are constants near the other ingest tunables in `ingest.ts`. Out-of-order arrival (child before parent) drops the child cleanly; we don't buffer.
+
+4. **Auto-creation of ServiceNode and DatabaseNode for unseen peers (issue #134).** When `handleSpan` resolves a `service.name` not present in the graph, it creates a minimal ServiceNode at `serviceId(span.service)` with `language: 'unknown'`, no `version`, no `dependencies`. Same for unseen `db.system` + host — a minimal DatabaseNode at `databaseId(host)`. Auto-created nodes carry `discoveredVia: 'otel'` (schema growth governed by ADR-031 — adds an optional field to ServiceNode/DatabaseNode, snapshot regenerates). Static extraction that later finds the same id **merges** attributes per ADR-028 §3 reconciliation rule; static fields override OTel-derived fields where both exist, but `discoveredVia` is only updated to `'merged'` if both layers recorded the node independently.
+
+5. **Exception data parsed from span events (issue #135).** `OtlpSpan` is extended with `events: Array<{ name, timeUnixNano, attributes }>` in the parser. When a span has an `events[]` entry with `name === 'exception'`, the parser extracts `exception.type`, `exception.message`, and `exception.stacktrace` from its attributes. `handleSpan`'s ErrorEvent path prefers `exception.message` over `status.message` over `span.name`. `exception.type` is added to ErrorEvent as an optional field (schema growth via ADR-031).
+
+6. **HTTP receiver supports both JSON and protobuf bodies.** Today only JSON. The receiver checks `Content-Type` and dispatches to either `parseOtlpJsonRequest` or `parseOtlpProtobufRequest`. Protobuf parsing uses the bundled `.proto` definitions (ADR-020). gRPC continues to handle protobuf natively.
+
+7. **`db.system` is data, not a switch.** Engine identification is read from the span attribute as a string and never compared against a hardcoded list (no `if (db.system === 'postgresql')` branches). Engine-specific behavior lives in `compat.json` and is consulted via `compat.ts` per the demo-name-freedom contract (Rule 8 in `docs/contracts.md`).
+
+8. **Error events are ndjson-appended, never lost on receiver shutdown.** `appendErrorEvent` writes to `errors.ndjson` synchronously after the graph mutation but before the receiver replies — this is the one explicit ordering point. If the file write fails, the receiver returns 500 so the OTel SDK retries. ErrorEvent shape stays as defined in `@neat/types` per the schema-growth contract; new fields land via the snapshot guard.
+
+**Authority.**
+
+The OTel ingest contract is owned by `packages/core/src/ingest.ts` per ADR-030 lifecycle authority. The receiver shape lives in `otel.ts` / `otel-grpc.ts`; mutation logic lives in `ingest.ts`. Neither file may be mutated outside the producer-author's edits during v0.2.2.
+
+**Enforcement.**
+
+`packages/core/test/audits/contracts.test.ts` adds `it.todo` items keyed to issues #131-#135. They flip to live assertions as each issue ships:
+- non-blocking ingest (timing-based test on the receiver),
+- `lastObserved` from span time (replay-a-backdated-span fixture),
+- parent-span cache correlation (parent-then-child fixture, child-then-parent fixture),
+- auto-creation (span for unseen service produces ServiceNode),
+- exception event parsing (span with `events[]` produces ErrorEvent with exception fields).
+
+**What this ADR is not deciding.**
+
+Trace stitcher rules — see ADR-034. FrontierNode promotion — see ADR-035. Whether `discoveredVia` becomes a generalized provenance-on-nodes field (deferred — today it's a service/database-level concern, not a node-shape concern). eBPF / mesh-Net source variants (deferred to v1.0+ per the v0.2.x discussion).
+
+**When to revisit.**
+
+When auto-creation lands and OTel-only services start landing in real codebases — the merge rules (#4) might surface edge cases the contract didn't anticipate. When a non-Node OTel SDK arrives that uses semconv variants the parser doesn't handle — the address picker (`pickAddress`) might need extension.
+
+---
+
+## ADR-034 — Trace stitcher contract
+
+**Date:** 2026-05-05
+**Status:** Active.
+
+Governs the trace stitcher in `packages/core/src/ingest.ts` (`stitchTrace`, `upsertInferredEdge`). The trace stitcher is what bridges OBSERVED gaps when an instrumentation library can't emit spans for a particular driver — the demo's pg 7.4.0 case (PROVENANCE.md, ADR-027). It's the load-bearing concrete example of NEAT's value: when declared intent and observed reality diverge, NEAT infers the bridge and labels it as inferred.
+
+Sibling contracts: ADR-033 (OTel ingest), ADR-035 (FrontierNode promotion).
+
+**Decision.**
+
+1. **Stitcher fires only on ERROR spans.** `stitchTrace` is called by `handleSpan` only when `span.statusCode === 2`. The stitcher's job is to surface inferred dependency paths when an erroring service was exercising downstream services that may not have been observed directly. Non-error spans don't trigger inference — if the call succeeded, the OBSERVED layer captured what it could and INFERRED edges aren't needed.
+
+2. **Depth limit of 2 hops, hardcoded.** `STITCH_MAX_DEPTH = 2` in `ingest.ts`. Walking deeper produces speculative edges that are too far from the originating error to claim relevance. The constant is a contract value, not a tunable — changing it requires an ADR amendment.
+
+3. **Walks EXTRACTED outbound edges only.** The stitcher BFS-walks `graph.outboundEdges(node)` and considers only edges where `provenance === Provenance.EXTRACTED`. OBSERVED edges already carry the relationship (no inference needed). INFERRED edges are themselves the stitcher's output (no recursion). FRONTIER edges represent unknown territory and are excluded per Rule 3 of `docs/contracts.md`. STALE edges represent decayed observation and are not inferable from a fresh error.
+
+4. **OBSERVED-twin skip rule (issue: refinement).** When the stitcher considers an EXTRACTED edge `(source, target, type)`, it checks whether an OBSERVED edge for the same triplet already exists (`graph.hasEdge(observedEdgeId(source, target, type))`). If so, the OBSERVED edge already provides ground-truth coverage for that hop — the stitcher skips it and does not produce an INFERRED twin. Today the stitcher writes INFERRED edges regardless of OBSERVED twins; the rule closes that gap.
+
+5. **Confidence is `0.6` by default, capped at `0.7`.** `INFERRED_CONFIDENCE = 0.6` is the default applied at edge creation. The stitcher does not produce edges with confidence > 0.7 even if a custom override is added later — INFERRED is by definition less trustworthy than OBSERVED, which carries `1.0`. The cap is a contract value.
+
+6. **Idempotent on re-arrival.** When a second error span produces the same stitched edges, `upsertInferredEdge` updates `lastObserved` on the existing edge — it does not create duplicates, does not increment a confidence score, does not add evidence. The edge id (`inferredEdgeId(source, target, type)`) is the deduplication key.
+
+7. **Origin generality.** `stitchTrace(graph, sourceServiceId, ts)` accepts any `service:*` id as the origin. No special-case for the demo (`service:service-b`); no hardcoded driver ('pg'); no hardcoded engine ('postgresql'). The stitcher walks whatever EXTRACTED edges exist outbound from the erroring service.
+
+8. **No node creation.** The stitcher only writes edges. It never creates nodes; it never modifies existing nodes; it doesn't extend across FrontierNode boundaries.
+
+**Authority.**
+
+`stitchTrace` is owned by `ingest.ts` per ADR-030. Called only from `handleSpan` (error path). No other module triggers stitching.
+
+**Enforcement.**
+
+`contracts.test.ts` includes:
+- A live test asserting `stitchTrace` produces no edges when called with a node that has no outbound EXTRACTED edges.
+- A live test asserting `STITCH_MAX_DEPTH` is enforced (depth-3 EXTRACTED chain produces edges only at depth 1 and 2).
+- An `it.todo` keyed to the OBSERVED-twin-skip refinement, which lands when implementation does.
+- An idempotency test (calling `stitchTrace` twice produces identical edge state).
+
+**What this ADR is not deciding.**
+
+Per-edge confidence beyond the default 0.6 (no implementation requires it today). Stitcher behavior on FRONTIER edges (excluded — never traversable). Stitching across multiple traces (single-trace context only; cross-trace inference is a v1.0 concern).
+
+**When to revisit.**
+
+When a real codebase's INFERRED layer becomes load-bearing for the MVP-success PR (ADR-027) and the depth-2 limit produces too many or too few edges. When OBSERVED coverage improves enough that the stitcher fires rarely — at that point the OBSERVED-twin-skip rule is doing most of the work and the contract may simplify.
+
+---
+
+## ADR-035 — FrontierNode promotion contract
+
+**Date:** 2026-05-05
+**Status:** Active.
+
+Governs `promoteFrontierNodes` in `packages/core/src/ingest.ts`. FrontierNodes (ADR-023) are placeholders for OTel peers that don't match any known service. Promotion is the act of replacing a FrontierNode with a real typed node once an alias resolves the host. The contract locks the trigger conditions, alias-match rules, edge-rewrite semantics, and the FRONTIER → OBSERVED provenance upgrade.
+
+Sibling contracts: ADR-033 (OTel ingest), ADR-034 (trace stitcher).
+
+**Decision.**
+
+1. **Promotion runs after every extract pass.** `promoteFrontierNodes(graph)` is called at the end of `extract/index.ts:extractFromDirectory` and at the end of every watch-driven phase rerun in `watch.ts`. Promotion is **batched per pass**, not per-edge. The ingest path itself does not trigger promotion — only the static-extraction lifecycle does, because aliases land during static extraction.
+
+2. **Alias matching: name first, then alias list.** The function walks every ServiceNode and builds a `Map<string, string>` from `attrs.name → id` and `attrs.aliases[i] → id`. Then it walks every FrontierNode and looks up `attrs.host` in the map. First match wins. If the FrontierNode's host doesn't resolve, the FrontierNode persists for the next extract pass to handle. **Aliases are populated by `extract/aliases.ts`** — typically docker-compose service names, k8s metadata.name, Dockerfile labels.
+
+3. **Promotion is atomic per FrontierNode.** When a FrontierNode is selected for promotion, all of its incident edges (inbound and outbound) are rewired to the typed node id, and the FrontierNode is dropped — in one synchronous pass. There is no point at which a partial state is visible. ADR-030 §9 atomicity applies.
+
+4. **Edge rewrite rebuilds the edge under the new id.** `rewireFrontierEdges` walks `graph.inboundEdges(frontierId)` and `graph.outboundEdges(frontierId)`. For each, `rebuildEdge` drops the old edge and constructs a new edge under the typed-node id. This is the only place in the codebase where an edge id changes — not because the edge content changed, but because one of its endpoints did.
+
+5. **Provenance upgrade rule: FRONTIER → OBSERVED.** When `rebuildEdge` is rewriting an edge whose provenance was `FRONTIER`, the new edge's provenance is `OBSERVED`. The reasoning: the call certainty was always there (the OTel span was observed), only the target identity was unknown. Now it's known, so the edge graduates from placeholder to direct measurement. Other provenance values (EXTRACTED, INFERRED) pass through unchanged.
+
+6. **Edge id construction MUST use the canonical helpers.** `rebuildEdge` constructs the new edge id via `observedEdgeId`, `inferredEdgeId`, etc. from `@neat/types/identity` (ADR-029). Hand-rolling a template literal like `` `${edge.type}:${promotedProvenance}:${newSource}->${newTarget}` `` is a contract violation. **Today's `rebuildEdge` at `ingest.ts:463` does hand-roll this id** — a v0.2.2 cleanup task: replace the literal with a dispatch on `promotedProvenance` to the appropriate canonical helper. The contracts.test.ts scan (#2) didn't catch it because the literal interpolates the provenance variable rather than embedding `:OBSERVED:` directly. The scan is extended in this batch.
+
+7. **Edge merge on collision.** If the rewritten edge id already exists (because an OBSERVED edge between the typed source and target was previously created independently), the rebuilt edge merges into the existing one: `callCount` sums, `lastObserved` takes the later timestamp via `pickLater`. No duplicate edge is created.
+
+8. **No reverse promotion.** A typed node never reverts to a FrontierNode. If OTel later observes a peer that matches no known service, a *new* FrontierNode is created at a different host id; the previously-promoted typed node is unaffected.
+
+**Authority.**
+
+`promoteFrontierNodes` is owned by `ingest.ts` per ADR-030. Triggered by `extract/index.ts` and `watch.ts`. No other module calls it.
+
+**Enforcement.**
+
+`contracts.test.ts` includes:
+- A live test asserting alias-matched FrontierNode is promoted, edges are rewired, FRONTIER provenance becomes OBSERVED on rebuilt edges (already exists from contract #3 lifecycle work — extended here to also assert id construction routes through `observedEdgeId`).
+- A new live test asserting `rebuildEdge` does not hand-roll edge id template literals — extended hand-rolled-template-literal scan that includes the provenance-variable case (catches `${edge.type}:${promotedProvenance}:...`).
+- An `it.todo` keyed to the rebuildEdge-uses-canonical-helpers fix, which lands as part of the v0.2.2 cleanup against this contract.
+
+**What this ADR is not deciding.**
+
+Cross-host-port database ids (deferred per ADR-028 §6). Workspace-scoped service ids that change the alias-matching shape (deferred per ADR-028 §5). Promotion across project scopes (single-project per ADR-026; cross-project promotion is post-multi-project work).
+
+**When to revisit.**
+
+When workspace scoping lands and aliases need to scope to a workspace. When the alias index becomes a bottleneck on large monorepos (today rebuilt every promotion call; could be cached if the call frequency justifies it).

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -493,6 +493,59 @@ describe('Static-extraction contract (ADR-032)', () => {
 })
 
 // ──────────────────────────────────────────────────────────────────────────
+// OTel ingest contract — non-blocking, span-time, parent-cache (ADR-033)
+// ──────────────────────────────────────────────────────────────────────────
+describe('OTel ingest contract (ADR-033)', () => {
+  it.todo('OTel receiver replies before mutation completes (issue #131)')
+  it.todo('lastObserved derives from span.startTimeUnixNano, not Date.now() (issue #132)')
+  it.todo('parent-span cache resolves cross-service CALLS when address-based resolution fails (issue #133)')
+  it.todo('handleSpan auto-creates ServiceNode at serviceId(span.service) for unseen services (issue #134)')
+  it.todo('handleSpan auto-creates DatabaseNode at databaseId(host) for unseen db.system+host (issue #134)')
+  it.todo('parser extracts exception.type/message/stacktrace from span events with name=exception (issue #135)')
+  it.todo('handleSpan prefers exception event message over span.status.message (issue #135)')
+})
+
+// ──────────────────────────────────────────────────────────────────────────
+// Trace stitcher contract — ERROR-only, depth-2, OBSERVED-twin-skip (ADR-034)
+// ──────────────────────────────────────────────────────────────────────────
+describe('Trace stitcher contract (ADR-034)', () => {
+  it('stitchTrace produces no edges from a node with no outbound EXTRACTED edges', async () => {
+    const { stitchTrace } = await import('../../src/ingest.js')
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:lonely', {
+      id: 'service:lonely',
+      type: NodeType.ServiceNode,
+      name: 'lonely',
+      language: 'javascript',
+    })
+    const before = g.size
+    stitchTrace(g, 'service:lonely', '2026-05-05T12:00:00.000Z')
+    expect(g.size).toBe(before)
+  })
+
+  it('stitchTrace returns cleanly when sourceServiceId is missing from the graph', async () => {
+    const { stitchTrace } = await import('../../src/ingest.js')
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    expect(() => stitchTrace(g, 'service:does-not-exist', '2026-05-05T12:00:00.000Z')).not.toThrow()
+    expect(g.order).toBe(0)
+  })
+
+  it.todo('stitchTrace skips a hop when an OBSERVED twin already exists for the (source, target, type) triplet (refinement)')
+})
+
+// ──────────────────────────────────────────────────────────────────────────
+// FrontierNode promotion contract — atomic, FRONTIER→OBSERVED, canonical ids (ADR-035)
+// ──────────────────────────────────────────────────────────────────────────
+describe('FrontierNode promotion contract (ADR-035)', () => {
+  // Catches the variable-interpolated provenance pattern that the contract #2
+  // scan (line ~499) misses. `${edge.type}:${promotedProvenance}:${...}->${...}`
+  // is exactly the violation present at ingest.ts:463 today.
+  it.todo(
+    'no variable-interpolated provenance segment in edge id template literals — `${X}:${Y}:${Z}->${W}` (FrontierNode rebuild fix)',
+  )
+})
+
+// ──────────────────────────────────────────────────────────────────────────
 // Provenance contract — Edge identity helpers + PROV_RANK (ADR-029)
 // ──────────────────────────────────────────────────────────────────────────
 describe('Provenance contract — edge identity (ADR-029)', () => {


### PR DESCRIPTION
## Summary

The v0.2.2 contract batch. Three contracts opening the OTel rebuild milestone. They share vocabulary and govern overlapping concerns in \`ingest.ts\`; bundling them into one PR so the implementation agent reads them as one unit.

Implementation work for v0.2.2 issues #131-#135 lands against these locked contracts.

## What's locked

### Contract #6 — OTel ingest (ADR-033)

- **Non-blocking ingest.** Receiver replies 200 OK before mutation. Sender is never blocked. Closes #131.
- **\`lastObserved\` from span time.** Derived from \`span.startTimeUnixNano\`, not \`Date.now()\`. Replayed/backdated traces produce honest timestamps. Closes #132.
- **Parent-span cache.** Bounded TTL cache keyed by \`\${traceId}:\${spanId}\`. When address-based peer resolution misses, fall through to a \`parentSpanId\` lookup. Closes #133.
- **Auto-creation.** Unseen \`service.name\` → minimal ServiceNode at \`serviceId(span.service)\`. Unseen \`db.system\`+host → minimal DatabaseNode at \`databaseId(host)\`. New optional \`discoveredVia: 'otel' | 'static' | 'merged'\` field (schema growth via ADR-031). Static-extracted nodes merge by id. Closes #134.
- **Exception event parsing.** Parser extracts \`exception.type\`/\`message\`/\`stacktrace\` from \`events[]\` entries named \`exception\`. ErrorEvent prefers exception data over \`status.message\`. Closes #135.
- **HTTP receiver supports JSON and protobuf** via \`Content-Type\` dispatch.
- **\`db.system\` stays data, not a switch.** No \`if (db.system === 'postgresql')\` branches.

### Contract #7 — Trace stitcher (ADR-034)

- Fires only on ERROR spans (\`statusCode === 2\`).
- \`STITCH_MAX_DEPTH = 2\`, hardcoded contract value.
- Walks EXTRACTED outbound only. OBSERVED, INFERRED, FRONTIER, STALE excluded for explicit reasons.
- **OBSERVED-twin-skip rule (refinement).** When an OBSERVED edge for \`(source, target, type)\` already exists, the stitcher does not produce an INFERRED twin. Closes the verification.md OTel §7 finding.
- Default confidence \`0.6\`, capped at \`0.7\`.
- Origin-general — no demo-name special-cases.
- Idempotent on re-arrival; never creates nodes.

### Contract #8 — FrontierNode promotion (ADR-035)

- Runs at the end of every extract pass and watch tick. Batched per pass, not per-edge.
- Alias-matches via \`name\` then \`aliases[]\` list. First match wins.
- Atomic per FrontierNode — all incident edges rewired and the placeholder dropped in one synchronous pass.
- FRONTIER → OBSERVED on edge rewrite (the call certainty was always there; only the target identity was unknown).
- **Edge id construction MUST use canonical helpers** from \`@neat/types/identity\`. Today \`ingest.ts:463\` hand-rolls the id — a contract violation that contract #2's scan missed because the literal interpolates the provenance variable. Contract #8 adds the variable-interpolation scan; cleanup is a v0.2.2 implementation task.
- Edge merge on collision (sums \`callCount\`, picks later \`lastObserved\`).
- No reverse promotion.

## What this PR contains

- \`docs/decisions.md\` — ADRs 033, 034, 035 appended.
- \`docs/contracts/otel-ingest.md\`, \`docs/contracts/trace-stitcher.md\`, \`docs/contracts/frontier-promotion.md\` — three per-topic contracts with frontmatter \`governs:\`. The PreToolUse hook now surfaces six contracts (identity, provenance, lifecycle, otel-ingest, trace-stitcher, frontier-promotion) when editing \`ingest.ts\`.
- \`docs/contracts.md\` — index updated; #6/#7/#8 marked landed (v0.2.2 opens).
- \`packages/core/test/audits/contracts.test.ts\` — two new live assertions for the trace stitcher (no-outbound case, missing-source case) plus 9 new \`it.todo\` items keyed to issues #131-#135 and the two refinements.

## Test totals

248 passing across @neat/core (up from 246), 30 todo, 0 fail.

## What this PR doesn't do

- No source code in \`ingest.ts\` is modified — implementation lands under v0.2.2 cleanup issues.
- No GitHub issue closures.

## Test plan

- [ ] \`npx turbo build test lint\` clean
- [ ] Verify the hook surfaces all six contracts when editing ingest.ts:
  \`\`\`bash
  CLAUDE_PROJECT_DIR=\"\$PWD\" bash docs/contracts/_hook.sh \\
    < <(echo '{\"tool_input\":{\"file_path\":\"'\"\$PWD\"'/packages/core/src/ingest.ts\"}}') \\
    | jq -r '.hookSpecificOutput.additionalContext' | grep '^name: '
  \`\`\`
- [ ] Read the three contract files end to end. Confirm the locked rules match v0.2.2's intended cleanup scope.
- [ ] After merge: implementation agent picks up #131-#135 against these contracts, plus the rebuildEdge canonical-helpers fix flagged in contract #8.

Refs #126