### PR TITLE
Add v0.2.6 to the roadmap — CLI parity + frontend-API surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,9 @@ v0.2.2 closed on 2026-05-06 — see `docs/plans/2026-05-06-v0.2.2-close.md` for 
 
 **v0.2.5 — `neat init` + SDK install + Claude skill.** Opens with contracts #19-#22 (init, SDK install, machine registry, daemon). Then ships #119.
 
-After v0.2.5: the MVP-success PR experiment (ADR-027) — point NEAT at an open-source codebase. Self-hosting on the NEAT codebase activates only after that PR closes.
+**v0.2.6 — CLI parity + frontend-API surface.** Opens with contracts #23-#24 (CLI surface, frontend-facing API). Ships CLI verbs that mirror the nine MCP tools (so a human at a terminal has the same reach as an agent), plus the API surface a local frontend needs — SSE / WebSocket live-updates, multi-project switcher endpoints, anything else surfaced as v0.3.0 prep work. The `(if that's needed)` qualifier is honest: parts of this milestone wait until Jed's frontend track surfaces concrete API gaps.
+
+After v0.2.6: the MVP-success PR experiment (ADR-027) — point NEAT at an open-source codebase. Self-hosting on the NEAT codebase activates only after that PR closes.
 
 ### Track 1 — v0.3.0 Frontend (Jed)
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -28,17 +28,17 @@ This file is the index. Each rule has a short summary and a link to its full per
 | 16 | Policy evaluation | [`contracts/policy-evaluation.md`](./contracts/policy-evaluation.md) | Pure `evaluateAllPolicies`, three triggers, per-type dispatch, deterministic violation ids (ADR-043) | ✅ landed (v0.2.4 opens) |
 | 17 | Policy onViolation actions | [`contracts/policy-actions.md`](./contracts/policy-actions.md) | `log` / `alert` / `block`; severity-driven defaults; block applies to FrontierNode promotion gating only in MVP (ADR-044) | ✅ landed (v0.2.4 opens) |
 | 18 | Policy tool surface | [`contracts/policy-tools.md`](./contracts/policy-tools.md) | Single `check_policies` tool, REST under `/policies`, resource at `neat://policies/violations` (ADR-045) | ✅ landed (v0.2.4 opens) |
+| 19 | `neat init` | [`contracts/init.md`](./contracts/init.md) | One-time registration. Discovery before mutation. Patch-by-default; `--apply` opt-in. Lockfiles never touched (ADR-046) | ✅ landed (v0.2.5 opens) |
+| 20 | SDK install | [`contracts/sdk-install.md`](./contracts/sdk-install.md) | Per-language installer modules (Node + Python in MVP). Plan/apply decoupled. Manifests touched, lockfiles never (ADR-047) | ✅ landed (v0.2.5 opens) |
+| 21 | Machine-level project registry | [`contracts/project-registry.md`](./contracts/project-registry.md) | `~/.neat/projects.json` per-user, atomic writes via tmp+rename, flock during writes, path-normalized (ADR-048) | ✅ landed (v0.2.5 opens) |
+| 22 | Daemon | [`contracts/daemon.md`](./contracts/daemon.md) | Single long-lived process, per-project graph isolation, mtime + OTel + policy.json triggers, graceful per-project failure (ADR-049) | ✅ landed (v0.2.5 opens) |
 
 ### Future contracts — opened at the start of each milestone
 
-Producer-, consumer-, surface-, policy-, and distribution-layer contracts open at the start of the milestone where their layer gets rebuilt.
-
 | # | Contract | Milestone | Governs (target) |
 |---|----------|-----------|------------------|
-| 19 | `neat init` | v0.2.5 | What init does, what it writes, what it doesn't touch, codemod patch-vs-apply semantics |
-| 20 | SDK install | v0.2.5 | Per-language installer module interface, dependency-file edits, entrypoint modifications, opt-in semantics |
-| 21 | Machine-level project registry | v0.2.5 | `~/.neat/projects.json` shape, daemon discovery rules, project lifecycle |
-| 22 | Daemon | v0.2.5 | Continuous extraction triggers (file mtime, OTel arrival), per-project graph isolation, lifecycle |
+| 23 | CLI surface | v0.2.6 | CLI verbs mirror MCP tools — nine `neat <verb>` commands calling the same REST client. Output format, exit codes, project scoping. |
+| 24 | Frontend-facing API | v0.2.6 | API surface a local frontend needs that the existing REST + MCP set doesn't already cover — SSE / WebSocket live updates, anything Jed's v0.3.0 track surfaces as a gap. The `(if needed)` qualifier is honest; parts of this contract wait for v0.3.0 to surface concrete demands. |
 
 The full reasoning and per-milestone sequencing live in `docs/plans/2026-05-04-v0.2.x-sequencing.md`. The current state of the active milestone lives in `docs/plans/<latest-date>-v0.2.x-status.md`.
 

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -27,8 +27,9 @@ Source of truth for sprint status. Update this file at the end of every session.
   - **v0.2.3 — Traversal rebuild.** Opens with contracts #9-#11. Ships #136-#139, #123.
   - **v0.2.4 — Policies + MCP refresh.** Opens with contracts #12-#18. Ships #115-#118, #143, #144.
   - **v0.2.5 — `neat init` + SDK install + Claude skill.** Opens with contracts #19-#22. Ships #119.
