### PR TITLE
Re-land v0.2.5 contracts onto current main (ADRs 046-049)

### DIFF
--- a/docs/contracts/daemon.md
+++ b/docs/contracts/daemon.md
@@ -1,0 +1,77 @@
+---
+name: daemon
+description: Single long-lived process watching every registered project. Per-project graph isolation. File-mtime + OTel + policy.json triggers. Graceful per-project failure. Self-hosting gate stays closed during v0.2.5.
+governs:
+  - "packages/core/src/daemon.ts"
+  - "packages/core/src/cli.ts"
+  - "packages/core/src/ingest.ts"
+  - "packages/core/src/extract/index.ts"
+  - "packages/core/src/persist.ts"
+adr: [ADR-049, ADR-048, ADR-026, ADR-027]
+---
+
+# Daemon contract
+
+The fourth of four v0.2.5 distribution-layer contracts. Sibling contracts: [`init.md`](./init.md), [`sdk-install.md`](./sdk-install.md), [`project-registry.md`](./project-registry.md).
+
+The daemon is what makes the graph **continuous**. Without it, `init` snapshots once and the user re-runs extraction manually. With it, edits to source, OTel arrivals, and policy changes drive ongoing graph mutation across every registered project — without per-project `neat watch` invocations.
+
+## Single long-lived process
+
+`neatd start` boots one daemon watching every project in `~/.neat/projects.json`. Per-project graphs in `Map<string, NeatGraph>` per ADR-026. No clustering in MVP.
+
+## Lifecycle commands
+
+| Command | Effect |
+|---------|--------|
+| `neatd start [--foreground]` | start the daemon (default backgrounds via nohup/launchd/systemd; user runs it manually in MVP) |
+| `neatd stop` | graceful shutdown. Flush per [persistence.md](./persistence.md), release lock, exit |
+| `neatd reload` | re-read `~/.neat/projects.json`. Pick up new projects, drop removed ones |
+| `neatd status` | print PID, registered projects, last-seen timestamps |
+
+## Continuous extraction triggers
+
+Per project, daemon watches:
+
+- **Source file mtimes** via chokidar — re-extract phase per [static-extraction.md](./static-extraction.md).
+- **`policy.json` mtime** — reload policies per [policy-schema.md](./policy-schema.md).
+- **`compat.json` mtime** in NEAT's install dir — reload matrix; re-evaluate compatibility policies.
+- **OTel HTTP/gRPC ingest** on `:4318` / `:4317` — `handleSpan` per [otel-ingest.md](./otel-ingest.md).
+- **Staleness loop** per ADR-024 — every 60s.
+
+## Per-project isolation
+
+Each project's graph is its own `MultiDirectedGraph`. File watching, OTel ingest, policy evaluation scoped to the project. A failure in one project does not affect others.
+
+## OTel routing
+
+Spans route to a project by `service.name` lookup across registered projects. Spans for unknown services route to a fallback `'default'` project for FrontierNode auto-creation per ADR-033.
+
+## Graceful degradation
+
+- Registry file missing → daemon refuses to boot with a clear error.
+- Project path missing → mark `status: 'broken'`, continue with others.
+- OTel ingest overwhelmed → backpressure via the queue (ADR-033 #1); spans drop, never block.
+
+## No automatic restart on crash
+
+PID at `~/.neat/neatd.pid` for external supervisors. MVP does not respawn itself.
+
+## Self-hosting gate stays closed
+
+Per ADR-027 + the v0.2.x sequencing: self-hosting NEAT on the NEAT codebase only flips on after the MVP-success PR closes. The daemon contract specifies how self-hosting *would* work; running it on the NEAT codebase is post-#126.
+
+## Authority
+
+`packages/core/src/daemon.ts`. Composes:
+- `registry.ts` — reads `~/.neat/projects.json`.
+- `extract/*` — re-extraction triggers.
+- `ingest.ts` — OTel ingest routing.
+- `policy.ts` — policy reload + evaluation triggers.
+- `persist.ts` — per-project snapshot writes.
+
+## Enforcement
+
+`it.todo` for v0.2.5 #119. Regression test: daemon writes `graph.json` only via `persist.ts` loop and shutdown handlers.
+
+Full rationale: [ADR-049](../decisions.md#adr-049--daemon-contract).

--- a/docs/contracts/init.md
+++ b/docs/contracts/init.md
@@ -1,0 +1,63 @@
+---
+name: init
+description: neat init is one-time registration. Discovery before mutation. Patch-by-default; --apply opt-in. Lockfiles never touched. Idempotent. init and install are one command.
+governs:
+  - "packages/core/src/cli.ts"
+  - "packages/core/src/installers/**"
+  - "packages/core/src/registry.ts"
+adr: [ADR-046, ADR-026, ADR-027]
+---
+
+# `neat init` contract
+
+The first of four v0.2.5 distribution-layer contracts. Sibling contracts: [`sdk-install.md`](./sdk-install.md), [`project-registry.md`](./project-registry.md), [`daemon.md`](./daemon.md).
+
+## One-time registration
+
+`neat init <path>` is the install moment. Like `brew install` followed by `claude init`. Re-running is idempotent but the user's mental model is install-once.
+
+## What `init` does, in order
+
+1. **Discover.** Walk `<path>` honoring `.gitignore` + `IGNORED_DIRS`. Identify services, languages, frameworks. Print a discovery report **before any file mutation.**
+2. **Build initial graph.** Run static extraction (per [static-extraction.md](./static-extraction.md)). Write snapshot.
+3. **Register.** Write a project entry to `~/.neat/projects.json` (per [project-registry.md](./project-registry.md)).
+4. **Generate SDK install patch** for every detected service (per [sdk-install.md](./sdk-install.md)).
+5. **Apply or hold.** With `--apply`, the patch is applied directly. Without it, the patch is written to `neat.patch` for user review and `NEAT_INSTRUMENT.md` explains how to apply.
+6. **Reload daemon.** If running (per [daemon.md](./daemon.md)), signal it to pick up the new project.
+
+## Patch-by-default; `--apply` is opt-in
+
+Init **never** modifies user code without explicit consent. The codemod path produces a patch file for review; only `--apply` runs the patch in-place. `--dry-run` prints without writing.
+
+## What `init` doesn't touch by default
+
+- Manifests (`package.json`, `requirements.txt`, `pyproject.toml`, `Gemfile`, `pom.xml`) — only modified under `--apply`.
+- Lockfiles — never modified directly. Post-`--apply` prints "run `npm install`" so user owns the lockfile commit.
+- `.env` and config files — never modified.
+- Running processes — never instrumented; SDK install only modifies start commands for next-process start.
+
+## Discovery report
+
+Lists what `init` will / won't do, what it found, what it skipped. Includes services + language + framework, files patched if `--apply`, target SDK package versions, runtime overhead estimate.
+
+## Idempotency
+
+Re-running on already-initialized: re-runs discovery, overwrites registry entry, re-generates patch (skipping applied changes), re-builds snapshot. No double-install, no duplicate registry entries.
+
+## Project naming
+
+`--project <name>` overrides; default is `<path>` basename. Names unique within `~/.neat/projects.json`; collisions fail loudly.
+
+## `init` and `install` are one command
+
+The audit's split is rejected. One command with `--apply` flag handles both.
+
+## Authority
+
+Owned by `packages/core/src/cli.ts`. Composes `extract/*`, `persist.ts`, `installers/`, `registry.ts`. Does **not** start the daemon — that's `neatd start`.
+
+## Enforcement
+
+`it.todo` for v0.2.5 #119. Discovery-before-mutation is a CLI test (`init --dry-run`, assert no file changes).
+
+Full rationale: [ADR-046](../decisions.md#adr-046--neat-init-contract).

--- a/docs/contracts/project-registry.md
+++ b/docs/contracts/project-registry.md
@@ -1,0 +1,75 @@
+---
+name: project-registry
+description: Single file ~/.neat/projects.json, per-user, machine-local. Atomic writes via tmp+rename. flock during writes. Path-normalized to prevent duplicate entries.
+governs:
+  - "packages/core/src/registry.ts"
+  - "packages/core/src/cli.ts"
+  - "packages/core/src/daemon.ts"
+adr: [ADR-048, ADR-046, ADR-049]
+---
+
+# Machine-level project registry contract
+
+The third of four v0.2.5 distribution-layer contracts. Sibling contracts: [`init.md`](./init.md), [`sdk-install.md`](./sdk-install.md), [`daemon.md`](./daemon.md).
+
+The registry is what makes the daemon possible. Without a machine-level "what projects has the user registered," the daemon has nothing to watch.
+
+## Single source of truth
+
+`~/.neat/projects.json` — per-user, machine-local. Not synced. Not version-controlled.
+
+## Shape
+
+```ts
+{
+  version: 1,
+  projects: Array<{
+    name: string,
+    path: string,                  // resolved absolute
+    registeredAt: ISO8601,
+    lastSeenAt?: ISO8601,
+    languages: string[],
+    status: 'active' | 'paused' | 'broken',
+  }>
+}
+```
+
+`version: z.literal(1)`.
+
+## Atomicity
+
+Writes go through `writeAtomically(path, contents)` — tmp + fsync + rename. No torn writes if daemon and `init` race.
+
+## Lock file
+
+Writes acquire exclusive flock on `~/.neat/projects.json.lock`. 5s timeout; failure is loud.
+
+## Status semantics
+
+| Status | Meaning |
+|--------|---------|
+| `active` | daemon watching; OTel ingest accepting spans |
+| `paused` | registered but daemon ignores |
+| `broken` | last operation failed (e.g. path missing) |
+
+## Removal
+
+`neat uninstall <name>` removes the entry. **Does not** delete `neat-out/`, `policy.json`, or user files. Reverses SDK-install patch via `neat-rollback.patch` if user opts in.
+
+## Path normalization
+
+Stored as resolved absolute path. Two `init` calls from different relative paths to the same dir don't create two entries.
+
+## Multi-machine sync deferred
+
+Per-machine for MVP.
+
+## Authority
+
+`packages/core/src/registry.ts`. CLI commands and daemon call into it. Daemon reads on boot and on `SIGHUP`.
+
+## Enforcement
+
+`it.todo` for v0.2.5 #119. Regression test: registry path is `~/.neat/projects.json` and no other module reads/writes it.
+
+Full rationale: [ADR-048](../decisions.md#adr-048--machine-level-project-registry-contract).

--- a/docs/contracts/sdk-install.md
+++ b/docs/contracts/sdk-install.md
@@ -1,0 +1,82 @@
+---
+name: sdk-install
+description: Per-language installer modules. Plan/apply decoupled. Manifests touched, lockfiles never. Idempotent. Composable with init.
+governs:
+  - "packages/core/src/installers/**"
+  - "packages/core/src/cli.ts"
+adr: [ADR-047, ADR-046, ADR-027]
+---
+
+# SDK install contract
+
+The second of four v0.2.5 distribution-layer contracts. Sibling contracts: [`init.md`](./init.md), [`project-registry.md`](./project-registry.md), [`daemon.md`](./daemon.md).
+
+NEAT's MVP success criterion (ADR-027) requires runtime telemetry. Pre-v1, NEAT installs the OTel SDK across the user's codebase via `neat init`. eBPF and service-mesh capture out of MVP.
+
+## Installer module interface
+
+```ts
+{
+  language: 'javascript' | 'python' | ...,
+  detect(serviceDir): boolean,
+  plan(serviceDir): InstallPlan,
+  apply(serviceDir, plan): ApplyResult,
+}
+```
+
+`plan` and `apply` decoupled — patch can be saved, reviewed, re-applied later.
+
+## Two languages in MVP
+
+| Language | Manifest edits | Entrypoint edits |
+|----------|----------------|------------------|
+| Node | `@opentelemetry/api`, `sdk-node`, `auto-instrumentations-node` → `package.json` deps | `scripts.start` (or Procfile / Dockerfile CMD) prefixed with auto-instrumentation hook |
+| Python | `opentelemetry-distro`, `opentelemetry-exporter-otlp` → `requirements.txt` or `pyproject.toml` | entrypoint prefixed with `opentelemetry-instrument` |
+
+Both set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`.
+
+**Java, Ruby, .NET, Go, Rust** — out of MVP. Each requires a successor ADR.
+
+## Patch shape
+
+```ts
+InstallPlan = {
+  language: string,
+  dependencyEdits: Array<{ file, kind: 'add'|'remove', name, version }>,
+  entrypointEdits: Array<{ file, before, after }>,
+  envEdits: Array<{ file, key, value }>,
+}
+```
+
+The plan is what `init` writes to `neat.patch`.
+
+## Lockfiles never touched
+
+Installers update **manifests** only. After `--apply`, init prints `Run "npm install"` so user owns the lockfile commit. NEAT does not run `npm install` itself.
+
+## Idempotency
+
+`plan(dir)` returns empty plan when SDK is already installed. Re-running `init --apply` produces no diff. No version-bump churn.
+
+## Patch is deterministic
+
+Same input → same patch. Reviewable byte-for-byte across runs.
+
+## Apply failure is recoverable
+
+Partial success → emits `neat-rollback.patch`. NEAT does not silently leave broken state.
+
+## Composability
+
+- `neat init --no-install` — graph + registry without SDK install.
+- `neat install <path>` — alias for `init --skip-discovery --skip-registry`.
+
+## Authority
+
+`packages/core/src/installers/`. One file per language. Common patch-application in `installers/shared.ts`.
+
+## Enforcement
+
+`it.todo` for v0.2.5 #119. "Lockfiles never touched" is a regression scan.
+
+Full rationale: [ADR-047](../decisions.md#adr-047--sdk-install-contract).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1236,3 +1236,99 @@ Sibling contracts: ADR-039, ADR-040, ADR-042-044.
 4. **Three-part response format** from ADR-039. Confidence `1.00` for confirmed violations; lower for hypothetical-action results.
 
 5. **Routes dual-mount per ADR-026.**
+
+---
+
+## ADR-046 — `neat init` contract
+
+**Date:** 2026-05-06
+**Status:** Active.
+
+The first of four v0.2.5 distribution-layer contracts. Governs `packages/core/src/cli.ts`'s `init` command and the codemod path it triggers. Sibling contracts: ADR-047 (SDK install), ADR-048 (machine registry), ADR-049 (daemon).
+
+**Decision.**
+
+1. **`neat init <path>` is a one-time registration moment.** Like `brew install` followed by `claude init`. Re-running is idempotent.
+2. **What `init` does, in order.** Discover (with report before mutation), build initial graph, register in `~/.neat/projects.json`, generate SDK install patch, apply or hold (patch-by-default; `--apply` opt-in), reload daemon if running.
+3. **Patch-by-default; `--apply` opt-in.** Init never modifies user code without explicit consent. `--dry-run` prints without writing.
+4. **What `init` doesn't touch by default.** Manifests only under `--apply`. Lockfiles never modified directly. `.env` and config files never modified. Running processes never instrumented.
+5. **Discovery report is honest.** Lists what `init` will / won't do, what it found, what it skipped.
+6. **Idempotency.** Re-running on already-initialized: re-runs discovery, overwrites registry entry, re-generates patch (skips applied changes), re-builds snapshot. No double-install, no duplicate registry entries.
+7. **Project naming.** `--project <name>` overrides; default basename. Names unique within `~/.neat/projects.json`; collisions fail loudly.
+8. **`init` and `install` are one command.** Audit's split rejected — one command with `--apply` flag handles both.
+
+**Authority.** `packages/core/src/cli.ts`. Composes extract/, persist.ts, installers/, registry.ts. Does **not** start the daemon (`neatd start` is separate).
+
+**Enforcement.** `it.todo` for v0.2.5 #119. Discovery-report-before-mutation gets a CLI test (`init --dry-run` → no files changed).
+
+---
+
+## ADR-047 — SDK install contract
+
+**Date:** 2026-05-06
+**Status:** Active.
+
+Governs per-language installer modules under `packages/core/src/installers/` (new directory). Sibling contracts: ADR-046, ADR-048, ADR-049.
+
+**Decision.**
+
+1. **Installer module interface.** Every language exports `{ language, detect(serviceDir), plan(serviceDir): InstallPlan, apply(serviceDir, plan): ApplyResult }`. Plan and apply decoupled — patch can be saved, reviewed, re-applied later.
+2. **Two languages in MVP: Node and Python.** Node adds `@opentelemetry/api`, `sdk-node`, `auto-instrumentations-node`; modifies `scripts.start` (or Procfile/Dockerfile CMD). Python adds `opentelemetry-distro`, `opentelemetry-exporter-otlp`; prefixes entrypoint with `opentelemetry-instrument`. Both set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`. Java/Ruby/.NET/Go/Rust out of MVP.
+3. **Patch shape.** Serializable: `{ language, dependencyEdits, entrypointEdits, envEdits }`. The plan is what `init` writes to `neat.patch` for review.
+4. **Lockfiles never touched.** Manifests only. After `--apply`, init prints `Run "npm install"` so user owns the lockfile commit.
+5. **Idempotency.** `plan(dir)` returns empty plan when SDK is already installed. Re-running `init --apply` produces no diff.
+6. **Patch is deterministic.** Same input → same patch. Reviewable byte-for-byte.
+7. **Apply failure is recoverable.** Partial success → emits `neat-rollback.patch`. NEAT does not silently leave broken state.
+8. **Composability.** `neat init --no-install` for graph + registry only. `neat install <path>` alias for `init --skip-discovery --skip-registry`.
+
+**Authority.** `packages/core/src/installers/`. One file per language. Common patch-application in `installers/shared.ts`.
+
+**Enforcement.** `it.todo` for v0.2.5 #119. "Lockfiles never touched" lands as regression scan.
+
+---
+
+## ADR-048 — Machine-level project registry contract
+
+**Date:** 2026-05-06
+**Status:** Active.
+
+Governs `~/.neat/projects.json` and `packages/core/src/registry.ts`. Sibling contracts: ADR-046, ADR-047, ADR-049.
+
+**Decision.**
+
+1. **Single source of truth: `~/.neat/projects.json`.** Per-user, machine-local. Not synced. Not version-controlled.
+2. **Shape.** `{ version: 1, projects: [{ name, path, registeredAt, lastSeenAt?, languages, status: 'active' | 'paused' | 'broken' }] }`. `version: z.literal(1)`.
+3. **Atomicity.** `writeAtomically(path, contents)` — tmp + fsync + rename. No torn writes.
+4. **Lock file.** Exclusive flock on `~/.neat/projects.json.lock` for writes. 5s timeout; failure is loud.
+5. **Status semantics.** `active` (daemon watching), `paused` (user-paused), `broken` (path missing or last op failed).
+6. **Removal.** `neat uninstall <name>` removes entry. Does **not** delete `neat-out/`, `policy.json`, or user files. Reverses SDK-install patch via `neat-rollback.patch` if user opts in.
+7. **Path normalization.** Stored as resolved absolute path. Two `init` calls from different relative paths to the same dir don't create two entries.
+8. **Multi-machine sync deferred.** Per-machine for MVP.
+
+**Authority.** `packages/core/src/registry.ts`. CLI commands and daemon call into it. Daemon reads on boot and on `SIGHUP`.
+
+**Enforcement.** `it.todo` for v0.2.5 #119. Regression test asserts registry path is `~/.neat/projects.json` and no other module reads/writes it.
+
+---
+
+## ADR-049 — Daemon contract
+
+**Date:** 2026-05-06
+**Status:** Active.
+
+Governs the long-lived `neatd` process. Sibling contracts: ADR-046, ADR-047, ADR-048.
+
+**Decision.**
+
+1. **Single long-lived process.** `neatd start` boots one daemon watching every project in `~/.neat/projects.json`. Per-project graphs in `Map<string, NeatGraph>` per ADR-026. No clustering in MVP.
+2. **Lifecycle commands.** `neatd start [--foreground]`, `neatd stop`, `neatd reload`, `neatd status`.
+3. **Continuous extraction triggers.** Source mtimes (chokidar → re-extract phase per ADR-032), `policy.json` mtime (reload per ADR-042), `compat.json` mtime (reload matrix), OTel HTTP/gRPC (`:4318`/`:4317` → `handleSpan` per ADR-033), staleness loop (60s per ADR-024).
+4. **Per-project isolation.** Each project's graph is its own `MultiDirectedGraph`. File watching, OTel ingest, policy evaluation scoped to project. Failure in one project doesn't affect others.
+5. **OTel routing.** Spans route to a project by `service.name` lookup across registered projects. Unknowns route to `'default'` for FrontierNode auto-creation.
+6. **Graceful degradation.** Missing registry → boot refuses. Missing path → mark `status: 'broken'`. OTel overwhelmed → backpressure via queue (ADR-033 #1); spans drop, never block.
+7. **No automatic restart on crash.** PID at `~/.neat/neatd.pid` for external supervisors (systemd / launchd).
+8. **Self-hosting gate stays closed during v0.2.5.** Per ADR-027 + the v0.2.x sequencing: self-hosting NEAT on the NEAT codebase only flips on after the MVP-success PR closes.
+
+**Authority.** `packages/core/src/daemon.ts`. Composes registry.ts, extract/, ingest.ts, policy.ts, persist.ts.
+
+**Enforcement.** `it.todo` for v0.2.5 #119. Regression test asserts daemon writes `graph.json` only via persist.ts loop and shutdown handlers.

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -2116,6 +2116,47 @@ describe('Policy contracts (ADRs 042-045)', () => {
 })
 
 // ──────────────────────────────────────────────────────────────────────────
+// Distribution layer — neat init, SDK install, registry, daemon (ADRs 046-049)
+// All queued for v0.2.5 #119 implementation.
+// ──────────────────────────────────────────────────────────────────────────
+describe('neat init contract (ADR-046)', () => {
+  it.todo('init prints discovery report before any file mutation (ADR-046 #2)')
+  it.todo('init does not modify package.json/requirements.txt/Gemfile/pom.xml without --apply (ADR-046 #4)')
+  it.todo('init never modifies lockfiles (package-lock, poetry.lock, Gemfile.lock) (ADR-046 #4)')
+  it.todo('init --dry-run produces a patch but does not write any file other than neat.patch (ADR-046 #3)')
+  it.todo('init is idempotent — second run on same project produces no graph diff (ADR-046 #6)')
+  it.todo('init writes ~/.neat/projects.json entry per ADR-048')
+  it.todo('init exits with non-zero on project name collision (ADR-046 #7)')
+})
+
+describe('SDK install contract (ADR-047)', () => {
+  it.todo('every installer module exports detect/plan/apply (ADR-047 #1)')
+  it.todo('Node installer plan adds @opentelemetry/sdk-node and modifies entrypoint (ADR-047 #2)')
+  it.todo('Python installer plan adds opentelemetry-distro and prefixes entrypoint (ADR-047 #2)')
+  it.todo('no installer plan output references package-lock.json/poetry.lock/Gemfile.lock (ADR-047 #4)')
+  it.todo('plan(dir) returns an empty plan when SDK is already installed (ADR-047 #5)')
+  it.todo('plan output is deterministic across runs (ADR-047 #6)')
+  it.todo('apply failure produces a neat-rollback.patch (ADR-047 #7)')
+})
+
+describe('Machine-level project registry contract (ADR-048)', () => {
+  it.todo('registry.ts is the only module reading/writing ~/.neat/projects.json (ADR-048 #8)')
+  it.todo('writes go through writeAtomically (tmp + rename) (ADR-048 #3)')
+  it.todo('writes acquire flock on ~/.neat/projects.json.lock (ADR-048 #4)')
+  it.todo('paths are stored as resolved absolute (no duplicate entries from relative paths) (ADR-048 #7)')
+  it.todo('removal does not delete neat-out/ or policy.json or user files (ADR-048 #6)')
+})
+
+describe('Daemon contract (ADR-049)', () => {
+  it.todo('daemon writes only via persist.ts loop and shutdown handlers (ADR-049 — mutation authority)')
+  it.todo('per-project graph isolation: failure in one project does not affect others (ADR-049 #4)')
+  it.todo('OTel span routing matches by service.name across registered projects (ADR-049 #5)')
+  it.todo('graceful degradation: missing registry → boot refuses with clear error (ADR-049 #6)')
+  it.todo('daemon writes PID to ~/.neat/neatd.pid (ADR-049 #7)')
+  it.todo('SIGHUP triggers registry re-read (ADR-049 #2)')
+})
+
+// ──────────────────────────────────────────────────────────────────────────
 // Queued — flipped from todo to live as cleanup issues land
 // ──────────────────────────────────────────────────────────────────────────
 describe('Queued contracts (v0.2.1 leftovers — #141, #142, #145)', () => {


### PR DESCRIPTION
## Summary

PR #166 shows MERGED in the GitHub UI, but the merge result never landed on \`main\`. The other agent flagged it: the four \`docs/contracts/\` files (init, sdk-install, project-registry, daemon) and ADRs 046-049 are missing from \`main\` even though #166 closed.

Probable cause: #166 was authored against a pre-v0.2.4 base of \`contracts.test.ts\`. Merging it against today's main would have wiped the ~500 lines of v0.2.4 live assertions that landed via #175-#180. Something either rejected the merge or auto-reverted it. Either way, \`main\` doesn't include #166's content.

This PR re-authors the v0.2.5 contracts cleanly against current main, preserving every v0.2.4 live test.

## What this PR does

- Appends **ADRs 046-049** to \`docs/decisions.md\` (49 total now).
- Creates the four per-topic contract files: \`docs/contracts/{init,sdk-install,project-registry,daemon}.md\`.
- Adds **25 new \`it.todo\` items** to \`packages/core/test/audits/contracts.test.ts\` — one describe block per ADR (046, 047, 048, 049), all queued for v0.2.5 #119 implementation.

## What this PR does not touch

- The v0.2.4 live assertions in \`contracts.test.ts\` (97 passing). All preserved.
- \`docs/contracts.md\` index. Already has #19-#22 in the landed table from PR #176 (roadmap update).
- Any source code under \`packages/\`. Implementation lands under v0.2.5 #119, not here.

## Test totals after this PR

- 97 live tests passing across \`@neat/core\` contracts.test.ts.
- 29 todos queued (25 new v0.2.5 + 4 v0.2.1 leftovers tracked under v0.x rolling cleanup).
- 0 fail.

## Test plan

- [ ] \`npx turbo build test lint\` clean.
- [ ] Spot-check that the four new contract files have correct frontmatter \`governs:\` paths.
- [ ] Spot-check that ADRs 046-049 appear in order at the bottom of \`decisions.md\`.
- [ ] After merge: the next implementation agent reads \`docs/plans/2026-05-07-v0.2.5-kickoff.md\` (PR #183) and starts on #119.

## Closing note

PR #166 should be closed manually after this merges (its content is now on main, so it serves no purpose). The \`19-22-distribution-contracts\` branch can be deleted on origin too.

Refs #126