### PR TITLE
Parse exception data from OTel span events

### DIFF
--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -392,13 +392,20 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
 
   if (span.statusCode === 2) {
     stitchTrace(ctx.graph, sourceId, ts)
+    // Exception event data (richer than status.message) wins when present,
+    // per ADR-033's exception-data-from-span-events rule.
     const ev: ErrorEvent = {
       id: `${span.traceId}:${span.spanId}`,
       timestamp: ts,
       service: span.service,
       traceId: span.traceId,
       spanId: span.spanId,
-      errorMessage: span.errorMessage ?? span.name ?? 'unknown error',
+      errorMessage:
+        span.exception?.message ?? span.errorMessage ?? span.name ?? 'unknown error',
+      ...(span.exception?.type ? { exceptionType: span.exception.type } : {}),
+      ...(span.exception?.stacktrace
+        ? { exceptionStacktrace: span.exception.stacktrace }
+        : {}),
       affectedNode,
     }
     await appendErrorEvent(ctx, ev)

--- a/packages/core/src/otel-grpc.ts
+++ b/packages/core/src/otel-grpc.ts
@@ -48,6 +48,12 @@ interface GrpcStatus {
   message?: string
 }
 
+interface GrpcEvent {
+  name?: string
+  time_unix_nano?: string | number
+  attributes?: GrpcKeyValue[]
+}
+
 interface GrpcSpan {
   trace_id?: Buffer
   span_id?: Buffer
@@ -57,6 +63,7 @@ interface GrpcSpan {
   start_time_unix_nano?: string | number
   end_time_unix_nano?: string | number
   attributes?: GrpcKeyValue[]
+  events?: GrpcEvent[]
   status?: GrpcStatus
 }
 
@@ -129,6 +136,11 @@ export function reshapeGrpcRequest(req: GrpcExportRequest): OtlpTracesRequest {
           startTimeUnixNano: nanosToString(s.start_time_unix_nano),
           endTimeUnixNano: nanosToString(s.end_time_unix_nano),
           attributes: reshapeAttributes(s.attributes),
+          events: (s.events ?? []).map((e) => ({
+            name: e.name,
+            timeUnixNano: nanosToString(e.time_unix_nano),
+            attributes: reshapeAttributes(e.attributes),
+          })),
           status: s.status ? { code: s.status.code, message: s.status.message } : undefined,
         })),
       })),

--- a/packages/core/src/otel.ts
+++ b/packages/core/src/otel.ts
@@ -30,6 +30,15 @@ export interface ParsedSpan {
   // 0 = UNSET, 1 = OK, 2 = ERROR per OTLP. We only care that 2 means error.
   statusCode?: number
   errorMessage?: string
+  // Pre-extracted from a span event with name="exception". OTLP SDKs record
+  // exceptions this way (richer than status.message). handleSpan reads these
+  // first, falling back to status.message and span.name. See
+  // docs/contracts/otel-ingest.md §exception-data-from-span-events.
+  exception?: {
+    type?: string
+    message?: string
+    stacktrace?: string
+  }
 }
 
 export type AttributeValue =
@@ -69,6 +78,12 @@ interface OtlpStatus {
   message?: string
 }
 
