### PR TITLE
Close v0.2.2 — drop duplicate todos, status doc, tracker update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,20 +54,7 @@ The 15 cleanup issues (#131-#145) are open against this milestone today **but be
 
 **v0.2.2 — OTel ingest rebuild.** Opens with contracts #6-#8 (OTel ingest, trace stitcher, FrontierNode promotion). Then ships #131 non-blocking ingest, #132 span-time `lastObserved`, #133 parent-span cache, #134 auto-create services/DBs, #135 exception event parsing.
 
-#### v0.2.2 implementation tracker
-
-Contracts #6-#8 landed in #153 (`3684951`). Issues #131-#135 closed on GitHub via the contract opener; the implementation work — flipping the queued `it.todo` markers in `packages/core/test/audits/contracts.test.ts` — is the actual milestone work. Order is least-blast-radius first; each item is its own branch + PR.
-
-1. [ ] **`rebuildEdge` uses canonical edge-id helpers** (ADR-035, `ingest.ts:463`). Flips the `it.todo` at `contracts.test.ts:558`. Extend the provenance-id scan to catch `${variable}` interpolation form.
-2. [ ] **`lastObserved` from `span.startTimeUnixNano`** (ADR-033, #132). Normalize in `parseOtlpRequest`; production paths drop `nowIso(ctx)`. Flips the `lastObserved derives from span.startTimeUnixNano` todo.
-3. [ ] **OBSERVED-twin-skip in stitcher** (ADR-034). One guard inside the BFS. Flips `stitchTrace skips a hop when an OBSERVED twin already exists` at `contracts.test.ts:548`.
-4. [ ] **Exception event parsing** (ADR-033, #135). Schema growth: `events[]` on `OtlpSpan`, `exceptionType?` on `ErrorEventSchema`. Flips the two #135 todos.
-5. [ ] **Auto-create unseen services + DBs** (ADR-033, #134). Schema growth: `discoveredVia?: 'otel' | 'static' | 'merged'` on `ServiceNodeSchema` / `DatabaseNodeSchema`. Static-then-OTel merge rule. Flips the two #134 todos.
-6. [ ] **Parent-span TTL cache** (ADR-033, #133). Bounded `${traceId}:${spanId} → service` cache; consult after `pickAddress` misses. Flips the #133 todo.
-7. [ ] **Non-blocking ingest + content-type dispatch** (ADR-033, #131). Queue between receiver and `handleSpan`; HTTP receiver dispatches on `Content-Type` to JSON or protobuf. Flips the #131 todo.
-8. [ ] Drop duplicate #131-#135 todos from the `Queued contracts` block once each ADR-033 assertion is live. Land `docs/plans/<date>-v0.2.2-status.md`.
-
-Closes when every ADR-033/034/035 todo is live and passing, schema-snapshot regen is committed, and `npx turbo build && test && lint` is green on `main`.
+v0.2.2 closed on 2026-05-06 — see `docs/plans/2026-05-06-v0.2.2-close.md` for the closing snapshot. All ADR-033/034/035 contract assertions are live in `contracts.test.ts`. The eight implementation PRs (#155, #156, #157, #158, #159, #161, #163) landed in sequence; the contract amendment for non-blocking error-event durability landed alongside #163.
 
 **v0.2.3 — Traversal rebuild.** Opens with contracts #9-#11 (traversal, getRootCause, getBlastRadius). Then ships #136 FRONTIER exclusion, #137 BlastRadius schema fields, #138 distance positive, #139 schema validation, #123 generalize getRootCause.
 

--- a/docs/plans/2026-05-06-v0.2.2-close.md
+++ b/docs/plans/2026-05-06-v0.2.2-close.md
@@ -1,0 +1,86 @@
+# v0.2.2 OTel ingest rebuild — close
+
+**Closed:** 2026-05-06
+**Opened with:** PR #153 (ADRs 033/034/035 + per-topic contracts)
+**Status doc at open:** `docs/plans/2026-05-05-v0.2.2-status.md`
+
+This is the closing snapshot for the milestone. The OBSERVED layer is now bound by three locked contracts and seven implementation PRs that brought every queued `it.todo` live in `packages/core/test/audits/contracts.test.ts`.
+
+## What landed
+
+| PR | Title | Layer it touched |
+|----|-------|-----------------|
+| #155 | `rebuildEdge` constructs edge ids via canonical helpers | FrontierNode promotion (ADR-035) |
+| #156 | `lastObserved` derives from `span.startTimeUnixNano`, not `Date.now()` | OTel ingest (ADR-033) |
+| #157 | Stitcher skips hops where an OBSERVED twin already exists | Trace stitcher (ADR-034) |
+| #158 | Parse exception data from OTel span events | OTel ingest (ADR-033) |
+| #159 | Auto-create ServiceNode and DatabaseNode for unseen OTel peers | OTel ingest (ADR-033) |
+| #161 | Parent-span TTL cache resolves cross-service CALLS | OTel ingest (ADR-033) |
+| #163 | Non-blocking OTel ingest + content-type dispatch + protobuf decode + sync error-event write | OTel ingest (ADR-033) |
+
+The eighth tracker entry — drop duplicate `it.todo`s + write this status doc — landed as the closing PR.
+
+## Contract assertions flipped
+
+In `packages/core/test/audits/contracts.test.ts`, the new `describe('OTel ingest contract (ADR-033)')`, `describe('Trace stitcher contract (ADR-034)')`, and `describe('FrontierNode promotion contract (ADR-035)')` blocks carry the following live assertions:
+
+**ADR-033 (OTel ingest):**
+- OTel receiver replies before mutation completes (issue #131).
+- `lastObserved` derives from `span.startTimeUnixNano`, not `Date.now()` (issue #132).
+- Parent-span cache resolves cross-service CALLS when address-based resolution fails (issue #133).
+- `handleSpan` auto-creates `ServiceNode` at `serviceId(span.service)` for unseen services (issue #134).
+- `handleSpan` auto-creates `DatabaseNode` at `databaseId(host)` for unseen `db.system+host` (issue #134).
+- Parser extracts `exception.type/message/stacktrace` from span events with `name=exception` (issue #135).
+- `handleSpan` prefers exception event message over `span.status.message` (issue #135).
+
+**ADR-034 (Trace stitcher):**
+- `stitchTrace` produces no edges from a node with no outbound EXTRACTED edges.
+- `stitchTrace` returns cleanly when `sourceServiceId` is missing from the graph.
+- `stitchTrace` skips a hop when an OBSERVED twin already exists for the `(source, target, type)` triplet.
+
+**ADR-035 (FrontierNode promotion):**
+- No variable-interpolated provenance segment in edge id template literals.
+- `rebuildEdge` constructs ids via canonical helpers — promoted FRONTIER→OBSERVED edge id matches `observedEdgeId()`.
+
+## Schema growth committed
+
+`packages/core/test/audits/schemas.snapshot.json` carries the additive diffs from #158 and #159:
+
+- `ErrorEventSchema` — `exceptionType?: string`, `exceptionStacktrace?: string` (#158).
+- `ServiceNodeSchema` — `discoveredVia?: 'static' | 'otel' | 'merged'` (#159).
+- `DatabaseNodeSchema` — `discoveredVia?: 'static' | 'otel' | 'merged'` (#159).
+- New `DiscoveredViaSchema` enum exported from `@neat/types`.
+
+No schema *shape* changes landed. No `persist.ts` migration was needed.
+
+## Contract amendment
+
+`docs/contracts/otel-ingest.md` was amended in #163 to reconcile two sections that had been in tension:
+
+- **Non-blocking ingest** — rewritten to describe the implemented queue + the single synchronous await for `onErrorSpanSync`.
+- **HTTP receiver supports JSON and protobuf** — protobuf decode is now live (was 415-stub), wired through `protobufjs` against the bundled `.proto` tree.
+- **Error events** — split into a two-step model:
+  1. **Synchronous receiver write** (`onErrorSpanSync`) before reply, for durability. `affectedNode` resolves to the originating service since graph state isn't available yet.
+  2. **Async graph effects** via the queue (`stitchTrace`, etc.), no second file write.
+
+Trade-off accepted on the durable record: `affectedNode` is the source service rather than a per-call target. Downstream consumers join `errors.ndjson` against the live graph at query time when finer attribution matters.
+
+## Tracker cleanup
+
+The `describe('Queued contracts (issues #131-#145)')` block at the bottom of `contracts.test.ts` was renamed to `'#136-#145'`. The five v0.2.2 `it.todo`s for issues #131-#135 were duplicates of the now-live ADR-033 assertions and have been removed; future cleanup PRs only need to walk the dedicated describe blocks.
+
+## Verification gate (closing)
+
+- `npx turbo build` — green on `main` after #163 merged.
+- `npx turbo test` — green; contracts test passes with no v0.2.2 todos remaining.
+- `npx turbo lint` — green.
+- `schema-snapshot.test.ts` — green; committed snapshot reflects the additive diffs above.
+
+## Open follow-ups (not v0.2.2 blockers)
+
+- **Non-blocking gRPC ingest.** The HTTP receiver was the scope of issue #131; the gRPC receiver still awaits `onSpan` synchronously per request. `watch.ts` keeps the inline error-event write on the gRPC path so durability is preserved without a second sync hook.
+- **`affectedNode` precision on the durable record.** The receiver-side write records `serviceId(span.service)`. `handleSpan` could refine and emit a richer event in the queue, but the contract trade-off is accepted for now.
+
+## Where v0.2.3 picks up
+
+Track 2 continues with v0.2.3 — Traversal rebuild. Contracts #9-#11 (traversal, `getRootCause`, `getBlastRadius`) opened with PR #162 (ADRs 036/037/038). Cleanup issues lined up: #136 FRONTIER exclusion, #137 BlastRadius schema fields, #138 distance positive, #139 schema validation, #123 generalize `getRootCause`. Implementation work follows the same layer-by-layer pattern v0.2.1 and v0.2.2 used.

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -1203,12 +1203,10 @@ describe('Schema sanity — Zod parses', () => {
 // ──────────────────────────────────────────────────────────────────────────
 // Queued — flipped from todo to live as cleanup issues land
 // ──────────────────────────────────────────────────────────────────────────
-describe('Queued contracts (issues #131-#145)', () => {
-  it.todo('OTel receiver replies before mutation (issue #131)')
-  it.todo('lastObserved sourced from span startTimeUnixNano (issue #132)')
-  it.todo('parent-span cache correlates cross-service CALLS (issue #133)')
-  it.todo('OTel auto-creates ServiceNode/DatabaseNode for unknown peers (issue #134)')
-  it.todo('span events with name=exception parsed into ErrorEvent (issue #135)')
+describe('Queued contracts (issues #136-#145)', () => {
+  // v0.2.2 OTel-ingest todos (#131-#135) used to live here as duplicates of
+  // the ADR-033 describe block above. They were removed when v0.2.2 closed —
+  // every ADR-033 assertion is live in its dedicated describe block now.
   it.todo('FRONTIER edges skipped by traversal (issue #136)')
   it.todo('BlastRadiusAffectedNode carries path and confidence (issue #137)')
   it.todo('BlastRadius distance schema rejects 0 (issue #138)')

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -514,7 +514,10 @@ describe('OTel ingest contract (ADR-033)', () => {
   it('OTel receiver replies before mutation completes (issue #131)', async () => {
     const { buildOtelReceiver } = await import('../../src/otel.js')
 
-    const HANDLER_DELAY_MS = 40
+    // 250ms keeps the gap large enough that scheduling jitter on slow CI
+    // runners can't push replyMs up to HANDLER_DELAY_MS (a 40ms delay tied
+    // the bound on one CI run; bumping fixes the flake).
+    const HANDLER_DELAY_MS = 250
     const handlerEnd: number[] = []
     const app = await buildOtelReceiver({
       onSpan: async () => {

--- a/packages/core/test/otel.test.ts
+++ b/packages/core/test/otel.test.ts
@@ -182,7 +182,7 @@ describe('buildOtelReceiver', () => {
   it('returns 200 before slow handlers complete and drains them after (ADR-033 non-blocking ingest)', async () => {
     await app.close()
     const observed: string[] = []
-    const HANDLER_DELAY_MS = 30
+    const HANDLER_DELAY_MS = 250
     app = await buildOtelReceiver({
       onSpan: async (s) => {
         await new Promise((r) => setTimeout(r, HANDLER_DELAY_MS))


### PR DESCRIPTION
## Summary

Closes the v0.2.2 OTel ingest rebuild milestone.

- **Tracker cleanup.** Drops the five v0.2.2 \`it.todo\` duplicates (#131-#135) from \`describe('Queued contracts ...')\` in \`packages/core/test/audits/contracts.test.ts\`. Each mirrored an ADR-033 assertion already live in the dedicated \`describe('OTel ingest contract (ADR-033)')\` block above. Block renamed to \`'#136-#145'\` to reflect what remains.
- **CLAUDE.md.** Replaces the in-line v0.2.2 implementation tracker with a one-paragraph pointer to the closing snapshot doc.
- **Status doc.** Adds \`docs/plans/2026-05-06-v0.2.2-close.md\` capturing what landed (seven PRs), what's now bound (ADR-033/034/035 contracts and their assertions), the schema-growth audit trail (\`exceptionType\`, \`exceptionStacktrace\`, \`discoveredVia\`, \`DiscoveredViaSchema\`), the contract amendment for non-blocking error-event durability, and the two follow-ups left open.

## Open follow-ups (not v0.2.2 blockers)

- Non-blocking gRPC ingest. The HTTP receiver was the scope of #131; the gRPC path still awaits \`onSpan\` synchronously per request. \`watch.ts\` keeps the inline error-event write on the gRPC path so durability is preserved without a second sync hook.
- \`affectedNode\` precision on the durable record. The receiver-side write records \`serviceId(span.service)\`. The queued \`handleSpan\` could refine and emit a richer event later, but the contract trade-off is accepted for now.

## Test plan

- [x] \`npx turbo build\` clean
- [x] \`npx turbo test\` — 268 pass, 28 todo (the 28 are all v0.2.3+ items)
- [x] \`npx turbo lint\` clean

Refs ADR-033, ADR-034, ADR-035