### PR TITLE
MCP three-part response — formatToolResponse helper + retrofit

### DIFF
--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -1556,7 +1556,15 @@ describe('MCP tool surface contract (ADR-039)', () => {
   })
 
   it.todo('every server.tool registration in mcp/src/index.ts has a name from the locked allowlist of nine tools (ADR-039)')
-  it.todo('formatToolResponse helper exists at mcp/src/format.ts (issue #143)')
+  it('formatToolResponse helper exists at mcp/src/format.ts (issue #143)', () => {
+    const formatPath = join(MCP_SRC, 'format.ts')
+    const content = readFileSync(formatPath, 'utf8')
+    expect(content).toMatch(/export function formatToolResponse/)
+    // Three-part output shape: summary + block + footer.
+    expect(content).toMatch(/confidence:.*provenance:/)
+    // Empty-result footer reads n/a / n/a per the contract.
+    expect(content).toMatch(/n\/a/)
+  })
   it.todo('get_dependencies is transitive — calls /graph/node/:id/dependencies?depth=N (issue #144)')
   it.todo('check_policies tool registered with optional hypotheticalAction (v0.2.4 #117)')
 })
@@ -1929,7 +1937,19 @@ describe('Queued contracts (issues #140-#145)', () => {
   })
   it.todo('Source-level DB connection + import detection (issue #141)')
   it.todo('ServiceNode.framework populated from package.json (issue #142)')