+  - **v0.2.6 — CLI parity + frontend-API surface.** Opens with contracts #23-#24. CLI verbs mirroring the nine MCP tools (so a human at a terminal has the same reach as an agent), plus whatever API surface Jed's v0.3.0 frontend track surfaces as a gap. The `(if needed)` qualifier is honest — parts of this milestone wait until v0.3.0 starts pulling on concrete demands.
 
-After v0.2.5: the MVP-success PR experiment (ADR-027). Self-hosting on the NEAT codebase activates only after that PR closes — until then NEAT is the target of construction, not the tool.
+After v0.2.6: the MVP-success PR experiment (ADR-027). Self-hosting on the NEAT codebase activates only after that PR closes — until then NEAT is the target of construction, not the tool.
 
 ### Active work — start here
 

--- a/docs/plans/2026-05-04-v0.2.x-sequencing.md
+++ b/docs/plans/2026-05-04-v0.2.x-sequencing.md
@@ -27,8 +27,15 @@ The architecture-first surface from the neat.is manifesto, finally buildable bec
 **Output:** policies layer live. Architecture-first surface visible.
 
 ### v0.2.5 — `neat init` + SDK install + Claude skill
-Distribution layer. Init owns SDK install (Node + Python first), codemod with `--apply` opt-in, machine-level `~/.neat/projects.json` registry, daemon model. Last in v0.2.x because init has to know what NEAT supports — feature set must be frozen first.
+Distribution layer. Init owns SDK install (Node + Python first), codemod with `--apply` opt-in, machine-level `~/.neat/projects.json` registry, daemon model. Comes after the layers below it in the dependency stack are stable because init has to know what NEAT supports.
 **Output:** `neat install` + `neat init <repo>` + Claude skill. End-to-end usable on an arbitrary codebase.
+
+### v0.2.6 — CLI parity + frontend-API surface
+The last engineering milestone before the MVP-success PR experiment. Two contracts open it:
+- **#23 CLI surface.** Nine `neat <verb>` commands mirroring the MCP tool set (root-cause, blast-radius, dependencies, observed-dependencies, incidents, search, diff, stale-edges, policies). Each calls the same REST client the MCP tools use — single source of truth. Project-scoped via `--project`. Exit codes for CI use.
+- **#24 Frontend-facing API.** API surface a local frontend needs that the existing REST + MCP set doesn't already cover — SSE / WebSocket live updates from `neatd`, multi-project switcher endpoints, anything Jed's v0.3.0 track surfaces as a real gap. The `(if needed)` qualifier is honest: parts of this contract wait for v0.3.0 to start pulling on concrete demands.
+
+**Output:** human operators can drive NEAT from a terminal without going through MCP; Jed's frontend has the API surface it needs to build against. CI pipelines can call `neat policies --check` as a deploy gate.
 
 ### v0.3.0 — Frontend + open-source release
 Jed's track. Builds against fully stable v0.2.x API. Repo opens publicly. Engineering pace drops to ambient. Pre-v1.0 product-discovery mode begins — bugs, blog posts, talks, watching real users, letting v1.0 design crystallize from usage not assumption.


### PR DESCRIPTION
## Summary

The v0.2.x sequence grows from six sub-versions to seven. v0.2.6 lands between the distribution layer (v0.2.5) and the MVP-success PR experiment.

Use case: human operators get the same reach as an MCP agent (one CLI verb per tool); Jed's v0.3.0 frontend track gets a clear API surface to build against.

## What's added

**Two new contracts** (queued, not drafted yet — they open at the start of the milestone per the rebuild-contract discipline):

- **#23 CLI surface** — nine \`neat <verb>\` commands mirroring the MCP tool set. Each calls the same REST client \`packages/mcp/src/client.ts\` uses. One source of truth, two surfaces.
- **#24 Frontend-facing API** — API surface a local frontend needs that the existing REST + MCP set doesn't cover. SSE / WebSocket live updates from \`neatd\`, multi-project switcher endpoints, anything v0.3.0 surfaces as a concrete gap. The \`(if needed)\` qualifier is honest: parts of this wait for v0.3.0 to start pulling on real demands.

## Files changed

- \`CLAUDE.md\` — Track 2 section adds v0.2.6 alongside v0.2.0-v0.2.5.
- \`docs/milestones.md\` — sub-version list extends.
- \`docs/contracts.md\` — moves #19-#22 from future-contracts table to landed (per #166 merge) and adds #23/#24 entries to future-contracts.
- \`docs/plans/2026-05-04-v0.2.x-sequencing.md\` — v0.2.6 section describing both contracts.

## What this PR doesn't do

- No ADRs drafted yet for #23/#24 — they land at the start of v0.2.6 alongside their contract markdown files.
- No new \`it.todo\` items in \`contracts.test.ts\`.
- No GitHub issues filed for v0.2.6 work yet — those open when the milestone starts.

GitHub milestone v0.2.6 created.

## Test plan

- [x] Read each diff. Confirm the description matches the intent.
- [x] After merge: v0.2.4 + v0.2.5 implementation continues. v0.2.6 contract drafting starts when v0.2.5 closes.

Refs #126