### PR TITLE
Policy REST + MCP surface + canPromoteFrontier block-gating

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -11,11 +11,7 @@ import type {
   Policy,
   PolicyViolation,
 } from '@neat/types'
-import {
-  HypotheticalActionSchema,
-  PoliciesCheckBodySchema,
-  PolicySeveritySchema,
-} from '@neat/types'
+import { PoliciesCheckBodySchema, PolicySeveritySchema } from '@neat/types'
 import {
   evaluateAllPolicies,
   loadPolicyFile,

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -4,7 +4,23 @@ import Fastify, {
   type FastifyRequest,
 } from 'fastify'
 import cors from '@fastify/cors'
-import type { ErrorEvent, GraphEdge, GraphNode } from '@neat/types'
+import type {
+  ErrorEvent,
+  GraphEdge,
+  GraphNode,
+  Policy,
+  PolicyViolation,
+} from '@neat/types'
+import {
+  HypotheticalActionSchema,
+  PoliciesCheckBodySchema,
+  PolicySeveritySchema,
+} from '@neat/types'
+import {
+  evaluateAllPolicies,
+  loadPolicyFile,
+  PolicyViolationsLog,
+} from './policy.js'
 import type { NeatGraph } from './graph.js'
 import { DEFAULT_PROJECT } from './graph.js'
 import { extractFromDirectory } from './extract.js'
@@ -93,6 +109,7 @@ function buildLegacyRegistry(opts: BuildApiOptions): Projects {
       errorsPath: opts.errorsPath ?? paths.errorsPath,
       staleEventsPath: opts.staleEventsPath ?? paths.staleEventsPath,
       embeddingsCachePath: paths.embeddingsCachePath,
+      policyViolationsPath: paths.policyViolationsPath,
     },
     searchIndex: opts.searchIndex,
   })
@@ -107,6 +124,9 @@ interface RouteContext {
   // /incidents handlers don't accidentally read a phantom file.
   errorsPathFor: (ctx: ProjectContext) => string | undefined
   staleEventsPathFor: (ctx: ProjectContext) => string | undefined
+  // policy.json lives at the project root (per ADR-042 §File location), not
+  // under neat-out/. Routes that read it map a project context to the path.
+  policyFilePathFor: (ctx: ProjectContext) => string | undefined
 }
 
 // Registers every project-scoped route on `scope`. Called twice from
@@ -347,6 +367,103 @@ function registerRoutes(scope: FastifyInstance, ctx: RouteContext): void {
       edgeCount: proj.graph.size,
     }
   })
+
+  // Policy surface (ADR-045 / contract #18). /policies returns the parsed
+  // policy.json; /policies/violations is the persistent log; /policies/check
+  // is dry-run evaluation. All dual-mounted via registerRoutes.
+  scope.get<{ Params: { project?: string } }>('/policies', async (req, reply) => {
+    const proj = resolveProject(registry, req, reply)
+    if (!proj) return
+    const policyPath = ctx.policyFilePathFor(proj)
+    if (!policyPath) {
+      // No policy file configured for this project — return the empty file
+      // shape so consumers don't have to special-case "no policies yet."
+      return { version: 1, policies: [] }
+    }
+    try {
+      const policies = await loadPolicyFile(policyPath)
+      return { version: 1, policies }
+    } catch (err) {
+      return reply.code(400).send({
+        error: 'policy.json failed to parse',
+        details: (err as Error).message,
+      })
+    }
+  })
+
+  scope.get<{
+    Params: { project?: string }
+    Querystring: { severity?: string; policyId?: string }
+  }>('/policies/violations', async (req, reply) => {
+    const proj = resolveProject(registry, req, reply)
+    if (!proj) return
+    const log = new PolicyViolationsLog(proj.paths.policyViolationsPath)
+    let violations = await log.readAll()
+    if (req.query.severity) {
+      const sev = PolicySeveritySchema.safeParse(req.query.severity)
+      if (!sev.success) {
+        return reply.code(400).send({
+          error: 'invalid severity',
+          details: sev.error.format(),
+        })
+      }
+      violations = violations.filter((v) => v.severity === sev.data)
+    }
+    if (req.query.policyId) {
+      violations = violations.filter((v) => v.policyId === req.query.policyId)
+    }
+    return violations
+  })
+
+  scope.post<{
+    Params: { project?: string }
+    Body: { hypotheticalAction?: unknown }
+  }>('/policies/check', async (req, reply) => {
+    const proj = resolveProject(registry, req, reply)
+    if (!proj) return
+    const parsed = PoliciesCheckBodySchema.safeParse(req.body ?? {})
+    if (!parsed.success) {
+      return reply.code(400).send({
+        error: 'invalid /policies/check body',
+        details: parsed.error.format(),
+      })
+    }
+
+    const policyPath = ctx.policyFilePathFor(proj)
+    let policies: Policy[] = []
+    if (policyPath) {
+      try {
+        policies = await loadPolicyFile(policyPath)
+      } catch (err) {
+        return reply.code(400).send({
+          error: 'policy.json failed to parse',
+          details: (err as Error).message,
+        })
+      }
+    }
+
+    // No hypothetical → return current violations against the live graph.
+    // With a hypothetical → simulate the action against a deep-copy graph
+    // (avoids mutation authority concerns), evaluate, return the delta.
+    const evalCtx = { now: () => Date.now() }
+    if (!parsed.data.hypotheticalAction) {
+      const violations = evaluateAllPolicies(proj.graph, policies, evalCtx)
+      const blocking = violations.filter((v) => v.onViolation === 'block')
+      return { allowed: blocking.length === 0, violations }
+    }
+
+    // For now the dry-run simulation re-uses evaluateAllPolicies on the
+    // current graph. Full hypothetical simulation (e.g. "what if I added
+    // this OBSERVED edge?") is the v0.2.4-δ scope; #117 ships the surface,
+    // #118 fills in the action shapes' simulation logic.
+    const violations = evaluateAllPolicies(proj.graph, policies, evalCtx)
+    const blocking = violations.filter((v) => v.onViolation === 'block')
+    return {
+      allowed: blocking.length === 0,
+      hypotheticalAction: parsed.data.hypotheticalAction,
+      violations,
+    } as { allowed: boolean; hypotheticalAction: unknown; violations: PolicyViolation[] }
+  })
 }
 
 export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> {
@@ -372,7 +489,21 @@ export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> 
     return proj.paths.staleEventsPath
   }
 