-  it.todo('MCP tools emit standardized three-part response (issue #143)')
+  it('MCP tools emit standardized three-part response (issue #143)', () => {
+    // Static assertion: every server.tool implementation in tools.ts routes
+    // through formatToolResponse / formatEmptyResponse / formatErrorResponse.
+    // The tool body uses one of those exports somewhere; absent that, output
+    // drift is possible.
+    const tools = readFileSync(join(MCP_SRC, 'tools.ts'), 'utf8')
+    expect(tools).toMatch(/from\s+['"]\.\/format\.js['"]/)
+    expect(tools).toMatch(/formatToolResponse\s*\(/)
+    expect(tools).toMatch(/formatEmptyResponse\s*\(/)
+    expect(tools).toMatch(/formatErrorResponse\s*\(/)
+    // No raw `return text(...)` stragglers that bypass the helper.
+    expect(tools).not.toMatch(/return\s+text\s*\(/)
+  })
   it.todo('get_dependencies is transitive (issue #144)')
   it.todo('Drop unused graphology-traversal/-shortest-path deps (issue #145)')
 })

--- a/packages/mcp/src/format.ts
+++ b/packages/mcp/src/format.ts
@@ -1,0 +1,77 @@
+// Standardized three-part response format for every MCP tool (ADR-039,
+// issue #143). Output shape:
+//
+//   {summary — NL paragraph: what was found, why it matters}
+//
+//   {block — typed payload, formatted}
+//
+//   confidence: 0.94 · provenance: OBSERVED
+//
+// Empty result → footer reads "confidence: n/a · provenance: n/a". Every tool
+// in packages/mcp/src/tools.ts routes through this helper so consumers get a
+// consistent shape — agents can pattern-match on the footer to know how much
+// to trust the answer.
+
+export interface ToolResponse {
+  [x: string]: unknown
+  content: { type: 'text'; text: string }[]
+  isError?: boolean
+}
+
+export interface FormatToolResponseInput {
+  // NL paragraph. One or two sentences. What was found and why it matters.
+  summary: string
+  // Structured block. The formatted typed payload — usually a bullet list,
+  // sometimes a multi-section breakdown. May be empty when the summary
+  // already conveys everything.
+  block?: string
+  // Per-result confidence in [0, 1]. Undefined → footer reads "n/a".
+  confidence?: number
+  // Per-result provenance. Single value, or an array if the result spans
+  // mixed provenances (e.g. a path of OBSERVED + EXTRACTED edges). Undefined
+  // → footer reads "n/a".
+  provenance?: string | string[]
+  // Set on transport / 5xx errors. Routes through ToolResponse.isError so
+  // MCP clients can surface a non-"normal" return.
+  isError?: boolean
+}
+
+function formatFooter(
+  confidence: number | undefined,
+  provenance: string | string[] | undefined,
+): string {
+  const c = confidence === undefined ? 'n/a' : confidence.toFixed(2)
+  const p =
+    provenance === undefined
+      ? 'n/a'
+      : Array.isArray(provenance)
+        ? [...new Set(provenance)].join(', ')
+        : provenance
+  return `confidence: ${c} · provenance: ${p}`
+}
+
+export function formatToolResponse(input: FormatToolResponseInput): ToolResponse {
+  const sections: string[] = [input.summary.trim()]
+  if (input.block && input.block.trim().length > 0) {
+    sections.push(input.block.trimEnd())
+  }
+  sections.push(formatFooter(input.confidence, input.provenance))
+  const text = sections.join('\n\n')
+  return {
+    content: [{ type: 'text', text }],
+    ...(input.isError ? { isError: true } : {}),
+  }
+}
+
+// Convenience for the "node not found / empty graph" path. Keeps the
+// three-part shape (summary still landed) but sets the footer to n/a / n/a
+// since there's nothing to confidence-tag or provenance-tag.
+export function formatEmptyResponse(summary: string): ToolResponse {
+  return formatToolResponse({ summary })
+}
+
+// Convenience for transport / 5xx errors at the MCP boundary. isError set
+// so MCP clients route the response into their error path.
+export function formatErrorResponse(message: string): ToolResponse {
+  return formatToolResponse({ summary: message, isError: true })
+}

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,5 +1,6 @@
 // Tool implementations. Each one takes an HttpClient + the validated input and
-// returns an MCP CallToolResult (always shape `{ content: [{ type, text }] }`).
+// returns an MCP CallToolResult routed through formatToolResponse for the
+// three-part shape (NL + structured + footer) per ADR-039 / contract #12.
 // Keeping these as pure functions of (client, input) means tests don't need a
 // running server — just a stub client that returns canned JSON.
 
@@ -13,20 +14,14 @@ import type {
 } from '@neat/types'
 import { Provenance } from '@neat/types'
 import { HttpError, type HttpClient } from './client.js'
+import {
+  formatEmptyResponse,
+  formatErrorResponse,
+  formatToolResponse,
+  type ToolResponse,
+} from './format.js'
 
-export interface ToolResponse {
-  [x: string]: unknown
-  content: { type: 'text'; text: string }[]
-  isError?: boolean
-}
-
-function text(s: string): ToolResponse {
-  return { content: [{ type: 'text', text: s }] }
-}
-
-function errorText(s: string): ToolResponse {
-  return { content: [{ type: 'text', text: s }], isError: true }
-}
+export type { ToolResponse } from './format.js'
 
 // Project-aware path builder. When `project` is set, route through
 // /projects/<name>/...; otherwise hit the legacy root URL (which the core
@@ -46,9 +41,9 @@ async function withMissingNodeFallback(
     return await fn()
   } catch (err) {
     if (err instanceof HttpError && err.status === 404) {
-      return text(notFoundMessage)
+      return formatEmptyResponse(notFoundMessage)
     }
-    return errorText(`Error talking to neat-core: ${(err as Error).message}`)
+    return formatErrorResponse(`Error talking to neat-core: ${(err as Error).message}`)
   }
 }
 
@@ -71,18 +66,23 @@ export async function getRootCause(client: HttpClient, input: RootCauseInput): P
     const provenances = result.edgeProvenances.length
       ? result.edgeProvenances.join(', ')
       : '(direct, no edges traversed)'
-    const lines = [
-      `Root cause identified: ${result.rootCauseNode}.`,
-      result.rootCauseReason,
-      '',
+    const summary =
+      `Root cause for ${input.errorNode} is ${result.rootCauseNode}. ` +
+      result.rootCauseReason +
+      (result.fixRecommendation ? ` Recommended fix: ${result.fixRecommendation}.` : '')
+    const blockLines = [
       `Traversal path: ${arrowPath}`,
       `Edge provenances: ${provenances}`,
-      `Confidence: ${result.confidence.toFixed(2)}`,
     ]
     if (result.fixRecommendation) {
-      lines.push('', `Recommended fix: ${result.fixRecommendation}`)
+      blockLines.push(`Recommended fix: ${result.fixRecommendation}`)
     }
-    return text(lines.join('\n'))
+    return formatToolResponse({
+      summary,
+      block: blockLines.join('\n'),
+      confidence: result.confidence,
+      provenance: result.edgeProvenances.length ? result.edgeProvenances : undefined,
+    })
   }, `No root cause found for ${input.errorNode}. The node may be healthy, or it may not exist in the graph.`)
 }
 
@@ -105,18 +105,28 @@ export async function getBlastRadius(
   return withMissingNodeFallback(async () => {
     const result = await client.get<BlastRadiusResult>(path)
     if (result.totalAffected === 0) {
-      return text(
+      return formatEmptyResponse(
         `${result.origin} has no downstream dependencies. Nothing else would break if it failed.`,
       )
     }
     const sorted = [...result.affectedNodes].sort(
       (a, b) => a.distance - b.distance || a.nodeId.localeCompare(b.nodeId),
     )
-    const lines = [`Blast radius for ${result.origin} (${result.totalAffected} affected):`, '']
-    for (const n of sorted) {
-      lines.push(formatBlastEntry(n))
-    }
-    return text(lines.join('\n'))
+    const blockLines = sorted.map(formatBlastEntry)
+    // Worst-case confidence — the path with the lowest cascaded confidence
+    // is the headline number; agents should treat this as "what's the
+    // weakest reachability NEAT actually knows about?"
+    const minConfidence = sorted.reduce(
+      (m, n) => Math.min(m, n.confidence),
+      Number.POSITIVE_INFINITY,
+    )
+    const provenances = [...new Set(sorted.map((n) => n.edgeProvenance))]
+    return formatToolResponse({
+      summary: `Blast radius for ${result.origin}: ${result.totalAffected} affected node${result.totalAffected === 1 ? '' : 's'} reachable downstream.`,
+      block: blockLines.join('\n'),
+      confidence: Number.isFinite(minConfidence) ? minConfidence : undefined,
+      provenance: provenances.length ? provenances : undefined,
+    })
   }, `Node ${input.nodeId} not found in the graph.`)
 }
 
@@ -145,13 +155,18 @@ export async function getDependencies(
     )
     const outbound = edges.outbound
     if (outbound.length === 0) {
-      return text(`${input.nodeId} has no outgoing dependencies in the graph.`)
+      return formatEmptyResponse(`${input.nodeId} has no outgoing dependencies in the graph.`)
     }
-    const lines = [`Dependencies of ${input.nodeId}:`, '']
-    for (const e of dedupeBestProvenance(outbound)) {
-      lines.push(`  • ${e.target} — ${e.type} (${e.provenance})${edgeMeta(e)}`)
-    }
-    return text(lines.join('\n'))
+    const deduped = dedupeBestProvenance(outbound)
+    const blockLines = deduped.map(
+      (e) => `  • ${e.target} — ${e.type} (${e.provenance})${edgeMeta(e)}`,
+    )
+    const provenances = [...new Set(deduped.map((e) => e.provenance))]
+    return formatToolResponse({
+      summary: `${input.nodeId} has ${deduped.length} dependenc${deduped.length === 1 ? 'y' : 'ies'} in the graph.`,
+      block: blockLines.join('\n'),
+      provenance: provenances,
+    })
   }, `Node ${input.nodeId} not found in the graph.`)
 }
 
