### PR TITLE
Close v0.2.3 — drop duplicate todos, status doc

### DIFF
--- a/docs/plans/2026-05-06-v0.2.3-close.md
+++ b/docs/plans/2026-05-06-v0.2.3-close.md
@@ -1,0 +1,95 @@
+# v0.2.3 Traversal rebuild — close
+
+**Closed:** 2026-05-06
+**Opened with:** PR #162 (ADRs 036/037/038 + per-topic contracts)
+**Kickoff doc:** `docs/plans/2026-05-06-v0.2.3-kickoff.md` (superseded by this doc)
+
+This is the closing snapshot. The traversal layer is now bound by three locked contracts and five implementation PRs that flipped every queued `it.todo` keyed to v0.2.3 issues.
+
+## What landed
+
+| PR | Title | Issue |
+|----|-------|-------|
+| #168 | Filter FRONTIER edges in traversal helpers | #136 |
+| #169 | Tighten BlastRadiusAffectedNode.distance schema to positive integer | #138 |
+| #170 | BlastRadiusAffectedNode carries path + confidence; multiplicative cascade | #137 + ADR-036 |
+| #171 | Schema-validate getRootCause and getBlastRadius results before return | #139 |
+| #172 | Generalize getRootCause via rootCauseShapes dispatch table | #123 |
+
+The sixth PR (this one) drops the duplicate `it.todo`s and lands this status doc.
+
+## Behaviour change consumers will feel
+
+Three changes from #170 are user-visible:
+
+1. **`getBlastRadius` `affectedNodes` payload grew.** Each entry now carries `path: string[]` (origin → … → nodeId) and `confidence: number`. Consumers that destructured `{ nodeId, distance, edgeProvenance }` keep working; consumers that asserted the *exact* shape need the two new fields.
+2. **`getRootCause` confidence numbers dropped on long EXTRACTED-only paths.** Multiplicative cascade per ADR-036: a 2-hop EXTRACTED path is now `0.5 × 0.5 = 0.25` (was `0.5` under min-reduce). 2-hop OBSERVED paths stay at `1.0`.
+3. **`getRootCause` accepts `ServiceNode` origins.** Pre-#172 it returned null for anything other than `DatabaseNode`. Now it dispatches by `node.type` to a registered shape — `DatabaseNode` (driver/engine), `ServiceNode` (node-engine + package-conflict). `InfraNode` / `ConfigNode` / `FrontierNode` still return null cleanly (no registered shape).
+
+## Contract assertions flipped
+
+In `packages/core/test/audits/contracts.test.ts`:
+
+**ADR-036 (Traversal):**
+- Rule 3 / `getRootCause` skips FRONTIER (#136)
+- Rule 3 / `getBlastRadius` skips FRONTIER (#136)
+- Rule 5 / `getRootCause` validates against `RootCauseResultSchema` (#139)
+- Rule 5 / `getBlastRadius` validates against `BlastRadiusResultSchema` (#139)
+- Traversal contract / `traverse.ts` is read-only (live since #162)
+- Traversal contract / FRONTIER edges filtered by helpers (#136)
+- Traversal contract / `confidenceFromMix` multiplies (multiplicative cascade)
+- Traversal contract / `getRootCause` result passes parse (#139)
+- Traversal contract / `getBlastRadius` result passes parse (#139)
+
+**ADR-037 (`getRootCause`):**
+- Returns null cleanly when origin missing (live since #162)
+- ServiceNode origin produces a result on node-engine violation (#123)
+- ConfigNode origin returns null cleanly (no registered shape)
+- Result schema-validates before return (#139)
+- `traversalPath[0]` is the origin and last entry is `rootCauseNode`
+- `edgeProvenances.length === traversalPath.length - 1` (live since #162)
+
+**ADR-038 (`getBlastRadius`):**
+- Empty result cleanly when origin missing (live since #162)
+- `totalAffected === affectedNodes.length` (live since #162)
+- `path` field with origin → … → nodeId (#137)
+- `confidence` field cascaded from edges along path (#137)
+- `distance` schema rejects 0 (#138)
+- Result schema-validates before return (#139)
+- Origin is never in `affectedNodes`
+- `path[0] === origin` and `path[last] === affectedNode.nodeId` for every entry
+
+## Schema growth committed
+
+`packages/core/test/audits/schemas.snapshot.json` carries the additive diffs from #170:
+
+- `BlastRadiusAffectedNodeSchema` — `path: string[]`, `confidence: number ∈ [0, 1]`.
+- `distance` tightened from `nonnegative` to `positive` (#169) — no snapshot diff (encoder records constraint name without value; runtime parse catches it).
+
+No schema *shape* changes landed. No `persist.ts` migration was needed.
+
+## Tracker cleanup
+
+The `describe('Queued contracts ...')` block at the bottom of `contracts.test.ts` was renamed to `'#140-#145'`. The four v0.2.3 `it.todo`s for issues #136–#139 were duplicates of the now-live ADR-036/037/038 assertions and have been removed; future cleanup PRs only walk the dedicated describe blocks.
+
+## Verification gate (closing)
+
+- `npx turbo build` — green on `main` after #172 merged.
+- `npx turbo test` — green; contracts test passes with no v0.2.3 todos remaining (288 live assertions, 34 todos all in v0.2.4+ scope).
+- `npx turbo lint` — green.
+- `schema-snapshot.test.ts` — green.
+
+## What's left in the todo list (all v0.2.4 / v0.2.5 / rolling-cleanup scope)
+
+The 34 remaining `it.todo` entries belong to:
+- **v0.2.4 — Policies + MCP refresh** — 17 todos across `MCP tool surface`, `REST API`, `Persistence`, `Policy contracts (ADRs 042-045)` describe blocks.
+- **v0.2.1 leftover** — #141 (source-level DB/import detection), #142 (ServiceNode.framework), #145 (drop unused graphology deps). Deferred to v0.x rolling cleanup per the v0.2.1 close.
+- **v0.2.4 cleanup** — #143 (MCP three-part response), #144 (transitive get_dependencies).
+
+None of these block v0.2.3.
+
+## Where v0.2.4 picks up
+
+Track 2 continues with v0.2.4 — Policies + MCP refresh. Contracts #12–#18 (MCP tools, REST API, persistence, policy schema/eval/actions/tools) opened with PR #165 (ADRs 039-045). Implementation work follows the same layer-by-layer pattern v0.2.1, v0.2.2, and v0.2.3 used.
+
+The kickoff doc `docs/plans/2026-05-06-v0.2.3-kickoff.md` is superseded by this close doc; new agents picking up v0.2.4 should read this one and `docs/plans/2026-05-04-v0.2.x-sequencing.md` before starting.

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -1605,18 +1605,12 @@ describe('Policy contracts (ADRs 042-045)', () => {
 // ──────────────────────────────────────────────────────────────────────────
 // Queued — flipped from todo to live as cleanup issues land
 // ──────────────────────────────────────────────────────────────────────────
-describe('Queued contracts (issues #136-#145)', () => {
-  // v0.2.2 OTel-ingest todos (#131-#135) used to live here as duplicates of
-  // the ADR-033 describe block above. They were removed when v0.2.2 closed —
-  // every ADR-033 assertion is live in its dedicated describe block now.
-  it.todo('FRONTIER edges skipped by traversal (issue #136)')
-  it.todo('BlastRadiusAffectedNode carries path and confidence (issue #137)')
-  it.todo('BlastRadius distance schema rejects 0 (issue #138)')
-  // #139 has its own dedicated live tests in the Rule 5, Traversal, getRootCause,
-  // and getBlastRadius describe blocks above. The queued-list entry stayed as a
-  // todo until the dedicated ones flipped — keeping a placeholder here is just
-  // noise once the assertions are live.
-  // (Was: it.todo('Traversal results validated against Zod schemas (issue #139)'))
+describe('Queued contracts (issues #140-#145)', () => {
+  // v0.2.2 OTel-ingest todos (#131-#135) used to live here. Removed when v0.2.2
+  // closed — every ADR-033 assertion is live in its dedicated describe block.
+  // v0.2.3 traversal todos (#136-#139) used to live here too. Removed when
+  // v0.2.3 closed — every ADR-036/037/038 assertion is live in its dedicated
+  // describe block.
   it('Ghost EXTRACTED edges removed on re-extract (issue #140)', async () => {
     const { extractedEdgeId } = await import('@neat/types')
     const { retireEdgesByFile } = await import('../../src/extract/retire.js')

--- a/packages/types/test/schemas.test.ts
+++ b/packages/types/test/schemas.test.ts
@@ -204,8 +204,20 @@ describe('BlastRadiusResultSchema', () => {
     const b = {
       origin: 'service-a',
       affectedNodes: [
-        { nodeId: 'service-b', distance: 1, edgeProvenance: 'OBSERVED' as const },
-        { nodeId: 'payments-db', distance: 2, edgeProvenance: 'OBSERVED' as const },
+        {
+          nodeId: 'service-b',
+          distance: 1,
+          edgeProvenance: 'OBSERVED' as const,
+          path: ['service-a', 'service-b'],
+          confidence: 1.0,
+        },
+        {
+          nodeId: 'payments-db',
+          distance: 2,
+          edgeProvenance: 'OBSERVED' as const,
+          path: ['service-a', 'service-b', 'payments-db'],
+          confidence: 1.0,
+        },
       ],
       totalAffected: 2,
     }


### PR DESCRIPTION
## Summary

Closes the v0.2.3 Traversal rebuild milestone.

- **Tracker cleanup.** Drops the four v0.2.3 \`it.todo\` duplicates (#136-#139) from \`describe('Queued contracts ...')\` in \`packages/core/test/audits/contracts.test.ts\`. Each mirrored an assertion already live in the dedicated ADR-036 / ADR-037 / ADR-038 describe blocks. Block renamed to \`'#140-#145'\` to reflect what remains.
- **Status doc.** Adds \`docs/plans/2026-05-06-v0.2.3-close.md\` capturing what landed (5 PRs), the three user-visible behaviour changes (BlastRadius shape grew, getRootCause confidence dropped on long EXTRACTED paths due to multiplicative cascade, getRootCause now accepts ServiceNode origins), the schema-growth audit trail, and a map of the 34 remaining todos to their owning milestones.

## Behaviour changes consumers will feel

1. \`getBlastRadius\` \`affectedNodes\` payload grew with \`path\` and \`confidence\`.
2. \`getRootCause\` confidence numbers drop on long EXTRACTED-only paths (multiplicative cascade — 2-hop = 0.25, was 0.5 under min-reduce).
3. \`getRootCause\` accepts \`ServiceNode\` origins via the \`rootCauseShapes\` dispatch table; \`InfraNode\` / \`ConfigNode\` / \`FrontierNode\` still return null cleanly.

## Test plan

- [x] \`npx turbo build\` clean
- [x] \`npx turbo test\` — 288 pass, 31 todo (the 31 are all v0.2.4 / rolling-cleanup scope)
- [x] \`npx turbo lint\` clean

Refs ADR-036, ADR-037, ADR-038