### PR TITLE
v0.2.2 status doc — OTel rebuild open

### DIFF
--- a/docs/plans/2026-05-05-v0.2.2-status.md
+++ b/docs/plans/2026-05-05-v0.2.2-status.md
@@ -1,0 +1,82 @@
+# v0.2.2 OTel rebuild — current state
+
+**Last updated:** 2026-05-05 (later in the day than `2026-05-05-v0.2.0-status.md`)
+
+This is the "pick up here" doc for v0.2.2 work. Read this before any tool call. Supersedes the v0.2.0 status doc as the active milestone tracker.
+
+## What v0.2.2 is
+
+v0.2.2 is the OTel ingest rebuild milestone. It rebuilds `packages/core/src/ingest.ts` against three contracts that landed at the start of the milestone:
+
+- **#6 OTel ingest** (ADR-033, `docs/contracts/otel-ingest.md`)
+- **#7 Trace stitcher** (ADR-034, `docs/contracts/trace-stitcher.md`)
+- **#8 FrontierNode promotion** (ADR-035, `docs/contracts/frontier-promotion.md`)
+
+The contracts share vocabulary and govern overlapping concerns in `ingest.ts`. They were drafted as one batch in PR #153 and merged together. The PreToolUse hook surfaces all three (plus identity, provenance, lifecycle) when any agent edits `ingest.ts`.
+
+## Where v0.2.1 left off
+
+v0.2.1 — Tree-sitter rebuild — closed at tag `v0.2.1` on commit `8d7e9ce` with PR #152 (ghost-edge cleanup + universal `evidence.file`). Three issues from the v0.2.1 milestone deferred:
+
+- **#141** — Source-level DB connection / `import` detection
+- **#142** — `framework` field on ServiceNode
+- **#145** — Drop unused graphology-traversal / -shortest-path deps
+
+These remain open. **Decision pending** on whether to slot them into a v0.2.1.x patch, fold them into v0.2.2/v0.2.3 work, or accept them as v0.x rolling cleanup. They do not block v0.2.2.
+
+## What v0.2.2 implementation work covers
+
+Five issues, all queued under the v0.2.2 milestone. Each closes when its corresponding `it.todo` in `packages/core/test/audits/contracts.test.ts` flips to a live assertion and passes:
+
+- **#131** — OTel receiver replies before mutation
+- **#132** — `lastObserved` from `span.startTimeUnixNano`, not `Date.now()`
+- **#133** — Parent-span TTL cache for cross-service CALLS
+- **#134** — Auto-create ServiceNode and DatabaseNode for unseen peers (schema growth: `discoveredVia`)
+- **#135** — Parse exception data from span events (schema growth: `exceptionType`/`exceptionStacktrace` on ErrorEvent)
+
+Plus one additional cleanup task surfaced during contract drafting:
+
+- **`rebuildEdge` canonical-helpers fix.** `ingest.ts:463` hand-rolls an edge id template literal — `${edge.type}:${promotedProvenance}:${newSource}->${newTarget}`. Contract #2's scan didn't catch it because the literal interpolates the provenance variable. Contract #8's regression scan does. The cleanup is to dispatch on `promotedProvenance` to `observedEdgeId` / `inferredEdgeId` / `extractedEdgeId` / `frontierEdgeId` from `@neat/types/identity`. Not yet a tracked GitHub issue — should be opened or rolled into one of the existing v0.2.2 cleanup PRs.
+
+## Recommended implementation order
+
+1. **#131** non-blocking ingest. Architectural — introduces the queue. Land first; it shapes how every other v0.2.2 fix integrates.
+2. **#132** span-time `lastObserved`. Small, schema-side. Quick win.
+3. **#135** exception event parsing. Schema growth + parser extension. Independent of #131 once #131's queue is in place.
+4. **#133** parent-span cache. Builds on #131's queue (the cache lives in the same module).
+5. **#134** auto-creation. Schema growth (`discoveredVia` field) + handler logic. Lands last because it depends on #133's correlation working.
+6. **`rebuildEdge` fix.** Drop-in — replace the literal with the helper dispatch. Can land any time; recommend bundling into the same PR as one of the smaller fixes above.
+
+## Issue-state caveat
+
+GitHub currently shows #131-#135 as **CLOSED** even though no implementation has shipped on `main`. This is a likely accidental closure from earlier in the session — the contracts (#153) merged but the implementation did not. Implementation agents picking up this work should:
+
+1. Verify their target issue is reopened on GitHub before starting (or open a new issue referencing the closed one).
+2. Do not assume the closed state means the work is done.
+
+The contracts.test.ts `it.todo` items are still queued and will fail to flip to live assertions if the implementation isn't actually written.
+
+## Open product calls (carried from v0.2.0)
+
+Decisions still pending, blocking v0.2.4+:
+
+1. **Policies REST path** — `/policies` (recommended) vs `/policy/violations`.
+2. **Policies MCP tools** — one (`check_policies`) vs two (`check_policies` + `get_policy_violations`).
+3. **`drivers` vs `dependencies` field name** — recommended: keep `dependencies` raw, defer `drivers` until a second consumer materializes.
+
+## Self-hosting gate (unchanged)
+
+NEAT does NOT self-host on the NEAT codebase yet. The gate is the MVP-success PR (ADR-027). Until that closes, agents work on NEAT the same way they work on any codebase: read source, query contracts via the PreToolUse hook, no MCP queries against `neat-out/graph.json` for NEAT itself.
+
+## Where to look next
+
+- `docs/contracts/otel-ingest.md`, `docs/contracts/trace-stitcher.md`, `docs/contracts/frontier-promotion.md` — the three binding contracts for v0.2.2.
+- `docs/decisions.md` ADRs 033, 034, 035 — full rationale per contract.
+- `packages/core/src/ingest.ts` — the single file most v0.2.2 work touches.
+- `packages/core/test/audits/contracts.test.ts` — the `it.todo` items that flip as cleanup ships.
+- `docs/plans/2026-05-05-v0.2.0-status.md` — the prior status doc (now historical; this one supersedes it for the active milestone).
+- `docs/plans/2026-05-04-v0.2.x-sequencing.md` — the full v0.2.x roadmap.
+
+## When this file is wrong
+
+If `main` has moved since the date at the top, treat the description as historical and check `git log` + `gh release list` for canonical state. New status docs land as `docs/plans/<date>-<milestone>-status.md`. Old ones stay for context.