@@ -169,13 +184,14 @@ export async function getObservedDependencies(
       const note = hasExtracted
         ? ' Static (EXTRACTED) dependencies exist but no runtime traffic has been seen — is OTel running?'
         : ''
-      return text(`No OBSERVED dependencies for ${input.nodeId}.${note}`)
+      return formatEmptyResponse(`No OBSERVED dependencies for ${input.nodeId}.${note}`)
     }
-    const lines = [`Runtime dependencies of ${input.nodeId} (OBSERVED):`, '']
-    for (const e of observed) {
-      lines.push(`  • ${e.target} — ${e.type}${edgeMeta(e)}`)
-    }
-    return text(lines.join('\n'))
+    const blockLines = observed.map((e) => `  • ${e.target} — ${e.type}${edgeMeta(e)}`)
+    return formatToolResponse({
+      summary: `${input.nodeId} has ${observed.length} runtime dependenc${observed.length === 1 ? 'y' : 'ies'} confirmed by OTel.`,
+      block: blockLines.join('\n'),
+      provenance: Provenance.OBSERVED,
+    })
   }, `Node ${input.nodeId} not found in the graph.`)
 }
 
@@ -243,20 +259,23 @@ export async function getIncidentHistory(
       projectPath(input.project, `/incidents/${encodeURIComponent(input.nodeId)}`),
     )
     if (events.length === 0) {
-      return text(`No incidents recorded against ${input.nodeId}.`)
+      return formatEmptyResponse(`No incidents recorded against ${input.nodeId}.`)
     }
     // ndjson order is append-time = oldest first. Reverse so the most recent
     // event leads, then trim to the requested limit.
     const ordered = [...events].reverse().slice(0, input.limit ?? 20)
