### PR TITLE
Auto-create ServiceNode and DatabaseNode for unseen OTel peers

### DIFF
--- a/packages/core/src/extract/databases/index.ts
+++ b/packages/core/src/extract/databases/index.ts
@@ -206,8 +206,20 @@ export async function addDatabasesAndCompat(
     for (const config of allConfigs) {
       const dbNode = toDatabaseNode(config)
       if (!graph.hasNode(dbNode.id)) {
-        graph.addNode(dbNode.id, dbNode)
+        graph.addNode(dbNode.id, { ...dbNode, discoveredVia: 'static' })
         nodesAdded++
+      } else {
+        // OTel ingest may have auto-created a minimal node at this id. Merge
+        // per ADR-033: static fields override OTel-derived fields, discoveredVia
+        // flips to 'merged' when both layers contributed.
+        const existing = graph.getNodeAttributes(dbNode.id) as DatabaseNode
+        const mergedDiscoveredVia: 'static' | 'otel' | 'merged' =
+          existing.discoveredVia === 'otel' ? 'merged' : 'static'
+        graph.replaceNodeAttributes(dbNode.id, {
+          ...existing,
+          ...dbNode,
+          discoveredVia: mergedDiscoveredVia,
+        })
       }
       const edge: GraphEdge = {
         id: makeEdgeId(service.node.id, dbNode.id, EdgeType.CONNECTS_TO),

--- a/packages/core/src/extract/services.ts
+++ b/packages/core/src/extract/services.ts
@@ -226,9 +226,21 @@ export function addServiceNodes(graph: NeatGraph, services: DiscoveredService[])
   let nodesAdded = 0
   for (const service of services) {
     if (!graph.hasNode(service.node.id)) {
-      graph.addNode(service.node.id, service.node)
+      graph.addNode(service.node.id, { ...service.node, discoveredVia: 'static' })
       nodesAdded++
+      continue
     }
+    // OTel ingest may have auto-created a minimal node at this id. Merge per
+    // ADR-033 / identity contract: static fields override OTel-derived fields,
+    // and discoveredVia flips to 'merged' when both layers contributed.
+    const existing = graph.getNodeAttributes(service.node.id) as ServiceNode
+    const mergedDiscoveredVia: 'static' | 'otel' | 'merged' =
+      existing.discoveredVia === 'otel' ? 'merged' : 'static'
+    graph.replaceNodeAttributes(service.node.id, {
+      ...existing,
+      ...service.node,
+      discoveredVia: mergedDiscoveredVia,
+    })
   }
   return nodesAdded
 }

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -1,6 +1,12 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
-import type { ErrorEvent, FrontierNode, GraphEdge, ServiceNode } from '@neat/types'
+import type {
+  DatabaseNode,
+  ErrorEvent,
+  FrontierNode,
+  GraphEdge,
+  ServiceNode,
+} from '@neat/types'
 import {
   EdgeType,
   NodeType,
@@ -158,6 +164,47 @@ function resolveServiceId(graph: NeatGraph, host: string): string | null {
 
 export function frontierIdFor(host: string): string {
   return frontierId(host)
+}
+
+// Auto-create a minimal ServiceNode for span.service when no such node exists.
+// Used at the top of handleSpan so subsequent edge upserts always have endpoints
+// — without it, OBSERVED edges silently drop for any service the static
+// extractor hasn't reached yet (and never reaches at all in OTel-only setups).
+// `language: 'unknown'` is the contract's specified placeholder (ADR-033). When
+// static extraction later produces a ServiceNode at the same id, addServiceNodes
+// merges and flips discoveredVia to 'merged' rather than overwriting.
+function ensureServiceNode(graph: NeatGraph, serviceName: string): string {
+  const id = serviceId(serviceName)
+  if (graph.hasNode(id)) return id
+  const node: ServiceNode = {
+    id,
+    type: NodeType.ServiceNode,
+    name: serviceName,
+    language: 'unknown',
+    discoveredVia: 'otel',
+  }
+  graph.addNode(id, node)
+  return id
+}
+
+// Same shape for unseen db.system + host pairs. Engine comes off the OTel
+// attribute as a string per Rule 8 — no hardcoded engine list. compatibleDrivers
+// is empty until static extraction merges in the matrix-derived drivers.
+function ensureDatabaseNode(graph: NeatGraph, host: string, engine: string): string {
+  const id = databaseId(host)
+  if (graph.hasNode(id)) return id
+  const node: DatabaseNode = {
+    id,
+    type: NodeType.DatabaseNode,
+    name: host,
+    engine,
+    engineVersion: 'unknown',
+    compatibleDrivers: [],
+    host,
+    discoveredVia: 'otel',
+  }
+  graph.addNode(id, node)
+  return id
 }
 
 function ensureFrontierNode(graph: NeatGraph, host: string, ts: string): string {
@@ -340,7 +387,10 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
   // actually fired, not when the receiver received it. Wall-clock is only the
   // fallback for spans whose startTimeUnixNano is missing or unparseable.
   const ts = span.startTimeIso ?? nowIso(ctx)
-  const sourceId = serviceId(span.service)
+  // Auto-create a minimal ServiceNode for unseen span.service so OBSERVED
+  // edges land instead of silently dropping. Static extraction merges richer
+  // fields when it later finds the same id (ADR-033).
+  const sourceId = ensureServiceNode(ctx.graph, span.service)
   const isError = span.statusCode === 2
 
   let affectedNode = sourceId
@@ -349,6 +399,9 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
     // Database span — try to resolve the DatabaseNode by host.
     const host = pickAddress(span)
     if (host) {
+      // Auto-create a minimal DatabaseNode when this host hasn't been seen.
+      // Engine comes off the OTel attribute as a string per Rule 8.
+      ensureDatabaseNode(ctx.graph, host, span.dbSystem)
       const targetId = databaseId(host)
       const result = upsertObservedEdge(
         ctx.graph,

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -564,8 +564,78 @@ describe('OTel ingest contract (ADR-033)', () => {
     expect(edge.lastObserved).toBe('2026-04-01T09:00:00.000Z')
   })
   it.todo('parent-span cache resolves cross-service CALLS when address-based resolution fails (issue #133)')
-  it.todo('handleSpan auto-creates ServiceNode at serviceId(span.service) for unseen services (issue #134)')
-  it.todo('handleSpan auto-creates DatabaseNode at databaseId(host) for unseen db.system+host (issue #134)')
+  it('handleSpan auto-creates ServiceNode at serviceId(span.service) for unseen services (issue #134)', async () => {
+    const { handleSpan } = await import('../../src/ingest.js')
+    const { serviceId } = await import('@neat/types')
+    const { mkdtempSync } = await import('node:fs')
+    const { tmpdir } = await import('node:os')
+
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    const errorsPath = join(mkdtempSync(join(tmpdir(), 'contract-test-')), 'errors.ndjson')
+
+    expect(g.hasNode(serviceId('unseen-svc'))).toBe(false)
+    await handleSpan(
+      { graph: g, errorsPath, now: () => Date.parse('2026-05-05T12:00:00.000Z') },
+      {
+        traceId: 't1',
+        spanId: 's1',
+        service: 'unseen-svc',
+        name: 'GET /things',
+        startTimeUnixNano: '0',
+        endTimeUnixNano: '0',
+        durationNanos: 0n,
+        attributes: {},
+      },
+    )
+
+    expect(g.hasNode(serviceId('unseen-svc'))).toBe(true)
+    const node = g.getNodeAttributes(serviceId('unseen-svc')) as {
+      type: string
+      language: string
+      discoveredVia?: string
+    }
+    expect(node.type).toBe(NodeType.ServiceNode)
+    expect(node.language).toBe('unknown')
+    expect(node.discoveredVia).toBe('otel')
+  })
+
+  it('handleSpan auto-creates DatabaseNode at databaseId(host) for unseen db.system+host (issue #134)', async () => {
+    const { handleSpan } = await import('../../src/ingest.js')
+    const { databaseId } = await import('@neat/types')
+    const { mkdtempSync } = await import('node:fs')
+    const { tmpdir } = await import('node:os')
+
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    const errorsPath = join(mkdtempSync(join(tmpdir(), 'contract-test-')), 'errors.ndjson')
+
+    await handleSpan(
+      { graph: g, errorsPath, now: () => Date.parse('2026-05-05T12:00:00.000Z') },
+      {
+        traceId: 't2',
+        spanId: 's2',
+        service: 'caller',
+        name: 'SELECT 1',
+        startTimeUnixNano: '0',
+        endTimeUnixNano: '0',
+        durationNanos: 0n,
+        attributes: { 'server.address': 'analytics.internal', 'db.system': 'postgresql' },
+        dbSystem: 'postgresql',
+      },
+    )
+
+    const dbId = databaseId('analytics.internal')
+    expect(g.hasNode(dbId)).toBe(true)
+    const dbNode = g.getNodeAttributes(dbId) as {
+      type: string
+      engine: string
+      engineVersion: string
+      discoveredVia?: string
+    }
+    expect(dbNode.type).toBe(NodeType.DatabaseNode)
+    expect(dbNode.engine).toBe('postgresql')
+    expect(dbNode.engineVersion).toBe('unknown')
+    expect(dbNode.discoveredVia).toBe('otel')
+  })
   it('parser extracts exception.type/message/stacktrace from span events with name=exception (issue #135)', async () => {
     const { parseOtlpRequest } = await import('../../src/otel.js')
     const spans = parseOtlpRequest({

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -175,6 +175,15 @@
                 "_record": "_string"
               }
             },
+            "discoveredVia": {
+              "_optional": {
+                "_enum": [
+                  "merged",
+                  "otel",
+                  "static"
+                ]
+              }
+            },
             "id": "_string",
             "incompatibilities": {
               "_optional": {
@@ -271,6 +280,15 @@
                   "minVersion": "_string",
                   "name": "_string"
                 }
+              }
+            },
+            "discoveredVia": {
+              "_optional": {
+                "_enum": [
+                  "merged",
+                  "otel",
+                  "static"
+                ]
               }
             },
             "engine": "_string",

--- a/packages/types/src/nodes.ts
+++ b/packages/types/src/nodes.ts
@@ -7,11 +7,19 @@ export const CompatibleDriverSchema = z.object({
 })
 export type CompatibleDriver = z.infer<typeof CompatibleDriverSchema>
 
+// How NEAT first learned of a node. Static-extraction fills in the rich
+// fields (language, version, dependencies); OTel ingest can also create a
+// minimal node when it sees a span for an unknown peer. When both layers
+// recorded the same node, the value is 'merged'. ADR-031 schema growth.
+export const DiscoveredViaSchema = z.enum(['static', 'otel', 'merged'])
+export type DiscoveredVia = z.infer<typeof DiscoveredViaSchema>
+
 export const ServiceNodeSchema = z.object({
   id: z.string(),
   type: z.literal(NodeType.ServiceNode),
   name: z.string(),
   language: z.string(),
+  discoveredVia: DiscoveredViaSchema.optional(),
   version: z.string().optional(),
   dbConnectionTarget: z.string().optional(),
   repoPath: z.string().optional(),
@@ -79,6 +87,7 @@ export const DatabaseNodeSchema = z.object({
   compatibleDrivers: z.array(CompatibleDriverSchema),
   host: z.string().optional(),
   port: z.number().optional(),
+  discoveredVia: DiscoveredViaSchema.optional(),
 })
 export type DatabaseNode = z.infer<typeof DatabaseNodeSchema>
 


### PR DESCRIPTION
## Summary

\`handleSpan\` now ensures a \`ServiceNode\` at \`serviceId(span.service)\` and a \`DatabaseNode\` at \`databaseId(host)\` before any edge upsert. Without this, OBSERVED edges for any service the static extractor hasn't reached (or never reaches at all in OTel-only setups) silently dropped because \`upsertObservedEdge\` requires both endpoints to exist.

Auto-created nodes carry the contract-specified placeholders:
- \`ServiceNode\` — \`{ language: 'unknown', discoveredVia: 'otel' }\`
- \`DatabaseNode\` — \`{ engineVersion: 'unknown', compatibleDrivers: [], discoveredVia: 'otel' }\`

Engine on the DB comes from \`span.dbSystem\` verbatim — no hardcoded engine list per Rule 8.

## Static / OTel merge

Static extraction now merges instead of skipping when an OTel-created node exists at the same id:
- Static fields override OTel-derived ones (more authoritative on declared intent: \`language\`, \`version\`, \`dependencies\`, \`engineVersion\`, \`compatibleDrivers\`).
- \`discoveredVia\` flips to \`'merged'\` when both layers contributed; otherwise stays \`'static'\`.

Touches \`extract/services.ts\` (\`addServiceNodes\`) and \`extract/databases/index.ts\` (\`addDatabasesAndCompat\`).

## Schema growth

New optional \`discoveredVia\` field on \`ServiceNodeSchema\` and \`DatabaseNodeSchema\`, backed by a shared \`DiscoveredViaSchema\` enum (\`'static' | 'otel' | 'merged'\`). Snapshot regenerated; the diff is the audit trail. Additive only — no \`persist.ts\` migration needed.

## Contract assertions flipped

In \`packages/core/test/audits/contracts.test.ts\`:

- ✅ \`handleSpan auto-creates ServiceNode at serviceId(span.service) for unseen services (issue #134)\`
- ✅ \`handleSpan auto-creates DatabaseNode at databaseId(host) for unseen db.system+host (issue #134)\`

258 contract assertions passing (was 256), 21 todos remaining (was 23).

## Test plan

- [x] \`npx turbo build\` clean
- [x] \`npx turbo test\` — 258 pass, 21 todo
- [x] \`schema-snapshot.test.ts\` green (regenerated, additive diff only)

Refs ADR-033, #134