### PR DESCRIPTION
## Summary

v0.2.1 closed at tag \`v0.2.1\` (commit \`8d7e9ce\`). v0.2.2 opens with the OTel-batch contracts already on main (PR #153).

This PR adds the per-session status doc that future agents land on. Same shape as \`docs/plans/2026-05-05-v0.2.0-status.md\`. Supersedes that one as the active milestone tracker.

## What it documents

- **Where v0.2.1 left off.** Tag, deferred issues (#141, #142, #145), what shipped vs what didn't.
- **What v0.2.2 is.** Three contracts (#6/#7/#8) already on main. Five implementation issues (#131-#135). One additional cleanup task surfaced during contract drafting (\`rebuildEdge\` at \`ingest.ts:463\` hand-rolls an edge id template literal).
- **Recommended implementation order** with reasoning.
- **Issue-state caveat.** #131-#135 currently show CLOSED on GitHub but no implementation has shipped. Implementation agents should verify state before starting.
- **Self-hosting gate** unchanged (ADR-027).

## Test plan

- [ ] Read end to end. Confirm it reflects current main + GitHub state.
- [ ] Spot-check the contract file references (otel-ingest.md, trace-stitcher.md, frontier-promotion.md) exist on main.
- [ ] After merge: surface the issue-state question (#131-#135 closed without code) for the user to clarify.

Refs #126