### PR TITLE
BlastRadiusAffectedNode carries path + confidence; multiplicative cascade

### DIFF
--- a/packages/core/src/traverse.ts
+++ b/packages/core/src/traverse.ts
@@ -127,18 +127,19 @@ function lastObservedAge(edge: GraphEdge, now: number): number | undefined {
   return Math.max(0, now - t)
 }
 
-// Path-level confidence is the bottleneck along the walk: the weakest edge
-// dictates the result. Multiplying would punish long-but-strong walks;
-// taking the min keeps the existing semantics while letting per-edge signal
-// pull the number down where it matters.
+// Path-level confidence is the *product* of per-edge confidences (ADR-036).
+// Each hop is independent evidence and uncertainty compounds — a 3-hop path
+// of edges at confidence 0.8 each gives 0.512, not 0.8. Multiplying punishes
+// long walks accordingly, which is the contract's intent: traversal should
+// surface the cumulative trust the graph actually has, not the weakest link
+// alone.
 function confidenceFromMix(edges: GraphEdge[], now = Date.now()): number {
   if (edges.length === 0) return 1.0
-  let min = 1
+  let product = 1
   for (const e of edges) {
-    const c = confidenceForEdge(e, now)
-    if (c < min) min = c
+    product *= confidenceForEdge(e, now)
   }
-  return Math.max(0, Math.min(1, min))
+  return Math.max(0, Math.min(1, product))
 }
 
 interface Walk {
@@ -256,23 +257,31 @@ export function getBlastRadius(
     return { origin: nodeId, affectedNodes: [], totalAffected: 0 }
   }
 
+  // Each frame carries its full predecessor chain so the affected-node payload
+  // can surface `path` (origin → ... → nodeId) and `confidence` (cascaded over
+  // every edge along that path). The BFS visits each reachable node once on
+  // its shortest-distance path; later frames at greater distance are dropped.
   interface Frame {
     nodeId: string
     distance: number
-    edge: GraphEdge | null
+    path: string[]
+    pathEdges: GraphEdge[]
   }
 
   const seen = new Map<string, BlastRadiusAffectedNode>()
-  const queue: Frame[] = [{ nodeId, distance: 0, edge: null }]
+  const queue: Frame[] = [{ nodeId, distance: 0, path: [nodeId], pathEdges: [] }]
   const enqueued = new Set<string>([nodeId])
 
   while (queue.length > 0) {
     const frame = queue.shift()!
-    if (frame.distance > 0 && frame.edge) {
+    if (frame.distance > 0 && frame.pathEdges.length > 0) {
+      const lastEdge = frame.pathEdges[frame.pathEdges.length - 1]!
       seen.set(frame.nodeId, {
         nodeId: frame.nodeId,
         distance: frame.distance,
-        edgeProvenance: frame.edge.provenance,
+        edgeProvenance: lastEdge.provenance,
+        path: frame.path,
+        confidence: confidenceFromMix(frame.pathEdges),
       })
     }
     if (frame.distance >= maxDepth) continue
@@ -281,7 +290,12 @@ export function getBlastRadius(
     for (const [tgtId, edge] of outgoing) {
       if (enqueued.has(tgtId)) continue
       enqueued.add(tgtId)
-      queue.push({ nodeId: tgtId, distance: frame.distance + 1, edge })
+      queue.push({
+        nodeId: tgtId,
+        distance: frame.distance + 1,
+        path: [...frame.path, tgtId],
+        pathEdges: [...frame.pathEdges, edge],
+      })
     }
   }
 

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -131,7 +131,9 @@ describe('REST API (fastify.inject)', () => {
       'service:service-b',
       'service:service-a',
     ])
-    expect(body.confidence).toBe(0.5)
+    // Multiplicative cascade per ADR-036: two EXTRACTED hops at ceiling 0.5 each
+    // → 0.25 (was 0.5 under min-reduce).
+    expect(body.confidence).toBeCloseTo(0.25, 5)
     expect(body.fixRecommendation).toMatch(/8\.0\.0/)
   })
 
@@ -164,26 +166,23 @@ describe('REST API (fastify.inject)', () => {
     // and the db-config.yaml ConfigNode are reachable from service-b at
     // distance 2.
     expect(body.totalAffected).toBe(4)
-    expect(body.affectedNodes).toContainEqual({
-      nodeId: 'service:service-b',
-      distance: 1,
-      edgeProvenance: 'EXTRACTED',
-    })
-    expect(body.affectedNodes).toContainEqual({
-      nodeId: 'database:payments-db',
-      distance: 2,
-      edgeProvenance: 'EXTRACTED',
-    })
-    expect(body.affectedNodes).toContainEqual({
-      nodeId: 'config:service-b/db-config.yaml',
-      distance: 2,
-      edgeProvenance: 'EXTRACTED',
-    })
-    expect(body.affectedNodes).toContainEqual({
-      nodeId: 'infra:container-image:node:20-bookworm-slim',
-      distance: 1,
-      edgeProvenance: 'EXTRACTED',
-    })
+    // path + confidence land per ADR-038 §affectedNodes payload. Property-style
+    // assertions so this test doesn't pin every BFS path detail — the contract
+    // tests in contracts.test.ts pin the per-node invariants tightly.
+    for (const n of body.affectedNodes) {
+      expect(n.path[0]).toBe('service:service-a')
+      expect(n.path[n.path.length - 1]).toBe(n.nodeId)
+      expect(n.path.length).toBe(n.distance + 1)
+      expect(n.confidence).toBeGreaterThan(0)
+      expect(n.confidence).toBeLessThanOrEqual(1)
+    }
+    const ids = body.affectedNodes.map((n: { nodeId: string }) => n.nodeId).sort()
+    expect(ids).toEqual([
+      'config:service-b/db-config.yaml',
+      'database:payments-db',
+      'infra:container-image:node:20-bookworm-slim',
+      'service:service-b',
+    ])
   })
 
   it('GET /traverse/blast-radius/:nodeId returns 404 for an unknown node', async () => {

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -1017,7 +1017,28 @@ describe('Traversal contract (ADR-036)', () => {
       expect(re.test(content), `${helper} must filter FRONTIER edges explicitly`).toBe(true)
     }
   })
-  it.todo('confidenceFromMix multiplies per-edge confidences (multiplicative cascade)')
+  it('confidenceFromMix multiplies per-edge confidences (multiplicative cascade)', () => {
+    // The cascade is observable through getBlastRadius: a 2-hop EXTRACTED-only
+    // path puts the per-edge confidence at the EXTRACTED ceiling 0.5. Min-reduce
+    // would return 0.5; the contract requires the product 0.25.
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:a', { id: 'service:a', type: NodeType.ServiceNode, name: 'a', language: 'javascript' })
+    g.addNode('service:b', { id: 'service:b', type: NodeType.ServiceNode, name: 'b', language: 'javascript' })
+    g.addNode('service:c', { id: 'service:c', type: NodeType.ServiceNode, name: 'c', language: 'javascript' })
+    const ab = `${EdgeType.CALLS}:service:a->service:b`
+    g.addEdgeWithKey(ab, 'service:a', 'service:b', {
+      id: ab, source: 'service:a', target: 'service:b',
+      type: EdgeType.CALLS, provenance: Provenance.EXTRACTED,
+    })
+    const bc = `${EdgeType.CALLS}:service:b->service:c`
+    g.addEdgeWithKey(bc, 'service:b', 'service:c', {
+      id: bc, source: 'service:b', target: 'service:c',
+      type: EdgeType.CALLS, provenance: Provenance.EXTRACTED,
+    })
+    const result = getBlastRadius(g, 'service:a')
+    const c = result.affectedNodes.find((n) => n.nodeId === 'service:c')!
+    expect(c.confidence).toBeCloseTo(0.25, 5)
+  })
   it.todo('getRootCause result passes RootCauseResultSchema.parse (issue #139)')
   it.todo('getBlastRadius result passes BlastRadiusResultSchema.parse (issue #139)')
 })