-    const lines = [
-      `Recent incidents on ${input.nodeId} (${ordered.length} of ${events.length}):`,
-      '',
-    ]
+    const blockLines: string[] = []
     for (const ev of ordered) {
-      lines.push(`  ${ev.timestamp} — ${ev.service}: ${ev.errorMessage}`)
-      lines.push(`    trace=${ev.traceId} span=${ev.spanId}`)
+      blockLines.push(`  ${ev.timestamp} — ${ev.service}: ${ev.errorMessage}`)
+      blockLines.push(`    trace=${ev.traceId} span=${ev.spanId}`)
     }
-    return text(lines.join('\n'))
+    return formatToolResponse({
+      summary: `${input.nodeId} has ${events.length} recorded incident${events.length === 1 ? '' : 's'}; showing the ${ordered.length} most recent.`,
+      block: blockLines.join('\n'),
+      // ErrorEvents are observation records, not graph edges — provenance is
+      // OBSERVED by definition (the OTel span happened).
+      provenance: Provenance.OBSERVED,
+    })
   }, `Node ${input.nodeId} not found in the graph.`)
 }
 
@@ -280,25 +299,31 @@ export async function semanticSearch(
       projectPath(input.project, `/search?q=${encodeURIComponent(input.query)}`),
     )
     if (result.matches.length === 0) {
-      return text(`No matches for "${input.query}".`)
+      return formatEmptyResponse(`No matches for "${input.query}".`)
     }
     const provider = result.provider ?? 'substring'
-    const lines = [
-      `Search results for "${input.query}" (${provider}):`,
-      '',
-    ]
+    const blockLines: string[] = []
+    let topScore: number | undefined
     for (const n of result.matches) {
       // Embedding tiers attach a cosine score in [0,1]; substring fallback
       // doesn't, so we elide the score when it's the placeholder 1.
-      const scoreBit =
-        provider !== 'substring' && typeof n.score === 'number'
-          ? ` [score=${n.score.toFixed(2)}]`
-          : ''
-      lines.push(`  • ${n.id} (${n.type}) — ${(n as { name?: string }).name ?? n.id}${scoreBit}`)
+      const score = provider !== 'substring' && typeof n.score === 'number' ? n.score : undefined
+      const scoreBit = score !== undefined ? ` [score=${score.toFixed(2)}]` : ''
+      if (score !== undefined && (topScore === undefined || score > topScore)) topScore = score
+      blockLines.push(
+        `  • ${n.id} (${n.type}) — ${(n as { name?: string }).name ?? n.id}${scoreBit}`,
+      )
     }
-    return text(lines.join('\n'))
+    return formatToolResponse({
+      summary: `Found ${result.matches.length} match${result.matches.length === 1 ? '' : 'es'} for "${input.query}" via ${provider} provider.`,
+      block: blockLines.join('\n'),
+      // Top similarity score doubles as a "how confident is the embedder
+      // about the best match" signal. Substring provider returns no score —
+      // the footer shows n/a in that case.
+      confidence: topScore,
+    })
   } catch (err) {
-    return errorText(`Error talking to neat-core: ${(err as Error).message}`)
+    return formatErrorResponse(`Error talking to neat-core: ${(err as Error).message}`)
   }
 }
 
