### PR TITLE
Contracts #12-#18: v0.2.4 batch (ADRs 039-045) — surface refresh + policies

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -21,6 +21,13 @@ This file is the index. Each rule has a short summary and a link to its full per
 | 9 | Traversal | [`contracts/traversal.md`](./contracts/traversal.md) | PROV_RANK at every hop, FRONTIER excluded entirely, multiplicative confidence cascading, no mutation, schema-validated results (ADR-036) | ✅ landed (v0.2.3 opens) |
 | 10 | `getRootCause` | [`contracts/get-root-cause.md`](./contracts/get-root-cause.md) | Walks incoming edges to depth 5, dispatches by origin node type, human-readable reason, derived fix recommendation (ADR-037) | ✅ landed (v0.2.3 opens) |
 | 11 | `getBlastRadius` | [`contracts/get-blast-radius.md`](./contracts/get-blast-radius.md) | BFS outbound default depth 10, distance positive, per-node path + cascaded confidence, schema-validated (ADR-038) | ✅ landed (v0.2.3 opens) |
+| 12 | MCP tool surface | [`contracts/mcp-tools.md`](./contracts/mcp-tools.md) | Nine tools, three-part response, transitive `get_dependencies`, REST-only data path (ADR-039) | ✅ landed (v0.2.4 opens) |
+| 13 | REST API | [`contracts/rest-api.md`](./contracts/rest-api.md) | Dual-mount per ADR-026, locked endpoint set, JSON errors, Zod-validated bodies (ADR-040) | ✅ landed (v0.2.4 opens) |
+| 14 | Persistence | [`contracts/persistence.md`](./contracts/persistence.md) | Snapshot at `<projectDir>/neat-out/graph.json`, `SCHEMA_VERSION` bumps on shape change only, append-only ndjson sidecars (ADR-041) | ✅ landed (v0.2.4 opens) |
+| 15 | Policy schema | [`contracts/policy-schema.md`](./contracts/policy-schema.md) | `policy.json` at project root, version 1, five rule types (ADR-042) | ✅ landed (v0.2.4 opens) |
+| 16 | Policy evaluation | [`contracts/policy-evaluation.md`](./contracts/policy-evaluation.md) | Pure `evaluateAllPolicies`, three triggers, per-type dispatch, deterministic violation ids (ADR-043) | ✅ landed (v0.2.4 opens) |
+| 17 | Policy onViolation actions | [`contracts/policy-actions.md`](./contracts/policy-actions.md) | `log` / `alert` / `block`; severity-driven defaults; block applies to FrontierNode promotion gating only in MVP (ADR-044) | ✅ landed (v0.2.4 opens) |
+| 18 | Policy tool surface | [`contracts/policy-tools.md`](./contracts/policy-tools.md) | Single `check_policies` tool, REST under `/policies`, resource at `neat://policies/violations` (ADR-045) | ✅ landed (v0.2.4 opens) |
 
 ### Future contracts — opened at the start of each milestone
 
@@ -28,13 +35,6 @@ Producer-, consumer-, surface-, policy-, and distribution-layer contracts open a
 
 | # | Contract | Milestone | Governs (target) |
 |---|----------|-----------|------------------|
-| 12 | MCP tool surface | v0.2.4 | Three-part response, confidence/provenance footer, transitive vs direct, tool count and naming (`packages/mcp/src/`) |
-| 13 | REST API | v0.2.4 | Endpoint shape per resource, project-scoped routing, error response shape (`packages/core/src/api.ts`) |
-| 14 | Persistence | v0.2.4 | Snapshot schema versioning, migration rules, startup-load behavior (`packages/core/src/persist.ts`) |
-| 15 | Policy schema | v0.2.4 | `policy.json` shape, version literal, type dispatch, rule structure |
-| 16 | Policy evaluation | v0.2.4 | When policies evaluate (post-ingest, post-extract, post-stale), evaluator dispatch, violation-event shape |
-| 17 | Policy onViolation actions | v0.2.4 | alert / log / block — what each does, what authority each carries |
-| 18 | Policy tool surface | v0.2.4 | MCP tool naming and shape, REST endpoints |
 | 19 | `neat init` | v0.2.5 | What init does, what it writes, what it doesn't touch, codemod patch-vs-apply semantics |
 | 20 | SDK install | v0.2.5 | Per-language installer module interface, dependency-file edits, entrypoint modifications, opt-in semantics |
 | 21 | Machine-level project registry | v0.2.5 | `~/.neat/projects.json` shape, daemon discovery rules, project lifecycle |