@@ -1075,6 +1096,8 @@ describe('getBlastRadius contract (ADR-038)', () => {
         nodeId: 'service:x',
         distance: 0,
         edgeProvenance: Provenance.OBSERVED,
+        path: ['service:origin', 'service:x'],
+        confidence: 1.0,
       }),
     ).toThrow()
     // Distance 1 stays valid.
@@ -1083,12 +1106,97 @@ describe('getBlastRadius contract (ADR-038)', () => {
         nodeId: 'service:x',
         distance: 1,
         edgeProvenance: Provenance.OBSERVED,
+        path: ['service:origin', 'service:x'],
+        confidence: 1.0,
       }),
     ).not.toThrow()
   })
+
+  it('BlastRadiusAffectedNode carries path field with origin → ... → nodeId (issue #137)', () => {
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:a', { id: 'service:a', type: NodeType.ServiceNode, name: 'a', language: 'javascript' })
+    g.addNode('service:b', { id: 'service:b', type: NodeType.ServiceNode, name: 'b', language: 'javascript' })
+    g.addNode('service:c', { id: 'service:c', type: NodeType.ServiceNode, name: 'c', language: 'javascript' })
+    const ab = `${EdgeType.CALLS}:service:a->service:b`
+    g.addEdgeWithKey(ab, 'service:a', 'service:b', {
+      id: ab, source: 'service:a', target: 'service:b',
+      type: EdgeType.CALLS, provenance: Provenance.OBSERVED,
+      lastObserved: '2026-05-06T00:00:00.000Z', callCount: 1, confidence: 1.0,
+    })
+    const bc = `${EdgeType.CALLS}:service:b->service:c`
+    g.addEdgeWithKey(bc, 'service:b', 'service:c', {
+      id: bc, source: 'service:b', target: 'service:c',
+      type: EdgeType.CALLS, provenance: Provenance.OBSERVED,
+      lastObserved: '2026-05-06T00:00:00.000Z', callCount: 1, confidence: 1.0,
+    })
+    const result = getBlastRadius(g, 'service:a')
+    const b = result.affectedNodes.find((n) => n.nodeId === 'service:b')!
+    const c = result.affectedNodes.find((n) => n.nodeId === 'service:c')!
+    expect(b.path).toEqual(['service:a', 'service:b'])
+    expect(c.path).toEqual(['service:a', 'service:b', 'service:c'])
+  })
+
+  it('BlastRadiusAffectedNode carries confidence field cascaded from edges along path (issue #137)', () => {
+    // Two OBSERVED hops at confidence 1.0 each → product 1.0. Two EXTRACTED
+    // hops at ceiling 0.5 each → product 0.25 (multiplicative cascade per
+    // ADR-036; min-reduce would give 0.5).
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:a', { id: 'service:a', type: NodeType.ServiceNode, name: 'a', language: 'javascript' })
+    g.addNode('service:b', { id: 'service:b', type: NodeType.ServiceNode, name: 'b', language: 'javascript' })
+    g.addNode('service:c', { id: 'service:c', type: NodeType.ServiceNode, name: 'c', language: 'javascript' })
+    const ab = `${EdgeType.CALLS}:service:a->service:b`
+    g.addEdgeWithKey(ab, 'service:a', 'service:b', {
+      id: ab, source: 'service:a', target: 'service:b',
+      type: EdgeType.CALLS, provenance: Provenance.EXTRACTED,
+    })
+    const bc = `${EdgeType.CALLS}:service:b->service:c`
+    g.addEdgeWithKey(bc, 'service:b', 'service:c', {
+      id: bc, source: 'service:b', target: 'service:c',
+      type: EdgeType.CALLS, provenance: Provenance.EXTRACTED,
+    })
+    const result = getBlastRadius(g, 'service:a')
+    const c = result.affectedNodes.find((n) => n.nodeId === 'service:c')!
+    expect(c.confidence).toBeCloseTo(0.25, 5)
+  })
+
   it.todo('result schema-validates before return (issue #139)')