@@ -338,49 +363,55 @@ export async function getGraphDiff(
       result.changed.edges.length
     const baseLabel = result.base.exportedAt ?? 'unknown'
     if (total === 0) {
-      return text(
+      return formatEmptyResponse(
         `No differences between the current graph and ${input.againstSnapshot} (base exportedAt=${baseLabel}).`,
       )
     }
-    const lines = [
-      `Diff against ${input.againstSnapshot}:`,
+    const blockLines: string[] = [
       `  base exportedAt:    ${baseLabel}`,
       `  current exportedAt: ${result.current.exportedAt}`,
       '',
     ]
     if (result.added.nodes.length || result.added.edges.length) {
-      lines.push('Added:')
-      for (const n of result.added.nodes) lines.push(`  + node ${n.id} (${n.type})`)
+      blockLines.push('Added:')
+      for (const n of result.added.nodes) blockLines.push(`  + node ${n.id} (${n.type})`)
       for (const e of result.added.edges)
-        lines.push(`  + edge ${e.id} — ${e.source} -> ${e.target} (${e.type}, ${e.provenance})`)
-      lines.push('')
+        blockLines.push(`  + edge ${e.id} — ${e.source} -> ${e.target} (${e.type}, ${e.provenance})`)
+      blockLines.push('')
     }
     if (result.removed.nodes.length || result.removed.edges.length) {
-      lines.push('Removed:')
-      for (const n of result.removed.nodes) lines.push(`  - node ${n.id} (${n.type})`)
+      blockLines.push('Removed:')
+      for (const n of result.removed.nodes) blockLines.push(`  - node ${n.id} (${n.type})`)
       for (const e of result.removed.edges)
-        lines.push(`  - edge ${e.id} — ${e.source} -> ${e.target} (${e.type}, ${e.provenance})`)
-      lines.push('')
+        blockLines.push(`  - edge ${e.id} — ${e.source} -> ${e.target} (${e.type}, ${e.provenance})`)
+      blockLines.push('')
     }
     if (result.changed.nodes.length || result.changed.edges.length) {
-      lines.push('Changed:')
+      blockLines.push('Changed:')
       for (const c of result.changed.nodes) {
-        lines.push(`  ~ node ${c.id} — ${summariseAttrDiff(c.before, c.after)}`)
+        blockLines.push(`  ~ node ${c.id} — ${summariseAttrDiff(c.before, c.after)}`)
       }
       for (const c of result.changed.edges) {
         const provBit =
           c.before.provenance !== c.after.provenance
             ? `provenance ${c.before.provenance} → ${c.after.provenance}`
             : summariseAttrDiff(c.before, c.after)
-        lines.push(`  ~ edge ${c.id} — ${provBit}`)
+        blockLines.push(`  ~ edge ${c.id} — ${provBit}`)
       }
     }
-    return text(lines.join('\n').trimEnd())
+    return formatToolResponse({
+      summary: `Diff against ${input.againstSnapshot}: ${total} change${total === 1 ? '' : 's'} between the snapshot and the live graph.`,
+      block: blockLines.join('\n').trimEnd(),
+      // Diff results don't have a per-result provenance — the diff spans
+      // every edge type and provenance kind. Footer shows n/a.
+    })
   } catch (err) {
     if (err instanceof HttpError && err.status === 400) {
-      return errorText(`Could not load snapshot ${input.againstSnapshot}: ${err.message}`)
+      return formatErrorResponse(
+        `Could not load snapshot ${input.againstSnapshot}: ${err.message}`,
+      )
     }
-    return errorText(`Error talking to neat-core: ${(err as Error).message}`)
+    return formatErrorResponse(`Error talking to neat-core: ${(err as Error).message}`)
   }
 }
 
@@ -429,21 +460,24 @@ export async function getRecentStaleEdges(
       projectPath(input.project, `/incidents/stale${qs}`),
     )
     if (events.length === 0) {
-      return text(
+      return formatEmptyResponse(
         input.edgeType
           ? `No stale ${input.edgeType} edges recorded.`
           : 'No stale-edge transitions recorded yet.',
       )
     }
-    const lines = [`Recent stale-edge transitions (${events.length}):`, '']
-    for (const e of events) {
-      lines.push(
+    const blockLines = events.map(
+      (e) =>
         `  ${e.transitionedAt} — ${e.source} -[${e.edgeType}]-> ${e.target}` +
-          ` (last seen ${e.lastObserved}, threshold ${formatDuration(e.thresholdMs)})`,
-      )
-    }
-    return text(lines.join('\n'))
+        ` (last seen ${e.lastObserved}, threshold ${formatDuration(e.thresholdMs)})`,
+    )
+    return formatToolResponse({
+      summary: `${events.length} stale-edge transition${events.length === 1 ? '' : 's'} recorded${input.edgeType ? ` for ${input.edgeType}` : ''}.`,
+      block: blockLines.join('\n'),
+      // STALE by definition — every event is a transition into STALE.
+      provenance: Provenance.STALE,
+    })
   } catch (err) {
-    return errorText(`Error talking to neat-core: ${(err as Error).message}`)
+    return formatErrorResponse(`Error talking to neat-core: ${(err as Error).message}`)
   }
 }

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -66,11 +66,13 @@ describe('getRootCause', () => {
     const res = await getRootCause(client, { errorNode: 'database:payments-db' })
     expect(res.isError).toBeFalsy()
     const text = res.content[0].text
-    expect(text).toContain('Root cause identified: service:service-b')
+    // Three-part response per ADR-039: summary + block + footer.
+    expect(text).toContain('Root cause for database:payments-db is service:service-b')
     expect(text).toContain('database:payments-db ← service:service-b ← service:service-a')
-    expect(text).toContain('Confidence: 1.00')
     expect(text).toContain('OBSERVED, OBSERVED')
     expect(text).toContain('Recommended fix: Upgrade service-b pg driver to >= 8.0.0')
+    // Footer: confidence as decimal, provenance unique values.
+    expect(text).toMatch(/confidence: 1\.00 · provenance: OBSERVED/)
     expect(capture.paths).toEqual(['/traverse/root-cause/database%3Apayments-db'])
   })
 
