### PR TITLE
v0.2.5 kickoff status doc — implementation queue for the next agent

### DIFF
--- a/docs/plans/2026-05-07-v0.2.5-kickoff.md
+++ b/docs/plans/2026-05-07-v0.2.5-kickoff.md
@@ -1,0 +1,107 @@
+# v0.2.5 Distribution layer — kickoff for the implementation agent
+
+**Last updated:** 2026-05-07
+
+This is the "pick up here" doc for v0.2.5 work. Read it first. Supersedes the v0.2.4 kickoff doc as the active milestone tracker.
+
+## Where we are
+
+- **v0.2.0 Sunrise** — closed, tagged [`v0.2.0`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.0).
+- **v0.2.1 — Tree-sitter rebuild** — closed, tagged [`v0.2.1`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.1).
+- **v0.2.2 — OTel ingest rebuild** — closed, tagged [`v0.2.2`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.2).
+- **v0.2.3 — Traversal rebuild** — closed, tagged [`v0.2.3`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.3).
+- **v0.2.4 — Policies + MCP refresh** — implementation effectively complete on `main` (#175 / #177 / #178 / #179 / #180 / #181 / #182). Tag `v0.2.4` lands when the milestone formally closes; the issue list still shows OPEN by GitHub-state convention but the work has shipped.
+- **v0.2.5 — Distribution layer** — **OPEN. Contracts on main; implementation has not shipped.**
+- **v0.2.6 — CLI parity + frontend-API surface** — milestone exists; contracts queued (#23, #24); not yet drafted.
+
+## What v0.2.5 is
+
+The distribution layer — what makes NEAT installable on a real codebase. Four contracts already on main govern this work (PR #166):
+
+- **#19 `neat init`** ([`init.md`](../contracts/init.md), ADR-046) — one-time registration moment. Discovery before mutation. Patch-by-default; `--apply` opt-in. Lockfiles never touched. Idempotent. `init` and `install` are one command.
+- **#20 SDK install** ([`sdk-install.md`](../contracts/sdk-install.md), ADR-047) — per-language installer modules with a `detect` / `plan` / `apply` interface. Plan and apply decoupled. Two languages in MVP: Node and Python. Java / Ruby / .NET / Go / Rust deferred.
+- **#21 Machine-level project registry** ([`project-registry.md`](../contracts/project-registry.md), ADR-048) — single file `~/.neat/projects.json`, per-user, machine-local. Atomic writes (tmp + rename). Exclusive flock during writes. Path-normalized.
+- **#22 Daemon** ([`daemon.md`](../contracts/daemon.md), ADR-049) — single long-lived `neatd` process watching every registered project. Per-project graph isolation. File mtime + OTel + `policy.json` triggers. Graceful per-project failure.
+
+The contracts shipped via PR #166. Implementation against them is the work this milestone does.
+
+## Why v0.2.5 matters
+
+Without v0.2.5, NEAT is a local toolchain that requires manual setup per codebase. With v0.2.5, NEAT is **installable** — `neat init <repo>` is the single command that bootstraps the whole stack on any codebase. The MVP-success-PR experiment (ADR-027) becomes runnable: point NEAT at an open-source codebase, instrument it, watch the daemon find the divergence-shaped bug.
+
+This is also where the **Claude Code skill** ships, so the AI-agent integration story isn't manual MCP wiring per project.
+
+## Issue queued
+
+One umbrella issue against the v0.2.5 milestone:
+
+- **#119** — v0.2.5 — `neat init` for arbitrary codebases + SDK install + Claude Code skill
+
+The umbrella shape reflects how interlocked the four contracts are — `init` calls into `installers/`, `installers/` writes patches that `daemon` will pick up, `daemon` reads the `registry`, `registry` is what `init` writes. Closing #119 means all four contracts have implementation that flips their `it.todo` items to live assertions.
+
+## Recommended implementation order
+
+Build outside-in: registry first (everything else writes to it), then init's discovery + graph build (existing `extractFromDirectory` plus a registry write), then per-language installers, then daemon, then Claude skill packaging. Each step lands as a sub-PR; #119 closes when the last one merges.
+
+1. **Registry (#21 / ADR-048)** — `packages/core/src/registry.ts`. `~/.neat/projects.json` reader/writer with `writeAtomically` (tmp + fsync + rename), exclusive flock on `~/.neat/projects.json.lock`, path normalization. CLI commands `neat list`, `neat pause`, `neat resume`, `neat uninstall`. Flips the five ADR-048 `it.todo` items.
+
+2. **`neat init` mechanics (#19 / ADR-046)** — extend `cli.ts` to:
+   - run discovery (existing `discoverServices`),
+   - print the discovery report,
+   - run static extraction (existing `extractFromDirectory`),
+   - write the registry entry,
+   - generate the SDK install plan (next step),
+   - apply or hold based on `--apply`.
+
+   Add `--dry-run`, `--apply`, `--no-install`, `--project <name>` flags. Idempotency check: re-running on already-registered project produces no diff in registry, regenerates patch skipping already-applied changes. Flips the seven ADR-046 `it.todo` items.
+
+3. **SDK installers — Node (#20 / ADR-047)** — `packages/core/src/installers/javascript.ts`. `detect(serviceDir)` → does it look like Node? `plan(serviceDir)` → `InstallPlan` with `dependencyEdits` (add `@opentelemetry/api`, `sdk-node`, `auto-instrumentations-node` to `package.json`), `entrypointEdits` (prefix `scripts.start` or Procfile / Dockerfile CMD with auto-instrumentation hook), `envEdits` (`OTEL_EXPORTER_OTLP_ENDPOINT`). `apply(plan)` runs the codemod; partial-apply produces `neat-rollback.patch`. Flips four ADR-047 `it.todo` items including the empty-plan-on-already-installed case.
+
+4. **SDK installers — Python (#20 / ADR-047)** — `packages/core/src/installers/python.ts`. Same interface. `detect` looks for `requirements.txt` / `pyproject.toml` / `setup.py`. `plan` adds `opentelemetry-distro` + `opentelemetry-exporter-otlp` to the right manifest, prefixes the entrypoint with `opentelemetry-instrument`. Flips two more ADR-047 `it.todo` items.
+
+5. **Daemon (#22 / ADR-049)** — `packages/core/src/daemon.ts` plus a `neatd` bin entry. CLI commands `neatd start [--foreground]`, `neatd stop`, `neatd reload`, `neatd status`. Per-project chokidar watchers, OTel ingest routing by `service.name`, policy reload on `policy.json` mtime change, staleness loop per ADR-024. `~/.neat/neatd.pid` for external supervisors. `SIGHUP` triggers registry re-read. Graceful per-project failure. Flips six ADR-049 `it.todo` items.
+
+6. **Claude Code skill packaging** — package up an MCP config the user can drop into their Claude Code settings, plus any documentation. The shape lives outside the four locked contracts; this step is the "make NEAT installable as a Claude Code tool" piece. Could be a small `packages/claude-skill/` directory with the `claude_code_config.json` template and a README.
+
+## Reference points
+
+- Contracts: [`init.md`](../contracts/init.md), [`sdk-install.md`](../contracts/sdk-install.md), [`project-registry.md`](../contracts/project-registry.md), [`daemon.md`](../contracts/daemon.md).
+- ADRs: 046-049 in [`docs/decisions.md`](../decisions.md).
+- Existing source touched: `packages/core/src/{cli,extract,ingest,persist,watch}.ts`, `packages/core/src/extract/index.ts`.
+- New source: `packages/core/src/{registry,daemon}.ts`, `packages/core/src/installers/{javascript,python,shared}.ts`.
+- Existing tests: `packages/core/test/{api,persist,watch}.test.ts`, `packages/core/test/audits/contracts.test.ts`.
+- Hook surface: editing `cli.ts` will surface `init` + `sdk-install`. Editing `installers/*` surfaces `sdk-install`. Editing `registry.ts` surfaces `project-registry` + `init` + `daemon`. Editing `daemon.ts` surfaces `daemon` + `project-registry` + `lifecycle`.
+
+## Closing condition
+
+v0.2.5 closes when:
+
+1. #119 has shipped on `main` (the umbrella implementation issue).
+2. Every `it.todo` in `contracts.test.ts` keyed to ADRs 046-049 has flipped to a live assertion and passes — that's roughly 25 todos across the four contracts.
+3. `neat init <some-test-codebase>` produces a clean discovery report, an applied or held patch, a registry entry, and a graph snapshot — verified end-to-end on a real OSS repo.
+4. `neatd start` watches the registry, picks up new projects on `neatd reload`, routes OTel spans correctly, gracefully handles a missing project path.
+5. The Claude Code skill installs into Claude Code with one command and exposes the nine MCP tools.
+6. `npx turbo build test lint` is green on `main`.
+7. Tag `v0.2.5` is created at the last v0.2.5 implementation commit; GitHub release published.
+
+## What's not in v0.2.5
+
+- **eBPF / service-mesh capture** — out of scope per the v0.2.x sequencing discussion. SDK install at `init` time is the only OBSERVED-edge mechanism in MVP.
+- **Java / Ruby / .NET / Go / Rust SDK installers** — out of MVP scope per ADR-047. Each requires a successor ADR.
+- **Multi-machine registry sync** — deferred; per-machine is MVP per ADR-048.
+- **Daemon auto-restart on crash** — supervisor's job (systemd / launchd); MVP daemon writes its PID and lets the user / OS restart.
+- **Self-hosting on the NEAT codebase** — gated behind the MVP-success PR (ADR-027). Until that closes, NEAT is the target of construction, not the tool.
+
+## Open product calls (carried)
+
+- `drivers` vs `dependencies` field name on ServiceNode — recommended: keep `dependencies` raw, defer `drivers` until a second consumer materializes. Doesn't block v0.2.5.
+
+The previous open calls on policies REST path and MCP tool count were resolved in the v0.2.4 contract batch.
+
+## What v0.2.6 looks like
+
+Not part of this milestone, but for context: v0.2.6 (CLI parity + frontend-API surface) opens immediately after v0.2.5 closes. Contracts #23 / #24 will be drafted at that point — not now, per the rebuild-contract discipline. The CLI parity contract specifically benefits from seeing how `init` actually shapes up before deciding what other CLI verbs need to look like.
+
+## When this file is wrong
+
+Snapshot, not contract. If `main` has moved since the date at the top, treat the description as historical and check `git log` + `gh release list` for canonical state. New status docs land as `docs/plans/<date>-<milestone>-status.md`.


### PR DESCRIPTION
## Summary

Sets up v0.2.5 (Distribution layer) for the next implementation agent. Same shape as the v0.2.3 / v0.2.4 kickoff docs.

## What this PR contains

\`docs/plans/2026-05-07-v0.2.5-kickoff.md\` — one new status doc.

## What's documented

- **Where we are.** v0.2.0/v0.2.1/v0.2.2/v0.2.3 closed and tagged. v0.2.4 implementation effectively complete on main; tag lands when the milestone formally closes.
- **What v0.2.5 is.** Distribution layer — what makes NEAT installable on a real codebase. Four contracts (#19 init, #20 SDK install, #21 registry, #22 daemon) already on main via PR #166.
- **One umbrella issue queued:** #119.
- **Recommended outside-in implementation order:**
  1. Registry (everything else writes to it)
  2. \`neat init\` mechanics (discovery + report + extract + register + plan + apply-or-hold)
  3. Node SDK installer
  4. Python SDK installer
  5. Daemon (\`neatd\` + chokidar + OTel routing + policy reload + staleness loop)
  6. Claude Code skill packaging
- **Reference points:** four contract files, ADRs 046-049, source files to touch, new files to create, hook surfacing.
- **Closing condition:** all contract \`it.todo\` items flipped to live, end-to-end \`neat init\` on a test OSS repo, daemon watches registry cleanly, Claude skill installs in one command.

## Test plan

- [ ] Read the kickoff doc end to end.
- [ ] Confirm v0.2.4 close-out / tag is the next thing to land before this milestone formally opens.
- [ ] After merge: spin up the next implementation agent with this doc as the entry point.

Refs #126