-  it.todo('origin is never present in affectedNodes')
-  it.todo('path[0] === origin and path[path.length - 1] === affectedNode.nodeId for every entry')
+
+  it('origin is never present in affectedNodes', () => {
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:a', { id: 'service:a', type: NodeType.ServiceNode, name: 'a', language: 'javascript' })
+    g.addNode('service:b', { id: 'service:b', type: NodeType.ServiceNode, name: 'b', language: 'javascript' })
+    const ab = `${EdgeType.CALLS}:service:a->service:b`
+    g.addEdgeWithKey(ab, 'service:a', 'service:b', {
+      id: ab, source: 'service:a', target: 'service:b',
+      type: EdgeType.CALLS, provenance: Provenance.OBSERVED,
+      lastObserved: '2026-05-06T00:00:00.000Z', callCount: 1, confidence: 1.0,
+    })
+    const result = getBlastRadius(g, 'service:a')
+    expect(result.affectedNodes.find((n) => n.nodeId === 'service:a')).toBeUndefined()
+  })
+
+  it('path[0] === origin and path[path.length - 1] === affectedNode.nodeId for every entry', () => {
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:a', { id: 'service:a', type: NodeType.ServiceNode, name: 'a', language: 'javascript' })
+    g.addNode('service:b', { id: 'service:b', type: NodeType.ServiceNode, name: 'b', language: 'javascript' })
+    g.addNode('service:c', { id: 'service:c', type: NodeType.ServiceNode, name: 'c', language: 'javascript' })
+    const ab = `${EdgeType.CALLS}:service:a->service:b`
+    g.addEdgeWithKey(ab, 'service:a', 'service:b', {
+      id: ab, source: 'service:a', target: 'service:b',
+      type: EdgeType.CALLS, provenance: Provenance.EXTRACTED,
+    })
+    const bc = `${EdgeType.CALLS}:service:b->service:c`
+    g.addEdgeWithKey(bc, 'service:b', 'service:c', {
+      id: bc, source: 'service:b', target: 'service:c',
+      type: EdgeType.CALLS, provenance: Provenance.EXTRACTED,
+    })
+    const result = getBlastRadius(g, 'service:a')
+    for (const n of result.affectedNodes) {
+      expect(n.path[0]).toBe('service:a')
+      expect(n.path[n.path.length - 1]).toBe(n.nodeId)
+      expect(n.path.length).toBe(n.distance + 1)
+    }
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -4,6 +4,12 @@
       "affectedNodes": {
         "_array": {
           "_object": {
+            "confidence": {
+              "_number": [
+                "max",
+                "min"
+              ]
+            },
             "distance": {
               "_number": [
                 "int",
@@ -19,7 +25,10 @@
                 "STALE"
               ]
             },
-            "nodeId": "_string"
+            "nodeId": "_string",
+            "path": {
+              "_array": "_string"
+            }
           }
         }
       },

--- a/packages/core/test/traverse.test.ts
+++ b/packages/core/test/traverse.test.ts
@@ -106,7 +106,9 @@ describe('getRootCause', () => {
     addEdge(g, connectsEdge(Provenance.EXTRACTED))
 
     const result = getRootCause(g, 'database:payments-db')
-    expect(result!.confidence).toBe(0.5)
+    // Multiplicative cascade per ADR-036: two EXTRACTED edges at ceiling 0.5
+    // each → 0.5 × 0.5 = 0.25. Pre-contract min-reduce returned 0.5.
+    expect(result!.confidence).toBeCloseTo(0.25, 5)
     expect(result!.edgeProvenances).toEqual([Provenance.EXTRACTED, Provenance.EXTRACTED])
   })
 
@@ -287,11 +289,17 @@ describe('getBlastRadius', () => {
         nodeId: 'service:service-b',
         distance: 1,
         edgeProvenance: Provenance.EXTRACTED,
+        path: ['service:service-a', 'service:service-b'],
+        // 1-hop EXTRACTED at ceiling 0.5 → 0.5.
+        confidence: 0.5,
       },
       {
         nodeId: 'database:payments-db',
         distance: 2,
         edgeProvenance: Provenance.EXTRACTED,
+        path: ['service:service-a', 'service:service-b', 'database:payments-db'],
+        // 2-hop EXTRACTED-only path: 0.5 × 0.5 = 0.25 (multiplicative cascade).
+        confidence: 0.25,
       },
     ])
   })