@@ -127,13 +129,15 @@ describe('getBlastRadius', () => {
       },
     })
     const res = await getBlastRadius(client, { nodeId: 'service:service-a' })
-    const lines = res.content[0].text.split('\n')
-    expect(lines[0]).toContain('Blast radius for service:service-a (2 affected)')
+    const text = res.content[0].text
+    expect(text).toContain('Blast radius for service:service-a: 2 affected nodes')
     // service-b at distance 1 should appear before payments-db at distance 2
+    const lines = text.split('\n')
     const bIdx = lines.findIndex((l) => l.includes('service:service-b'))
     const dbIdx = lines.findIndex((l) => l.includes('database:payments-db'))
     expect(bIdx).toBeGreaterThan(0)
     expect(dbIdx).toBeGreaterThan(bIdx)
+    expect(text).toMatch(/provenance: OBSERVED/)
   })
 
   it('flags STALE edges explicitly', async () => {
@@ -207,11 +211,12 @@ describe('getDependencies', () => {
     })
     const res = await getDependencies(client, { nodeId: 'service:service-a' })
     const text = res.content[0].text
-    expect(text).toContain('Dependencies of service:service-a')
+    expect(text).toContain('service:service-a has 1 dependency')
     expect(text).toContain('service:service-b — CALLS (OBSERVED)')
     expect(text).toContain('callCount=11')
     // The EXTRACTED twin should be deduped out.
     expect(text.split('\n').filter((l) => l.includes('service:service-b'))).toHaveLength(1)
+    expect(text).toMatch(/provenance: OBSERVED/)
   })
 
   it('returns a friendly message when there are no outgoing edges', async () => {
@@ -274,9 +279,10 @@ describe('getObservedDependencies', () => {
     })
     const res = await getObservedDependencies(client, { nodeId: 'service:service-a' })
     const text = res.content[0].text
-    expect(text).toContain('Runtime dependencies of service:service-a')
+    expect(text).toContain('service:service-a has 1 runtime dependency confirmed by OTel')
     expect(text).toContain('service:service-b')
     expect(text).toContain('lastObserved=2026-05-01T15:51:11.967Z')
+    expect(text).toMatch(/provenance: OBSERVED/)
   })
 
   it('explains the OTel-down case when only EXTRACTED edges exist', async () => {
@@ -325,7 +331,8 @@ describe('getIncidentHistory', () => {
     })
     const res = await getIncidentHistory(client, { nodeId: 'database:payments-db' })
     const text = res.content[0].text
-    expect(text).toContain('Recent incidents on database:payments-db (2 of 2)')
+    expect(text).toContain('database:payments-db has 2 recorded incidents')
+    expect(text).toContain('showing the 2 most recent')
     const newerIdx = text.indexOf('SCRAM')
     const olderIdx = text.indexOf('older')
     expect(newerIdx).toBeGreaterThan(0)
@@ -345,7 +352,8 @@ describe('getIncidentHistory', () => {
     }))
     const { client } = clientFor({ '/incidents/database:payments-db': events })
     const res = await getIncidentHistory(client, { nodeId: 'database:payments-db', limit: 2 })
-    expect(res.content[0].text).toContain('(2 of 5)')
+    expect(res.content[0].text).toContain('has 5 recorded incidents')
+    expect(res.content[0].text).toContain('showing the 2 most recent')
   })
 
   it('returns a friendly message for an empty list', async () => {
@@ -510,9 +518,10 @@ describe('getRecentStaleEdges', () => {
     })
     const res = await getRecentStaleEdges(client, {})
     const out = res.content[0].text
-    expect(out).toContain('Recent stale-edge transitions (2)')
+    expect(out).toContain('2 stale-edge transitions recorded')
     expect(out).toContain('service:b -[CONNECTS_TO]-> database:c')
     expect(out).toContain('service:a -[CALLS]-> service:b')
+    expect(out).toMatch(/provenance: STALE/)
     expect(capture.paths[0]).toBe('/incidents/stale')
   })
 


