### PR TITLE
rebuildEdge constructs edge ids via canonical helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,21 @@ The 15 cleanup issues (#131-#145) are open against this milestone today **but be
 
 **v0.2.2 — OTel ingest rebuild.** Opens with contracts #6-#8 (OTel ingest, trace stitcher, FrontierNode promotion). Then ships #131 non-blocking ingest, #132 span-time `lastObserved`, #133 parent-span cache, #134 auto-create services/DBs, #135 exception event parsing.
 
+#### v0.2.2 implementation tracker
+
+Contracts #6-#8 landed in #153 (`3684951`). Issues #131-#135 closed on GitHub via the contract opener; the implementation work — flipping the queued `it.todo` markers in `packages/core/test/audits/contracts.test.ts` — is the actual milestone work. Order is least-blast-radius first; each item is its own branch + PR.
+
+1. [ ] **`rebuildEdge` uses canonical edge-id helpers** (ADR-035, `ingest.ts:463`). Flips the `it.todo` at `contracts.test.ts:558`. Extend the provenance-id scan to catch `${variable}` interpolation form.
+2. [ ] **`lastObserved` from `span.startTimeUnixNano`** (ADR-033, #132). Normalize in `parseOtlpRequest`; production paths drop `nowIso(ctx)`. Flips the `lastObserved derives from span.startTimeUnixNano` todo.
+3. [ ] **OBSERVED-twin-skip in stitcher** (ADR-034). One guard inside the BFS. Flips `stitchTrace skips a hop when an OBSERVED twin already exists` at `contracts.test.ts:548`.
+4. [ ] **Exception event parsing** (ADR-033, #135). Schema growth: `events[]` on `OtlpSpan`, `exceptionType?` on `ErrorEventSchema`. Flips the two #135 todos.
+5. [ ] **Auto-create unseen services + DBs** (ADR-033, #134). Schema growth: `discoveredVia?: 'otel' | 'static' | 'merged'` on `ServiceNodeSchema` / `DatabaseNodeSchema`. Static-then-OTel merge rule. Flips the two #134 todos.
+6. [ ] **Parent-span TTL cache** (ADR-033, #133). Bounded `${traceId}:${spanId} → service` cache; consult after `pickAddress` misses. Flips the #133 todo.
+7. [ ] **Non-blocking ingest + content-type dispatch** (ADR-033, #131). Queue between receiver and `handleSpan`; HTTP receiver dispatches on `Content-Type` to JSON or protobuf. Flips the #131 todo.
+8. [ ] Drop duplicate #131-#135 todos from the `Queued contracts` block once each ADR-033 assertion is live. Land `docs/plans/<date>-v0.2.2-status.md`.
+
+Closes when every ADR-033/034/035 todo is live and passing, schema-snapshot regen is committed, and `npx turbo build && test && lint` is green on `main`.
+
 **v0.2.3 — Traversal rebuild.** Opens with contracts #9-#11 (traversal, getRootCause, getBlastRadius). Then ships #136 FRONTIER exclusion, #137 BlastRadius schema fields, #138 distance positive, #139 schema validation, #123 generalize getRootCause.
 
 **v0.2.4 — Policies + MCP refresh.** Opens with contracts #12-#18 (MCP, REST, persistence, policy schema/eval/actions/tools). Then ships #115-#118 + #143 three-part response, #144 transitive `get_dependencies`.

--- a/docs/plans/2026-05-05-v0.2.2-status.md
+++ b/docs/plans/2026-05-05-v0.2.2-status.md
@@ -1,0 +1,82 @@
+# v0.2.2 OTel rebuild — current state
+
+**Last updated:** 2026-05-05 (later in the day than `2026-05-05-v0.2.0-status.md`)
+
+This is the "pick up here" doc for v0.2.2 work. Read this before any tool call. Supersedes the v0.2.0 status doc as the active milestone tracker.
+
+## What v0.2.2 is
+
+v0.2.2 is the OTel ingest rebuild milestone. It rebuilds `packages/core/src/ingest.ts` against three contracts that landed at the start of the milestone:
+
+- **#6 OTel ingest** (ADR-033, `docs/contracts/otel-ingest.md`)
+- **#7 Trace stitcher** (ADR-034, `docs/contracts/trace-stitcher.md`)
+- **#8 FrontierNode promotion** (ADR-035, `docs/contracts/frontier-promotion.md`)
+
+The contracts share vocabulary and govern overlapping concerns in `ingest.ts`. They were drafted as one batch in PR #153 and merged together. The PreToolUse hook surfaces all three (plus identity, provenance, lifecycle) when any agent edits `ingest.ts`.
+
+## Where v0.2.1 left off
+
+v0.2.1 — Tree-sitter rebuild — closed at tag `v0.2.1` on commit `8d7e9ce` with PR #152 (ghost-edge cleanup + universal `evidence.file`). Three issues from the v0.2.1 milestone deferred:
+
+- **#141** — Source-level DB connection / `import` detection
+- **#142** — `framework` field on ServiceNode
+- **#145** — Drop unused graphology-traversal / -shortest-path deps
+
+These remain open. **Decision pending** on whether to slot them into a v0.2.1.x patch, fold them into v0.2.2/v0.2.3 work, or accept them as v0.x rolling cleanup. They do not block v0.2.2.
+
+## What v0.2.2 implementation work covers
+
+Five issues, all queued under the v0.2.2 milestone. Each closes when its corresponding `it.todo` in `packages/core/test/audits/contracts.test.ts` flips to a live assertion and passes:
+
+- **#131** — OTel receiver replies before mutation
+- **#132** — `lastObserved` from `span.startTimeUnixNano`, not `Date.now()`
+- **#133** — Parent-span TTL cache for cross-service CALLS
+- **#134** — Auto-create ServiceNode and DatabaseNode for unseen peers (schema growth: `discoveredVia`)
+- **#135** — Parse exception data from span events (schema growth: `exceptionType`/`exceptionStacktrace` on ErrorEvent)
+
+Plus one additional cleanup task surfaced during contract drafting:
+
+- **`rebuildEdge` canonical-helpers fix.** `ingest.ts:463` hand-rolls an edge id template literal — `${edge.type}:${promotedProvenance}:${newSource}->${newTarget}`. Contract #2's scan didn't catch it because the literal interpolates the provenance variable. Contract #8's regression scan does. The cleanup is to dispatch on `promotedProvenance` to `observedEdgeId` / `inferredEdgeId` / `extractedEdgeId` / `frontierEdgeId` from `@neat/types/identity`. Not yet a tracked GitHub issue — should be opened or rolled into one of the existing v0.2.2 cleanup PRs.
+
+## Recommended implementation order
+
+1. **#131** non-blocking ingest. Architectural — introduces the queue. Land first; it shapes how every other v0.2.2 fix integrates.
+2. **#132** span-time `lastObserved`. Small, schema-side. Quick win.
+3. **#135** exception event parsing. Schema growth + parser extension. Independent of #131 once #131's queue is in place.
+4. **#133** parent-span cache. Builds on #131's queue (the cache lives in the same module).
+5. **#134** auto-creation. Schema growth (`discoveredVia` field) + handler logic. Lands last because it depends on #133's correlation working.
+6. **`rebuildEdge` fix.** Drop-in — replace the literal with the helper dispatch. Can land any time; recommend bundling into the same PR as one of the smaller fixes above.
+
+## Issue-state caveat
+
+GitHub currently shows #131-#135 as **CLOSED** even though no implementation has shipped on `main`. This is a likely accidental closure from earlier in the session — the contracts (#153) merged but the implementation did not. Implementation agents picking up this work should:
+
+1. Verify their target issue is reopened on GitHub before starting (or open a new issue referencing the closed one).
+2. Do not assume the closed state means the work is done.
+
+The contracts.test.ts `it.todo` items are still queued and will fail to flip to live assertions if the implementation isn't actually written.
+
+## Open product calls (carried from v0.2.0)
+
+Decisions still pending, blocking v0.2.4+:
+
+1. **Policies REST path** — `/policies` (recommended) vs `/policy/violations`.
+2. **Policies MCP tools** — one (`check_policies`) vs two (`check_policies` + `get_policy_violations`).
+3. **`drivers` vs `dependencies` field name** — recommended: keep `dependencies` raw, defer `drivers` until a second consumer materializes.
+
+## Self-hosting gate (unchanged)
+
+NEAT does NOT self-host on the NEAT codebase yet. The gate is the MVP-success PR (ADR-027). Until that closes, agents work on NEAT the same way they work on any codebase: read source, query contracts via the PreToolUse hook, no MCP queries against `neat-out/graph.json` for NEAT itself.
+
+## Where to look next
+
+- `docs/contracts/otel-ingest.md`, `docs/contracts/trace-stitcher.md`, `docs/contracts/frontier-promotion.md` — the three binding contracts for v0.2.2.
+- `docs/decisions.md` ADRs 033, 034, 035 — full rationale per contract.
+- `packages/core/src/ingest.ts` — the single file most v0.2.2 work touches.
+- `packages/core/test/audits/contracts.test.ts` — the `it.todo` items that flip as cleanup ships.
+- `docs/plans/2026-05-05-v0.2.0-status.md` — the prior status doc (now historical; this one supersedes it for the active milestone).
+- `docs/plans/2026-05-04-v0.2.x-sequencing.md` — the full v0.2.x roadmap.
+
+## When this file is wrong
+
+If `main` has moved since the date at the top, treat the description as historical and check `git log` + `gh release list` for canonical state. New status docs land as `docs/plans/<date>-<milestone>-status.md`. Old ones stay for context.

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -6,6 +6,7 @@ import {
   NodeType,
   Provenance,
   databaseId,
+  extractedEdgeId,
   frontierEdgeId,
   frontierId,
   inferredEdgeId,
@@ -460,7 +461,14 @@ function rebuildEdge(
   // it isn't.
   const promotedProvenance =
     edge.provenance === Provenance.FRONTIER ? Provenance.OBSERVED : edge.provenance
-  const newId = `${edge.type}:${promotedProvenance}:${newSource}->${newTarget}`
+  const newId =
+    promotedProvenance === Provenance.OBSERVED
+      ? observedEdgeId(newSource, newTarget, edge.type)
+      : promotedProvenance === Provenance.INFERRED
+        ? inferredEdgeId(newSource, newTarget, edge.type)
+        : promotedProvenance === Provenance.EXTRACTED
+          ? extractedEdgeId(newSource, newTarget, edge.type)
+          : frontierEdgeId(newSource, newTarget, edge.type)
 
   if (graph.hasEdge(newId)) {
     const existing = graph.getEdgeAttributes(newId) as GraphEdge

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -553,11 +553,67 @@ describe('Trace stitcher contract (ADR-034)', () => {
 // ──────────────────────────────────────────────────────────────────────────
 describe('FrontierNode promotion contract (ADR-035)', () => {
   // Catches the variable-interpolated provenance pattern that the contract #2
-  // scan (line ~499) misses. `${edge.type}:${promotedProvenance}:${...}->${...}`
-  // is exactly the violation present at ingest.ts:463 today.
-  it.todo(
-    'no variable-interpolated provenance segment in edge id template literals — `${X}:${Y}:${Z}->${W}` (FrontierNode rebuild fix)',
-  )
+  // scan (line ~570) misses. `${edge.type}:${promotedProvenance}:${...}->${...}`
+  // is exactly the violation that lived at ingest.ts:463 before the rebuildEdge
+  // fix routed through the canonical helpers in @neat/types/identity.
+  it('no variable-interpolated provenance segment in edge id template literals — `${X}:${Y}:${Z}->${W}` (FrontierNode rebuild fix)', () => {
+    const offenders: string[] = []
+    // Four interpolations chained with `:` between the first three and `->`
+    // before the fourth — the literal-segment-free form the original scan
+    // doesn't catch. The provenance variable sits in the second slot.
+    const re = /`\$\{[^}]+\}:\$\{[^}]+\}:\$\{[^}]+\}->\$\{[^}]+\}`/
+    for (const file of [...walkSrc(CORE_SRC), ...walkSrc(MCP_SRC)]) {
+      const content = readFileSync(file, 'utf8')
+      content.split('\n').forEach((line, i) => {
+        const trimmed = line.trim()
+        if (re.test(line) && !trimmed.startsWith('//') && !trimmed.startsWith('*')) {
+          offenders.push(`${file}:${i + 1}: ${trimmed}`)
+        }
+      })
+    }
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
+
+  it('rebuildEdge constructs ids via canonical helpers — promoted FRONTIER→OBSERVED edge id matches observedEdgeId()', async () => {
+    const { observedEdgeId, frontierId, frontierEdgeId } = await import('@neat/types')
+    const { promoteFrontierNodes } = await import('../../src/ingest.js')
+
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:caller', {
+      id: 'service:caller',
+      type: NodeType.ServiceNode,
+      name: 'caller',
+      language: 'javascript',
+    })
+    g.addNode('service:callee', {
+      id: 'service:callee',
+      type: NodeType.ServiceNode,
+      name: 'callee',
+      language: 'javascript',
+      aliases: ['callee.internal'],
+    })
+    const fid = frontierId('callee.internal')
+    g.addNode(fid, {
+      id: fid,
+      type: NodeType.FrontierNode,
+      name: 'callee.internal',
+      host: 'callee.internal',
+    })
+    const oldEdgeId = frontierEdgeId('service:caller', fid, EdgeType.CALLS)
+    g.addEdgeWithKey(oldEdgeId, 'service:caller', fid, {
+      id: oldEdgeId,
+      source: 'service:caller',
+      target: fid,
+      type: EdgeType.CALLS,
+      provenance: Provenance.FRONTIER,
+      lastObserved: '2026-05-05T12:00:00.000Z',
+      callCount: 3,
+    })
+
+    expect(promoteFrontierNodes(g)).toBe(1)
+    const expectedId = observedEdgeId('service:caller', 'service:callee', EdgeType.CALLS)
+    expect(g.hasEdge(expectedId)).toBe(true)
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replaces the hand-rolled edge-id template literal at \`ingest.ts:463\` with the canonical four-way dispatch through \`observedEdgeId\` / \`inferredEdgeId\` / \`extractedEdgeId\` / \`frontierEdgeId\` from \`@neat/types\`. The FrontierNode-promotion contract (ADR-035) names this exact site as a current violation.
- Extends the provenance-id scan to catch the variable-interpolation form (\`\${X}:\${Y}:\${Z}->\${W}\`) the original scan missed.
- Adds a live test asserting \`promoteFrontierNodes\` constructs the rebuilt id at the same wire format \`observedEdgeId()\` returns.
- Adds a v0.2.2 implementation tracker to CLAUDE.md so future sessions land grounded.

## Contract assertions flipped

In \`packages/core/test/audits/contracts.test.ts\`:

- ✅ The \`describe('FrontierNode promotion contract (ADR-035)')\` block now carries two live assertions (was one \`it.todo\`).

37 contract assertions passing (was 36), 27 todos remaining (was 28).

## Test plan

- [x] \`npx turbo build\` clean
- [x] \`npx turbo test\` — 252 pass, 27 todo
- [x] \`packages/core/test/audits/contracts.test.ts\` — new ADR-035 assertions green

Refs ADR-035