@@ -342,6 +350,8 @@ describe('getBlastRadius', () => {
         nodeId: 'service:service-b',
         distance: 1,
         edgeProvenance: Provenance.EXTRACTED,
+        path: ['service:service-a', 'service:service-b'],
+        confidence: 0.5,
       },
     ])
   })

--- a/packages/types/src/results.ts
+++ b/packages/types/src/results.ts
@@ -19,6 +19,13 @@ export const BlastRadiusAffectedNodeSchema = z.object({
   // mechanically (ADR-038, issue #138).
   distance: z.number().int().positive(),
   edgeProvenance: ProvenanceSchema,
+  // path: origin → ... → nodeId. Length === distance + 1. Surfaced from the
+  // BFS predecessor chain so consumers don't have to reconstruct it from
+  // distance + the graph (ADR-038, issue #137).
+  path: z.array(z.string()).min(2),
+  // confidence: confidenceFromMix(...edgesAlongPath). Multiplicative cascade —
+  // each hop is independent evidence and uncertainty compounds. ADR-036.
+  confidence: z.number().min(0).max(1),
 })
 export type BlastRadiusAffectedNode = z.infer<typeof BlastRadiusAffectedNodeSchema>
 


### PR DESCRIPTION
## Summary

Two contract behaviours land together because both touch the BFS in \`traverse.ts\` and the per-affected-node confidence is what makes the multiplicative-vs-min difference user-visible.

### #137 — \`path\` + \`confidence\` on \`BlastRadiusAffectedNode\`

Schema growth on \`BlastRadiusAffectedNodeSchema\`:
- \`path: z.array(z.string()).min(2)\` — origin → … → nodeId. Length === distance + 1.
- \`confidence: z.number().min(0).max(1)\` — cascaded over edges along the path.

The BFS at \`traverse.ts\` already tracked distance per frame; extending each frame to carry its predecessor chain + the edges it walked surfaces the contract-required fields without changing the BFS shape.

### Multiplicative cascade (ADR-036 §Confidence cascading)

\`confidenceFromMix\` moves from min-reduce to product. Each hop is independent evidence, uncertainty compounds. A 3-hop EXTRACTED-only path produces \`0.5³ = 0.125\` instead of \`0.5\`; a 2-hop OBSERVED path stays at \`1.0\`.

The verification audit graded the previous min-reduce behaviour PASS because the audit text described it that way — but the contract supersedes the audit. This is the drift the v0.2.x rebuild pattern exists to catch.

## Behavior change consumers will feel

- \`getRootCause\` confidence drops on long EXTRACTED-only paths. The driver-mismatch demo: 0.5 → 0.25 (two EXTRACTED hops).
- \`getBlastRadius\` \`affectedNodes\` gain \`path\` and \`confidence\` per node. Pre-contract: \`{ nodeId, distance, edgeProvenance }\`. Post-contract: those plus \`{ path, confidence }\`.

## Contract assertions flipped

In \`packages/core/test/audits/contracts.test.ts\`:

- ✅ \`BlastRadiusAffectedNode carries path field with origin → ... → nodeId\` (#137)
- ✅ \`BlastRadiusAffectedNode carries confidence field cascaded from edges along path\` (#137)
- ✅ \`confidenceFromMix multiplies per-edge confidences\` (multiplicative cascade)
- ✅ \`origin is never present in affectedNodes\`
- ✅ \`path[0] === origin and path[path.length - 1] === affectedNode.nodeId for every entry\`
- ✅ \`#138 schema rejects 0\` test updated with new field shape

279 contract assertions passing (was 271), 44 todos remaining (was 50).

## Schema snapshot

Regenerated. Diff is purely additive: two new fields on \`BlastRadiusAffectedNodeSchema\`. No \`persist.ts\` migration needed (graph is regenerated each ingest cycle; snapshots aren't long-lived load-bearing data for these query results).

## Test plan

- [x] \`npx turbo build\` clean
- [x] \`npx turbo test\` — 279 pass, 44 todo
- [x] Updated \`traverse.test.ts\` confidence assertions for multiplicative semantics.
- [x] Updated \`api.test.ts\` REST blast-radius assertions to property-style for path/confidence.

Refs ADR-036, ADR-038, #137