### PR TITLE
Transitive get_dependencies — new core endpoint + MCP tool rewrite

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -9,7 +9,13 @@ import type { NeatGraph } from './graph.js'
 import { DEFAULT_PROJECT } from './graph.js'
 import { extractFromDirectory } from './extract.js'
 import { readErrorEvents, readStaleEvents } from './ingest.js'
-import { getBlastRadius, getRootCause } from './traverse.js'
+import {
+  getBlastRadius,
+  getRootCause,
+  getTransitiveDependencies,
+  TRANSITIVE_DEPENDENCIES_DEFAULT_DEPTH,
+  TRANSITIVE_DEPENDENCIES_MAX_DEPTH,
+} from './traverse.js'
 import { computeGraphDiff, loadSnapshotForDiff } from './diff.js'
 import type { SearchIndex } from './search.js'
 import type { Projects, ProjectContext } from './projects.js'
@@ -159,6 +165,28 @@ function registerRoutes(scope: FastifyInstance, ctx: RouteContext): void {
       return { inbound, outbound }
     },
   )
+
+  // Transitive dependencies (issue #144). BFS outbound to depth N, returning
+  // a flat list with distance + edgeType + provenance per dependency.
+  // Default depth 3, max 10. The MCP get_dependencies tool calls this.
+  scope.get<{
+    Params: { project?: string; id: string }
+    Querystring: { depth?: string }
+  }>('/graph/node/:id/dependencies', async (req, reply) => {
+    const proj = resolveProject(registry, req, reply)
+    if (!proj) return
+    const { id } = req.params
+    if (!proj.graph.hasNode(id)) {
+      return reply.code(404).send({ error: 'node not found', id })
+    }
+    const depth = req.query.depth ? Number(req.query.depth) : TRANSITIVE_DEPENDENCIES_DEFAULT_DEPTH
+    if (!Number.isFinite(depth) || depth < 1 || depth > TRANSITIVE_DEPENDENCIES_MAX_DEPTH) {
+      return reply.code(400).send({
+        error: `depth must be an integer in [1, ${TRANSITIVE_DEPENDENCIES_MAX_DEPTH}]`,
+      })
+    }
+    return getTransitiveDependencies(proj.graph, id, depth)
+  })
 
   scope.get<{ Params: { project?: string } }>('/incidents', async (req, reply) => {
     const proj = resolveProject(registry, req, reply)

--- a/packages/core/src/traverse.ts
+++ b/packages/core/src/traverse.ts
@@ -7,6 +7,8 @@ import type {
   GraphNode,
   RootCauseResult,
   ServiceNode,
+  TransitiveDependenciesResult,
+  TransitiveDependency,
 } from '@neat/types'
 import {
   BlastRadiusResultSchema,
@@ -14,6 +16,7 @@ import {
   PROV_RANK,
   Provenance,
   RootCauseResultSchema,
+  TransitiveDependenciesResultSchema,
 } from '@neat/types'
 import type { NeatGraph } from './graph.js'
 import {
@@ -403,5 +406,74 @@ export function getBlastRadius(
     origin: nodeId,
     affectedNodes,
     totalAffected: affectedNodes.length,
+  })
+}
+
+// Default + max depth for transitive get_dependencies (issue #144). Default
+// 3 keeps the output legible at the agent layer; the contract caps the
+// caller-supplied value at 10 to prevent BFS blow-up on dense graphs.
+export const TRANSITIVE_DEPENDENCIES_DEFAULT_DEPTH = 3
+export const TRANSITIVE_DEPENDENCIES_MAX_DEPTH = 10
+
+// Transitive get_dependencies (ADR-039 / #144). BFS outbound from origin to
+// `depth` hops, returning a flat list with distance, edgeType, and provenance
+// per dependency. Origin is never in the list. Direct-only consumers pass
+// depth=1; the MCP get_dependencies tool defaults to 3.
+//
+// Reuses bestEdgeByTarget (FRONTIER filtered, PROV_RANK-best per pair) so
+// dedup behavior matches the rest of traversal. Result is schema-validated
+// before return per ADR-036 §Result schema validation.
+export function getTransitiveDependencies(
+  graph: NeatGraph,
+  nodeId: string,
+  depth: number = TRANSITIVE_DEPENDENCIES_DEFAULT_DEPTH,
+): TransitiveDependenciesResult {
+  if (!graph.hasNode(nodeId)) {
+    return TransitiveDependenciesResultSchema.parse({
+      origin: nodeId,
+      depth,
+      dependencies: [],
+      total: 0,
+    })
+  }
+
+  interface Frame {
+    nodeId: string
+    distance: number
+    edge: GraphEdge | null
+  }
+
+  const seen = new Map<string, TransitiveDependency>()
+  const queue: Frame[] = [{ nodeId, distance: 0, edge: null }]
+  const enqueued = new Set<string>([nodeId])
+
+  while (queue.length > 0) {
+    const frame = queue.shift()!
+    if (frame.distance > 0 && frame.edge) {
+      seen.set(frame.nodeId, {
+        nodeId: frame.nodeId,
+        distance: frame.distance,
+        edgeType: frame.edge.type,
+        provenance: frame.edge.provenance,
+      })
+    }
+    if (frame.distance >= depth) continue
+
+    const outgoing = bestEdgeByTarget(graph, graph.outboundEdges(frame.nodeId))
+    for (const [tgtId, edge] of outgoing) {
+      if (enqueued.has(tgtId)) continue
+      enqueued.add(tgtId)
+      queue.push({ nodeId: tgtId, distance: frame.distance + 1, edge })
+    }
+  }
+
+  const dependencies = [...seen.values()].sort(
+    (a, b) => a.distance - b.distance || a.nodeId.localeCompare(b.nodeId),
+  )
+  return TransitiveDependenciesResultSchema.parse({
+    origin: nodeId,
+    depth,
+    dependencies,
+    total: dependencies.length,
   })
 }

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -1565,7 +1565,13 @@ describe('MCP tool surface contract (ADR-039)', () => {
     // Empty-result footer reads n/a / n/a per the contract.
     expect(content).toMatch(/n\/a/)
   })
-  it.todo('get_dependencies is transitive — calls /graph/node/:id/dependencies?depth=N (issue #144)')
+  it('get_dependencies is transitive — calls /graph/node/:id/dependencies?depth=N (issue #144)', () => {
+    const tools = readFileSync(join(MCP_SRC, 'tools.ts'), 'utf8')
+    expect(tools).toMatch(/\/graph\/node\/[^`'"\s]*dependencies\?depth=/)
+    // The old direct-only path is gone — getDependencies must not call
+    // /graph/edges/:id anymore.
+    expect(tools).not.toMatch(/getDependencies[\s\S]{0,500}\/graph\/edges/)
+  })
   it.todo('check_policies tool registered with optional hypotheticalAction (v0.2.4 #117)')
 })
 
@@ -1575,7 +1581,13 @@ describe('MCP tool surface contract (ADR-039)', () => {
 describe('REST API contract (ADR-040)', () => {
   it.todo('every read endpoint mounts at both /X and /projects/:project/X')
   it.todo('error responses are JSON-shaped { error, status, details? }')
-  it.todo('GET /graph/node/:id/dependencies?depth=N exists (issue #144)')
+  it('GET /graph/node/:id/dependencies?depth=N exists (issue #144)', () => {
+    const api = readFileSync(join(CORE_SRC, 'api.ts'), 'utf8')
+    expect(api).toMatch(/['"]\/graph\/node\/:id\/dependencies['"]/)
+    // Default 3, max 10 per the contract.
+    expect(api).toMatch(/TRANSITIVE_DEPENDENCIES_DEFAULT_DEPTH/)
+    expect(api).toMatch(/TRANSITIVE_DEPENDENCIES_MAX_DEPTH/)
+  })
   it.todo('POST endpoints validate inbound bodies with Zod schemas from @neat/types')
   it.todo('GET /policies and /policies/violations exist (v0.2.4 #117)')
 })
@@ -1950,6 +1962,31 @@ describe('Queued contracts (issues #140-#145)', () => {
     // No raw `return text(...)` stragglers that bypass the helper.
     expect(tools).not.toMatch(/return\s+text\s*\(/)
   })
-  it.todo('get_dependencies is transitive (issue #144)')
+  it('get_dependencies is transitive (issue #144)', async () => {
+    // End-to-end shape check: getTransitiveDependencies returns a flat list
+    // with distance + edgeType + provenance. Zod validates the shape on
+    // return; this assertion exercises the schema-validation path too.
+    const { getTransitiveDependencies } = await import('../../src/traverse.js')
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:a', { id: 'service:a', type: NodeType.ServiceNode, name: 'a', language: 'javascript' })
+    g.addNode('service:b', { id: 'service:b', type: NodeType.ServiceNode, name: 'b', language: 'javascript' })
+    g.addNode('service:c', { id: 'service:c', type: NodeType.ServiceNode, name: 'c', language: 'javascript' })
+    const ab = `${EdgeType.CALLS}:service:a->service:b`
+    g.addEdgeWithKey(ab, 'service:a', 'service:b', {
+      id: ab, source: 'service:a', target: 'service:b',
+      type: EdgeType.CALLS, provenance: Provenance.OBSERVED,
+      lastObserved: '2026-05-06T00:00:00.000Z', callCount: 1, confidence: 1.0,
+    })
+    const bc = `${EdgeType.CALLS}:service:b->service:c`
+    g.addEdgeWithKey(bc, 'service:b', 'service:c', {
+      id: bc, source: 'service:b', target: 'service:c',
+      type: EdgeType.CALLS, provenance: Provenance.EXTRACTED,
+    })
+    const result = getTransitiveDependencies(g, 'service:a', 3)
+    expect(result.total).toBe(2)
+    expect(result.dependencies[0]!.distance).toBe(1)
+    expect(result.dependencies[1]!.distance).toBe(2)
+    expect(result.dependencies[0]!.edgeType).toBe(EdgeType.CALLS)
+  })
   it.todo('Drop unused graphology-traversal/-shortest-path deps (issue #145)')
 })

--- a/packages/core/test/audits/schema-snapshot.test.ts
+++ b/packages/core/test/audits/schema-snapshot.test.ts
@@ -31,6 +31,7 @@ import {
   PolicyViolationSchema,
   ProvenanceSchema,
   RootCauseResultSchema,
+  TransitiveDependenciesResultSchema,
 } from '@neat/types'
 
 const SNAPSHOT_PATH = join(__dirname, 'schemas.snapshot.json')
@@ -47,6 +48,7 @@ const BINDING_SCHEMAS: Record<string, z.ZodTypeAny> = {
   ErrorEventSchema,
   RootCauseResultSchema,
   BlastRadiusResultSchema,
+  TransitiveDependenciesResultSchema,
   PolicyFileSchema,
   PolicyViolationSchema,
 }

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -684,5 +684,55 @@
         "_array": "_string"
       }
     }
+  },
+  "TransitiveDependenciesResultSchema": {
+    "_object": {
+      "dependencies": {
+        "_array": {
+          "_object": {
+            "distance": {
+              "_number": [
+                "int",
+                "min"
+              ]
+            },
+            "edgeType": {
+              "_enum": [
+                "CALLS",
+                "CONFIGURED_BY",
+                "CONNECTS_TO",
+                "CONSUMES_FROM",
+                "DEPENDS_ON",
+                "PUBLISHES_TO",
+                "RUNS_ON"
+              ]
+            },
+            "nodeId": "_string",
+            "provenance": {
+              "_enum": [
+                "EXTRACTED",
+                "FRONTIER",
+                "INFERRED",
+                "OBSERVED",
+                "STALE"
+              ]
+            }
+          }
+        }
+      },
+      "depth": {
+        "_number": [
+          "int",
+          "min"
+        ]
+      },
+      "origin": "_string",
+      "total": {
+        "_number": [
+          "int",
+          "min"
+        ]
+      }
+    }
   }
 }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -74,9 +74,16 @@ server.tool(
 
 server.tool(
   'get_dependencies',
-  'List the outgoing dependencies of a node — both static (EXTRACTED from source) and runtime (OBSERVED via OTel), de-duplicated to the most trustworthy provenance per pair.',
+  'List the transitive outgoing dependencies of a node, BFS to depth N (default 3, max 10). Each result carries distance, edge type, and provenance — both static (EXTRACTED) and runtime (OBSERVED). Pass depth=1 for direct-only.',
   {
     nodeId: z.string().describe('Graph node id to inspect'),
+    depth: z
+      .number()
+      .int()
+      .min(1)
+      .max(10)
+      .optional()
+      .describe('BFS depth (default 3, max 10). depth=1 returns direct dependencies only.'),
     project: projectField,
   },
   async (input) => getDependencies(client, { ...input, project: projectFor(input) }),

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -11,6 +11,7 @@ import type {
   GraphEdge,
   GraphNode,
   RootCauseResult,
+  TransitiveDependenciesResult,
 } from '@neat/types'
 import { Provenance } from '@neat/types'
 import { HttpError, type HttpClient } from './client.js'
@@ -142,28 +143,58 @@ interface EdgesResponse {
 
 export interface DependenciesInput {
   nodeId: string
+  // BFS depth. Default 3; max 10. Direct-only consumers pass 1.
+  depth?: number
   project?: string
 }
 
+// Transitive get_dependencies (issue #144). Calls the new core endpoint
+// /graph/node/:id/dependencies?depth=N which BFS-walks outbound. The output
+// groups results by hop so direct dependencies stand out from transitives —
+// agents asked "what does X depend on?" usually want the direct list with
+// transitives as context.
 export async function getDependencies(
   client: HttpClient,
   input: DependenciesInput,
 ): Promise<ToolResponse> {
+  const depth = input.depth ?? 3
+  const path = projectPath(
+    input.project,
+    `/graph/node/${encodeURIComponent(input.nodeId)}/dependencies?depth=${depth}`,
+  )
+
   return withMissingNodeFallback(async () => {
-    const edges = await client.get<EdgesResponse>(
-      projectPath(input.project, `/graph/edges/${encodeURIComponent(input.nodeId)}`),
-    )
-    const outbound = edges.outbound
-    if (outbound.length === 0) {
-      return formatEmptyResponse(`${input.nodeId} has no outgoing dependencies in the graph.`)
+    const result = await client.get<TransitiveDependenciesResult>(path)
+    if (result.total === 0) {
+      return formatEmptyResponse(
+        depth === 1
+          ? `${input.nodeId} has no direct dependencies in the graph.`
+          : `${input.nodeId} has no dependencies (BFS to depth ${depth}).`,
+      )
     }
-    const deduped = dedupeBestProvenance(outbound)
-    const blockLines = deduped.map(
-      (e) => `  • ${e.target} — ${e.type} (${e.provenance})${edgeMeta(e)}`,
-    )
-    const provenances = [...new Set(deduped.map((e) => e.provenance))]
+    // Group by distance so the structured block reads as concentric rings.
+    const byDistance = new Map<number, typeof result.dependencies>()
+    for (const dep of result.dependencies) {
+      const ring = byDistance.get(dep.distance) ?? []
+      ring.push(dep)
+      byDistance.set(dep.distance, ring)
+    }
+    const blockLines: string[] = []
+    for (const distance of [...byDistance.keys()].sort((a, b) => a - b)) {
+      const label = distance === 1 ? 'Direct (distance 1)' : `Distance ${distance}`
+      blockLines.push(`${label}:`)
+      for (const dep of byDistance.get(distance)!) {
+        blockLines.push(`  • ${dep.nodeId} — ${dep.edgeType} (${dep.provenance})`)
+      }
+    }
+    const provenances = [...new Set(result.dependencies.map((d) => d.provenance))]
+    const directCount = byDistance.get(1)?.length ?? 0
+    const summary =
+      depth === 1
+        ? `${input.nodeId} has ${directCount} direct dependenc${directCount === 1 ? 'y' : 'ies'}.`
+        : `${input.nodeId} has ${result.total} dependenc${result.total === 1 ? 'y' : 'ies'} reachable to depth ${depth} (${directCount} direct).`
     return formatToolResponse({
-      summary: `${input.nodeId} has ${deduped.length} dependenc${deduped.length === 1 ? 'y' : 'ies'} in the graph.`,
+      summary,
       block: blockLines.join('\n'),
       provenance: provenances,
     })
@@ -222,26 +253,6 @@ function formatDuration(ms: number): string {
   const h = Math.round(m / 60)
   if (h < 48) return `${h}h`
   return `${Math.round(h / 24)}d`
-}
-
-// Two services can have an EXTRACTED edge AND an OBSERVED edge AND an INFERRED
-// edge between the same pair. For "dependencies" output we want one line per
-// (target, type), preferring the most-trustworthy provenance.
-function dedupeBestProvenance(edges: GraphEdge[]): GraphEdge[] {
-  const rank: Record<string, number> = {
-    OBSERVED: 3,
-    INFERRED: 2,
-    EXTRACTED: 1,
-    STALE: 0,
-    FRONTIER: 0,
-  }
-  const best = new Map<string, GraphEdge>()
-  for (const e of edges) {
-    const key = `${e.target}|${e.type}`
-    const cur = best.get(key)
-    if (!cur || rank[e.provenance] > rank[cur.provenance]) best.set(key, e)
-  }
-  return [...best.values()]
 }
 
 export interface IncidentHistoryInput {

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -184,70 +184,70 @@ describe('getBlastRadius', () => {
 })
 
 describe('getDependencies', () => {
-  it('returns outgoing edges with the best provenance per pair', async () => {
+  it('returns transitive dependencies grouped by distance with best provenance per pair (#144)', async () => {
     const { client } = clientFor({
-      '/graph/edges/service:service-a': {
-        inbound: [],
-        outbound: [
+      '/graph/node/service:service-a/dependencies?depth=3': {
+        origin: 'service:service-a',
+        depth: 3,
+        total: 2,
+        dependencies: [
           {
-            id: 'CALLS:service:service-a->service:service-b',
-            source: 'service:service-a',
-            target: 'service:service-b',
-            type: EdgeType.CALLS,
-            provenance: Provenance.EXTRACTED,
+            nodeId: 'service:service-b',
+            distance: 1,
+            edgeType: EdgeType.CALLS,
+            provenance: Provenance.OBSERVED,
           },
           {
-            id: 'CALLS:OBSERVED:service:service-a->service:service-b',
-            source: 'service:service-a',
-            target: 'service:service-b',
-            type: EdgeType.CALLS,
-            provenance: Provenance.OBSERVED,
-            confidence: 1,
-            callCount: 11,
-            lastObserved: '2026-05-01T15:51:11.967Z',
+            nodeId: 'database:payments-db',
+            distance: 2,
+            edgeType: EdgeType.CONNECTS_TO,
+            provenance: Provenance.EXTRACTED,
           },
         ],
       },
     })
     const res = await getDependencies(client, { nodeId: 'service:service-a' })
     const text = res.content[0].text
-    expect(text).toContain('service:service-a has 1 dependency')
+    expect(text).toContain('service:service-a has 2 dependencies reachable to depth 3 (1 direct)')
+    expect(text).toContain('Direct (distance 1):')
     expect(text).toContain('service:service-b — CALLS (OBSERVED)')
-    expect(text).toContain('callCount=11')
-    // The EXTRACTED twin should be deduped out.
-    expect(text.split('\n').filter((l) => l.includes('service:service-b'))).toHaveLength(1)
-    expect(text).toMatch(/provenance: OBSERVED/)
+    expect(text).toContain('Distance 2:')
+    expect(text).toContain('database:payments-db — CONNECTS_TO (EXTRACTED)')
+    expect(text).toMatch(/provenance: OBSERVED, EXTRACTED|provenance: EXTRACTED, OBSERVED/)
   })
 
-  it('returns a friendly message when there are no outgoing edges', async () => {
+  it('returns a friendly message when there are no dependencies', async () => {
     const { client } = clientFor({
-      '/graph/edges/database:payments-db': { inbound: [], outbound: [] },
+      '/graph/node/database:payments-db/dependencies?depth=3': {
+        origin: 'database:payments-db',
+        depth: 3,
+        total: 0,
+        dependencies: [],
+      },
     })
     const res = await getDependencies(client, { nodeId: 'database:payments-db' })
-    expect(res.content[0].text).toContain('no outgoing dependencies')
+    expect(res.content[0].text).toContain('no dependencies')
   })
 
-  it('surfaces signal numbers (spans, errors, age) when the edge carries them', async () => {
-    const { client } = clientFor({
-      '/graph/edges/service:service-a': {
-        inbound: [],
-        outbound: [
+  it('depth=1 returns direct dependencies only', async () => {
+    const { client, capture } = clientFor({
+      '/graph/node/service:service-a/dependencies?depth=1': {
+        origin: 'service:service-a',
+        depth: 1,
+        total: 1,
+        dependencies: [
           {
-            id: 'CALLS:OBSERVED:service:service-a->service:service-b',
-            source: 'service:service-a',
-            target: 'service:service-b',
-            type: EdgeType.CALLS,
+            nodeId: 'service:service-b',
+            distance: 1,
+            edgeType: EdgeType.CALLS,
             provenance: Provenance.OBSERVED,
-            signal: { spanCount: 1247, errorCount: 3, lastObservedAgeMs: 5000 },
           },
         ],
       },
     })
-    const res = await getDependencies(client, { nodeId: 'service:service-a' })
-    const out = res.content[0].text
-    expect(out).toContain('spans=1247')
-    expect(out).toContain('errors=3')
-    expect(out).toContain('age=5s')
+    const res = await getDependencies(client, { nodeId: 'service:service-a', depth: 1 })
+    expect(capture.paths[0]).toBe('/graph/node/service%3Aservice-a/dependencies?depth=1')
+    expect(res.content[0].text).toContain('service:service-a has 1 direct dependency')
   })
 })
 
@@ -557,6 +557,12 @@ describe('project routing', () => {
         affectedNodes: [],
       },
       '/projects/alpha/graph/edges/service:a': { inbound: [], outbound: [] },
+      '/projects/alpha/graph/node/service:a/dependencies?depth=3': {
+        origin: 'service:a',
+        depth: 3,
+        total: 0,
+        dependencies: [],
+      },
       '/projects/alpha/incidents/service:a': [],
       '/projects/alpha/search?q=foo': { query: 'foo', provider: 'substring', matches: [] },
       '/projects/alpha/graph/diff?against=snap.json': {

--- a/packages/types/src/results.ts
+++ b/packages/types/src/results.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { ProvenanceSchema } from './edges.js'
+import { ProvenanceSchema, EdgeTypeSchema } from './edges.js'
 
 export const RootCauseResultSchema = z.object({
   rootCauseNode: z.string(),
@@ -35,3 +35,28 @@ export const BlastRadiusResultSchema = z.object({
   totalAffected: z.number().int().nonnegative(),
 })
 export type BlastRadiusResult = z.infer<typeof BlastRadiusResultSchema>
+
+// Transitive get_dependencies (issue #144). Flat list with distance, edge
+// type, and provenance per dependency. Sibling shape to BlastRadius but
+// thinner — no path tracking, no confidence cascade. Use cases live in the
+// MCP get_dependencies tool ("what does X depend on, transitively?").
+export const TransitiveDependencySchema = z.object({
+  nodeId: z.string(),
+  // Distance from the origin in BFS hops. The origin itself is never in
+  // dependencies, so distance is positive (>= 1).
+  distance: z.number().int().positive(),
+  // Type of the edge that brought traversal to this node (CALLS,
+  // CONNECTS_TO, DEPENDS_ON, etc.).
+  edgeType: EdgeTypeSchema,
+  // Provenance of that edge.
+  provenance: ProvenanceSchema,
+})
+export type TransitiveDependency = z.infer<typeof TransitiveDependencySchema>
+
+export const TransitiveDependenciesResultSchema = z.object({
+  origin: z.string(),
+  depth: z.number().int().positive(),
+  dependencies: z.array(TransitiveDependencySchema),
+  total: z.number().int().nonnegative(),
+})
+export type TransitiveDependenciesResult = z.infer<typeof TransitiveDependenciesResultSchema>


### PR DESCRIPTION
## Summary

Adds \`GET /graph/node/:id/dependencies?depth=N\` per ADR-039 §Transitive get_dependencies + ADR-040. BFS outbound from the node id, returning a flat list with \`{nodeId, distance, edgeType, provenance}\` per dependency. Default depth 3, max 10. Direct-only consumers pass \`depth=1\`.

## Three implementations

1. **Core traversal** (\`packages/core/src/traverse.ts\`): \`getTransitiveDependencies(graph, nodeId, depth)\`. Reuses \`bestEdgeByTarget\` so FRONTIER filtering and PROV_RANK-best dedup match the rest of traversal. Result schema-validated before return per ADR-036.

2. **REST endpoint** (\`packages/core/src/api.ts\`): \`GET /graph/node/:id/dependencies?depth=N\`. Validates \`depth ∈ [1, 10]\`. 404 on unknown node, 400 on bad depth.

3. **MCP tool** (\`packages/mcp/src/tools.ts\`): \`getDependencies\` now calls the new endpoint. Output groups by hop:
   \`\`\`
   Direct (distance 1):
     • target — EdgeType (Provenance)
   Distance 2:
     • ...
   \`\`\`
   The summary differentiates direct count from transitive total when \`depth > 1\`. \`mcp/src/index.ts\` grows an optional \`depth\` input parameter (\`z.number().int().min(1).max(10)\`).

## Schema growth

Two new schemas in \`@neat/types/results.ts\`:

- \`TransitiveDependencySchema\` — \`{ nodeId, distance, edgeType, provenance }\`. \`distance\` is positive (>=1); origin never in dependencies.
- \`TransitiveDependenciesResultSchema\` — \`{ origin, depth, dependencies, total }\`.

Both added to \`BINDING_SCHEMAS\` in the snapshot guard. Snapshot regenerated; diff is purely additive.

## Cleanup

The old direct-only path through \`/graph/edges/:id\` is gone from \`getDependencies\`. The \`dedupeBestProvenance\` helper that backed it has been removed — \`bestEdgeByTarget\` in \`traverse.ts\` handles the same logic with the contract guarantees attached.

## Test changes

- \`mcp/test/tools.test.ts\` — getDependencies tests updated to mock \`/graph/node/:id/dependencies?depth=N\` and assert the new grouped-by-distance output. The old "surfaces signal numbers" test was tied to per-edge inspection — that data isn't in the flat-list shape and is available via \`get_observed_dependencies\` instead. Test removed rather than retrofitted.
- A new test asserts \`depth=1\` routes to the right path and renders \"X has N direct dependency\".

## Contract assertions flipped

In \`packages/core/test/audits/contracts.test.ts\`:

- ✅ \`get_dependencies is transitive — calls /graph/node/:id/dependencies?depth=N\` (#144)
- ✅ \`GET /graph/node/:id/dependencies?depth=N exists\` (#144)
- ✅ \`get_dependencies is transitive\` (queued-list duplicate flipped)

302 contract assertions passing (was 299), 17 todos remaining (was 20).

## Test plan

- [x] \`npx turbo build\` clean
- [x] \`npx turbo test\` — all 5 packages green; mcp 35 pass, core 302 pass / 17 todo
- [x] Schema-snapshot regenerated; diff is additive

Refs ADR-039, ADR-040, #144