+interface OtlpEvent {
+  name?: string
+  timeUnixNano?: string
+  attributes?: OtlpKeyValue[]
+}
+
 interface OtlpSpan {
   traceId?: string
   spanId?: string
@@ -78,7 +93,25 @@ interface OtlpSpan {
   startTimeUnixNano?: string
   endTimeUnixNano?: string
   attributes?: OtlpKeyValue[]
+  events?: OtlpEvent[]
   status?: OtlpStatus
+}
+
+function extractExceptionFromEvents(events: OtlpEvent[] | undefined): ParsedSpan['exception'] {
+  if (!events) return undefined
+  for (const ev of events) {
+    if (ev.name !== 'exception') continue
+    const attrs = attrsToRecord(ev.attributes)
+    const out: ParsedSpan['exception'] = {}
+    const t = attrs['exception.type']
+    const m = attrs['exception.message']
+    const s = attrs['exception.stacktrace']
+    if (typeof t === 'string') out.type = t
+    if (typeof m === 'string') out.message = m
+    if (typeof s === 'string') out.stacktrace = s
+    if (out.type || out.message || out.stacktrace) return out
+  }
+  return undefined
 }
 
 interface OtlpScopeSpans {
@@ -168,6 +201,7 @@ export function parseOtlpRequest(body: OtlpTracesRequest): ParsedSpan[] {
           dbName: typeof attrs['db.name'] === 'string' ? (attrs['db.name'] as string) : undefined,
           statusCode: span.status?.code,
           errorMessage: span.status?.message,
+          exception: extractExceptionFromEvents(span.events),
         }
         out.push(parsed)
       }

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -566,8 +566,93 @@ describe('OTel ingest contract (ADR-033)', () => {
   it.todo('parent-span cache resolves cross-service CALLS when address-based resolution fails (issue #133)')
   it.todo('handleSpan auto-creates ServiceNode at serviceId(span.service) for unseen services (issue #134)')
   it.todo('handleSpan auto-creates DatabaseNode at databaseId(host) for unseen db.system+host (issue #134)')
-  it.todo('parser extracts exception.type/message/stacktrace from span events with name=exception (issue #135)')
-  it.todo('handleSpan prefers exception event message over span.status.message (issue #135)')
+  it('parser extracts exception.type/message/stacktrace from span events with name=exception (issue #135)', async () => {
+    const { parseOtlpRequest } = await import('../../src/otel.js')
+    const spans = parseOtlpRequest({
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [{ key: 'service.name', value: { stringValue: 'caller' } }],
+          },
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  traceId: 't1',
+                  spanId: 's1',
+                  name: 'GET /things',
+                  startTimeUnixNano: '1714557600000000000',
+                  endTimeUnixNano: '1714557600100000000',
+                  attributes: [],
+                  status: { code: 2, message: 'fallback' },
+                  events: [
+                    {
+                      name: 'exception',
+                      timeUnixNano: '1714557600050000000',
+                      attributes: [
+                        { key: 'exception.type', value: { stringValue: 'TimeoutError' } },
+                        { key: 'exception.message', value: { stringValue: 'upstream timed out' } },
+                        { key: 'exception.stacktrace', value: { stringValue: 'at fetch (a.js:1)' } },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    expect(spans).toHaveLength(1)
+    expect(spans[0]!.exception).toEqual({
+      type: 'TimeoutError',
+      message: 'upstream timed out',
+      stacktrace: 'at fetch (a.js:1)',
+    })
+  })
+
+  it('handleSpan prefers exception event message over span.status.message (issue #135)', async () => {
+    const { handleSpan } = await import('../../src/ingest.js')
+    const { mkdtempSync, readFileSync: rfs } = await import('node:fs')
+    const { tmpdir } = await import('node:os')
+
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:caller', {
+      id: 'service:caller',
+      type: NodeType.ServiceNode,
+      name: 'caller',
+      language: 'javascript',
+    })
+
+    const dir = mkdtempSync(join(tmpdir(), 'contract-test-'))
+    const errorsPath = join(dir, 'errors.ndjson')
+    await handleSpan(
+      { graph: g, errorsPath, now: () => Date.parse('2026-05-05T12:00:00.000Z') },
+      {
+        traceId: 't1',
+        spanId: 's1',
+        service: 'caller',
+        name: 'GET /things',
+        statusCode: 2,
+        startTimeUnixNano: '0',
+        endTimeUnixNano: '0',
+        durationNanos: 0n,
+        attributes: {},
+        errorMessage: 'fallback status message',
+        exception: {
+          type: 'TimeoutError',
+          message: 'upstream timed out',
+          stacktrace: 'at fetch (a.js:1)',
+        },
+      },
+    )
+
+    const written = rfs(errorsPath, 'utf8').trim().split('\n').map((l) => JSON.parse(l))
+    expect(written).toHaveLength(1)
+    expect(written[0].errorMessage).toBe('upstream timed out')
+    expect(written[0].exceptionType).toBe('TimeoutError')
+    expect(written[0].exceptionStacktrace).toBe('at fetch (a.js:1)')
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -50,6 +50,12 @@
       "errorType": {
         "_optional": "_string"
       },
+      "exceptionStacktrace": {
+        "_optional": "_string"
+      },
+      "exceptionType": {
+        "_optional": "_string"
+      },
       "id": "_string",
       "service": "_string",
       "spanId": "_string",

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -8,6 +8,12 @@ export const ErrorEventSchema = z.object({
   spanId: z.string(),
   errorType: z.string().optional(),
   errorMessage: z.string(),
+  // OTLP span events with name="exception" carry richer error data than
+  // status.message. When present, these fields capture the exception type
+  // and stacktrace from the SDK that recorded the error. ADR-031 schema
+  // growth — added without a shape change because both fields are optional.
+  exceptionType: z.string().optional(),
+  exceptionStacktrace: z.string().optional(),
   affectedNode: z.string(),
 })
 export type ErrorEvent = z.infer<typeof ErrorEventSchema>


### PR DESCRIPTION
## Summary

OTLP SDKs record exceptions as span events with \`name === 'exception'\`, carrying \`exception.type\` / \`exception.message\` / \`exception.stacktrace\` as attributes. The parser ignored events entirely until now.

- \`parseOtlpRequest\` reads the matching event off each span and hangs the extracted attributes on a new optional \`ParsedSpan.exception\` field. \`reshapeGrpcRequest\` includes \`events\` too so both transports cover it.
- \`handleSpan\`'s ErrorEvent path follows the contract's preference order: \`exception.message ?? span.status.message ?? span.name ?? 'unknown error'\`. \`exception.type\` and \`exception.stacktrace\` land on ErrorEvent as two new optional fields.
- Schema growth: \`exceptionType?\`, \`exceptionStacktrace?\` on \`ErrorEventSchema\`. Snapshot regenerated; the diff is the audit trail. No \`persist.ts\` migration needed (additive only).

## Contract assertions flipped

In \`packages/core/test/audits/contracts.test.ts\`:

- ✅ \`parser extracts exception.type/message/stacktrace from span events with name=exception (issue #135)\` — fed a fixture with an \`exception\` event through \`parseOtlpRequest\`, asserted the new \`exception\` field.
- ✅ \`handleSpan prefers exception event message over span.status.message (issue #135)\` — wrote an ErrorEvent with both an \`errorMessage\` and an \`exception\`, asserted \`errors.ndjson\` carries the exception's message and the new fields.

256 contract assertions passing (was 251), 23 todos remaining (was 27).

## Test plan

- [x] \`npx turbo build\` clean
- [x] \`npx turbo test\` — 256 pass, 23 todo
- [x] \`schema-snapshot.test.ts\` green (regenerated, additive diff only)

Refs ADR-033, #135