--- a/docs/contracts/mcp-tools.md
+++ b/docs/contracts/mcp-tools.md
@@ -1,0 +1,61 @@
+---
+name: mcp-tools
+description: Nine MCP tools, all read-only over REST, three-part response (NL + structured + confidence/provenance footer), get_dependencies is transitive, project scoping consistent.
+governs:
+  - "packages/mcp/src/**"
+adr: [ADR-039]
+---
+
+# MCP tool surface contract
+
+Governs `packages/mcp/src/`. Tools call REST against `NEAT_CORE_URL`; never read `graph.json` or mutate the graph.
+
+## Tool count (locked)
+
+Nine tools: `get_root_cause`, `get_blast_radius`, `get_dependencies`, `get_observed_dependencies`, `get_incident_history`, `semantic_search`, `get_graph_diff`, `get_recent_stale_edges`, `check_policies` (lands with #117).
+
+The audit's `evaluate_policy` + `get_policy_violations` two-tool split is rejected per CLAUDE.md framing — `check_policies` handles both modes via optional `hypotheticalAction`.
+
+## Three-part response (issue #143)
+
+```
+{NL paragraph — what was found, why it matters}
+
+{structured block — typed payload, formatted}
+
+confidence: X.XX · provenance: OBSERVED|EXTRACTED|...
+```
+
+Confidence and provenance derived per-result. Empty result → footer reads `confidence: n/a · provenance: n/a`.
+
+A helper `formatToolResponse({ summary, block, confidence?, provenance? })` lives in `packages/mcp/src/format.ts`. Every tool routes through it.
+
+## Transitive `get_dependencies` (issue #144)
+
+Default depth 3, max 10. Calls a new core endpoint `GET /graph/node/:id/dependencies?depth=N` (see ADR-040). Returns flat list with distance, edge type, provenance. Direct-only consumers pass `depth=1`.
+
+## REST-only data path
+
+Every tool calls `NEAT_CORE_URL` via `client.ts`. No `graph.json` reads.
+
+## Project scoping
+
+Optional `project?: string`, defaulting to `'default'` per ADR-026. Multi-project routing happens at REST.
+
+## No demo-name hardcoding
+
+`payments-db`, `pg`, `postgresql` allowed only inside Zod `.describe()` strings. Never in branching logic.
+
+## `semantic_search`
+
+Tool description reflects the ADR-025 embedder chain (Ollama → MiniLM → substring), not "keyword search."
+
+## Stdio only
+
+HTTP / SSE / WebSocket transports remain post-MVP.
+
+## Authority
+
+Read-only. Mutation-authority scan in `contracts.test.ts` enforces this for `packages/mcp/src/`.
+
+Full rationale: [ADR-039](../decisions.md#adr-039--mcp-tool-surface-contract).

--- a/docs/contracts/persistence.md
+++ b/docs/contracts/persistence.md
@@ -1,0 +1,48 @@
+---
+name: persistence
+description: Snapshot at <projectDir>/neat-out/graph.json. SCHEMA_VERSION bumps on shape change only. Forward-only migrations. Append-only ndjson sidecars (errors, stale-events, policy-violations).
+governs:
+  - "packages/core/src/persist.ts"
+adr: [ADR-041, ADR-017, ADR-019, ADR-026, ADR-031]
+---
+
+# Persistence contract
+
+Governs `packages/core/src/persist.ts`.
+
+## Snapshot location
+
+Default project: `<scanPath>/neat-out/graph.json` per ADR-017.
+
+Named projects: `~/.neat/projects/<name>/graph.json` per ADR-026.
+
+## Schema versioning
+
+`SCHEMA_VERSION = 2` today (v1→v2 migration removed `pgDriverVersion` per ADR-019).
+
+**Schema growth (ADR-031) does not bump the version.** Adding optional fields → snapshot regenerates, version stays. Only **shape changes** bump the version. Each shape change adds a `migrate_vN_to_vN+1` function and bumps the constant.
+
+## Forward-only migrations
+
+Old snapshots load cleanly into the new schema. New snapshots cannot be loaded by old code — intentional.
+
+## Lifecycle
+
+- **Loaded once at startup.** `loadGraphFromDisk` runs in `server.ts` / `watch.ts` boot.
+- **Persisted on interval + shutdown.** `startPersistLoop` writes every 60s (configurable) and on `SIGTERM` / `SIGINT`.
+
+Nothing else reads `graph.json` per Rule 6.
+
+## Append-only ndjson sidecars
+
+- `errors.ndjson` — ErrorEvents.
+- `stale-events.ndjson` — STALE transitions per ADR-024.
+- `policy-violations.ndjson` — policy violations (v0.2.4).
+
+All append-only. No rewrites, no deletions, no rotation. External archival is fine.
+
+## Multi-project isolation
+
+`Map<string, NeatGraph>` keyed by project name. Each project has its own `graph.json` and ndjson sidecars.
+
+Full rationale: [ADR-041](../decisions.md#adr-041--persistence-contract).

--- a/docs/contracts/policy-actions.md
+++ b/docs/contracts/policy-actions.md
@@ -1,0 +1,56 @@
+---
+name: policy-actions
+description: Three onViolation actions — log, alert, block. Defaults derive from severity. Block applies to FrontierNode promotion gating only in MVP.
+governs:
+  - "packages/core/src/policy.ts"
+  - "packages/core/src/ingest.ts"
+  - "packages/mcp/src/resources.ts"
+adr: [ADR-044]
+---
+
+# Policy onViolation actions contract
+
+The third of four policy contracts. Sibling contracts: [`policy-schema.md`](./policy-schema.md), [`policy-evaluation.md`](./policy-evaluation.md), [`policy-tools.md`](./policy-tools.md).
+
+## Three actions: `log`, `alert`, `block`
+
+No others in MVP.
+
+### `log`
+
+Append to `policy-violations.ndjson`. No surface effect.
+
+### `alert`
+
+`log` + emit MCP `notifications/resources/updated` for `neat://policies/violations`.
+
+### `block`
+
+`log` + `alert` + **prevent** the action that would cause the violation.
+
+**MVP scope: FrontierNode promotion gating only.** A `block`-action policy with a `provenance` or `compatibility` rule can return `{ allowed: false, violations: [...] }` from `canPromoteFrontier(nodeId)`, preventing the rewire.
+
+Other gating points (deploy, codemod, OTel auto-create) need their own ADRs.
+
+## Severity-driven defaults
+
+When `onViolation` is omitted:
+
+| Severity | Default |
+|----------|---------|
+| `info` | `log` |
+| `warning` | `alert` |
+| `error` | `alert` |
+| `critical` | `block` |
+
+Override per-policy.
+
+## Authority
+
+`packages/core/src/policy.ts`. Calls `appendPolicyViolation` (persist.ts) and `emitMcpNotification`. `block` returns `false` from gating checks; never reverts state.
+
+## Block scope tightly bounded
+
+Adding new block points requires an ADR amendment.
+
+Full rationale: [ADR-044](../decisions.md#adr-044--policy-onviolation-actions-contract).

--- a/docs/contracts/policy-evaluation.md
+++ b/docs/contracts/policy-evaluation.md
@@ -1,0 +1,78 @@
+---
+name: policy-evaluation
+description: evaluateAllPolicies is pure. Triggers post-ingest, post-extract, post-stale-transition. Per-type evaluator dispatch. Violations append to policy-violations.ndjson; ids are deterministic.
+governs:
+  - "packages/core/src/policy.ts"
+  - "packages/core/src/ingest.ts"
+  - "packages/core/src/extract/index.ts"
+  - "packages/core/src/persist.ts"
+adr: [ADR-043, ADR-042, ADR-030]
+---
+
+# Policy evaluation contract
+
+The second of four policy contracts. Sibling contracts: [`policy-schema.md`](./policy-schema.md), [`policy-actions.md`](./policy-actions.md), [`policy-tools.md`](./policy-tools.md).
+
+## Entry point
+
+```ts
+evaluateAllPolicies(
+  graph: NeatGraph,
+  policies: Policy[],
+  context: EvaluationContext
+): PolicyViolation[]
+```
+
+Pure function. Walks the policy list, dispatches each by `policy.rule.type` to a per-type evaluator, accumulates violations.
+
+## Triggers
+
+- **Post-ingest** — after `handleSpan` completes.
+- **Post-extract** — after `extractFromDirectory` completes.
+- **Post-stale-transition** — after `markStaleEdges` ticks.
+
+Other call sites (REST `POST /policies/check`, MCP `check_policies`) call the same function; not separate triggers.
+
+## `PolicyViolation` shape
+
+```ts
+{
+  id: string,                  // ${policy.id}:${violation-context}
+  policyId: string,
+  policyName: string,
+  severity: Policy['severity'],
+  onViolation: Policy['onViolation'],
+  ruleType: PolicyRule['type'],
+  subject: { nodeId?: string; edgeId?: string; path?: string[] },
+  message: string,
+  observedAt: ISO8601
+}
+```
+
+## Deterministic ids
+
+Same graph + same policies → same violation ids. Append-only `policy-violations.ndjson` keys on `id`; duplicates skipped at write time.
+
+## Per-type dispatch
+
+```ts
+const policyEvaluators: Record<RuleType, Evaluator> = {
+  structural,
+  compatibility,
+  provenance,
+  ownership,
+  'blast-radius': blastRadius,
+}
+```
+
+Adding a rule type means one new entry plus the schema entry from `policy-schema.md`.
+
+## Idempotency
+
+Stateless. Same inputs → same violations.
+
+## Authority
+
+Lives in `packages/core/src/policy.ts`. Reads the live graph; calls `compat.ts`; never mutates the graph.
+
+Full rationale: [ADR-043](../decisions.md#adr-043--policy-evaluation-contract).

--- a/docs/contracts/policy-schema.md
+++ b/docs/contracts/policy-schema.md
@@ -1,0 +1,67 @@
+---
+name: policy-schema
+description: policy.json at project root, version 1, discriminated union of five rule types (structural, compatibility, provenance, ownership, blast-radius), Zod-validated at load and on file change.
+governs:
+  - "packages/types/src/policy.ts"
+  - "packages/core/src/policy.ts"
+  - "packages/core/src/watch.ts"
+adr: [ADR-042]
+---
+
+# Policy schema contract
+
+The first of four policy contracts. Sibling contracts: [`policy-evaluation.md`](./policy-evaluation.md), [`policy-actions.md`](./policy-actions.md), [`policy-tools.md`](./policy-tools.md).
+
+## File location
+
+`policy.json` at the **project root** — not under `neat-out/`. Version-controlled in the user's repo. Declares the policies the project asserts about its own architecture.
+
+## Top-level shape
+
+```ts
+{
+  version: 1,
+  policies: Policy[]
+}
+```
+
+`version: z.literal(1)`. Bumping requires an ADR.
+
+## `Policy` shape
+
+```ts
+{
+  id: string,                  // unique within the file
+  name: string,
+  description?: string,
+  severity: 'info' | 'warning' | 'error' | 'critical',
+  onViolation: 'alert' | 'log' | 'block',
+  rule: PolicyRule
+}
+```
+
+`id` uniqueness is checked at load. Duplicates fail loudly.
+
+## Five rule types (MVP)
+
+Discriminated by `rule.type`:
+
+| Type | Asserts |
+|------|---------|
+| `structural` | "every ServiceNode must have a CONNECTS_TO edge to a DatabaseNode." |
+| `compatibility` | re-runs `compat.ts` against current graph state. Catches OBSERVED-vs-EXTRACTED divergence. |
+| `provenance` | "every CALLS edge to `service:payments` must have OBSERVED provenance." |
+| `ownership` | "every ServiceNode must declare an `owner` field." |
+| `blast-radius` | "no ServiceNode may have more than N transitively-affected downstream nodes." |
+
+Each type has its own `PolicyRule<type>` Zod sub-schema. Adding a new type requires an ADR amendment.
+
+## Loading
+
+Loaded at startup; reloaded on file change. The watch loop treats `policy.json` as a phase trigger.
+
+## Validation
+
+`PolicyFileSchema.parse(json)` on load. Failure throws with the Zod error.
+
+Full rationale: [ADR-042](../decisions.md#adr-042--policy-schema-contract).

--- a/docs/contracts/policy-tools.md
+++ b/docs/contracts/policy-tools.md
@@ -1,0 +1,53 @@
+---
+name: policy-tools
+description: Single MCP tool check_policies (covers state-read and dry-run). REST under /policies. MCP resource at neat://policies/violations.
+governs:
+  - "packages/mcp/src/index.ts"
+  - "packages/mcp/src/tools.ts"
+  - "packages/mcp/src/resources.ts"
+  - "packages/core/src/api.ts"
+adr: [ADR-045, ADR-039, ADR-040, ADR-026]
+---
+
+# Policy tool surface contract
+
+The fourth of four policy contracts. Sibling contracts: [`policy-schema.md`](./policy-schema.md), [`policy-evaluation.md`](./policy-evaluation.md), [`policy-actions.md`](./policy-actions.md).
+
+## One MCP tool: `check_policies`
+
+```ts
+check_policies({
+  project?: string,
+  scope?: 'all' | 'unresolved' | { policyId: string },
+  hypotheticalAction?: { kind: 'promote-frontier' | 'add-edge', ... }
+})
+```
+
+- **No `hypotheticalAction`** → returns current violations.
+- **`hypotheticalAction` provided** → dry-run evaluation, returns violations that would result.
+
+The audit's two-tool split (`evaluate_policy` + `get_policy_violations`) is rejected per CLAUDE.md framing.
+
+## REST endpoints under `/policies`
+
+| Path | Returns |
+|------|---------|
+| `GET /policies` | parsed `policy.json` |
+| `GET /policies/violations` | current violations, `?severity=` and `?policyId=` filterable |
+| `POST /policies/check` | dry-run; body `{ hypotheticalAction }` → `{ allowed, violations }` |
+
+The audit's `/policy/violations` (singular) is rejected. `/policies` is the resource root with `/violations` as a sub-resource.
+
+## MCP resource
+
+`neat://policies/violations` — subscribers get `notifications/resources/updated` whenever a new violation appends. Same pattern as `neat://incidents`.
+
+## Three-part response format
+
+`check_policies` returns the format from [mcp-tools.md](./mcp-tools.md). Confidence `1.00` for confirmed violations; lower for hypothetical-action results.
+
+## Project scoping
+
+Routes dual-mount at `/policies` and `/projects/:project/policies` per ADR-026.
+
+Full rationale: [ADR-045](../decisions.md#adr-045--policy-tool-surface-contract).

--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -1,0 +1,62 @@
+---
+name: rest-api
+description: Routes dual-mount at /X and /projects/:project/X per ADR-026. JSON errors. Live graphology only — no graph.json reads at request time. Inbound bodies are Zod-validated.
+governs:
+  - "packages/core/src/api.ts"
+adr: [ADR-040, ADR-026]
+---
+
+# REST API contract
+
+Governs `packages/core/src/api.ts`.
+
+## Dual-mount per ADR-026
+
+Every route mounts at both `/X` and `/projects/:project/X`. `registerRoutes(scope, ctx)` is called twice with different scope prefixes. New routes use the helper from day one.
+
+`:project` defaults to `'default'` when missing.
+
+## Read-side endpoints (locked)
+
+| Path | Returns |
+|------|---------|
+| `GET /health` | receiver health + project name |
+| `GET /graph` | full snapshot (live graphology serialized) |
+| `GET /graph/node/:id` | single node by id |
+| `GET /graph/edges/:id` | outbound edges from a node |
+| `GET /graph/dependencies/:nodeId?depth=N` | transitive outbound walk (#144 — default 3, max 10) |
+| `GET /graph/blast-radius/:nodeId?depth=N` | BFS outbound (default 10, max 20) |
+| `GET /graph/root-cause/:nodeId` | getRootCause result |
+| `GET /graph/diff?against=path` | snapshot diff |
+| `GET /search?q=...` | semantic search via ADR-025 embedder chain |
+| `GET /incidents` | recent ErrorEvents |
+| `GET /stale-events` | recent STALE transitions |
+| `GET /policies` | parsed `policy.json` (v0.2.4 #117) |
+| `GET /policies/violations` | current violations, filterable by `?severity=` and `?policyId=` (v0.2.4) |
+
+## Write-side endpoints
+
+| Path | Effect |
+|------|--------|
+| `POST /graph/scan` | re-runs static-extraction pass |
+| `POST /policies/check` | dry-run policy evaluation; body `{ hypotheticalAction }` (v0.2.4) |
+
+The OTLP receiver lives on its own port (`:4318`) — not part of the REST API.
+
+## Error responses
+
+JSON shape: `{ error: string, status: number, details?: unknown }`. `400` for bad input / Zod failure, `404` for missing resource, `500` for schema violation. No HTML pages.
+
+## Schema validation
+
+Every `app.post` body parses via Zod schemas from `@neat/types`. Failure → 400 with the Zod error in `details`.
+
+## Live graphology, never `graph.json`
+
+Every read endpoint reads `proj.graph` (live in-memory). Already enforced by Rule 6.
+
+## Authority
+
+Mostly read-only. Two write-side endpoints (`/graph/scan`, `/policies/check`) trigger producers but don't mutate the graph directly.
+
+Full rationale: [ADR-040](../decisions.md#adr-040--rest-api-contract).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1063,3 +1063,176 @@ Whether blast radius should expand to inbound edges (no — by definition, blast
 **When to revisit.**
 
 When real codebase blast-radius queries return >100 affected nodes and pagination becomes a UX concern. When the MCP-side three-part response (contract #12 in v0.2.4) needs to format blast radius and the contract's `path` shape doesn't match the formatter's needs.
+
+---
+
+## ADR-039 — MCP tool surface contract
+
+**Date:** 2026-05-06
+**Status:** Active.
+
+The first of seven v0.2.4 contracts. Governs `packages/mcp/src/`. Sibling contracts: ADR-040 (REST API), ADR-041 (persistence), ADR-042-045 (policies).
+
+**Decision.**
+
+1. **Tool count is locked at nine.** Eight today (`get_root_cause`, `get_blast_radius`, `get_dependencies`, `get_observed_dependencies`, `get_incident_history`, `semantic_search`, `get_graph_diff`, `get_recent_stale_edges`) plus `check_policies` (lands with v0.2.4 #117). The audit's `evaluate_policy` + `get_policy_violations` two-tool split is rejected per CLAUDE.md framing — one tool with `scope?` and `hypotheticalAction?` arguments handles both cases.
+
+2. **Three-part response format (issue #143).** Every tool emits a natural-language paragraph, a structured block, and a footer line `confidence: X.XX · provenance: OBSERVED|EXTRACTED|...`. Confidence and provenance are derived per-result. Empty result → footer reads `confidence: n/a · provenance: n/a`. Helper `formatToolResponse` lives in `packages/mcp/src/format.ts`; every tool routes through it.
+
+3. **`get_dependencies` is transitive (issue #144).** Default depth 3, max 10. Calls a new core endpoint `GET /graph/node/:id/dependencies?depth=N`.
+
+4. **No `graph.json` reads.** Every tool calls REST against `NEAT_CORE_URL`.
+
+5. **No demo-name hardcoding in tool logic.** Allowed only inside Zod `.describe()` strings.
+
+6. **Project scoping.** Optional `project?: string`, defaulting to `'default'` per ADR-026.
+
+7. **`semantic_search` documentation reflects the ADR-025 embedder chain**, not "keyword search."
+
+8. **Stdio transport only for MVP.** HTTP / SSE / WebSocket post-MVP.
+
+**Authority.** Read-only. Owned by `packages/mcp/src/`.
+
+---
+
+## ADR-040 — REST API contract
+
+**Date:** 2026-05-06
+**Status:** Active.
+
+Governs `packages/core/src/api.ts`. Sibling contracts: ADR-039, ADR-041.
+
+**Decision.**
+
+1. **Dual-mount per ADR-026.** Every route mounts at both `/X` and `/projects/:project/X` via `registerRoutes(scope, ctx)`.
+
+2. **Read-side endpoints (locked).** `GET /health`, `/graph`, `/graph/node/:id`, `/graph/edges/:id`, `/graph/dependencies/:nodeId?depth=N` (new for #144), `/graph/blast-radius/:nodeId?depth=N`, `/graph/root-cause/:nodeId`, `/graph/diff?against=path`, `/search?q=...`, `/incidents`, `/stale-events`, `/policies`, `/policies/violations`.
+
+3. **Write-side endpoints.** `POST /graph/scan`, `POST /policies/check`. The OTLP receiver lives on its own port.
+
+4. **JSON errors.** `{ error, status, details? }`. 400 / 404 / 500. No HTML pages.
+
+5. **Schema validation on inbound bodies** via Zod from `@neat/types`.
+
+6. **Project param defaults to `'default'`.**
+
+7. **Live graphology, never `graph.json`.**
+
+---
+
+## ADR-041 — Persistence contract
+
+**Date:** 2026-05-06
+**Status:** Active.
+
+Governs `packages/core/src/persist.ts`. Sibling contracts: ADR-039, ADR-040.
+
+**Decision.**
+
+1. **Snapshot location.** Default project: `<scanPath>/neat-out/graph.json` per ADR-017. Named projects: `~/.neat/projects/<name>/graph.json` per ADR-026.
+
+2. **`SCHEMA_VERSION = 2` today.** Schema growth (ADR-031) does not bump the version; only shape changes do.
+
+3. **Forward-only migrations.** Old snapshots load cleanly; new snapshots cannot be loaded by old code.
+
+4. **Lifecycle.** Loaded once at startup; persisted on interval (default 60s) + `SIGTERM`/`SIGINT`.
+
+5. **Append-only ndjson sidecars.** `errors.ndjson`, `stale-events.ndjson`, `policy-violations.ndjson` (v0.2.4). No rewrites, no rotation.
+
+6. **Multi-project isolation.** `Map<string, NeatGraph>` keyed by project name.
+
+7. **Nothing else reads `graph.json`** per Rule 6.
+
+---
+
+## ADR-042 — Policy schema contract
+
+**Date:** 2026-05-06
+**Status:** Active.
+
+The first of four policy contracts. Governs `packages/types/src/policy.ts` (new). Sibling contracts: ADR-043, ADR-044, ADR-045.
+
+**Decision.**
+
+1. **`policy.json` at the project root** (not `neat-out/`). Version-controlled in the user's repo.
+
+2. **Top-level shape.** `{ version: 1, policies: Policy[] }`. `version: z.literal(1)`.
+
+3. **`Policy` shape.** `{ id, name, description?, severity, onViolation, rule }`. `id` uniqueness checked at load.
+
+4. **Five rule types (MVP).** `structural`, `compatibility`, `provenance`, `ownership`, `blast-radius`. Discriminated by `rule.type`. New types require an ADR amendment.
+
+5. **Loading.** Loaded at startup, reloaded on file change. Watch loop treats `policy.json` as a phase trigger.
+
+6. **Validation.** `PolicyFileSchema.parse(json)` on load. Failure throws.
+
+---
+
+## ADR-043 — Policy evaluation contract
+
+**Date:** 2026-05-06
+**Status:** Active.
+
+Governs `packages/core/src/policy.ts` (new). Sibling contracts: ADR-042, ADR-044, ADR-045.
+
+**Decision.**
+
+1. **`evaluateAllPolicies(graph, policies, context) → PolicyViolation[]`.** Pure function. Per-type evaluator dispatch.
+
+2. **Three triggers.** Post-ingest, post-extract, post-stale-transition.
+
+3. **`PolicyViolation` shape.** `{ id, policyId, policyName, severity, onViolation, ruleType, subject, message, observedAt }`. `id = ${policy.id}:${violation-context}` — dedup key.
+
+4. **Deterministic ids.** Same graph + same policies → same ids. ndjson append-only deduplicates.
+
+5. **Per-type dispatch table.**
+
+6. **Idempotency.** Stateless.
+
+7. **Authority.** Reads live graph; calls `compat.ts`; never mutates.
+
+---
+
+## ADR-044 — Policy onViolation actions contract
+
+**Date:** 2026-05-06
+**Status:** Active.
+
+Sibling contracts: ADR-042, ADR-043, ADR-045.
+
+**Decision.**
+
+1. **Three actions: `log`, `alert`, `block`.** No others in MVP.
+
+2. **`log`.** Append to `policy-violations.ndjson`. No surface effect.
+
+3. **`alert`.** `log` + emit MCP `notifications/resources/updated` for `neat://policies/violations`.
+
+4. **`block`.** `log` + `alert` + prevent the action. **MVP scope: FrontierNode promotion gating only.** Other gating points need their own ADRs.
+
+5. **Severity defaults** when `onViolation` is omitted: `info → log`, `warning → alert`, `error → alert`, `critical → block`.
+
+6. **Authority.** `packages/core/src/policy.ts`. Block returns `false` from gating checks; never mutates.
+
+7. **Block scope tightly bounded.**
+
+---
+
+## ADR-045 — Policy tool surface contract
+
+**Date:** 2026-05-06
+**Status:** Active.
+
+Sibling contracts: ADR-039, ADR-040, ADR-042-044.
+
+**Decision.**
+
+1. **Single MCP tool: `check_policies`** with optional `scope` and `hypotheticalAction`. Audit's two-tool split rejected.
+
+2. **REST under `/policies`.** `GET /policies` (parsed file), `GET /policies/violations` (filterable), `POST /policies/check` (dry-run, `{ hypotheticalAction }` → `{ allowed, violations }`). Audit's `/policy/violations` (singular) rejected.
+
+3. **MCP resource at `neat://policies/violations`.** Subscribers get update notifications.
+
+4. **Three-part response format** from ADR-039. Confidence `1.00` for confirmed violations; lower for hypothetical-action results.
+
+5. **Routes dual-mount per ADR-026.**

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -1201,6 +1201,72 @@ describe('Schema sanity — Zod parses', () => {
 })
 
 // ──────────────────────────────────────────────────────────────────────────
+// MCP tool surface contract (ADR-039)
+// ──────────────────────────────────────────────────────────────────────────
+describe('MCP tool surface contract (ADR-039)', () => {
+  it('mcp/src never mutates the graph', () => {
+    const offenders: string[] = []
+    const re = /\b(graph|g)\.(addNode|addEdge|dropNode|dropEdge|replaceEdgeAttributes|replaceNodeAttributes|mergeEdgeAttributes|mergeNodeAttributes)\s*\(/
+    for (const file of walkSrc(MCP_SRC)) {
+      const content = readFileSync(file, 'utf8')
+      content.split('\n').forEach((line, i) => {
+        const trimmed = line.trim()
+        if (re.test(line) && !trimmed.startsWith('//') && !trimmed.startsWith('*')) {
+          offenders.push(`${file}:${i + 1}: ${trimmed}`)
+        }
+      })
+    }
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
+
+  it.todo('every server.tool registration in mcp/src/index.ts has a name from the locked allowlist of nine tools (ADR-039)')
+  it.todo('formatToolResponse helper exists at mcp/src/format.ts (issue #143)')
+  it.todo('get_dependencies is transitive — calls /graph/node/:id/dependencies?depth=N (issue #144)')
+  it.todo('check_policies tool registered with optional hypotheticalAction (v0.2.4 #117)')
+})
+
+// ──────────────────────────────────────────────────────────────────────────
+// REST API contract (ADR-040)
+// ──────────────────────────────────────────────────────────────────────────
+describe('REST API contract (ADR-040)', () => {
+  it.todo('every read endpoint mounts at both /X and /projects/:project/X')
+  it.todo('error responses are JSON-shaped { error, status, details? }')
+  it.todo('GET /graph/node/:id/dependencies?depth=N exists (issue #144)')
+  it.todo('POST endpoints validate inbound bodies with Zod schemas from @neat/types')
+  it.todo('GET /policies and /policies/violations exist (v0.2.4 #117)')
+})
+
+// ──────────────────────────────────────────────────────────────────────────
+// Persistence contract (ADR-041)
+// ──────────────────────────────────────────────────────────────────────────
+describe('Persistence contract (ADR-041)', () => {
+  it('SCHEMA_VERSION constant exists in persist.ts', () => {
+    const persist = readFileSync(join(CORE_SRC, 'persist.ts'), 'utf8')
+    expect(persist).toMatch(/const\s+SCHEMA_VERSION\s*=\s*\d+/)
+  })
+  it.todo('policy-violations.ndjson append-only writer exists (v0.2.4 #116)')
+})
+
+// ──────────────────────────────────────────────────────────────────────────
+// Policy contracts (ADRs 042-045)
+// ──────────────────────────────────────────────────────────────────────────
+describe('Policy contracts (ADRs 042-045)', () => {
+  it.todo('PolicyFileSchema exists in @neat/types/policy.ts with version: z.literal(1) (ADR-042)')
+  it.todo('Policy is a discriminated union by rule.type with five MVP types (ADR-042)')
+  it.todo('PolicyFileSchema.parse fails loudly on malformed policy.json (ADR-042)')
+  it.todo('evaluateAllPolicies is pure and dispatches by rule.type (ADR-043)')
+  it.todo('PolicyViolation ids are deterministic (ADR-043)')
+  it.todo('post-ingest, post-extract, post-stale-transition all trigger evaluateAllPolicies (ADR-043)')
+  it.todo('log action appends to ndjson with no MCP notification (ADR-044)')
+  it.todo('alert action appends + emits notifications/resources/updated (ADR-044)')
+  it.todo('block action returns false from canPromoteFrontier when block-policy violates (ADR-044)')
+  it.todo('severity-driven default actions (info→log, warning→alert, error→alert, critical→block) (ADR-044)')
+  it.todo('check_policies MCP tool registered with optional scope and hypotheticalAction (ADR-045)')
+  it.todo('GET /policies and /policies/violations REST endpoints with dual-mount (ADR-045)')
+  it.todo('neat://policies/violations MCP resource registered and emits updates (ADR-045)')
+})
+
+// ──────────────────────────────────────────────────────────────────────────
 // Queued — flipped from todo to live as cleanup issues land
 // ──────────────────────────────────────────────────────────────────────────
 describe('Queued contracts (issues #131-#145)', () => {


### PR DESCRIPTION
## Summary

The v0.2.4 contract batch. Seven contracts opening the surface-refresh + policies milestone. They share vocabulary across MCP, REST, persistence, and the new policies feature.

Implementation work for v0.2.4 issues #115-#118 (policies α/β/γ/δ), #143 (MCP three-part response), #144 (transitive get_dependencies) lands against these locked contracts.

## What's locked

### Surface refresh

**#12 — MCP tool surface (ADR-039).** Nine tools locked. Three-part response format (closes #143's spec). Transitive `get_dependencies` (closes #144's spec). REST-only data path. Project scoping. `check_policies` is a single tool with optional `hypotheticalAction` — the audit's two-tool split is rejected.

**#13 — REST API (ADR-040).** Dual-mount per ADR-026. Locked endpoint set including new `GET /graph/node/:id/dependencies?depth=N` for #144. JSON errors. Zod-validated bodies. Live graphology only.

**#14 — Persistence (ADR-041).** Snapshot at `<projectDir>/neat-out/graph.json`. `SCHEMA_VERSION` bumps on shape change only (growth doesn't bump). Forward-only migrations. Append-only ndjson sidecars (`errors`, `stale-events`, `policy-violations`).

### Policies (new feature)

**#15 — Policy schema (ADR-042).** `policy.json` at project root. Version 1. Five rule types (structural, compatibility, provenance, ownership, blast-radius). Discriminated union. Reloaded on file change.

**#16 — Policy evaluation (ADR-043).** Pure `evaluateAllPolicies(graph, policies, context)`. Three triggers: post-ingest, post-extract, post-stale-transition. Per-type evaluator dispatch. Deterministic violation ids — same graph + same policies → same ids.

**#17 — Policy onViolation actions (ADR-044).** `log` / `alert` / `block`. Severity-driven defaults. **Block applies to FrontierNode promotion gating only in MVP** — other gating points (deploy, codemod, OTel auto-create) require their own ADRs.

**#18 — Policy tool surface (ADR-045).** Single `check_policies` MCP tool. REST under `/policies` with `/violations` sub-resource. MCP resource at `neat://policies/violations` for live updates. Audit's two-tool split and `/policy/violations` (singular) path both rejected.

## What this PR contains

- `docs/decisions.md` — ADRs 039-045 appended.
- `docs/contracts/{mcp-tools,rest-api,persistence,policy-schema,policy-evaluation,policy-actions,policy-tools}.md` — seven per-topic contracts with frontmatter `governs:`.
- `docs/contracts.md` — index updated; #12-#18 marked landed (v0.2.4 opens).
- `packages/core/test/audits/contracts.test.ts` — two new live assertions (mcp/src never mutates graph, SCHEMA_VERSION exists in persist.ts) plus 21 new `it.todo` items keyed to v0.2.4 implementation work.

## Test totals

270 passing across @neat/core (up from 264), 56 todo, 0 fail.

## What this PR doesn't do

- No source code changes — implementation lands under v0.2.4 cleanup issues.
- No GitHub issue closures.
- No `policy.json` file added — that's user-supplied per project.

## Test plan

- [ ] `npx turbo build test lint` clean
- [ ] Verify the hook surfaces relevant contracts for each governed file:
  - `packages/mcp/src/tools.ts` → mcp-tools, policy-tools, lifecycle
  - `packages/core/src/api.ts` → rest-api, policy-tools, lifecycle
  - `packages/core/src/persist.ts` → persistence, lifecycle
- [ ] Read the seven contract files end to end
- [ ] After merge: implementation agent picks up #115-#118, #143, #144 against these contracts

Refs #126