### PR TITLE
Filter FRONTIER edges in traversal helpers

### DIFF
--- a/packages/core/src/traverse.ts
+++ b/packages/core/src/traverse.ts
@@ -8,7 +8,7 @@ import type {
   RootCauseResult,
   ServiceNode,
 } from '@neat/types'
-import { NodeType, PROV_RANK } from '@neat/types'
+import { NodeType, PROV_RANK, Provenance } from '@neat/types'
 import type { NeatGraph } from './graph.js'
 import { checkCompatibility, compatPairs } from './compat.js'
 
@@ -29,10 +29,14 @@ const BLAST_RADIUS_DEFAULT_DEPTH = 10
 // Multiple edges between the same pair coexist by provenance (EXTRACTED next to
 // OBSERVED next to INFERRED). Traversal walks the system as the graph "sees it
 // best", so for any neighbour pair we pick the highest-provenance edge.
+// FRONTIER means unknown territory — ADR-036 / Rule 3 require these edges to
+// be skipped, not merely deprioritized. Filtering happens here so the rest of
+// traversal can stay generic.
 function bestEdgeBySource(graph: NeatGraph, edgeIds: string[]): Map<string, GraphEdge> {
   const best = new Map<string, GraphEdge>()
   for (const id of edgeIds) {
     const e = graph.getEdgeAttributes(id) as GraphEdge
+    if (e.provenance === Provenance.FRONTIER) continue
     const cur = best.get(e.source)
     if (!cur || PROV_RANK[e.provenance] > PROV_RANK[cur.provenance]) {
       best.set(e.source, e)
@@ -45,6 +49,7 @@ function bestEdgeByTarget(graph: NeatGraph, edgeIds: string[]): Map<string, Grap
   const best = new Map<string, GraphEdge>()
   for (const id of edgeIds) {
     const e = graph.getEdgeAttributes(id) as GraphEdge
+    if (e.provenance === Provenance.FRONTIER) continue
     const cur = best.get(e.target)
     if (!cur || PROV_RANK[e.provenance] > PROV_RANK[cur.provenance]) {
       best.set(e.target, e)

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -116,8 +116,54 @@ describe('Rule 2 — OBSERVED/EXTRACTED coexistence', () => {
 // Rule 3 — FRONTIER edges excluded from traversal
 // ──────────────────────────────────────────────────────────────────────────
 describe('Rule 3 — FRONTIER exclusion from traversal', () => {
-  it.todo('getRootCause skips FRONTIER edges (issue #136)')
-  it.todo('getBlastRadius skips FRONTIER edges (issue #136)')
+  it('getRootCause returns null when the only path to a candidate root cause is via FRONTIER (issue #136)', async () => {
+    const { frontierId, frontierEdgeId, extractedEdgeId, databaseId } = await import('@neat/types')
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    // Origin is a DatabaseNode (the only origin getRootCause currently handles).
+    // The would-be culprit ServiceNode sits behind a FRONTIER edge — if FRONTIER
+    // were traversed, the walk would reach the service and check compat. With
+    // FRONTIER filtered, the walk halts at the database and returns null.
+    const dbId = databaseId('payments')
+    g.addNode(dbId, {
+      id: dbId,
+      type: NodeType.DatabaseNode,
+      name: 'payments',
+      engine: 'postgresql',
+      engineVersion: '15',
+      compatibleDrivers: [{ name: 'pg', minVersion: '8.0.0' }],
+    })
+    const fid = frontierId('mystery-host')
+    g.addNode(fid, { id: fid, type: NodeType.FrontierNode, name: 'mystery-host', host: 'mystery-host' })
+    const eId = frontierEdgeId(fid, dbId, EdgeType.CONNECTS_TO)
+    g.addEdgeWithKey(eId, fid, dbId, {
+      id: eId,
+      source: fid,
+      target: dbId,
+      type: EdgeType.CONNECTS_TO,
+      provenance: Provenance.FRONTIER,
+    })
+    expect(getRootCause(g, dbId)).toBeNull()
+    void extractedEdgeId
+  })
+
+  it('getBlastRadius does not enqueue past a FRONTIER edge (issue #136)', async () => {
+    const { frontierId, frontierEdgeId } = await import('@neat/types')
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:origin', { id: 'service:origin', type: NodeType.ServiceNode, name: 'origin', language: 'javascript' })
+    const fid = frontierId('unknown:8080')
+    g.addNode(fid, { id: fid, type: NodeType.FrontierNode, name: 'unknown:8080', host: 'unknown:8080' })
+    const eId = frontierEdgeId('service:origin', fid, EdgeType.CALLS)
+    g.addEdgeWithKey(eId, 'service:origin', fid, {
+      id: eId,
+      source: 'service:origin',
+      target: fid,
+      type: EdgeType.CALLS,
+      provenance: Provenance.FRONTIER,
+    })
+    const result = getBlastRadius(g, 'service:origin')
+    expect(result.affectedNodes.find((n) => n.nodeId === fid)).toBeUndefined()
+    expect(result.totalAffected).toBe(0)
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -961,7 +1007,16 @@ describe('Traversal contract (ADR-036)', () => {
     expect(re.test(content), 'traverse.ts must be read-only').toBe(false)
   })
 
-  it.todo('FRONTIER edges are filtered (not just deprioritized) by bestEdgeBySource / bestEdgeByTarget (issue #136)')
+  it('FRONTIER edges are filtered (not just deprioritized) by bestEdgeBySource / bestEdgeByTarget (issue #136)', () => {
+    const content = readFileSync(join(CORE_SRC, 'traverse.ts'), 'utf8')
+    // Both helpers must guard with `Provenance.FRONTIER`. The contract is "skip,
+    // not deprioritize" — relying on PROV_RANK alone is the v0.1.x bug.
+    const helpers = ['bestEdgeBySource', 'bestEdgeByTarget']
+    for (const helper of helpers) {
+      const re = new RegExp(`function\\s+${helper}\\b[\\s\\S]*?provenance\\s*===\\s*Provenance\\.FRONTIER`)
+      expect(re.test(content), `${helper} must filter FRONTIER edges explicitly`).toBe(true)
+    }
+  })
   it.todo('confidenceFromMix multiplies per-edge confidences (multiplicative cascade)')
   it.todo('getRootCause result passes RootCauseResultSchema.parse (issue #139)')
   it.todo('getBlastRadius result passes BlastRadiusResultSchema.parse (issue #139)')


### PR DESCRIPTION
## Summary

\`bestEdgeBySource\` and \`bestEdgeByTarget\` now \`continue\` past edges with \`provenance === Provenance.FRONTIER\` before ranking. Previously these edges were merely deprioritized via \`PROV_RANK[FRONTIER] = 0\`, which meant they got walked when they were the only outbound option from a node.

The contract (Rule 3 in \`docs/contracts.md\`, ADR-036) is unambiguous: FRONTIER means unknown territory. Traversal stays inside the known graph. \"Skip, not deprioritize.\"

## Behavior change

On graphs where the only path runs through a FRONTIER edge:

- **Before:** \`getRootCause\` could walk past the placeholder and dispatch compat against the far-side node. \`getBlastRadius\` would include the far-side FrontierNode in \`affectedNodes\`.
- **After:** \`getRootCause\` halts at the boundary and returns \`null\`. \`getBlastRadius\` excludes the far-side node entirely.

This restores the audit-flagged FAIL at \`docs/audits/verification.md\` traversal §1.

## Contract assertions flipped

In \`packages/core/test/audits/contracts.test.ts\`:

- ✅ Rule 3 / \`getRootCause\` skips FRONTIER edges (issue #136)
- ✅ Rule 3 / \`getBlastRadius\` skips FRONTIER edges (issue #136)
- ✅ Traversal contract (ADR-036) / FRONTIER edges are filtered, not just deprioritized (issue #136)

The third assertion is a static scan that fails if either helper drops the explicit \`Provenance.FRONTIER\` guard, so future refactors can't reintroduce the deprioritize-only behavior.

273 contract assertions passing (was 270), 48 todos remaining (was 51).

## Test plan

- [x] \`npx turbo build\` clean
- [x] \`npx turbo test\` — 273 pass, 48 todo
- [x] No regressions in existing \`traverse.test.ts\` fixtures.

Refs ADR-036, #136