### PR TITLE
v0.2.4 kickoff status doc — implementation queue for the next agent

### DIFF
--- a/docs/plans/2026-05-06-v0.2.4-kickoff.md
+++ b/docs/plans/2026-05-06-v0.2.4-kickoff.md
@@ -1,0 +1,101 @@
+# v0.2.4 Policies + MCP refresh — kickoff for the implementation agent
+
+**Last updated:** 2026-05-06
+
+This is the "pick up here" doc for v0.2.4 work. Read it first. Supersedes the v0.2.3 kickoff doc as the active milestone tracker.
+
+## Where we are
+
+- **v0.2.0 Sunrise** — closed, tagged [`v0.2.0`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.0).
+- **v0.2.1 — Tree-sitter rebuild** — closed, tagged [`v0.2.1`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.1).
+- **v0.2.2 — OTel ingest rebuild** — closed, tagged [`v0.2.2`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.2).
+- **v0.2.3 — Traversal rebuild** — closed, tagged [`v0.2.3`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.3).
+- **v0.2.4 — Policies + MCP refresh** — **OPEN. Contracts on main; implementation has not shipped.**
+- **v0.2.5 — Distribution layer** — contracts pending in PR #166 (stacked on #165).
+
+## What v0.2.4 is
+
+The first user-facing surface refresh + the policies feature. Seven contracts already on main govern this work (PR #165):
+
+- **#12 MCP tool surface** ([`mcp-tools.md`](../contracts/mcp-tools.md), ADR-039) — nine tools locked, three-part response format, transitive `get_dependencies`, REST-only data path.
+- **#13 REST API** ([`rest-api.md`](../contracts/rest-api.md), ADR-040) — dual-mount per ADR-026, locked endpoint set including the new `GET /graph/node/:id/dependencies?depth=N` for #144.
+- **#14 Persistence** ([`persistence.md`](../contracts/persistence.md), ADR-041) — `SCHEMA_VERSION` bumps on shape change only, append-only ndjson sidecars (now adds `policy-violations.ndjson`).
+- **#15 Policy schema** ([`policy-schema.md`](../contracts/policy-schema.md), ADR-042) — `policy.json` at project root, `version: z.literal(1)`, five rule types (structural, compatibility, provenance, ownership, blast-radius). Discriminated union.
+- **#16 Policy evaluation** ([`policy-evaluation.md`](../contracts/policy-evaluation.md), ADR-043) — pure `evaluateAllPolicies(graph, policies, context)`, three triggers (post-ingest, post-extract, post-stale-transition), per-type dispatch, deterministic violation ids.
+- **#17 Policy onViolation actions** ([`policy-actions.md`](../contracts/policy-actions.md), ADR-044) — `log` / `alert` / `block`. Severity-driven defaults. Block applies to FrontierNode promotion gating only in MVP.
+- **#18 Policy tool surface** ([`policy-tools.md`](../contracts/policy-tools.md), ADR-045) — single `check_policies` MCP tool (audit's two-tool split rejected per CLAUDE.md framing). REST under `/policies`. Resource at `neat://policies/violations`.
+
+## Why v0.2.4 matters
+
+This is the first milestone where users experience NEAT as **something that asserts intent**, not just observes reality. Policies are the formalization of the OBSERVED-vs-EXTRACTED gap that ADR-027 names as NEAT's load-bearing value. The MVP-success-PR criterion (closing a real bug on an unfamiliar codebase) becomes much more likely once policies can flag divergences continuously.
+
+It's also the architecture-first surface from the manifesto — the first user-facing place NEAT resembles what neat.is sells.
+
+## Issues queued
+
+Six issues are open against the v0.2.4 milestone. Each closes when its corresponding `it.todo` in `packages/core/test/audits/contracts.test.ts` flips to a live assertion and passes.
+
+**MCP refresh:**
+- **#143** — MCP tools: emit standardized three-part response (NL paragraph + structured block + footer)
+- **#144** — Make `get_dependencies` transitive
+
+**Policies (α/β/γ/δ in dependency order):**
+- **#115** — v0.2.4-α — Policy schema + YAML parser in `@neat/types`
+- **#116** — v0.2.4-β — Policy evaluation engine + `policy-violations.ndjson` log
+- **#117** — v0.2.4-γ — REST and MCP surface for policies
+- **#118** — v0.2.4-δ — Real-world policy library + intent-vs-observed divergence detectors
+
+## Issue state caveat (important)
+
+**#143 and #144 had been marked CLOSED on GitHub without code shipping.** Same false-close pattern that appeared earlier in v0.2.2 and v0.2.3 — issues marked done but the contract `it.todo` items still queued. Both have been reopened in this release-prep pass.
+
+**Do not trust the GitHub issue state alone.** The `it.todo` items in `contracts.test.ts` are the source of truth for what hasn't shipped.
+
+## Recommended implementation order
+
+The MCP refresh issues (#143, #144) are independent of policies and small. Land them first to clear the surface. Policies are α/β/γ/δ — strict dependency order.
+
+1. **#143 — three-part response** (small, ~half-day). Add `packages/mcp/src/format.ts` with `formatToolResponse({ summary, block, confidence?, provenance? })` — NL paragraph + structured block + `confidence: X.XX · provenance: ...` footer line. Refactor each of the eight existing tools in `packages/mcp/src/tools.ts` to route through it. Empty result → footer reads `confidence: n/a · provenance: n/a`. Flips two `it.todo` items.
+
+2. **#144 — transitive `get_dependencies`** (medium, ~half-day). Add `GET /graph/node/:id/dependencies?depth=N` endpoint to `packages/core/src/api.ts` (default depth 3, max 10). BFS-walk outbound from the node id, returning a flat list of affected node ids with distance + edge type + provenance. Refactor the MCP `get_dependencies` tool to call the new endpoint. Direct-only consumers pass `depth=1`. Flips three `it.todo` items.
+
+3. **#115 — policy schema (α)** (medium, ~half-day to a day). Create `packages/types/src/policy.ts` with `PolicyFileSchema`, `PolicySchema`, `PolicyRuleSchema` (discriminated union over five types: `structural`, `compatibility`, `provenance`, `ownership`, `blast-radius`). `version: z.literal(1)`. Schema-snapshot regenerates. Flips two `it.todo` items.
+
+4. **#116 — evaluation engine (β)** (large, ~day to two). Create `packages/core/src/policy.ts` with `evaluateAllPolicies(graph, policies, context)` and a `policyEvaluators` table (one evaluator per rule type). Wire triggers from `ingest.ts` (post-`handleSpan`), `extract/index.ts` (post-`extractFromDirectory`), and `ingest.ts` (post-`markStaleEdges`). Append violations to `policy-violations.ndjson` via `persist.ts`'s ndjson helpers. Deterministic violation ids = `${policy.id}:${violation-context}`; duplicates skipped at write time. Flips four `it.todo` items.
+
+5. **#117 — REST + MCP surface (γ)** (medium, ~day). REST: `GET /policies`, `GET /policies/violations` (filterable), `POST /policies/check` (dry-run with `hypotheticalAction`). All dual-mounted. MCP: register `check_policies` tool with optional `scope` and `hypotheticalAction`. Resource at `neat://policies/violations` emitting `notifications/resources/updated` on append. Block actions plumb through `canPromoteFrontier`. Flips three `it.todo` items.
+
+6. **#118 — real-world policy library (δ)** (medium, ~day). Author 5-10 example policies under `examples/policies/` exercising the OBSERVED-vs-EXTRACTED divergence shape. These become the demo material for the MVP-success PR experiment (ADR-027). No `it.todo` flips — this is example content, not contract enforcement.
+
+## Reference points
+
+- Contracts: [`mcp-tools.md`](../contracts/mcp-tools.md), [`rest-api.md`](../contracts/rest-api.md), [`persistence.md`](../contracts/persistence.md), [`policy-schema.md`](../contracts/policy-schema.md), [`policy-evaluation.md`](../contracts/policy-evaluation.md), [`policy-actions.md`](../contracts/policy-actions.md), [`policy-tools.md`](../contracts/policy-tools.md).
+- ADRs: 039-045 in [`docs/decisions.md`](../decisions.md).
+- Existing source touched: `packages/mcp/src/{index,tools,resources}.ts`, `packages/core/src/{api,persist}.ts`, `packages/types/src/`.
+- New source: `packages/types/src/policy.ts`, `packages/core/src/policy.ts`, `packages/mcp/src/format.ts`.
+- Existing tests: `packages/core/test/api.test.ts`, `packages/mcp/test/*`, `packages/core/test/audits/contracts.test.ts`.
+- Hook surface: editing `mcp/src/tools.ts` auto-loads mcp-tools, policy-tools, lifecycle. Editing `api.ts` loads rest-api, policy-tools, lifecycle. Once `policy.ts` exists, editing it loads policy-schema, policy-evaluation, policy-actions, lifecycle.
+
+## Closing condition
+
+v0.2.4 closes when:
+
+1. All six issues (#115, #116, #117, #118, #143, #144) ship on `main`.
+2. Every `it.todo` in `contracts.test.ts` keyed to those issues has flipped to live and passes.
+3. The schema-snapshot guard accepts the regenerated snapshot (PolicyFileSchema added; ServiceNode growth if any).
+4. `npx turbo build test lint` is green.
+5. v0.2.4 verification re-runs green for the policies + MCP sections.
+6. Tag `v0.2.4` is created at the last v0.2.4 implementation commit; GitHub release published.
+
+## What's not in v0.2.4
+
+- v0.2.5 work (distribution layer — contracts in PR #166).
+- Self-hosting on the NEAT codebase (gated behind the MVP-success PR per ADR-027).
+
+## Open product calls (carried)
+
+- `drivers` vs `dependencies` field name on ServiceNode — recommended: keep `dependencies` raw, defer `drivers` until a second consumer materializes. Doesn't block v0.2.4.
+
+## When this file is wrong
+
+Snapshot, not contract. If `main` has moved since the date at the top, treat the description as historical and check `git log` + `gh release list` for the canonical state. New status docs land as `docs/plans/<date>-<milestone>-status.md`.


### PR DESCRIPTION
## Summary

Sets up v0.2.4 (Policies + MCP refresh) for the next implementation agent. Same shape as the v0.2.3 kickoff doc.

## What's done in this release-prep pass

- **v0.2.3 closed** — tagged \`v0.2.3\` at \`c62f107\`. Five issues (#123, #136-#139) closed with PR references. GitHub release published. Milestone closed.
- **v0.2.4 issues #143 + #144 reopened** — same false-close pattern as earlier milestones (issue closed but \`it.todo\` still queued in contracts.test.ts).
- **v0.2.4 kickoff doc** added at \`docs/plans/2026-05-06-v0.2.4-kickoff.md\`.

## What's documented

- **Where we are.** v0.2.0/v0.2.1/v0.2.2/v0.2.3 closed and tagged.
- **What v0.2.4 is.** Surface refresh + policies — the first user-facing place NEAT asserts intent.
- **Six issues queued:** #143 (three-part response), #144 (transitive deps), #115/#116/#117/#118 (policies α/β/γ/δ).
- **Recommended order:** #143 → #144 → #115 (α) → #116 (β) → #117 (γ) → #118 (δ). MCP refresh first because it's independent and small; policies in strict α/β/γ/δ dependency order.
- **Reference points:** seven contract files, ADRs 039-045, source files touched, new files to create, hook surfacing.
- **Closing condition:** all six issues shipped, every \`it.todo\` keyed to them flipped live, build/test/lint green, tag \`v0.2.4\` created.

## Test plan

- [x] Read the kickoff doc end to end.
- [x] Verify v0.2.3 release on GitHub.
- [x] Verify the six v0.2.4 issues are now OPEN on the milestone.
- [x] After merge: spin up the next implementation agent with this doc as the entry point.

Refs #126