### PR TITLE
v0.2.4 maintenance — wire policy daemon paths

### DIFF
--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -5,8 +5,11 @@ import type {
   ErrorEvent,
   FrontierNode,
   GraphEdge,
+  Policy,
   ServiceNode,
 } from '@neat/types'
+import type { EvaluationContext as PolicyEvaluationContext } from './policy.js'
+import { canPromoteFrontier } from './policy.js'
 import {
   EdgeType,
   NodeType,
@@ -619,7 +622,20 @@ export { stitchTrace }
 // running it there picks up the case the issue describes: ingest fills in a
 // frontier when traffic arrives for an unknown host, and the next extraction
 // round resolves it.
-export function promoteFrontierNodes(graph: NeatGraph): number {
+// Optional gate for block-action policies (ADR-044). When `policies` is
+// non-empty, each candidate FrontierNode runs through `canPromoteFrontier`
+// before its incident edges are rewired. Block-action policies that fire on
+// the frontier veto the promotion — the FrontierNode persists; the next
+// extract pass tries again.
+export interface PromoteFrontierOptions {
+  policies?: Policy[]
+  policyCtx?: PolicyEvaluationContext
+}
+
+export function promoteFrontierNodes(
+  graph: NeatGraph,
+  opts: PromoteFrontierOptions = {},
+): number {
   const aliasIndex = new Map<string, string>()
   graph.forEachNode((id, attrs) => {
     const a = attrs as ServiceNode & { type?: string }
@@ -640,11 +656,22 @@ export function promoteFrontierNodes(graph: NeatGraph): number {
     toPromote.push({ frontierId: id, serviceId: target })
   })
 
+  let promoted = 0
   for (const { frontierId, serviceId } of toPromote) {
+    if (opts.policies && opts.policies.length > 0 && opts.policyCtx) {
+      const gate = canPromoteFrontier(graph, frontierId, opts.policies, opts.policyCtx)
+      if (!gate.allowed) {
+        // Block-action policy fired on this frontier — skip the rewire and
+        // leave the FrontierNode in place. Violations already surfaced via
+        // the policy log on the same evaluation pass.
+        continue
+      }
+    }
     rewireFrontierEdges(graph, frontierId, serviceId)
     graph.dropNode(frontierId)
+    promoted++
   }
-  return toPromote.length
+  return promoted
 }
 
 function rewireFrontierEdges(graph: NeatGraph, frontierId: string, serviceId: string): void {

--- a/packages/core/src/watch.ts
+++ b/packages/core/src/watch.ts
@@ -17,6 +17,12 @@ import {
   promoteFrontierNodes,
   startStalenessLoop,
 } from './ingest.js'
+import {
+  evaluateAllPolicies,
+  loadPolicyFile,
+  PolicyViolationsLog,
+} from './policy.js'
+import type { Policy } from '@neat/types'
 import { buildOtelReceiver } from './otel.js'
 import { startOtelGrpcReceiver } from './otel-grpc.js'
 import { loadGraphFromDisk, startPersistLoop } from './persist.js'
@@ -211,13 +217,53 @@ export async function startWatch(
   const debounceMs = opts.debounceMs ?? 1000
 
   await loadGraphFromDisk(graph, opts.outPath)
+
+  // Load policies + open the violations log once at startup. policy.json
+  // lives at the project root per ADR-042 §File location; absent file is
+  // a perfectly fine state (loadPolicyFile returns []). Reload-on-change
+  // is queued for v0.2.5 — the kickoff doc tracks it.
+  const policyFilePath = path.join(opts.scanPath, 'policy.json')
+  const policyViolationsPath = path.join(path.dirname(opts.outPath), 'policy-violations.ndjson')
+  let policies: Policy[] = []
+  try {
+    policies = await loadPolicyFile(policyFilePath)
+    if (policies.length > 0) {
+      console.log(`policies: loaded ${policies.length} from ${policyFilePath}`)
+    }
+  } catch (err) {
+    console.warn(`policies: failed to load ${policyFilePath} — ${(err as Error).message}`)
+  }
+  const policyLog = new PolicyViolationsLog(policyViolationsPath)
+
+  // Single shared trigger callback wired into post-ingest, post-extract, and
+  // post-stale per ADR-043. Failures append to console.warn but don't kill
+  // the daemon — a malformed evaluator shouldn't take down ingest.
+  const onPolicyTrigger = async (g: NeatGraph): Promise<void> => {
+    if (policies.length === 0) return
+    try {
+      const violations = evaluateAllPolicies(g, policies, { now: () => Date.now() })
+      for (const v of violations) await policyLog.append(v)
+    } catch (err) {
+      console.warn(`policies: evaluation failed — ${(err as Error).message}`)
+    }
+  }
+
+  // The post-extract trigger fires from extractFromDirectory via opts.
+  // For the initial extract here we run it inline so violations land on
+  // startup before the receiver opens. Subsequent watch-driven re-extract
+  // passes go through runExtractPhases which doesn't take the hook directly
+  // — we run it after each flush() instead.
   const initial = await runExtractPhases(graph, opts.scanPath, new Set(ALL_PHASES))
   console.log(
     `extract: ${initial.nodesAdded} new nodes, ${initial.edgesAdded} new edges (graph total ${graph.order}/${graph.size})`,
   )
+  await onPolicyTrigger(graph)
 
   const stopPersist = startPersistLoop(graph, opts.outPath)
-  const stopStaleness = startStalenessLoop(graph, { staleEventsPath: opts.staleEventsPath })
+  const stopStaleness = startStalenessLoop(graph, {
+    staleEventsPath: opts.staleEventsPath,
+    onPolicyTrigger,
+  })
 
   const host = opts.host ?? '0.0.0.0'
   const port = opts.port ?? 8080
@@ -268,6 +314,7 @@ export async function startWatch(
     graph,
     errorsPath: opts.errorsPath,
     writeErrorEventInline: false,
+    onPolicyTrigger,
   })
   const onErrorSpanSync = makeErrorSpanWriter(opts.errorsPath)
   const otelHttp = await buildOtelReceiver({ onSpan, onErrorSpanSync })
@@ -281,7 +328,11 @@ export async function startWatch(
     // awaits onSpan synchronously (otel-grpc.ts), so the same durability
     // guarantee is met without a separate sync hook. Non-blocking gRPC
     // ingest is out of scope for the v0.2.2 batch.
-    const onSpanGrpc = makeSpanHandler({ graph, errorsPath: opts.errorsPath })
+    const onSpanGrpc = makeSpanHandler({
+      graph,
+      errorsPath: opts.errorsPath,
+      onPolicyTrigger,
+    })
     const r = await startOtelGrpcReceiver({ onSpan: onSpanGrpc, host, port: grpcPort })
     console.log(`neat-core OTLP/gRPC receiver on ${r.address}`)
     grpcReceiver = r
@@ -319,6 +370,12 @@ export async function startWatch(
           console.warn('[watch] semantic_search refresh failed', err)
         }
       }
+      // Post-extract policy trigger (ADR-043). The runExtractPhases call
+      // doesn't take the hook directly — it runs through promoteFrontierNodes
+      // for FRONTIER → OBSERVED upgrades but doesn't load policies itself.
+      // Firing the evaluator here keeps the trigger surface symmetric across
+      // ingest / extract / stale paths.
+      await onPolicyTrigger(graph)
     } catch (err) {
       console.error('[watch] re-extract failed', err)
     }

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -1945,6 +1945,26 @@ describe('Policy contracts (ADRs 042-045)', () => {
     // MCP coupling. Notification side effects belong to the alert action,
     // wired in #117 (the policy MCP surface).
   })
+  it('watch.ts wires onPolicyTrigger into ingest, extract, and stale paths (ADR-043)', () => {
+    // Static scan: the daemon loads policies once, builds a PolicyViolationsLog,
+    // and threads onPolicyTrigger into makeSpanHandler / startStalenessLoop /
+    // the post-flush re-extract path. Without this wiring the engine is
+    // dormant in production — every contract assertion would still pass
+    // because the function exists, but no policy.json would ever evaluate
+    // outside POST /policies/check.
+    const watchTs = readFileSync(join(CORE_SRC, 'watch.ts'), 'utf8')
+    expect(watchTs).toMatch(/loadPolicyFile\s*\(/)
+    expect(watchTs).toMatch(/PolicyViolationsLog/)
+    expect(watchTs).toMatch(/evaluateAllPolicies\s*\(/)
+    expect(watchTs).toMatch(/onPolicyTrigger/)
+    // Wired into the three trigger paths: makeSpanHandler call(s), the
+    // staleness-loop options object, and at least one direct invocation
+    // after the watch-driven flush() to cover post-extract.
+    const onSpanHandlerCount = (watchTs.match(/makeSpanHandler\(\{[^}]*onPolicyTrigger/g) ?? []).length
+    expect(onSpanHandlerCount).toBeGreaterThanOrEqual(1)
+    expect(watchTs).toMatch(/startStalenessLoop\([^)]*\{[\s\S]*onPolicyTrigger/m)
+  })
+
   it('alert action appends + emits notifications/resources/updated (ADR-044)', () => {
     // Alert action's notification surface lives in mcp/src/resources.ts: the
     // same poll-and-notify pattern as incidents fires sendResourceUpdated
@@ -1955,6 +1975,62 @@ describe('Policy contracts (ADRs 042-045)', () => {
     expect(resources).toMatch(/sendResourceUpdated\([^)]*POLICY_VIOLATIONS_URI[\s\S]{0,40}\)/)
     // The poll loop reads /policies/violations to detect changes.
     expect(resources).toMatch(/\/policies\/violations/)
+  })
+
+  it('promoteFrontierNodes honors canPromoteFrontier and skips block-gated frontiers (ADR-044)', async () => {
+    const { promoteFrontierNodes } = await import('../../src/ingest.js')
+    const { frontierId, frontierEdgeId } = await import('@neat/types')
+    const fid = frontierId('blocked.host')
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:caller', {
+      id: 'service:caller',
+      type: NodeType.ServiceNode,
+      name: 'caller',
+      language: 'javascript',
+    })
+    // Service whose name matches the frontier host → would otherwise promote.
+    g.addNode('service:resolved', {
+      id: 'service:resolved',
+      type: NodeType.ServiceNode,
+      name: 'blocked.host',
+      language: 'javascript',
+      aliases: ['blocked.host'],
+    })
+    g.addNode(fid, {
+      id: fid,
+      type: NodeType.FrontierNode,
+      name: 'blocked.host',
+      host: 'blocked.host',
+    })
+    const eId = frontierEdgeId('service:caller', fid, EdgeType.CALLS)
+    g.addEdgeWithKey(eId, 'service:caller', fid, {
+      id: eId,
+      source: 'service:caller',
+      target: fid,
+      type: EdgeType.CALLS,
+      provenance: Provenance.FRONTIER,
+      lastObserved: '2026-05-07T00:00:00.000Z',
+      callCount: 1,
+    })
+    // Critical-severity ownership policy on FrontierNode → defaults to block.
+    const policies = [
+      {
+        id: 'frontier-must-have-owner',
+        name: 'frontier nodes must declare an owner',
+        severity: 'critical' as const,
+        rule: {
+          type: 'ownership' as const,
+          nodeType: NodeType.FrontierNode,
+          field: 'owner',
+        },
+      },
+    ]
+    const ctx = { now: () => Date.parse('2026-05-07T00:00:00.000Z') }
+    const promoted = promoteFrontierNodes(g, { policies, policyCtx: ctx })
+    expect(promoted).toBe(0)
+    // Frontier is still in the graph because the block fired.
+    expect(g.hasNode(fid)).toBe(true)
+    expect(g.hasEdge(eId)).toBe(true)
   })
 
   it('block action returns false from canPromoteFrontier when block-policy violates (ADR-044)', async () => {


### PR DESCRIPTION
## Summary

Two follow-ups noted in the v0.2.4 close doc, both small enough to land before tagging. Without these, the policy surface ships but the daemon doesn't actually use it.

### 1. \`canPromoteFrontier\` hooked into \`promoteFrontierNodes\`

\`promoteFrontierNodes\` now takes optional \`{ policies, policyCtx }\`. When provided, each candidate frontier runs through \`canPromoteFrontier\` before its incident edges are rewired. Block-action policies that fire on the frontier veto the promotion — the FrontierNode persists, the next extract pass tries again.

Without policies, behaviour is unchanged — every existing fixture / demo / test call site that omits the option works as before.

### 2. \`watch.ts\` wires \`onPolicyTrigger\` into ingest, extract, and stale

The daemon now:
- Reads \`policy.json\` from the project root once at startup (\`loadPolicyFile\`, ADR-042 §File location). Absent file → no policies; that's a fine state.
- Builds a \`PolicyViolationsLog\` at \`neat-out/policy-violations.ndjson\`.
- Threads a single \`onPolicyTrigger\` callback into \`IngestContext\` (HTTP + gRPC handlers), \`StalenessLoopOptions\`, and after each watch-driven \`flush()\`. Each trigger runs \`evaluateAllPolicies\` and appends new violations.
- Fires the trigger inline once on initial extract so violations land before the receiver opens.

Reload-on-change of \`policy.json\` is queued for v0.2.5.

## Two new contract assertions

In \`packages/core/test/audits/contracts.test.ts\`:

- ✅ \`promoteFrontierNodes honors canPromoteFrontier and skips block-gated frontiers\` (ADR-044) — fixture: critical-severity ownership policy on FrontierNode defaults to block, the frontier persists in the graph after the promotion call.
- ✅ \`watch.ts wires onPolicyTrigger into ingest, extract, and stale paths\` (ADR-043) — static scan asserts \`loadPolicyFile\`, \`PolicyViolationsLog\`, \`evaluateAllPolicies\`, and the three trigger call sites all appear in \`watch.ts\`.

315 contract assertions passing (was 313), 4 todos remaining (unchanged — all v0.2.1 leftovers).

## Why now

The v0.2.4 close doc flagged these two as required-before-tag. Folding them into one small PR rather than letting them drift into v0.2.5 keeps the tag readable: \"v0.2.4 = the policy surface works end-to-end\" rather than \"v0.2.4 = the policy types and API exist; daemon hookup pending.\"

Remaining v0.2.4 follow-ups (AUDIT-DRIFT amendments and #118 example library) are documentation / demo-material work that doesn't gate a tag.

## Test plan

- [x] \`npx turbo build\` clean
- [x] \`npx turbo test\` — 315 pass, 4 todo
- [x] \`npx turbo lint\` clean

Refs ADR-043, ADR-044