### PR TITLE
Tighten BlastRadiusAffectedNode.distance schema to positive integer

### DIFF
--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -1010,7 +1010,27 @@ describe('getBlastRadius contract (ADR-038)', () => {
 
   it.todo('BlastRadiusAffectedNode carries path field with origin → ... → nodeId (issue #137)')
   it.todo('BlastRadiusAffectedNode carries confidence field cascaded from edges along path (issue #137)')
-  it.todo('BlastRadiusAffectedNode.distance schema rejects 0 (issue #138)')
+  it('BlastRadiusAffectedNode.distance schema rejects 0 (issue #138)', async () => {
+    const { BlastRadiusAffectedNodeSchema } = await import('@neat/types')
+    // distance must be positive — the origin is never in affectedNodes, so 0
+    // has no meaning. Locking this in the schema keeps the BFS at traverse.ts
+    // honest mechanically.
+    expect(() =>
+      BlastRadiusAffectedNodeSchema.parse({
+        nodeId: 'service:x',
+        distance: 0,
+        edgeProvenance: Provenance.OBSERVED,
+      }),
+    ).toThrow()
+    // Distance 1 stays valid.
+    expect(() =>
+      BlastRadiusAffectedNodeSchema.parse({
+        nodeId: 'service:x',
+        distance: 1,
+        edgeProvenance: Provenance.OBSERVED,
+      }),
+    ).not.toThrow()
+  })
   it.todo('result schema-validates before return (issue #139)')
   it.todo('origin is never present in affectedNodes')
   it.todo('path[0] === origin and path[path.length - 1] === affectedNode.nodeId for every entry')

--- a/packages/types/src/results.ts
+++ b/packages/types/src/results.ts
@@ -13,7 +13,11 @@ export type RootCauseResult = z.infer<typeof RootCauseResultSchema>
 
 export const BlastRadiusAffectedNodeSchema = z.object({
   nodeId: z.string(),
-  distance: z.number().int().nonnegative(),
+  // Distance from the origin in BFS hops. The origin itself is never in
+  // affectedNodes, so distance 0 has no meaning — the BFS at traverse.ts
+  // already skips frame 0. Tightening to positive() locks that invariant
+  // mechanically (ADR-038, issue #138).
+  distance: z.number().int().positive(),
   edgeProvenance: ProvenanceSchema,
 })
 export type BlastRadiusAffectedNode = z.infer<typeof BlastRadiusAffectedNodeSchema>


### PR DESCRIPTION
## Summary

\`BlastRadiusAffectedNodeSchema.distance\` was \`z.number().int().nonnegative()\`, allowing \`0\`. The BFS at \`traverse.ts:266\` already skips frame 0 (the origin is never in \`affectedNodes\`), so distance 0 has no meaning. Schema didn't enforce that.

Tightening to \`z.number().int().positive()\` locks the invariant mechanically.

## Schema-snapshot caveat

The snapshot encoder at \`packages/core/test/audits/schemas.snapshot.json\` records min as a constraint *name* (\`[\"int\", \"min\"]\`) without its *value*. \`nonnegative()\` (min=0) and \`positive()\` (min=1) both encode identically, so this change produces no snapshot diff. Worth a follow-up to teach the encoder to capture min/max values too — but out of scope here. The new contract assertion (parse \`{distance: 0}\` throws, parse \`{distance: 1}\` doesn't) catches the runtime difference at CI.

## Contract assertion flipped

In \`packages/core/test/audits/contracts.test.ts\`:

- ✅ \`BlastRadiusAffectedNode.distance schema rejects 0 (issue #138)\`

271 contract assertions passing (was 270), 50 todos remaining (was 51).

## Test plan

- [x] \`npx turbo build\` clean
- [x] \`npx turbo test\` — 271 pass, 50 todo
- [x] No regressions in \`traverse.test.ts\` (BFS already produced positive distances).

Refs ADR-038, #138