### PR TITLE
lastObserved derives from span.startTimeUnixNano, not Date.now()

### DIFF
--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -328,7 +328,11 @@ async function appendErrorEvent(ctx: IngestContext, ev: ErrorEvent): Promise<voi
 }
 
 export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<void> {
-  const ts = nowIso(ctx)
+  // lastObserved derives from the span's own startTime per ADR-033 — replayed
+  // traces and out-of-order spans get a timestamp that reflects when the call
+  // actually fired, not when the receiver received it. Wall-clock is only the
+  // fallback for spans whose startTimeUnixNano is missing or unparseable.
+  const ts = span.startTimeIso ?? nowIso(ctx)
   const sourceId = serviceId(span.service)
   const isError = span.statusCode === 2
 

--- a/packages/core/src/otel.ts
+++ b/packages/core/src/otel.ts
@@ -15,6 +15,12 @@ export interface ParsedSpan {
   kind?: number
   startTimeUnixNano: string
   endTimeUnixNano: string
+  // ISO8601 derived from startTimeUnixNano. Production paths (lastObserved on
+  // OBSERVED edges) read this so the recorded time reflects when the span fired,
+  // not when the receiver received it. Undefined only when startTimeUnixNano is
+  // missing or unparseable — handler falls back to wall-clock in that case.
+  // See docs/contracts/otel-ingest.md §lastObserved-from-span-time.
+  startTimeIso?: string
   // bigint so the 9-digit-nanos arithmetic doesn't lose precision on long traces.
   durationNanos: bigint
   attributes: Record<string, AttributeValue>
@@ -120,6 +126,21 @@ function durationNanos(start?: string, end?: string): bigint {
   }
 }
 
+// Convert OTLP's startTimeUnixNano (a base-10 string of nanoseconds since the
+// Unix epoch) to ISO8601. Returns undefined when the input is missing, zero,
+// or unparseable, so the caller can fall back to wall-clock without surfacing
+// a fake timestamp on the edge.
+export function isoFromUnixNano(nanos: string | undefined): string | undefined {
+  if (!nanos || nanos === '0') return undefined
+  try {
+    const ms = Number(BigInt(nanos) / 1_000_000n)
+    if (!Number.isFinite(ms)) return undefined
+    return new Date(ms).toISOString()
+  } catch {
+    return undefined
+  }
+}
+
 export function parseOtlpRequest(body: OtlpTracesRequest): ParsedSpan[] {
   const out: ParsedSpan[] = []
   for (const rs of body.resourceSpans ?? []) {
@@ -140,6 +161,7 @@ export function parseOtlpRequest(body: OtlpTracesRequest): ParsedSpan[] {
           kind: span.kind,
           startTimeUnixNano: span.startTimeUnixNano ?? '0',
           endTimeUnixNano: span.endTimeUnixNano ?? '0',
+          startTimeIso: isoFromUnixNano(span.startTimeUnixNano),
           durationNanos: durationNanos(span.startTimeUnixNano, span.endTimeUnixNano),
           attributes: attrs,
           dbSystem: typeof attrs['db.system'] === 'string' ? (attrs['db.system'] as string) : undefined,

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -512,7 +512,57 @@ describe('Static-extraction contract (ADR-032)', () => {
 // ──────────────────────────────────────────────────────────────────────────
 describe('OTel ingest contract (ADR-033)', () => {
   it.todo('OTel receiver replies before mutation completes (issue #131)')
-  it.todo('lastObserved derives from span.startTimeUnixNano, not Date.now() (issue #132)')
+  it('lastObserved derives from span.startTimeUnixNano, not Date.now() (issue #132)', async () => {
+    const { handleSpan } = await import('../../src/ingest.js')
+    const { isoFromUnixNano } = await import('../../src/otel.js')
+    const { observedEdgeId } = await import('@neat/types')
+    const { mkdtempSync } = await import('node:fs')
+    const { tmpdir } = await import('node:os')
+
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:caller', {
+      id: 'service:caller',
+      type: NodeType.ServiceNode,
+      name: 'caller',
+      language: 'javascript',
+    })
+    g.addNode('service:callee', {
+      id: 'service:callee',
+      type: NodeType.ServiceNode,
+      name: 'callee',
+      language: 'javascript',
+    })
+
+    const errorsPath = join(mkdtempSync(join(tmpdir(), 'contract-test-')), 'errors.ndjson')
+    // Backdated span: April 1st, ~5 weeks before "now". The receiver clock is
+    // pinned to 2026-05-05 so the only way the edge could end up with the
+    // April 1st timestamp is if the handler reads the span's own startTime.
+    const spanStartNano = (BigInt(Date.parse('2026-04-01T09:00:00.000Z')) * 1_000_000n).toString()
+    await handleSpan(
+      {
+        graph: g,
+        errorsPath,
+        now: () => Date.parse('2026-05-05T12:00:00.000Z'),
+      },
+      {
+        traceId: 't-backdated',
+        spanId: 's-backdated',
+        service: 'caller',
+        name: 'GET /things',
+        statusCode: 0,
+        startTimeUnixNano: spanStartNano,
+        endTimeUnixNano: spanStartNano,
+        startTimeIso: isoFromUnixNano(spanStartNano),
+        durationNanos: 0n,
+        attributes: { 'server.address': 'callee', 'http.method': 'GET' },
+      },
+    )
+
+    const edge = g.getEdgeAttributes(
+      observedEdgeId('service:caller', 'service:callee', EdgeType.CALLS),
+    ) as GraphEdge
+    expect(edge.lastObserved).toBe('2026-04-01T09:00:00.000Z')
+  })
   it.todo('parent-span cache resolves cross-service CALLS when address-based resolution fails (issue #133)')
   it.todo('handleSpan auto-creates ServiceNode at serviceId(span.service) for unseen services (issue #134)')
   it.todo('handleSpan auto-creates DatabaseNode at databaseId(host) for unseen db.system+host (issue #134)')


### PR DESCRIPTION
## Summary

- Adds \`startTimeIso\` to \`ParsedSpan\`, populated by a new \`isoFromUnixNano\` helper in \`otel.ts\`. Conversion lives in \`parseOtlpRequest\` so every consumer of the parsed span sees a normalized form (gRPC delegates here via \`reshapeGrpcRequest\`, so both transports are covered).
- \`handleSpan\` reads \`span.startTimeIso\` first; \`nowIso(ctx)\` is the fallback for spans whose \`startTimeUnixNano\` is missing, zero, or unparseable. Test fixtures using \`startTimeUnixNano: '0'\` keep their existing wall-clock behavior.
- \`stitchTrace\` already takes \`ts\` as a parameter, so it inherits the corrected timestamp from \`handleSpan\`.

## Contract assertion flipped

In \`packages/core/test/audits/contracts.test.ts\`:

- ✅ \`lastObserved derives from span.startTimeUnixNano, not Date.now() (issue #132)\` — backdated span fixture (~5 weeks before the receiver's wall clock) confirms the recorded edge timestamp matches the span's startTime.

251 contract assertions passing (was 250), 27 todos remaining (was 28).

## Test plan

- [x] \`npx turbo build\` clean
- [x] \`npx turbo test\` — 251 pass, 27 todo
- [x] All existing ingest tests pass (they use \`startTimeUnixNano: '0'\` which falls through to \`nowIso\`).

Refs ADR-033, #132