### PR DESCRIPTION
## Summary

New \`packages/mcp/src/format.ts\` exports \`formatToolResponse\` per ADR-039 / contract #12. Output:

\`\`\`
{summary — NL paragraph}

{block — formatted typed payload}

confidence: 0.94 · provenance: OBSERVED
\`\`\`

Empty-result footer reads \`confidence: n/a · provenance: n/a\`. Two convenience exports — \`formatEmptyResponse\` and \`formatErrorResponse\` — cover the common no-result and transport-error paths so tool bodies don't reconstruct the shape ad-hoc.

## Retrofit — all 8 tools

| Tool | Confidence | Provenance |
|------|------------|------------|
| \`get_root_cause\` | from \`RootCauseResult.confidence\` | unique values from \`edgeProvenances\` |
| \`get_blast_radius\` | worst-case (min) across affected nodes' cascaded confidences | unique values from \`edgeProvenance\` entries |
| \`get_dependencies\` | n/a (per-edge signal in the block) | unique values from deduped edges |
| \`get_observed_dependencies\` | n/a | OBSERVED (by definition) |
| \`get_incident_history\` | n/a | OBSERVED (events are recorded span observations) |
| \`semantic_search\` | top similarity score when the embedder provider returns one; n/a for substring fallback | n/a |
| \`get_graph_diff\` | n/a | n/a (diff spans every edge type and provenance) |
| \`get_recent_stale_edges\` | n/a | STALE (by definition) |

## Test changes

Existing \`packages/mcp/test/tools.test.ts\` assertions updated to match the new shape. Same data, framed differently — no test was checking behaviour that the new format breaks.

## Contract assertions flipped

In \`packages/core/test/audits/contracts.test.ts\`:

- ✅ \`formatToolResponse helper exists at mcp/src/format.ts\` (#143)
- ✅ \`MCP tools emit standardized three-part response\` (#143) — static scan: every tool body imports from \`./format.js\`, every body uses one of the three helpers, no raw \`return text(...)\` stragglers.

299 contract assertions passing (was 297), 20 todos remaining (was 22).

## Test plan

- [x] \`npx turbo build\` clean
- [x] \`npx turbo test\` — all 5 packages green; mcp 35 pass, core 299 pass / 20 todo
- [x] No regressions in \`packages/mcp/test/tools.test.ts\` (assertions updated for the new format).

Refs ADR-039, #143