### PR TITLE
Close v0.2.4 — drop duplicate todos, status doc, flip stragglers

### DIFF
--- a/docs/plans/2026-05-06-v0.2.4-close.md
+++ b/docs/plans/2026-05-06-v0.2.4-close.md
@@ -1,0 +1,113 @@
+# v0.2.4 Policies + MCP refresh — close
+
+**Closed:** 2026-05-06
+**Opened with:** PR #165 (ADRs 039–045 + per-topic contracts)
+**Kickoff doc:** `docs/plans/2026-05-06-v0.2.4-kickoff.md` (superseded by this doc)
+
+The architecture-first surface ships. NEAT now asserts intent (policies) in addition to observing reality (OTel) — the formalisation of the OBSERVED-vs-EXTRACTED gap that ADR-027 names as the load-bearing value. This is the milestone neat.is's manifesto pitch finally has running code behind it.
+
+## What landed
+
+| PR | Title | Issue / scope |
+|----|-------|---------------|
+| #175 | Policy schema in `@neat/types` | #115 — five rule types, version 1, `superRefine` id-uniqueness |
+| #177 | Policy evaluation engine + `policy-violations.ndjson` writer | #116 — pure `evaluateAllPolicies`, three triggers, deterministic ids |
+| #178 | MCP three-part response — `formatToolResponse` helper + retrofit | #143 — all 8 existing tools route through the new format |
+| #179 | Transitive `get_dependencies` — new core endpoint + MCP tool rewrite | #144 — `GET /graph/node/:id/dependencies?depth=N`, BFS outbound |
+| #180 | Policy REST + MCP surface + `canPromoteFrontier` block-gating | #117 — `/policies` routes, `check_policies` tool, `neat://policies/violations` resource |
+
+The sixth PR (this one) drops the duplicate `it.todo`s and lands this status doc.
+
+## Three behaviour changes consumers will feel
+
+1. **MCP tool output is a three-part response.** Every tool now emits `{NL summary} \n\n {structured block} \n\n confidence: X.XX · provenance: ...`. Empty-result footer reads `n/a / n/a`. Agents can pattern-match on the footer to know how much to trust the answer. (#178)
+2. **`get_dependencies` is transitive.** Default depth 3, max 10. `depth=1` recovers the old direct-only behaviour. The output groups by hop ("Direct (distance 1)", "Distance 2", …) and the structured block reads as concentric rings. (#179)
+3. **NEAT now asserts intent, not just observes it.** A `policy.json` at the project root declares architectural assertions in five shapes (`structural` / `compatibility` / `provenance` / `ownership` / `blast-radius`). Violations append to `policy-violations.ndjson`, surface via `GET /policies/violations`, and notify subscribers of the `neat://policies/violations` MCP resource on append. (#115, #116, #117)
+
+## Contract assertions flipped
+
+In `packages/core/test/audits/contracts.test.ts`:
+
+**ADR-039 (MCP tool surface):**
+- ✅ `formatToolResponse helper exists at mcp/src/format.ts` (#143)
+- ✅ `MCP tools emit standardized three-part response` (#143)
+- ✅ `get_dependencies is transitive — calls /graph/node/:id/dependencies?depth=N` (#144)
+- ✅ `check_policies tool registered with optional hypotheticalAction` (#117)
+
+**ADR-040 (REST API):**
+- ✅ `every read endpoint mounts at both /X and /projects/:project/X`
+- ✅ `error responses are JSON-shaped { error, status, details? }`
+- ✅ `GET /graph/node/:id/dependencies?depth=N exists` (#144)
+- ✅ `POST endpoints validate inbound bodies with Zod schemas from @neat/types`
+- ✅ `GET /policies and /policies/violations exist` (#117)
+
+**ADR-041 (Persistence):**
+- ✅ `SCHEMA_VERSION constant exists in persist.ts` (live since v0.2.0)
+- ✅ `policy-violations.ndjson append-only writer exists` (#116)
+
+**ADR-042 (Policy schema):**
+- ✅ `PolicyFileSchema exists with version: z.literal(1)`
+- ✅ `Policy is a discriminated union by rule.type with five MVP types`
+- ✅ `PolicyFileSchema.parse fails loudly on malformed policy.json`
+
+**ADR-043 (Policy evaluation):**
+- ✅ `evaluateAllPolicies is pure and dispatches by rule.type`
+- ✅ `PolicyViolation ids are deterministic`
+- ✅ `post-ingest, post-extract, post-stale-transition all trigger evaluateAllPolicies`
+
+**ADR-044 (Policy actions):**
+- ✅ `log action appends to ndjson with no MCP notification`
+- ✅ `alert action appends + emits notifications/resources/updated`
+- ✅ `block action returns false from canPromoteFrontier when block-policy violates`
+- ✅ `severity-driven default actions (info→log, warning→alert, error→alert, critical→block)`
+
+**ADR-045 (Policy tool surface):**
+- ✅ `check_policies MCP tool registered with optional scope and hypotheticalAction`
+- ✅ `GET /policies and /policies/violations REST endpoints with dual-mount`
+- ✅ `neat://policies/violations MCP resource registered and emits updates`
+
+## Schema growth committed
+
+Added to `packages/core/test/audits/schemas.snapshot.json` over the milestone:
+
+- `NodeTypeSchema` (Zod mirror of `NodeType` for discriminating schemas)
+- `PolicyFileSchema` (with `superRefine` id-uniqueness — encoder unwrapping `ZodEffects` was a sub-fix in #175)
+- `PolicyViolationSchema`
+- `TransitiveDependenciesResultSchema` (new flat-list result shape)
+
+Plus internal-shape schemas not in the snapshot list:
+- `HypotheticalActionSchema`
+- `PoliciesCheckBodySchema`
+- `CheckPoliciesScopeSchema`
+
+No schema *shape* changes landed. No `persist.ts` migration needed.
+
+## Tracker cleanup
+
+The `Queued contracts` block at the bottom of `contracts.test.ts` was renamed to `'v0.2.1 leftovers — #141, #142, #145'`. The two v0.2.4 `it.todo`/live-test duplicates (#143 ghost duplicate of MCP tool surface, #144 ghost duplicate of REST endpoint) were removed; future cleanup PRs walk the dedicated describe blocks only.
+
+## Verification gate (closing)
+
+- `npx turbo build` — green on `main` after #180 merged.
+- `npx turbo test` — green; contracts test passes with no v0.2.4 todos remaining (313 live assertions, 4 todos — all v0.2.1 leftovers: `#141` source-level DB/import detection, `#142` ServiceNode.framework field, `#145` drop unused graphology deps).
+- `npx turbo lint` — green.
+- `schema-snapshot.test.ts` — green; committed snapshot reflects the additive diffs above.
+
+## What's *not* in v0.2.4 — open follow-ups
+
+These are scope-bounded gaps the user may want to close before tagging `v0.2.4`, but they don't gate the milestone's contract assertions:
+
+1. **`canPromoteFrontier` is shipped as a function, not yet hooked into `promoteFrontierNodes`.** The block gate exists, is testable, and the contract assertion passes. Wiring it into the production promotion path is a one-line edit in `ingest.ts` plus a thread of `policies` through. Belongs in a small follow-up PR or rolled into the v0.2.5 work.
+2. **`watch.ts` doesn't yet wire `onPolicyTrigger` to `evaluateAllPolicies` + `PolicyViolationsLog`.** The hook surface exists (#116 added it to `IngestContext` / `ExtractOptions` / `StalenessLoopOptions`); the daemon caller is missing. Same scoping decision — small follow-up.
+3. **AUDIT-DRIFT amendments to `verification.md`.** Two MCP-audit findings are now stale because the contracts resolved them in favour of the contract:
+   - "HTTP transport for remote — FAIL" → contract is stdio-only, this is permanent.
+   - "evaluate_policy + get_policy_violations two-tool split" → rejected per ADR-045; single `check_policies` ships instead.
+4. **`#118` — real-world policy library.** Five to ten example policies under `examples/policies/` exercising the OBSERVED-vs-EXTRACTED divergence shape. Not contract-bound; demo-material work that supports the MVP-success-PR experiment.
+
+## Where v0.2.5 picks up
+
+Track 2 continues with v0.2.5 — Distribution layer. Contracts #19–#22 (`neat init`, SDK install, machine-level project registry, daemon) are pending in PR #166 (stacked on the now-merged #165). Implementation work follows the same layer-by-layer pattern.
+
+After v0.2.5 lands, the **MVP-success-PR experiment** opens per ADR-027: point NEAT at an open-source codebase, identify a real divergence-shaped bug, ship the fix. That's the gate for self-hosting on the NEAT codebase.
+
+The kickoff doc `docs/plans/2026-05-06-v0.2.4-kickoff.md` is superseded by this close doc.

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -1228,8 +1228,35 @@ describe('getBlastRadius contract (ADR-038)', () => {
     expect(result.totalAffected).toBe(result.affectedNodes.length)
   })
 
-  it.todo('BlastRadiusAffectedNode carries path field with origin → ... → nodeId (issue #137)')
-  it.todo('BlastRadiusAffectedNode carries confidence field cascaded from edges along path (issue #137)')
+  it('BlastRadiusAffectedNode carries path field with origin → ... → nodeId (issue #137)', () => {
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:a', { id: 'service:a', type: NodeType.ServiceNode, name: 'a', language: 'javascript' })
+    g.addNode('service:b', { id: 'service:b', type: NodeType.ServiceNode, name: 'b', language: 'javascript' })
+    const ab = `${EdgeType.CALLS}:service:a->service:b`
+    g.addEdgeWithKey(ab, 'service:a', 'service:b', {
+      id: ab, source: 'service:a', target: 'service:b',
+      type: EdgeType.CALLS, provenance: Provenance.OBSERVED,
+      lastObserved: '2026-05-06T00:00:00.000Z', callCount: 1, confidence: 1.0,
+    })
+    const result = getBlastRadius(g, 'service:a')
+    const b = result.affectedNodes.find((n) => n.nodeId === 'service:b')!
+    expect(b.path).toEqual(['service:a', 'service:b'])
+  })
+
+  it('BlastRadiusAffectedNode carries confidence field cascaded from edges along path (issue #137)', () => {
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:a', { id: 'service:a', type: NodeType.ServiceNode, name: 'a', language: 'javascript' })
+    g.addNode('service:b', { id: 'service:b', type: NodeType.ServiceNode, name: 'b', language: 'javascript' })
+    const ab = `${EdgeType.CALLS}:service:a->service:b`
+    g.addEdgeWithKey(ab, 'service:a', 'service:b', {
+      id: ab, source: 'service:a', target: 'service:b',
+      type: EdgeType.CALLS, provenance: Provenance.EXTRACTED,
+    })
+    const result = getBlastRadius(g, 'service:a')
+    const b = result.affectedNodes.find((n) => n.nodeId === 'service:b')!
+    // 1-hop EXTRACTED ceiling = 0.5.
+    expect(b.confidence).toBeCloseTo(0.5, 5)
+  })
   it('BlastRadiusAffectedNode.distance schema rejects 0 (issue #138)', async () => {
     const { BlastRadiusAffectedNodeSchema } = await import('@neat/types')
     // distance must be positive — the origin is never in affectedNodes, so 0
@@ -1555,7 +1582,32 @@ describe('MCP tool surface contract (ADR-039)', () => {
     expect(offenders, offenders.join('\n')).toEqual([])
   })
 
-  it.todo('every server.tool registration in mcp/src/index.ts has a name from the locked allowlist of nine tools (ADR-039)')
+  it('every server.tool registration in mcp/src/index.ts has a name from the locked allowlist of nine tools (ADR-039)', () => {
+    const ALLOWED = new Set([
+      'get_root_cause',
+      'get_blast_radius',
+      'get_dependencies',
+      'get_observed_dependencies',
+      'get_incident_history',
+      'semantic_search',
+      'get_graph_diff',
+      'get_recent_stale_edges',
+      'check_policies',
+    ])
+    const indexTs = readFileSync(join(MCP_SRC, 'index.ts'), 'utf8')
+    const re = /server\.tool\(\s*['"]([^'"]+)['"]/g
+    const found = new Set<string>()
+    let m: RegExpExecArray | null
+    while ((m = re.exec(indexTs)) !== null) {
+      found.add(m[1]!)
+    }
+    // Every found tool must be in the allowlist.
+    const offenders = [...found].filter((name) => !ALLOWED.has(name))
+    expect(offenders, offenders.join(', ')).toEqual([])
+    // And every allowed tool must be registered.
+    const missing = [...ALLOWED].filter((name) => !found.has(name))
+    expect(missing, missing.join(', ')).toEqual([])
+  })
   it('formatToolResponse helper exists at mcp/src/format.ts (issue #143)', () => {
     const formatPath = join(MCP_SRC, 'format.ts')
     const content = readFileSync(formatPath, 'utf8')
@@ -1990,12 +2042,16 @@ describe('Policy contracts (ADRs 042-045)', () => {
 // ──────────────────────────────────────────────────────────────────────────
 // Queued — flipped from todo to live as cleanup issues land
 // ──────────────────────────────────────────────────────────────────────────
-describe('Queued contracts (issues #140-#145)', () => {
+describe('Queued contracts (v0.2.1 leftovers — #141, #142, #145)', () => {
   // v0.2.2 OTel-ingest todos (#131-#135) used to live here. Removed when v0.2.2
   // closed — every ADR-033 assertion is live in its dedicated describe block.
   // v0.2.3 traversal todos (#136-#139) used to live here too. Removed when
   // v0.2.3 closed — every ADR-036/037/038 assertion is live in its dedicated
   // describe block.
+  // v0.2.4 MCP-refresh todos (#143, #144) likewise removed — both ADR-039
+  // assertions live in the MCP tool surface and queued-list duplicates were
+  // noise. The remaining three (#141, #142, #145) are v0.2.1 leftovers
+  // tracked under v0.x rolling cleanup per the v0.2.1 close.
   it('Ghost EXTRACTED edges removed on re-extract (issue #140)', async () => {
     const { extractedEdgeId } = await import('@neat/types')
     const { retireEdgesByFile } = await import('../../src/extract/retire.js')
@@ -2051,44 +2107,5 @@ describe('Queued contracts (issues #140-#145)', () => {
   })
   it.todo('Source-level DB connection + import detection (issue #141)')
   it.todo('ServiceNode.framework populated from package.json (issue #142)')
-  it('MCP tools emit standardized three-part response (issue #143)', () => {
-    // Static assertion: every server.tool implementation in tools.ts routes
-    // through formatToolResponse / formatEmptyResponse / formatErrorResponse.
-    // The tool body uses one of those exports somewhere; absent that, output
-    // drift is possible.
-    const tools = readFileSync(join(MCP_SRC, 'tools.ts'), 'utf8')
-    expect(tools).toMatch(/from\s+['"]\.\/format\.js['"]/)
-    expect(tools).toMatch(/formatToolResponse\s*\(/)
-    expect(tools).toMatch(/formatEmptyResponse\s*\(/)
-    expect(tools).toMatch(/formatErrorResponse\s*\(/)
-    // No raw `return text(...)` stragglers that bypass the helper.
-    expect(tools).not.toMatch(/return\s+text\s*\(/)
-  })
-  it('get_dependencies is transitive (issue #144)', async () => {
-    // End-to-end shape check: getTransitiveDependencies returns a flat list
-    // with distance + edgeType + provenance. Zod validates the shape on
-    // return; this assertion exercises the schema-validation path too.
-    const { getTransitiveDependencies } = await import('../../src/traverse.js')
-    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
-    g.addNode('service:a', { id: 'service:a', type: NodeType.ServiceNode, name: 'a', language: 'javascript' })
-    g.addNode('service:b', { id: 'service:b', type: NodeType.ServiceNode, name: 'b', language: 'javascript' })
-    g.addNode('service:c', { id: 'service:c', type: NodeType.ServiceNode, name: 'c', language: 'javascript' })
-    const ab = `${EdgeType.CALLS}:service:a->service:b`
-    g.addEdgeWithKey(ab, 'service:a', 'service:b', {
-      id: ab, source: 'service:a', target: 'service:b',
-      type: EdgeType.CALLS, provenance: Provenance.OBSERVED,
-      lastObserved: '2026-05-06T00:00:00.000Z', callCount: 1, confidence: 1.0,
-    })
-    const bc = `${EdgeType.CALLS}:service:b->service:c`
-    g.addEdgeWithKey(bc, 'service:b', 'service:c', {
-      id: bc, source: 'service:b', target: 'service:c',
-      type: EdgeType.CALLS, provenance: Provenance.EXTRACTED,
-    })
-    const result = getTransitiveDependencies(g, 'service:a', 3)
-    expect(result.total).toBe(2)
-    expect(result.dependencies[0]!.distance).toBe(1)
-    expect(result.dependencies[1]!.distance).toBe(2)
-    expect(result.dependencies[0]!.edgeType).toBe(EdgeType.CALLS)
-  })
   it.todo('Drop unused graphology-traversal/-shortest-path deps (issue #145)')
 })


### PR DESCRIPTION
## Summary

Closes the v0.2.4 Policies + MCP refresh milestone. The architecture-first surface ships — NEAT now asserts intent (policies) in addition to observing reality (OTel).

## Tracker cleanup (\`contracts.test.ts\`)

- Removes the v0.2.4 \`it.todo\` / live-test duplicates from \`describe('Queued contracts ...')\`. \`#143\` (three-part response) and \`#144\` (transitive \`get_dependencies\`) had ghost duplicates of their dedicated describe-block versions; the duplicates are gone, the block headline updated to \`'v0.2.1 leftovers — #141, #142, #145'\`.
- Flips three stragglers that survived prior closes:
  - \`BlastRadiusAffectedNode carries path field\` (#137) — implementation landed in #170, duplicate todo at \`getBlastRadius contract\` block stayed by accident
  - \`BlastRadiusAffectedNode carries confidence field\` (#137) — same
  - \`Nine-tool allowlist scan\` (ADR-039) — only verifiable once \`check_policies\` registered with #180

## Status doc

Adds \`docs/plans/2026-05-06-v0.2.4-close.md\` capturing what landed (5 implementation PRs across #175–#180), the three user-visible behaviour changes, the schema-growth audit trail, all 21 contract assertions flipped, and four follow-ups left open.

## Behaviour changes consumers will feel (from the milestone)

1. **MCP tool output is a three-part response** — \`{NL summary} \\n\\n {structured block} \\n\\n confidence: X.XX · provenance: ...\`. Empty result → footer reads \`n/a / n/a\`. (#178)
2. **\`get_dependencies\` is transitive.** Default depth 3, max 10. \`depth=1\` recovers direct-only behaviour. (#179)
3. **NEAT now asserts intent.** \`policy.json\` at the project root declares architectural assertions; violations append to \`policy-violations.ndjson\`, surface via \`GET /policies/violations\`, and notify subscribers of \`neat://policies/violations\`. (#115, #116, #117)

## Open follow-ups (not v0.2.4 blockers; surfaced for the user to decide before tagging)

1. \`canPromoteFrontier\` shipped as a function but not yet hooked into \`promoteFrontierNodes\`. Small follow-up edit in \`ingest.ts\`.
2. \`watch.ts\` doesn't yet wire \`onPolicyTrigger\` to \`evaluateAllPolicies\` + \`PolicyViolationsLog\`. Hooks exist (#116); daemon caller is missing.
3. AUDIT-DRIFT amendments to \`verification.md\`: HTTP-transport FAIL is now contract-resolved (stdio-only, permanent); \`evaluate_policy\` + \`get_policy_violations\` two-tool split rejected per ADR-045.
4. \`#118\` — real-world policy library. Not contract-bound; demo material for the MVP-success-PR experiment.

## Test plan

- [x] \`npx turbo build\` clean
- [x] \`npx turbo test\` — 313 pass, 4 todo (the 4 are all v0.2.1 leftovers: #141, #142 ×2, #145)
- [x] \`npx turbo lint\` clean

Refs ADR-039, ADR-040, ADR-041, ADR-042, ADR-043, ADR-044, ADR-045