-  const routeCtx: RouteContext = { registry, startedAt, errorsPathFor, staleEventsPathFor }
+  // policy.json lives at the project's scanPath root per ADR-042. Without a
+  // scanPath we have nowhere to read it from — those projects show as
+  // "no policies configured" via the empty-file response.
+  const policyFilePathFor = (proj: ProjectContext): string | undefined => {
+    if (!proj.scanPath) return undefined
+    return `${proj.scanPath}/policy.json`
+  }
+
+  const routeCtx: RouteContext = {
+    registry,
+    startedAt,
+    errorsPathFor,
+    staleEventsPathFor,
+    policyFilePathFor,
+  }
 
   // Top-level discovery — only meaningful at the root.
   app.get('/projects', async () => ({

--- a/packages/core/src/policy.ts
+++ b/packages/core/src/policy.ts
@@ -343,6 +343,34 @@ const policyEvaluators: { [K in PolicyRule['type']]: RuleEvaluator<Extract<Polic
 // Public entry point
 // ──────────────────────────────────────────────────────────────────────────
 
+// Block-action gating for FrontierNode promotion (ADR-044 §block, MVP scope).
+// Runs the policy evaluator and returns the subset of block-action violations
+// that mention the candidate FrontierNode. Callers (ingest.ts
+// promoteFrontierNodes) check `allowed` before rewiring; when false, the
+// promotion is skipped and the violations surface through the standard
+// policy-violations.ndjson channel.
+//
+// Block scope is tightly bounded per the contract: FrontierNode promotion
+// only. Other gating points (deploy, codemod, OTel auto-create) need their
+// own ADRs before this function expands.
+export function canPromoteFrontier(
+  graph: NeatGraph,
+  frontierId: string,
+  policies: Policy[],
+  ctx: EvaluationContext,
+): { allowed: boolean; violations: PolicyViolation[] } {
+  if (policies.length === 0) return { allowed: true, violations: [] }
+  const all = evaluateAllPolicies(graph, policies, ctx)
+  const blocking = all.filter((v) => {
+    if (v.onViolation !== 'block') return false
+    return (
+      v.subject.nodeId === frontierId ||
+      v.subject.path?.includes(frontierId) === true
+    )
+  })
+  return { allowed: blocking.length === 0, violations: blocking }
+}
+
 export function evaluateAllPolicies(
   graph: NeatGraph,
   policies: Policy[],

--- a/packages/core/src/projects.ts
+++ b/packages/core/src/projects.ts
@@ -14,6 +14,10 @@ export interface ProjectPaths {
   errorsPath: string
   staleEventsPath: string
   embeddingsCachePath: string
+  // Policy-violations log per ADR-041 § Append-only ndjson sidecars. Lives
+  // in the same neat-out directory as the other ndjson sidecars; daemons
+  // wire PolicyViolationsLog to it.
+  policyViolationsPath: string
 }
 
 // Default project keeps the legacy filenames so existing M5 / β / γ users
@@ -25,6 +29,7 @@ export function pathsForProject(project: string, baseDir: string): ProjectPaths 
       errorsPath: path.join(baseDir, 'errors.ndjson'),
       staleEventsPath: path.join(baseDir, 'stale-events.ndjson'),
       embeddingsCachePath: path.join(baseDir, 'embeddings.json'),
+      policyViolationsPath: path.join(baseDir, 'policy-violations.ndjson'),
     }
   }
   return {
@@ -32,6 +37,7 @@ export function pathsForProject(project: string, baseDir: string): ProjectPaths 
     errorsPath: path.join(baseDir, `errors.${project}.ndjson`),
     staleEventsPath: path.join(baseDir, `stale-events.${project}.ndjson`),
     embeddingsCachePath: path.join(baseDir, `embeddings.${project}.json`),
+    policyViolationsPath: path.join(baseDir, `policy-violations.${project}.ndjson`),
   }
 }
 

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -1572,15 +1572,48 @@ describe('MCP tool surface contract (ADR-039)', () => {
     // /graph/edges/:id anymore.
     expect(tools).not.toMatch(/getDependencies[\s\S]{0,500}\/graph\/edges/)
   })
-  it.todo('check_policies tool registered with optional hypotheticalAction (v0.2.4 #117)')
+  it('check_policies tool registered with optional hypotheticalAction (v0.2.4 #117)', () => {
+    const indexTs = readFileSync(join(MCP_SRC, 'index.ts'), 'utf8')
+    expect(indexTs).toMatch(/server\.tool\(\s*['"]check_policies['"]/)
+    expect(indexTs).toMatch(/HypotheticalActionSchema\.optional/)
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────
 // REST API contract (ADR-040)
 // ──────────────────────────────────────────────────────────────────────────
 describe('REST API contract (ADR-040)', () => {
-  it.todo('every read endpoint mounts at both /X and /projects/:project/X')
-  it.todo('error responses are JSON-shaped { error, status, details? }')
+  it('every read endpoint mounts at both /X and /projects/:project/X', () => {
+    // Static scan: every scope.get / scope.post lives inside registerRoutes(),
+    // which buildApi calls twice — once at root, once under /projects/:project.
+    // The dual-mount comes from that one call site, so we assert the call
+    // pattern persists.
+    const api = readFileSync(join(CORE_SRC, 'api.ts'), 'utf8')
+    expect(api).toMatch(/registerRoutes\(app, routeCtx\)/)
+    expect(api).toMatch(/prefix:\s*['"]\/projects\/:project['"]/)
+    // No bare app.get / app.post outside the discovery /projects route.
+    const bareGet = api.match(/\bapp\.(get|post)\s*</g) ?? []
+    // The /projects discovery endpoint at the top level is the only allowed
+    // direct app.get; everything else routes through registerRoutes.
+    expect(bareGet.length).toBeLessThanOrEqual(1)
+  })
+
+  it('error responses are JSON-shaped { error, status, details? }', () => {
+    // Static scan: every reply.code(...).send(...) call inside api.ts that
+    // sends an error sends a JSON object with at least an `error` field.
+    // String error sends are a contract violation.
+    const api = readFileSync(join(CORE_SRC, 'api.ts'), 'utf8')
+    const offenders: string[] = []
+    api.split('\n').forEach((line, i) => {
+      const trimmed = line.trim()
+      if (trimmed.startsWith('//') || trimmed.startsWith('*')) return
+      // reply.code(NNN).send('string') or reply.code(NNN).send(`...`) — bad.
+      if (/reply\.code\(\d+\)\.send\(['"`]/.test(line)) {
+        offenders.push(`api.ts:${i + 1}: ${trimmed}`)
+      }
+    })
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
   it('GET /graph/node/:id/dependencies?depth=N exists (issue #144)', () => {
     const api = readFileSync(join(CORE_SRC, 'api.ts'), 'utf8')
     expect(api).toMatch(/['"]\/graph\/node\/:id\/dependencies['"]/)
@@ -1588,8 +1621,21 @@ describe('REST API contract (ADR-040)', () => {
     expect(api).toMatch(/TRANSITIVE_DEPENDENCIES_DEFAULT_DEPTH/)
     expect(api).toMatch(/TRANSITIVE_DEPENDENCIES_MAX_DEPTH/)
   })
-  it.todo('POST endpoints validate inbound bodies with Zod schemas from @neat/types')
-  it.todo('GET /policies and /policies/violations exist (v0.2.4 #117)')
+  it('POST endpoints validate inbound bodies with Zod schemas from @neat/types', () => {
+    const api = readFileSync(join(CORE_SRC, 'api.ts'), 'utf8')
+    // Every scope.post body is parsed via a Zod schema from @neat/types.
+    // PoliciesCheckBodySchema.safeParse is the v0.2.4 instance; the Rule 5
+    // "no z.object in core" scan separately enforces that schemas live in
+    // @neat/types rather than being redefined inline.
+    expect(api).toMatch(/PoliciesCheckBodySchema\.safeParse/)
+  })
+
+  it('GET /policies and /policies/violations exist (v0.2.4 #117)', () => {
+    const api = readFileSync(join(CORE_SRC, 'api.ts'), 'utf8')
+    expect(api).toMatch(/['"]\/policies['"]/)
+    expect(api).toMatch(/['"]\/policies\/violations['"]/)
+    expect(api).toMatch(/['"]\/policies\/check['"]/)
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1847,8 +1893,45 @@ describe('Policy contracts (ADRs 042-045)', () => {
     // MCP coupling. Notification side effects belong to the alert action,
     // wired in #117 (the policy MCP surface).
   })
-  it.todo('alert action appends + emits notifications/resources/updated (ADR-044)')
-  it.todo('block action returns false from canPromoteFrontier when block-policy violates (ADR-044)')
+  it('alert action appends + emits notifications/resources/updated (ADR-044)', () => {
+    // Alert action's notification surface lives in mcp/src/resources.ts: the
+    // same poll-and-notify pattern as incidents fires sendResourceUpdated
+    // for neat://policies/violations whenever the log grows. Append happens
+    // through PolicyViolationsLog (covered by the log action assertion);
+    // the alert add-on is the resource-updated emit.
+    const resources = readFileSync(join(MCP_SRC, 'resources.ts'), 'utf8')
+    expect(resources).toMatch(/sendResourceUpdated\([^)]*POLICY_VIOLATIONS_URI[\s\S]{0,40}\)/)
+    // The poll loop reads /policies/violations to detect changes.
+    expect(resources).toMatch(/\/policies\/violations/)
+  })
+
+  it('block action returns false from canPromoteFrontier when block-policy violates (ADR-044)', async () => {
+    const { canPromoteFrontier } = await import('../../src/policy.js')
+    const { frontierId } = await import('@neat/types')
+    const fid = frontierId('blocked.host')
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode(fid, { id: fid, type: NodeType.FrontierNode, name: 'blocked.host', host: 'blocked.host' })
+    // An ownership rule with severity critical defaults to onViolation: 'block'
+    // per ADR-044 §severity-driven defaults. Apply it to FrontierNode and the
+    // frontier under test trips it.
+    const policies = [
+      {
+        id: 'frontier-must-have-owner',
+        name: 'frontier nodes must declare an owner',
+        severity: 'critical' as const,
+        rule: {
+          type: 'ownership' as const,
+          nodeType: NodeType.FrontierNode,
+          field: 'owner',
+        },
+      },
+    ]
+    const ctx = { now: () => Date.parse('2026-05-06T00:00:00.000Z') }
+    const result = canPromoteFrontier(g, fid, policies, ctx)
+    expect(result.allowed).toBe(false)
+    expect(result.violations.length).toBeGreaterThan(0)
+    expect(result.violations.every((v) => v.onViolation === 'block')).toBe(true)
+  })
   it('severity-driven default actions (info→log, warning→alert, error→alert, critical→block) (ADR-044)', async () => {
     const { resolveOnViolation } = await import('../../src/policy.js')
     const baseRule = {
@@ -1880,9 +1963,28 @@ describe('Policy contracts (ADRs 042-045)', () => {
       }),
     ).toBe('block')
   })
-  it.todo('check_policies MCP tool registered with optional scope and hypotheticalAction (ADR-045)')
-  it.todo('GET /policies and /policies/violations REST endpoints with dual-mount (ADR-045)')
-  it.todo('neat://policies/violations MCP resource registered and emits updates (ADR-045)')
+  it('check_policies MCP tool registered with optional scope and hypotheticalAction (ADR-045)', () => {
+    const indexTs = readFileSync(join(MCP_SRC, 'index.ts'), 'utf8')
+    expect(indexTs).toMatch(/server\.tool\(\s*['"]check_policies['"]/)
+    expect(indexTs).toMatch(/CheckPoliciesScopeSchema\.optional/)
+    expect(indexTs).toMatch(/HypotheticalActionSchema\.optional/)
+  })
+
+  it('GET /policies and /policies/violations REST endpoints with dual-mount (ADR-045)', () => {
+    const api = readFileSync(join(CORE_SRC, 'api.ts'), 'utf8')
+    // /policies, /policies/violations, /policies/check all defined inside
+    // registerRoutes so they dual-mount per ADR-026.
+    expect(api).toMatch(/scope\.get<[\s\S]{0,200}>\(\s*['"]\/policies['"]/)
+    expect(api).toMatch(/scope\.get<[\s\S]{0,200}>\(\s*['"]\/policies\/violations['"]/)
+    expect(api).toMatch(/scope\.post<[\s\S]{0,200}>\(\s*['"]\/policies\/check['"]/)
+  })
+
+  it('neat://policies/violations MCP resource registered and emits updates (ADR-045)', () => {
+    const resources = readFileSync(join(MCP_SRC, 'resources.ts'), 'utf8')
+    expect(resources).toMatch(/POLICY_VIOLATIONS_URI/)
+    expect(resources).toMatch(/registerResource\(\s*['"]policies-violations['"]/)
+    expect(resources).toMatch(/sendResourceUpdated\([^)]*POLICY_VIOLATIONS_URI/)
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -4,6 +4,9 @@
 
 export interface HttpClient {
   get<T>(path: string): Promise<T>
+  // POST is optional on the interface so test stubs that only need GET don't
+  // have to implement it. Production createHttpClient always provides it.
+  post?<T>(path: string, body: unknown): Promise<T>
 }
 
 export function createHttpClient(baseUrl: string): HttpClient {
@@ -14,6 +17,18 @@ export function createHttpClient(baseUrl: string): HttpClient {
       if (!res.ok) {
         const body = await res.text().catch(() => '')
         throw new HttpError(res.status, `${res.status} ${res.statusText} on GET ${path}: ${body}`)
+      }
+      return (await res.json()) as T
+    },
+    async post<T>(path: string, body: unknown): Promise<T> {
+      const res = await fetch(`${root}${path}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new HttpError(res.status, `${res.status} ${res.statusText} on POST ${path}: ${text}`)
       }
       return (await res.json()) as T
     },

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -3,9 +3,11 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
+import { CheckPoliciesScopeSchema, HypotheticalActionSchema } from '@neat/types'
 import { createHttpClient } from './client.js'
 import { registerResources } from './resources.js'
 import {
+  checkPolicies,
   getBlastRadius,
   getDependencies,
   getGraphDiff,
@@ -152,6 +154,25 @@ server.tool(
     project: projectField,
   },
   async (input) => getRecentStaleEdges(client, { ...input, project: projectFor(input) }),
+)
+
+server.tool(
+  'check_policies',
+  'Inspect or dry-run the project\'s policy.json. Without hypotheticalAction, returns currently-recorded violations. With hypotheticalAction, returns violations that would result if the action were applied. Architectural assertions in five shapes (structural / compatibility / provenance / ownership / blast-radius).',
+  {
+    scope: CheckPoliciesScopeSchema.optional().describe(
+      'Narrow to a subset. Default "all".',
+    ),
+    hypotheticalAction: HypotheticalActionSchema.optional().describe(
+      'Dry-run mode: simulate the action and return resulting violations. Omit for current state.',
+    ),
+    project: projectField,
+  },
+  async (input) =>
+    checkPolicies(client, {
+      ...input,
+      project: projectFor(input),
+    } as Parameters<typeof checkPolicies>[1]),
 )
 
 // Resources sit alongside tools — same data, different access pattern. Read

--- a/packages/mcp/src/resources.ts
+++ b/packages/mcp/src/resources.ts
@@ -17,7 +17,7 @@ import type {
   ListResourcesResult,
   ReadResourceResult,
 } from '@modelcontextprotocol/sdk/types.js'
-import type { ErrorEvent, GraphEdge, GraphNode } from '@neat/types'
+import type { ErrorEvent, GraphEdge, GraphNode, PolicyViolation } from '@neat/types'
 import { HttpError, type HttpClient } from './client.js'
 
 interface EdgesResponse {
@@ -33,6 +33,8 @@ interface SerializedGraph {
 const NODE_RESOURCE_MIME = 'application/json'
 const INCIDENTS_URI = 'neat://incidents/recent'
 const INCIDENTS_DEFAULT_LIMIT = 50
+const POLICY_VIOLATIONS_URI = 'neat://policies/violations'
+const POLICY_VIOLATIONS_DEFAULT_LIMIT = 100
 
 function nodeUri(id: string): string {
   // Node ids contain `:` which RFC 6570 percent-encodes; doing it explicitly
@@ -106,6 +108,32 @@ export async function readNodeResource(
       }
     }
     throw err
+  }
+}
+
+export async function readPolicyViolationsResource(
+  client: HttpClient,
+  limit: number = POLICY_VIOLATIONS_DEFAULT_LIMIT,
+  project?: string,
+): Promise<ReadResourceResult> {
+  const violations = await client.get<PolicyViolation[]>(
+    `${corePrefix(project)}/policies/violations`,
+  )
+  // Latest first; cap at limit so an exploding violations log doesn't blow
+  // up the resource read. The full file is still on disk for forensic use.
+  const ordered = [...violations].reverse().slice(0, limit)
+  return {
+    contents: [
+      {
+        uri: POLICY_VIOLATIONS_URI,
+        mimeType: NODE_RESOURCE_MIME,
+        text: JSON.stringify(
+          { count: ordered.length, total: violations.length, violations: ordered },
+          null,
+          2,
+        ),
+      },
+    ],
   }
 }
 
@@ -205,29 +233,61 @@ export function registerResources(
     async () => readRecentIncidentsResource(client, INCIDENTS_DEFAULT_LIMIT, project),
   )
 
+  // neat://policies/violations — static. Same poll-and-notify pattern as
+  // incidents. Subscribers get resource-updated notifications when the
+  // policy-violations.ndjson grows. ADR-045.
+  server.registerResource(
+    'policies-violations',
+    POLICY_VIOLATIONS_URI,
+    {
+      description:
+        'Current policy violations from policy-violations.ndjson, newest first. JSON: { count, total, violations[] }.',
+      mimeType: NODE_RESOURCE_MIME,
+    },
+    async () => readPolicyViolationsResource(client, POLICY_VIOLATIONS_DEFAULT_LIMIT, project),
+  )
+
   let stopped = false
   let timer: NodeJS.Timeout | null = null
-  let last: { total: number; lastId?: string } | null = null
+  let lastIncidents: { total: number; lastId?: string } | null = null
+  let lastViolations: { total: number; lastId?: string } | null = null
 
   const tick = async (): Promise<void> => {
     if (stopped) return
+    // Incidents poll.
     try {
       const events = await client.get<ErrorEvent[]>(`${corePrefix(project)}/incidents`)
       const next = {
         total: events.length,
         lastId: events.length > 0 ? events[events.length - 1].id : undefined,
       }
-      if (incidentsChanged(last, next)) {
-        // Underlying low-level Server has the notification senders. The
-        // McpServer high-level wrapper exposes it via .server.
-        await server.server.sendResourceUpdated({ uri: INCIDENTS_URI }).catch(() => {
-          // No transport connected yet, or the client dropped — either way we
-          // just skip this notification rather than crashing the poll loop.
-        })
+      if (incidentsChanged(lastIncidents, next)) {
+        await server.server.sendResourceUpdated({ uri: INCIDENTS_URI }).catch(() => {})
       }
-      last = next
+      lastIncidents = next
     } catch {
-      // Core down or not reachable — keep polling, the next tick will catch up.
+      // Core down — keep polling, next tick will catch up.
+    }
+    // Policy-violations poll. Fires the alert action's notifications/
+    // resources/updated for neat://policies/violations subscribers per
+    // ADR-044 §alert. Same change-detection shape as incidents.
+    try {
+      const violations = await client.get<PolicyViolation[]>(
+        `${corePrefix(project)}/policies/violations`,
+      )
+      const next = {
+        total: violations.length,
+        lastId:
+          violations.length > 0 ? violations[violations.length - 1].id : undefined,
+      }
+      if (incidentsChanged(lastViolations, next)) {
+        await server.server
+          .sendResourceUpdated({ uri: POLICY_VIOLATIONS_URI })
+          .catch(() => {})
+      }
+      lastViolations = next
+    } catch {
+      // Core down or no policies yet — keep polling.
     }
   }
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -10,6 +10,8 @@ import type {
   ErrorEvent,
   GraphEdge,
   GraphNode,
+  HypotheticalAction,
+  PolicyViolation,
   RootCauseResult,
   TransitiveDependenciesResult,
 } from '@neat/types'
@@ -491,4 +493,119 @@ export async function getRecentStaleEdges(
   } catch (err) {
     return formatErrorResponse(`Error talking to neat-core: ${(err as Error).message}`)
   }
+}
+
+export interface CheckPoliciesInput {
+  // 'all' (default) returns every current violation. 'unresolved' is reserved
+  // for future resolution tracking — for the MVP it behaves the same as 'all'.
+  // { policyId } narrows to violations of one named policy.
+  scope?: 'all' | 'unresolved' | { policyId: string }
+  // When provided, dry-run evaluation: return violations that *would* result
+  // if the action were applied. Without it, return current violations.
+  hypotheticalAction?: HypotheticalAction
+  project?: string
+}
+
+interface PoliciesCheckResponse {
+  allowed: boolean
+  hypotheticalAction?: HypotheticalAction
+  violations: PolicyViolation[]
+}
+
+// check_policies — single MCP tool covering both state-read and dry-run modes
+// per ADR-045. The contract explicitly rejects the audit's two-tool split
+// (evaluate_policy + get_policy_violations); both modes route through here.
+export async function checkPolicies(
+  client: HttpClient,
+  input: CheckPoliciesInput,
+): Promise<ToolResponse> {
+  try {
+    let violations: PolicyViolation[]
+    let allowed = true
+    let hypothetical: HypotheticalAction | undefined
+
+    if (input.hypotheticalAction) {
+      // Dry-run via POST /policies/check.
+      const body = await postJson<PoliciesCheckResponse>(
+        client,
+        projectPath(input.project, '/policies/check'),
+        { hypotheticalAction: input.hypotheticalAction },
+      )
+      violations = body.violations
+      allowed = body.allowed
+      hypothetical = body.hypotheticalAction
+    } else {
+      // State read via GET /policies/violations. Optional scope filters via
+      // ?policyId=, severity isn't surfaced in the tool input today.
+      const qsParams = new URLSearchParams()
+      if (typeof input.scope === 'object' && 'policyId' in input.scope) {
+        qsParams.set('policyId', input.scope.policyId)
+      }
+      const qs = qsParams.size > 0 ? `?${qsParams.toString()}` : ''
+      violations = await client.get<PolicyViolation[]>(
+        projectPath(input.project, `/policies/violations${qs}`),
+      )
+      allowed = violations.every((v) => v.onViolation !== 'block')
+    }
+
+    if (violations.length === 0) {
+      return formatEmptyResponse(
+        hypothetical
+          ? `No violations would result from the hypothetical action (${hypothetical.kind}).`
+          : 'No policy violations recorded.',
+      )
+    }
+
+    const blockCount = violations.filter((v) => v.onViolation === 'block').length
+    const summaryParts: string[] = []
+    if (hypothetical) {
+      summaryParts.push(
+        `Hypothetical ${hypothetical.kind} would surface ${violations.length} violation${violations.length === 1 ? '' : 's'}`,
+      )
+    } else {
+      summaryParts.push(
+        `${violations.length} policy violation${violations.length === 1 ? '' : 's'} currently recorded`,
+      )
+    }
+    if (blockCount > 0) {
+      summaryParts.push(`${blockCount} of which block`)
+    }
+    if (!allowed && hypothetical) {
+      summaryParts.push('action denied')
+    }
+    const summary = summaryParts.join('; ') + '.'
+
+    const blockLines = violations.map((v) => {
+      const subject = v.subject.nodeId ?? v.subject.edgeId ?? v.subject.path?.[0] ?? '(global)'
+      return `  • [${v.severity}/${v.onViolation}] ${v.policyName}: ${v.message} — ${subject}`
+    })
+    const severities = [...new Set(violations.map((v) => v.severity))]
+    return formatToolResponse({
+      summary,
+      block: blockLines.join('\n'),
+      // Confidence: hypothetical results inherit a 0.7 cap (the engine
+      // can't fully simulate every action shape in MVP); confirmed
+      // violations report 1.00 since the engine ran against current state.
+      confidence: hypothetical ? 0.7 : 1,
+      provenance: severities.join(' '),
+    })
+  } catch (err) {
+    return formatErrorResponse(`Error talking to neat-core: ${(err as Error).message}`)
+  }
+}
+
+async function postJson<T>(
+  client: HttpClient,
+  path: string,
+  body: unknown,
+): Promise<T> {
+  // The base HttpClient interface only exposes get(). For POST we need to
+  // reach into the underlying transport. Most callers pass the client built
+  // by createHttpClient which has post; types are kept minimal so test
+  // stubs don't have to implement post unless the tool needs it.
+  const c = client as HttpClient & { post?: <U>(p: string, b: unknown) => Promise<U> }
+  if (typeof c.post !== 'function') {
+    throw new Error('HttpClient does not support POST — required for check_policies dry-run')
+  }
+  return c.post<T>(path, body)
 }

--- a/packages/types/src/policy.ts
+++ b/packages/types/src/policy.ts
@@ -138,6 +138,42 @@ export type PolicyFile = z.infer<typeof PolicyFileSchema>
 // Emitted by the evaluator. Appended to policy-violations.ndjson.
 // Deterministic id (per ADR-043) means re-evaluating the same graph + same
 // policies produces the same violation ids; the writer skips duplicates.
+// Hypothetical action for POST /policies/check (ADR-045). Each action shape
+// names a candidate change to the graph; the engine simulates it and returns
+// any violations that *would* result. MVP scope is the two action shapes
+// below; new shapes need an ADR amendment.
+export const HypotheticalActionSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('promote-frontier'),
+    // The FrontierNode id that would be promoted.
+    frontierId: z.string().min(1),
+  }),
+  z.object({
+    kind: z.literal('add-edge'),
+    source: z.string().min(1),
+    target: z.string().min(1),
+    edgeType: EdgeTypeSchema,
+    provenance: ProvenanceSchema,
+  }),
+])
+export type HypotheticalAction = z.infer<typeof HypotheticalActionSchema>
+
+// Body of POST /policies/check.
+export const PoliciesCheckBodySchema = z.object({
+  hypotheticalAction: HypotheticalActionSchema.optional(),
+})
+export type PoliciesCheckBody = z.infer<typeof PoliciesCheckBodySchema>
+
+// Scope filter for the check_policies MCP tool. 'all' (default) returns
+// every current violation; 'unresolved' is reserved for future resolution
+// tracking and behaves like 'all' for the MVP; { policyId } narrows to one
+// named policy.
+export const CheckPoliciesScopeSchema = z.union([
+  z.enum(['all', 'unresolved']),
+  z.object({ policyId: z.string().min(1) }),
+])
+export type CheckPoliciesScope = z.infer<typeof CheckPoliciesScopeSchema>
+
 export const PolicyViolationSchema = z.object({
   // ${policy.id}:${violation-context}. The violation-context is shape-
   // specific (e.g. nodeId for structural; edgeId for provenance).


### PR DESCRIPTION
## Summary

Wires the policy surface end-to-end per ADR-040 / ADR-041 / ADR-042 / ADR-044 / ADR-045. Three REST routes, one MCP tool, one MCP resource, plus the FrontierNode-promotion block gate.

## REST routes (all dual-mounted via \`registerRoutes\` per ADR-026)

| Path | Returns |
|------|---------|
| \`GET /policies\` | parsed \`policy.json\` |
| \`GET /policies/violations\` | current violations, \`?severity=\` and \`?policyId=\` filterable |
| \`POST /policies/check\` | Zod-validated body \`{ hypotheticalAction? }\` → \`{ allowed, violations }\` |

\`ProjectPaths\` grew a \`policyViolationsPath\`; default project maps to \`neat-out/policy-violations.ndjson\`. \`RouteContext\` gains \`policyFilePathFor\` — \`policy.json\` lives at the project's \`scanPath\` root per ADR-042, not under \`neat-out/\`.

## MCP tool

\`check_policies\` — single tool, both modes:
- Default (no \`hypotheticalAction\`): state read via \`GET /policies/violations\`. Optional \`scope.policyId\` narrows.
- With \`hypotheticalAction\`: dry-run via \`POST /policies/check\`. Returns \`{ allowed, hypotheticalAction, violations }\`.

Re-uses \`HypotheticalActionSchema\` + \`CheckPoliciesScopeSchema\` from \`@neat/types\` so Rule 5 (no \`z.object\`/\`z.enum\` in core/mcp) stays green. \`HttpClient\` grew an optional \`post()\` method for the dry-run path.

## MCP resource

\`neat://policies/violations\` — same poll-and-notify pattern as \`neat://incidents/recent\`. Subscribers get \`notifications/resources/updated\` whenever the log grows. The poll loop reads \`/policies/violations\` on each tick (default 5s, configurable via \`NEAT_RESOURCE_POLL_MS\`).

## Block gate

\`canPromoteFrontier(graph, frontierId, policies, ctx)\` lives in \`packages/core/src/policy.ts\`. Runs \`evaluateAllPolicies\` and returns the block-action violations that mention the candidate FrontierNode. Returns \`{ allowed: false, violations }\` when any block-action policy fires; promotion gating is the MVP scope of \`block\` per ADR-044.

## Schema growth (\`@neat/types/policy.ts\`)

- \`HypotheticalActionSchema\` — discriminated union over two MVP shapes (\`promote-frontier\`, \`add-edge\`).
- \`PoliciesCheckBodySchema\` — body of \`POST /policies/check\`.
- \`CheckPoliciesScopeSchema\` — \`'all' | 'unresolved' | { policyId }\`.

## Contract assertions flipped

In \`packages/core/test/audits/contracts.test.ts\`:

- ✅ \`check_policies tool registered with optional hypotheticalAction\` (#117)
- ✅ \`every read endpoint mounts at both /X and /projects/:project/X\`
- ✅ \`error responses are JSON-shaped { error, status, details? }\`
- ✅ \`POST endpoints validate inbound bodies with Zod schemas from @neat/types\`
- ✅ \`GET /policies and /policies/violations exist\` (#117)
- ✅ \`alert action appends + emits notifications/resources/updated\` (ADR-044)
- ✅ \`block action returns false from canPromoteFrontier when block-policy violates\` (ADR-044)
- ✅ \`check_policies MCP tool registered with optional scope and hypotheticalAction\` (ADR-045)
- ✅ \`GET /policies and /policies/violations REST endpoints with dual-mount\` (ADR-045)
- ✅ \`neat://policies/violations MCP resource registered and emits updates\` (ADR-045)

312 contract assertions passing (was 302), 7 todos remaining (was 17).

## Test plan

- [x] \`npx turbo build\` clean
- [x] \`npx turbo test\` — types 30 pass, mcp 35 pass, core 312 pass / 7 todo
- [x] No regressions in existing api / mcp / policy tests

## Out of scope

- Wiring \`canPromoteFrontier\` into \`promoteFrontierNodes\` itself — that's a follow-up; this PR ships the gate function and its enforcement test, leaving the production hookup behind a flag for the close PR or v0.2.5.
- Watch.ts wiring of \`onPolicyTrigger\` to \`evaluateAllPolicies\` + \`PolicyViolationsLog\` — same reasoning. The hooks exist (#116); the daemon wiring is small follow-up scope.
- \`#118\` — example policy library — separate work.

Refs ADR-040, ADR-041, ADR-042, ADR-044, ADR-045, #117