### PR TITLE
neat init mechanics — discovery, registry write, patch flow (#19)

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -5,24 +5,63 @@ import { promises as fs } from 'node:fs'
 import type { GraphEdge, GraphNode, ServiceNode } from '@neat/types'
 import { DEFAULT_PROJECT, getGraph, resetGraph } from './graph.js'
 import { extractFromDirectory } from './extract.js'
+import { discoverServices } from './extract/services.js'
+import type { DiscoveredService } from './extract/shared.js'
 import { saveGraphToDisk } from './persist.js'
 import { startWatch, type WatchHandle } from './watch.js'
 import { pathsForProject } from './projects.js'
-import { listProjects, removeProject, setStatus } from './registry.js'
+import {
+  addProject,
+  listProjects,
+  ProjectNameCollisionError,
+  removeProject,
+  setStatus,
+} from './registry.js'
+import {
+  INSTALLERS,
+  isEmptyPlan,
+  pickInstaller,
+  renderPatch,
+  type InstallPlan,
+  type PatchSection,
+} from './installers/index.js'
 
-interface InitOptions {
+export interface InitOptions {
   scanPath: string
   outPath: string
+  // The project's registry name. Defaults to the basename of the scan path
+  // when the user didn't pass `--project` (ADR-046 — project naming).
   project: string
+  // Whether `project` was set explicitly via `--project`. The flag affects
+  // which in-memory graph slot we use: explicit names get isolated slots
+  // per ADR-026, the default basename keeps using DEFAULT_PROJECT for
+  // back-compat with `neat watch`.
+  projectExplicit: boolean
+  apply: boolean
+  dryRun: boolean
+  noInstall: boolean
+}
+
+export interface InitResult {
+  // Process exit code. 0 on success, 1 on collision / runtime failure,
+  // 2 on misuse (handled before we get here, but documented for completeness).
+  exitCode: number
+  // Paths the run actually wrote to. Empty in `--dry-run` except for
+  // `neat.patch`. Useful for tests asserting "init only wrote X".
+  writtenFiles: string[]
 }
 
 function usage(): void {
   console.log('usage: neat <command> [args] [--project <name>]')
   console.log('')
   console.log('commands:')
-  console.log('  init <path>    Scan <path>, build the static graph, save a snapshot.')
+  console.log('  init <path>    One-time install: discover, extract, register, plan SDK install.')
   console.log('                 Snapshot lands in <path>/neat-out/graph.json by default')
   console.log('                 (or <path>/neat-out/<project>.json for non-default).')
+  console.log('                 Flags:')
+  console.log('                   --apply       run the SDK install patch in place')
+  console.log('                   --dry-run     write only neat.patch; do not register or snapshot')
+  console.log('                   --no-install  skip SDK install planning entirely')
   console.log('  watch <path>   Start neat-core, watch <path>, re-extract on changes.')
   console.log('                 PORT (default 8080), OTEL_PORT (4318), HOST (0.0.0.0)')
   console.log('                 control listeners. NEAT_OTLP_GRPC=true also opens 4317.')
@@ -37,12 +76,24 @@ function usage(): void {
   console.log('  --project <name>   Name the project this command targets. Default: "default".')
 }
 
-// Tiny argv parser — pulls `--project <name>` out of `rest` and returns the
-// rest as positional args. Doesn't try to be a full flags library; just
-// enough for #83 without pulling commander in.
-function pluckProject(rest: string[]): { project: string; positional: string[] } {
+// Tiny argv parser — pulls `--project <name>` and the v0.2.5 init flags
+// (`--apply`, `--dry-run`, `--no-install`) out of `rest`. Boolean flags are
+// only meaningful for `init`; the parser surfaces them unconditionally so
+// `main` can validate per-command.
+interface ParsedArgs {
+  project: string | null
+  apply: boolean
+  dryRun: boolean
+  noInstall: boolean
+  positional: string[]
+}
+
+function parseArgs(rest: string[]): ParsedArgs {
   const positional: string[] = []
-  let project = DEFAULT_PROJECT
+  let project: string | null = null
+  let apply = false
+  let dryRun = false
+  let noInstall = false
   for (let i = 0; i < rest.length; i++) {
     const arg = rest[i] as string
     if (arg === '--project') {
@@ -59,9 +110,21 @@ function pluckProject(rest: string[]): { project: string; positional: string[] }
       project = arg.slice('--project='.length)
       continue
     }
+    if (arg === '--apply') {
+      apply = true
+      continue
+    }
+    if (arg === '--dry-run') {
+      dryRun = true
+      continue
+    }
+    if (arg === '--no-install') {
+      noInstall = true
+      continue
+    }
     positional.push(arg)
   }
-  return { project, positional }
+  return { project, apply, dryRun, noInstall, positional }
 }
 
 function summarise(nodes: GraphNode[], edges: GraphEdge[]): string {
@@ -104,25 +167,129 @@ function findIncompatibilities(nodes: GraphNode[]): ServiceNode[] {
   )
 }
 
-async function runInit(opts: InitOptions): Promise<void> {
+function printDiscoveryReport(opts: InitOptions, services: DiscoveredService[]): void {
+  const languages = [...new Set(services.map((s) => s.node.language))].sort()
+  const mode = opts.dryRun ? 'dry-run' : opts.apply ? 'apply' : 'patch-only'
+  console.log('=== neat init: discovery ===')
+  console.log(`scan path: ${opts.scanPath}`)
+  console.log(`project:   ${opts.project}`)
+  console.log(`mode:      ${mode}`)
+  console.log(`services:  ${services.length}`)
+  for (const s of services) {
+    const where = s.node.repoPath && s.node.repoPath.length > 0 ? s.node.repoPath : '.'
+    console.log(`  - ${s.node.name} (${s.node.language}) — ${where}`)
+  }
+  console.log(`languages: ${languages.length > 0 ? languages.join(', ') : '(none)'}`)
+  if (opts.noInstall) {
+    console.log('install:   skipped (--no-install)')
+  } else if (opts.dryRun) {
+    console.log('install:   patch will be written to neat.patch; nothing else.')
+  } else if (opts.apply) {
+    console.log('install:   patch will be applied in place. Run `npm install` afterwards.')
+  } else {
+    console.log('install:   patch will be written to neat.patch for review.')
+  }
+  console.log('')
+}
+
+async function buildPatchSections(
+  services: DiscoveredService[],
+): Promise<PatchSection[]> {
+  const sections: PatchSection[] = []
+  for (const svc of services) {
+    const installer = await pickInstaller(svc.dir)
+    if (!installer) continue
+    const plan: InstallPlan = await installer.plan(svc.dir)
+    if (isEmptyPlan(plan)) continue
+    sections.push({ installer: installer.name, plan })
+  }
+  return sections
+}
+
+export async function runInit(opts: InitOptions): Promise<InitResult> {
+  const written: string[] = []
+
+  // ── Step 1: validate path ────────────────────────────────────────────
   const stat = await fs.stat(opts.scanPath).catch(() => null)
   if (!stat || !stat.isDirectory()) {
     console.error(`neat init: ${opts.scanPath} is not a directory`)
-    process.exit(2)
+    return { exitCode: 2, writtenFiles: written }
   }
 
-  resetGraph(opts.project)
-  const graph = getGraph(opts.project)
+  // ── Step 2: discovery (ADR-046 #2 — before any mutation) ─────────────
+  const services = await discoverServices(opts.scanPath)
+  printDiscoveryReport(opts, services)
+
+  // ── Step 3: plan SDK install (pure data, no fs writes) ───────────────
+  const sections = opts.noInstall ? [] : await buildPatchSections(services)
+  const patch = renderPatch(sections)
+  const patchPath = path.join(opts.scanPath, 'neat.patch')
+
+  // ── Step 4: dry-run shortcut — only neat.patch is allowed to land ────
+  if (opts.dryRun) {
+    await fs.writeFile(patchPath, patch, 'utf8')
+    written.push(patchPath)
+    console.log(`dry-run: patch written to ${patchPath}`)
+    console.log('rerun without --dry-run to register and snapshot.')
+    return { exitCode: 0, writtenFiles: written }
+  }
+
+  // ── Step 5: extraction + snapshot ────────────────────────────────────
+  // Use DEFAULT_PROJECT for the in-memory graph slot when --project wasn't
+  // explicitly passed; named projects get isolated slots per ADR-026.
+  const graphKey = opts.projectExplicit ? opts.project : DEFAULT_PROJECT
+  resetGraph(graphKey)
+  const graph = getGraph(graphKey)
   const result = await extractFromDirectory(graph, opts.scanPath)
   await saveGraphToDisk(graph, opts.outPath)
+  written.push(opts.outPath)
 
+  // ── Step 6: register in the machine-level registry ───────────────────
+  // Idempotent re-init of the same path under the same name refreshes the
+  // entry; collision against a different path exits non-zero (ADR-046 #7).
+  const languages = [...new Set(services.map((s) => s.node.language))].sort()
+  try {
+    await addProject({
+      name: opts.project,
+      path: opts.scanPath,
+      languages,
+      status: 'active',
+    })
+  } catch (err) {
+    if (err instanceof ProjectNameCollisionError) {
+      console.error(`neat init: ${err.message}`)
+      console.error('pass --project <other-name> to register under a different name.')
+      return { exitCode: 1, writtenFiles: written }
+    }
+    throw err
+  }
+
+  // ── Step 7: write or apply patch ─────────────────────────────────────
+  if (!opts.noInstall) {
+    if (opts.apply) {
+      for (const section of sections) {
+        const installer = INSTALLERS.find((i) => i.name === section.installer)
+        if (!installer) continue
+        await installer.apply(section.plan)
+      }
+      if (sections.length > 0) {
+        console.log('')
+        console.log('patch applied. Run `npm install` (or your language equivalent) to refresh lockfiles.')
+      }
+    } else {
+      await fs.writeFile(patchPath, patch, 'utf8')
+      written.push(patchPath)
+    }
+  }
+
+  // ── Step 8: summary + incompatibilities ──────────────────────────────
   const nodes: GraphNode[] = []
   graph.forEachNode((_id, attrs) => nodes.push(attrs))
   const edges: GraphEdge[] = []
   graph.forEachEdge((_id, attrs) => edges.push(attrs))
 
-  console.log(`scanned: ${opts.scanPath}`)
-  console.log(`project: ${opts.project}`)
+  console.log('')
+  console.log('=== neat init: summary ===')
   console.log(`snapshot: ${opts.outPath}`)
   console.log(`added: ${result.nodesAdded} nodes, ${result.edgesAdded} edges`)
   console.log(`total:  ${graph.order} nodes, ${graph.size} edges`)
@@ -138,6 +305,8 @@ async function runInit(opts: InitOptions): Promise<void> {
       }
     }
   }
+
+  return { exitCode: 0, writtenFiles: written }
 }
 
 async function main(): Promise<void> {
@@ -148,7 +317,9 @@ async function main(): Promise<void> {
     process.exit(0)
   }
 
-  const { project, positional } = pluckProject(rest)
+  const parsed = parseArgs(rest)
+  const { positional, apply, dryRun, noInstall } = parsed
+  const project = parsed.project ?? DEFAULT_PROJECT
 
   if (cmd === 'init') {
     const target = positional[0]
@@ -157,12 +328,31 @@ async function main(): Promise<void> {
       usage()
       process.exit(2)
     }
+    if (apply && dryRun) {
+      console.error('neat init: --apply and --dry-run are mutually exclusive')
+      process.exit(2)
+    }
     const scanPath = path.resolve(target)
+    // ADR-046 — when --project isn't passed, the registry name defaults to
+    // the basename of the scan path. The in-memory graph slot stays on
+    // DEFAULT_PROJECT (back-compat with existing `neat watch` invocations).
+    const projectExplicit = parsed.project !== null
+    const projectName = projectExplicit ? project : path.basename(scanPath)
     // Default project keeps writing to graph.json (ADR-026 back-compat);
     // named projects use <project>.json under the same neat-out directory.
-    const fallback = pathsForProject(project, path.join(scanPath, 'neat-out')).snapshotPath
+    const projectKey = projectExplicit ? project : DEFAULT_PROJECT
+    const fallback = pathsForProject(projectKey, path.join(scanPath, 'neat-out')).snapshotPath
     const outPath = path.resolve(process.env.NEAT_OUT_PATH ?? fallback)
-    await runInit({ scanPath, outPath, project })
+    const result = await runInit({
+      scanPath,
+      outPath,
+      project: projectName,
+      projectExplicit,
+      apply,
+      dryRun,
+      noInstall,
+    })
+    if (result.exitCode !== 0) process.exit(result.exitCode)
     return
   }
 
@@ -297,7 +487,13 @@ async function main(): Promise<void> {
   process.exit(1)
 }
 
-main().catch((err) => {
-  console.error(err)
-  process.exit(1)
-})
+// Only auto-run when invoked as the CLI entry point. Importing this module
+// from tests must not start the parser; otherwise vitest sees a stray
+// `process.exit` from `main()` running with no argv.
+const entry = process.argv[1] ?? ''
+if (/[\\/]cli\.(?:cjs|js)$/.test(entry) || entry.endsWith('/cli')) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/packages/core/src/installers/index.ts
+++ b/packages/core/src/installers/index.ts
@@ -1,0 +1,116 @@
+/**
+ * Installer registry. v0.2.5 step 2 ships the scaffolding; the JavaScript
+ * installer (step 3) and Python installer (step 4) populate `INSTALLERS`.
+ */
+
+import type { Installer, InstallPlan } from './shared.js'
+export { isEmptyPlan } from './shared.js'
+export type {
+  DependencyEdit,
+  EntrypointEdit,
+  EnvEdit,
+  Installer,
+  InstallPlan,
+} from './shared.js'
+
+// Lockfile basenames installers must never write to (ADR-047 — "lockfiles
+// never touched"). Used by the patch renderer's safety check below.
+export const FORBIDDEN_LOCKFILES: ReadonlySet<string> = new Set([
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'yarn.lock',
+  'poetry.lock',
+  'Pipfile.lock',
+  'Gemfile.lock',
+  'Cargo.lock',
+  'go.sum',
+])
+
+export const INSTALLERS: Installer[] = []
+
+/**
+ * Resolve the first installer that claims a given service directory. Returns
+ * `null` if none match.
+ *
+ * Per language, the first matching installer wins. Order in `INSTALLERS`
+ * defines that priority — declarations are explicit, not alphabetical.
+ */
+export async function pickInstaller(serviceDir: string): Promise<Installer | null> {
+  for (const inst of INSTALLERS) {
+    if (await inst.detect(serviceDir)) return inst
+  }
+  return null
+}
+
+export interface PatchSection {
+  installer: string
+  plan: InstallPlan
+}
+
+/**
+ * Render install plans into a single review-friendly text patch. The format
+ * is intentionally human-shaped, not unified-diff: agents and humans both
+ * read this. Determinism — same input, byte-identical output — is the
+ * load-bearing property (ADR-047 #6).
+ */
+export function renderPatch(sections: PatchSection[]): string {
+  if (sections.length === 0) {
+    return [
+      '# neat install plan',
+      '',
+      'No SDK installers matched the discovered services. Two reasons this',
+      'normally happens:',
+      '  - the project uses a language NEAT does not yet instrument',
+      '    (Java / Ruby / .NET / Go / Rust are out of MVP scope per ADR-047);',
+      '  - the SDK is already installed, so the installer returned an empty',
+      '    plan.',
+      '',
+      'You can re-run `neat init --apply` later to pick up new services.',
+      '',
+    ].join('\n')
+  }
+
+  const lines: string[] = ['# neat install plan', '']
+  for (const section of sections) {
+    const { installer, plan } = section
+    lines.push(`## ${installer} (${plan.language}) — ${plan.serviceDir}`)
+    lines.push('')
+
+    if (plan.dependencyEdits.length > 0) {
+      lines.push('### dependencies')
+      for (const dep of plan.dependencyEdits) {
+        // Hard-fail rather than render a patch that could mislead the user
+        // into thinking NEAT touches lockfiles.
+        const base = dep.file.split(/[\\/]/).pop() ?? dep.file
+        if (FORBIDDEN_LOCKFILES.has(base)) {
+          throw new Error(
+            `installer "${installer}" produced a dependency edit against a lockfile (${dep.file}); ` +
+              `lockfiles must never be touched (ADR-047).`,
+          )
+        }
+        lines.push(`- ${dep.kind} ${dep.name}@${dep.version} in ${dep.file}`)
+      }
+      lines.push('')
+    }
+
+    if (plan.entrypointEdits.length > 0) {
+      lines.push('### entrypoint')
+      for (const e of plan.entrypointEdits) {
+        lines.push(`- ${e.file}`)
+        lines.push(`    - before: ${e.before}`)
+        lines.push(`    - after:  ${e.after}`)
+      }
+      lines.push('')
+    }
+
+    if (plan.envEdits.length > 0) {
+      lines.push('### env')
+      for (const env of plan.envEdits) {
+        const target = env.file ?? '(set in your orchestration layer)'
+        lines.push(`- ${env.key}=${env.value} → ${target}`)
+      }
+      lines.push('')
+    }
+  }
+  return lines.join('\n')
+}

--- a/packages/core/src/installers/shared.ts
+++ b/packages/core/src/installers/shared.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared types for SDK installer modules (ADR-047).
+ *
+ * Each language has its own installer at `installers/<language>.ts` exporting
+ * a `detect / plan / apply` triple. Plans are pure data — no fs side effects
+ * during planning — so `init --dry-run` can render a patch without ever
+ * touching the project. `apply` runs the codemod in place.
+ *
+ * Step 2 (this PR) ships the interface and an empty registry. Step 3 (Node
+ * installer) and step 4 (Python installer) populate it.
+ */
+
+// Field names match ADR-047's documented patch shape exactly: `file`, `kind`,
+// `name`, `version`. Patches will be reviewed by humans and matched in tests
+// by name; renaming for clarity would have cost more than it bought.
+
+export interface DependencyEdit {
+  file: string
+  kind: 'add' | 'remove'
+  name: string
+  version: string
+}
+
+export interface EntrypointEdit {
+  file: string
+  before: string
+  after: string
+}
+
+export interface EnvEdit {
+  // `null` denotes a recommendation only — the user will set the env var in
+  // their orchestration layer, NEAT does not write a `.env` file.
+  file: string | null
+  key: string
+  value: string
+}
+
+export interface InstallPlan {
+  // Free-form language tag matching the service node's language: `'javascript'`,
+  // `'python'`, …
+  language: string
+  // Service directory the plan targets. Absolute path.
+  serviceDir: string
+  dependencyEdits: DependencyEdit[]
+  entrypointEdits: EntrypointEdit[]
+  envEdits: EnvEdit[]
+}
+
+export interface Installer {
+  // Free-form module name. Used for the patch header and for diagnostics.
+  name: string
+  // Returns true if the installer thinks `serviceDir` is shaped like a project
+  // it can instrument. Cheap; no fs writes.
+  detect(serviceDir: string): boolean | Promise<boolean>
+  // Builds an `InstallPlan` describing the edits the installer would make.
+  // Pure data; no fs writes. An empty plan (every edits array empty) means
+  // the SDK is already installed and there is nothing to do.
+  plan(serviceDir: string): InstallPlan | Promise<InstallPlan>
+  // Apply a previously-produced plan. Mutates files in place. On failure,
+  // produces `<serviceDir>/neat-rollback.patch` per ADR-047 #7.
+  apply(plan: InstallPlan): Promise<void>
+}
+
+export function isEmptyPlan(plan: InstallPlan): boolean {
+  return (
+    plan.dependencyEdits.length === 0 &&
+    plan.entrypointEdits.length === 0 &&
+    plan.envEdits.length === 0
+  )
+}

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -2120,13 +2120,276 @@ describe('Policy contracts (ADRs 042-045)', () => {
 // All queued for v0.2.5 #119 implementation.
 // ──────────────────────────────────────────────────────────────────────────
 describe('neat init contract (ADR-046)', () => {
-  it.todo('init prints discovery report before any file mutation (ADR-046 #2)')
-  it.todo('init does not modify package.json/requirements.txt/Gemfile/pom.xml without --apply (ADR-046 #4)')
-  it.todo('init never modifies lockfiles (package-lock, poetry.lock, Gemfile.lock) (ADR-046 #4)')
-  it.todo('init --dry-run produces a patch but does not write any file other than neat.patch (ADR-046 #3)')
-  it.todo('init is idempotent — second run on same project produces no graph diff (ADR-046 #6)')
-  it.todo('init writes ~/.neat/projects.json entry per ADR-048')
-  it.todo('init exits with non-zero on project name collision (ADR-046 #7)')
+  // Shared scaffolding: every test below works in a fresh tmp NEAT_HOME and a
+  // fresh tmp scan path so they're independent of one another and of the
+  // user's real ~/.neat. The scan path always carries one minimal Node
+  // service so discovery returns something real.
+  async function setupSandbox(): Promise<{
+    home: string
+    project: string
+    projectReal: string
+    cleanup: () => Promise<void>
+  }> {
+    const os2 = await import('node:os')
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const home = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-init-home-'))
+    const project = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-init-project-'))
+    const projectReal = await fs2.realpath(project)
+    await fs2.writeFile(
+      path2.join(projectReal, 'package.json'),
+      JSON.stringify({ name: 'sandbox-svc', version: '0.0.0' }, null, 2),
+    )
+    return {
+      home,
+      project,
+      projectReal,
+      cleanup: async () => {
+        await fs2.rm(home, { recursive: true, force: true })
+        await fs2.rm(project, { recursive: true, force: true })
+      },
+    }
+  }
+
+  async function withInit<T>(
+    fn: (ctx: {
+      home: string
+      projectReal: string
+      runInit: typeof import('../../src/cli.js').runInit
+      defaultOpts: import('../../src/cli.js').InitOptions
+    }) => Promise<T>,
+  ): Promise<T> {
+    const path2 = await import('node:path')
+    const sandbox = await setupSandbox()
+    const prevHome = process.env.NEAT_HOME
+    const prevLog = console.log
+    process.env.NEAT_HOME = sandbox.home
+    console.log = () => {}
+    try {
+      const { runInit } = await import('../../src/cli.js')
+      const defaultOpts: import('../../src/cli.js').InitOptions = {
+        scanPath: sandbox.projectReal,
+        outPath: path2.join(sandbox.projectReal, 'neat-out', 'graph.json'),
+        project: 'sandbox',
+        projectExplicit: true,
+        apply: false,
+        dryRun: false,
+        noInstall: false,
+      }
+      return await fn({
+        home: sandbox.home,
+        projectReal: sandbox.projectReal,
+        runInit,
+        defaultOpts,
+      })
+    } finally {
+      console.log = prevLog
+      if (prevHome === undefined) delete process.env.NEAT_HOME
+      else process.env.NEAT_HOME = prevHome
+      await sandbox.cleanup()
+    }
+  }
+
+  it('init prints discovery report before any file mutation (ADR-046 #2)', async () => {
+    // We can't intercept fs.* easily without mocks, so we anchor on the
+    // observable order in source: runInit calls printDiscoveryReport before
+    // anything that mutates disk (`saveGraphToDisk`, `addProject`,
+    // `fs.writeFile(patchPath`). The check is structural, not runtime —
+    // exactly the shape ADR-046 #2 asks for.
+    const cli = readFileSync(join(CORE_SRC, 'cli.ts'), 'utf8')
+    const initBody = cli.match(/export async function runInit[\s\S]*?\n\}\n/)?.[0] ?? ''
+    expect(initBody.length).toBeGreaterThan(0)
+
+    const idxReport = initBody.indexOf('printDiscoveryReport(')
+    const idxSave = initBody.indexOf('saveGraphToDisk(')
+    const idxRegister = initBody.indexOf('addProject(')
+    const idxPatchWrite = initBody.indexOf("fs.writeFile(patchPath")
+    expect(idxReport).toBeGreaterThan(0)
+    expect(idxSave).toBeGreaterThan(idxReport)
+    expect(idxRegister).toBeGreaterThan(idxReport)
+    expect(idxPatchWrite).toBeGreaterThan(idxReport)
+  })
+
+  it('init does not modify package.json/requirements.txt/Gemfile/pom.xml without --apply (ADR-046 #4)', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    await withInit(async ({ projectReal, runInit, defaultOpts }) => {
+      const manifests = ['package.json', 'requirements.txt', 'Gemfile', 'pom.xml']
+      const stub = '{"name":"sandbox-svc","version":"0.0.0"}'
+      for (const m of manifests) {
+        if (m !== 'package.json') {
+          await fs2.writeFile(path2.join(projectReal, m), stub)
+        }
+      }
+      const before = new Map<string, string>()
+      for (const m of manifests) {
+        before.set(m, await fs2.readFile(path2.join(projectReal, m), 'utf8'))
+      }
+      const result = await runInit({ ...defaultOpts, apply: false })
+      expect(result.exitCode).toBe(0)
+      for (const m of manifests) {
+        const after = await fs2.readFile(path2.join(projectReal, m), 'utf8')
+        expect(after, `${m} was modified by init without --apply`).toBe(before.get(m))
+      }
+    })
+  })
+
+  it('init never modifies lockfiles (package-lock, poetry.lock, Gemfile.lock) (ADR-046 #4)', async () => {
+    // Two-part assertion. (a) Source-grep: nothing under installers/ or cli.ts
+    // names a lockfile as a write target. (b) End-to-end: --apply on a
+    // sandbox carrying lockfiles leaves them byte-identical.
+    const cli = readFileSync(join(CORE_SRC, 'cli.ts'), 'utf8')
+    const installerFiles = walkSrc(join(CORE_SRC, 'installers'))
+    const haystacks = [cli, ...installerFiles.map((f) => readFileSync(f, 'utf8'))]
+    const lockfiles = [
+      'package-lock.json',
+      'pnpm-lock.yaml',
+      'yarn.lock',
+      'poetry.lock',
+      'Pipfile.lock',
+      'Gemfile.lock',
+      'Cargo.lock',
+    ]
+    for (const haystack of haystacks) {
+      // The forbidden list lives in installers/index.ts as the SAFETY check
+      // — that's where we expect to see lockfile names. Anything else
+      // referencing them is the contract violation.
+      const lines = haystack.split('\n')
+      for (const lock of lockfiles) {
+        for (const line of lines) {
+          if (!line.includes(lock)) continue
+          if (line.includes('FORBIDDEN_LOCKFILES')) continue
+          if (line.trim().startsWith('//')) continue
+          if (line.trim().startsWith('*')) continue
+          // String entries inside the FORBIDDEN_LOCKFILES set itself.
+          if (/^\s*['"][^'"]+['"],?\s*$/.test(line)) continue
+          throw new Error(`unexpected lockfile reference: ${line.trim()}`)
+        }
+      }
+    }
+
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    await withInit(async ({ projectReal, runInit, defaultOpts }) => {
+      const lockfilePath = path2.join(projectReal, 'package-lock.json')
+      const lockBefore = '{"name":"sandbox-svc","lockfileVersion":3}'
+      await fs2.writeFile(lockfilePath, lockBefore)
+      const result = await runInit({ ...defaultOpts, apply: true })
+      expect(result.exitCode).toBe(0)
+      const lockAfter = await fs2.readFile(lockfilePath, 'utf8')
+      expect(lockAfter).toBe(lockBefore)
+    })
+  })
+
+  it('init --dry-run produces a patch but does not write any file other than neat.patch (ADR-046 #3)', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    await withInit(async ({ home, projectReal, runInit, defaultOpts }) => {
+      const result = await runInit({ ...defaultOpts, dryRun: true })
+      expect(result.exitCode).toBe(0)
+      // neat.patch is the only file the dry-run is allowed to write.
+      const patchPath = path2.join(projectReal, 'neat.patch')
+      await expect(fs2.access(patchPath)).resolves.toBeUndefined()
+      expect(result.writtenFiles).toEqual([patchPath])
+      // No registry entry was written (the file should not exist at all).
+      await expect(
+        fs2.access(path2.join(home, 'projects.json')),
+      ).rejects.toMatchObject({ code: 'ENOENT' })
+      // No graph snapshot was written.
+      await expect(
+        fs2.access(path2.join(projectReal, 'neat-out', 'graph.json')),
+      ).rejects.toMatchObject({ code: 'ENOENT' })
+    })
+  })
+
+  it('init is idempotent — second run on same project produces no graph diff (ADR-046 #6)', async () => {
+    const fs2 = await import('node:fs/promises')
+    await withInit(async ({ runInit, defaultOpts }) => {
+      const r1 = await runInit({ ...defaultOpts })
+      expect(r1.exitCode).toBe(0)
+      const snap1 = JSON.parse(await fs2.readFile(defaultOpts.outPath, 'utf8'))
+      const r2 = await runInit({ ...defaultOpts })
+      expect(r2.exitCode).toBe(0)
+      const snap2 = JSON.parse(await fs2.readFile(defaultOpts.outPath, 'utf8'))
+      // exportedAt is a per-write timestamp on the snapshot wrapper, not part
+      // of the graph itself. The graph payload must be byte-identical.
+      expect(snap2.graph).toEqual(snap1.graph)
+    })
+  })
+
+  it('init writes ~/.neat/projects.json entry per ADR-048', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    await withInit(async ({ home, projectReal, runInit, defaultOpts }) => {
+      const result = await runInit({ ...defaultOpts })
+      expect(result.exitCode).toBe(0)
+      const raw = await fs2.readFile(path2.join(home, 'projects.json'), 'utf8')
+      const reg = JSON.parse(raw)
+      expect(reg.version).toBe(1)
+      expect(reg.projects).toHaveLength(1)
+      expect(reg.projects[0]).toMatchObject({
+        name: 'sandbox',
+        path: projectReal,
+        status: 'active',
+      })
+      expect(reg.projects[0].languages).toContain('javascript')
+      expect(reg.projects[0].registeredAt).toMatch(/T/)
+    })
+  })
+
+  it('init exits with non-zero on project name collision (ADR-046 #7)', async () => {
+    const os2 = await import('node:os')
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const home = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-init-collision-home-'))
+    const projectA = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-init-collision-a-'))
+    const projectB = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-init-collision-b-'))
+    const realA = await fs2.realpath(projectA)
+    const realB = await fs2.realpath(projectB)
+    for (const dir of [realA, realB]) {
+      await fs2.writeFile(
+        path2.join(dir, 'package.json'),
+        JSON.stringify({ name: path2.basename(dir), version: '0.0.0' }),
+      )
+    }
+    const prevHome = process.env.NEAT_HOME
+    const prevLog = console.log
+    const prevErr = console.error
+    process.env.NEAT_HOME = home
+    console.log = () => {}
+    console.error = () => {}
+    try {
+      const { runInit } = await import('../../src/cli.js')
+      const r1 = await runInit({
+        scanPath: realA,
+        outPath: path2.join(realA, 'neat-out', 'graph.json'),
+        project: 'collide',
+        projectExplicit: true,
+        apply: false,
+        dryRun: false,
+        noInstall: false,
+      })
+      expect(r1.exitCode).toBe(0)
+      const r2 = await runInit({
+        scanPath: realB,
+        outPath: path2.join(realB, 'neat-out', 'graph.json'),
+        project: 'collide',
+        projectExplicit: true,
+        apply: false,
+        dryRun: false,
+        noInstall: false,
+      })
+      expect(r2.exitCode).not.toBe(0)
+    } finally {
+      console.log = prevLog
+      console.error = prevErr
+      if (prevHome === undefined) delete process.env.NEAT_HOME
+      else process.env.NEAT_HOME = prevHome
+      await fs2.rm(home, { recursive: true, force: true })
+      await fs2.rm(projectA, { recursive: true, force: true })
+      await fs2.rm(projectB, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('SDK install contract (ADR-047)', () => {


### PR DESCRIPTION
## Summary

Step 2 of v0.2.5. Rebuilds `runInit` around ADR-046's six-step flow:

1. Validate path.
2. Discover services via `discoverServices` and print the discovery report — **before any file mutation**.
3. Plan SDK install (pure data; no fs writes yet).
4. `--dry-run` shortcut: write only `neat.patch` and return.
5. Otherwise: static extraction + snapshot.
6. Register the project in `~/.neat/projects.json` via `addProject` (collision exits non-zero).
7. Write `neat.patch` for review, or run installers' `apply()` under `--apply`.

`runInit` now returns `{ exitCode, writtenFiles }` so the CLI shim and the contract tests both reason about it without each call ending in `process.exit`. Three new flags land:

- `--apply` — run the install patch in place
- `--dry-run` — write only `neat.patch`; no registry, no snapshot
- `--no-install` — skip install planning entirely

Project naming follows the contract: when `--project` isn't passed the registry name defaults to the basename of the scan path. The in-memory graph slot keeps the existing `DEFAULT_PROJECT` for back-compat with `neat watch`. Two inits at different paths under the same `--project` name surface a `ProjectNameCollisionError` and exit 1.

Installer scaffolding lands in `packages/core/src/installers/` with the `detect / plan / apply` interface ADR-047 specifies. The registry array is empty in this PR — the JavaScript installer (#20 step 3) and Python installer (#20 step 4) populate it later. `renderPatch` carries a hard guard against lockfile basenames so any future installer producing a `DependencyEdit` against `package-lock.json` or `poetry.lock` fails loudly.

`cli.ts` no longer auto-runs at module load; the entry-point check on `process.argv[1]` lets tests import `runInit` directly while the binary still works.

## Contract todos flipped

The seven queued ADR-046 items in `packages/core/test/audits/contracts.test.ts` are now live assertions:

- discovery report before any mutation (#2)
- no manifest writes without `--apply` (#4)
- no lockfile writes ever (#4) — source-grep + end-to-end with `--apply`
- `--dry-run` writes only `neat.patch` (#3)
- idempotent re-runs produce no graph diff (#6)
- writes `~/.neat/projects.json` entry per ADR-048
- non-zero exit on project-name collision (#7)

## Test plan

- [x] `npx turbo build test lint` green on `19-neat-init-mechanics` (327 tests pass; 17 todos remain — down 7)
- [ ] `node packages/core/dist/cli.cjs init <repo>` produces a discovery report, snapshot, registry entry, and a `neat.patch` placeholder (no installers wired yet)
- [ ] `node packages/core/dist/cli.cjs init <repo> --dry-run` writes only `neat.patch`
- [ ] `node packages/core/dist/cli.cjs init <repo>` twice with `--project foo` against different paths exits 1 the second time

Refs #19