### PR TITLE
Node SDK installer — javascript.ts (#20)

### DIFF
--- a/packages/core/src/installers/index.ts
+++ b/packages/core/src/installers/index.ts
@@ -4,7 +4,9 @@
  */
 
 import type { Installer, InstallPlan } from './shared.js'
+import { javascriptInstaller } from './javascript.js'
 export { isEmptyPlan } from './shared.js'
+export { javascriptInstaller } from './javascript.js'
 export type {
   DependencyEdit,
   EntrypointEdit,
@@ -26,7 +28,9 @@ export const FORBIDDEN_LOCKFILES: ReadonlySet<string> = new Set([
   'go.sum',
 ])
 
-export const INSTALLERS: Installer[] = []
+// Order is priority — first match wins per service. JavaScript leads because
+// it's the most common shape in the projects NEAT targets.
+export const INSTALLERS: Installer[] = [javascriptInstaller]
 
 /**
  * Resolve the first installer that claims a given service directory. Returns

--- a/packages/core/src/installers/javascript.ts
+++ b/packages/core/src/installers/javascript.ts
@@ -1,0 +1,206 @@
+/**
+ * Node / TypeScript SDK installer (ADR-047).
+ *
+ * Detects services by the presence of a `package.json` carrying a `name`
+ * field — same shape `extract/services.ts` uses to decide what counts as a
+ * Node service. The plan adds three OTel packages to `dependencies` and, if
+ * a `scripts.start` exists, prefixes it with the auto-instrumentation hook.
+ *
+ * Lockfiles are never touched. After `--apply`, init prints "run npm install"
+ * so the user owns the lockfile commit (ADR-047 — "Lockfiles never touched").
+ */
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import type { DependencyEdit, EntrypointEdit, EnvEdit, Installer, InstallPlan } from './shared.js'
+
+const SDK_PACKAGES = [
+  { name: '@opentelemetry/api', version: '^1.9.0' },
+  { name: '@opentelemetry/sdk-node', version: '^0.57.0' },
+  { name: '@opentelemetry/auto-instrumentations-node', version: '^0.55.0' },
+] as const
+
+const AUTO_INSTRUMENT_REQUIRE = '--require @opentelemetry/auto-instrumentations-node/register'
+
+const OTEL_ENV: EnvEdit = {
+  // null target — NEAT does not write `.env` itself; the user sets the env
+  // var in their orchestration layer.
+  file: null,
+  key: 'OTEL_EXPORTER_OTLP_ENDPOINT',
+  value: 'http://localhost:4318',
+}
+
+interface PackageJsonShape {
+  name?: string
+  scripts?: Record<string, string>
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+async function readPackageJson(serviceDir: string): Promise<PackageJsonShape | null> {
+  try {
+    const raw = await fs.readFile(path.join(serviceDir, 'package.json'), 'utf8')
+    return JSON.parse(raw) as PackageJsonShape
+  } catch {
+    return null
+  }
+}
+
+async function detect(serviceDir: string): Promise<boolean> {
+  const pkg = await readPackageJson(serviceDir)
+  return pkg !== null && typeof pkg.name === 'string'
+}
+
+function rewriteStartScript(start: string): string {
+  // Already wired via auto-instrumentation? Don't touch — idempotency
+  // (ADR-047 — "Re-running init --apply produces no diff").
+  if (start.includes(AUTO_INSTRUMENT_REQUIRE)) return start
+  // Most start scripts begin with `node …`. Keep the rest of the command and
+  // splice the require flag in. Non-`node` starts (e.g. `next start`,
+  // `tsx server.ts`) get the require flag prefixed via `node` since the
+  // OTel hook needs a Node entry to attach to.
+  if (/^\s*node\b/.test(start)) {
+    return start.replace(/^\s*node\b\s*/, `node ${AUTO_INSTRUMENT_REQUIRE} `)
+  }
+  return `node ${AUTO_INSTRUMENT_REQUIRE} -- ${start}`
+}
+
+async function plan(serviceDir: string): Promise<InstallPlan> {
+  const pkg = await readPackageJson(serviceDir)
+  const manifestPath = path.join(serviceDir, 'package.json')
+  const empty: InstallPlan = {
+    language: 'javascript',
+    serviceDir,
+    dependencyEdits: [],
+    entrypointEdits: [],
+    envEdits: [],
+  }
+  if (!pkg) return empty
+
+  const existingDeps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) }
+  const dependencyEdits: DependencyEdit[] = []
+  for (const sdk of SDK_PACKAGES) {
+    if (sdk.name in existingDeps) continue
+    dependencyEdits.push({
+      file: manifestPath,
+      kind: 'add',
+      name: sdk.name,
+      version: sdk.version,
+    })
+  }
+  // SDK_PACKAGES is already in stable declaration order, so the slice above
+  // is deterministic across runs (ADR-047 #6).
+
+  const entrypointEdits: EntrypointEdit[] = []
+  const startScript = pkg.scripts?.start
+  if (typeof startScript === 'string' && startScript.trim().length > 0) {
+    const rewritten = rewriteStartScript(startScript)
+    if (rewritten !== startScript) {
+      entrypointEdits.push({ file: manifestPath, before: startScript, after: rewritten })
+    }
+  }
+
+  // Empty plan when nothing needs to change anywhere — that is, every SDK
+  // dep is present and the start script already wires the hook (or there's
+  // no start script to wire). Surfaces ADR-047 #5: "plan(dir) returns an
+  // empty plan when SDK is already installed."
+  if (dependencyEdits.length === 0 && entrypointEdits.length === 0) {
+    return empty
+  }
+
+  return {
+    language: 'javascript',
+    serviceDir,
+    dependencyEdits,
+    entrypointEdits,
+    envEdits: [OTEL_ENV],
+  }
+}
+
+async function apply(installPlan: InstallPlan): Promise<void> {
+  const touched = new Set<string>()
+  for (const e of installPlan.dependencyEdits) touched.add(e.file)
+  for (const e of installPlan.entrypointEdits) touched.add(e.file)
+  if (touched.size === 0) return
+
+  // Snapshot every file we're about to mutate so a partial failure can roll
+  // back the whole batch (ADR-047 #7). Missing files are intentionally not
+  // an early-exit: the per-file mutation loop will hit them, fail, and
+  // trigger rollback for the files we already wrote.
+  const originals = new Map<string, string>()
+  for (const file of touched) {
+    try {
+      originals.set(file, await fs.readFile(file, 'utf8'))
+    } catch {
+      // No snapshot for this file. Mutation will fail loudly below.
+    }
+  }
+
+  try {
+    for (const file of touched) {
+      const raw = originals.get(file) ?? ''
+      const pkg = JSON.parse(raw) as PackageJsonShape
+      pkg.dependencies = pkg.dependencies ?? {}
+
+      for (const dep of installPlan.dependencyEdits) {
+        if (dep.file !== file) continue
+        if (dep.kind === 'add') {
+          pkg.dependencies[dep.name] = dep.version
+        } else {
+          delete pkg.dependencies[dep.name]
+        }
+      }
+
+      for (const ep of installPlan.entrypointEdits) {
+        if (ep.file !== file) continue
+        pkg.scripts = pkg.scripts ?? {}
+        if (pkg.scripts.start === ep.before) {
+          pkg.scripts.start = ep.after
+        }
+      }
+
+      // Match the most common npm formatting (two-space indent, trailing
+      // newline) so the diff stays minimal on review.
+      const newRaw = JSON.stringify(pkg, null, 2) + '\n'
+      const tmp = `${file}.${process.pid}.${Date.now()}.tmp`
+      await fs.writeFile(tmp, newRaw, 'utf8')
+      await fs.rename(tmp, file)
+    }
+  } catch (err) {
+    await rollback(installPlan, originals)
+    throw err
+  }
+}
+
+async function rollback(
+  installPlan: InstallPlan,
+  originals: Map<string, string>,
+): Promise<void> {
+  const restored: string[] = []
+  for (const [file, raw] of originals.entries()) {
+    try {
+      await fs.writeFile(file, raw, 'utf8')
+      restored.push(file)
+    } catch {
+      // Best-effort: keep going so we restore as much as we can.
+    }
+  }
+  const lines = [
+    '# neat-rollback.patch',
+    '',
+    `# Generated after a partial apply failure in the ${installPlan.language} installer.`,
+    '# Files listed below were restored to their pre-apply contents.',
+    '',
+    ...restored.map((f) => `restored: ${f}`),
+    '',
+  ]
+  const rollbackPath = path.join(installPlan.serviceDir, 'neat-rollback.patch')
+  await fs.writeFile(rollbackPath, lines.join('\n'), 'utf8')
+}
+
+export const javascriptInstaller: Installer = {
+  name: 'javascript',
+  detect,
+  plan,
+  apply,
+}

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -2393,13 +2393,204 @@ describe('neat init contract (ADR-046)', () => {
 })
 
 describe('SDK install contract (ADR-047)', () => {
-  it.todo('every installer module exports detect/plan/apply (ADR-047 #1)')
-  it.todo('Node installer plan adds @opentelemetry/sdk-node and modifies entrypoint (ADR-047 #2)')
+  async function makeNodeService(): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+    const os2 = await import('node:os')
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const dir = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-installer-js-'))
+    return {
+      dir: await fs2.realpath(dir),
+      cleanup: () => fs2.rm(dir, { recursive: true, force: true }),
+    }
+  }
+
+  it('every installer module exports detect/plan/apply (ADR-047 #1)', async () => {
+    const { INSTALLERS } = await import('../../src/installers/index.js')
+    expect(INSTALLERS.length).toBeGreaterThan(0)
+    for (const inst of INSTALLERS) {
+      expect(typeof inst.name).toBe('string')
+      expect(inst.name.length).toBeGreaterThan(0)
+      expect(typeof inst.detect).toBe('function')
+      expect(typeof inst.plan).toBe('function')
+      expect(typeof inst.apply).toBe('function')
+    }
+  })
+
+  it('Node installer plan adds @opentelemetry/sdk-node and modifies entrypoint (ADR-047 #2)', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { dir, cleanup } = await makeNodeService()
+    try {
+      await fs2.writeFile(
+        path2.join(dir, 'package.json'),
+        JSON.stringify(
+          { name: 'svc', version: '0.0.0', scripts: { start: 'node server.js' } },
+          null,
+          2,
+        ),
+      )
+      const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+      expect(await javascriptInstaller.detect(dir)).toBe(true)
+      const plan = await javascriptInstaller.plan(dir)
+      expect(plan.language).toBe('javascript')
+      const depNames = plan.dependencyEdits.map((d) => d.name)
+      expect(depNames).toContain('@opentelemetry/sdk-node')
+      expect(depNames).toContain('@opentelemetry/api')
+      expect(depNames).toContain('@opentelemetry/auto-instrumentations-node')
+      for (const dep of plan.dependencyEdits) {
+        expect(dep.kind).toBe('add')
+        expect(dep.file).toBe(path2.join(dir, 'package.json'))
+      }
+      expect(plan.entrypointEdits).toHaveLength(1)
+      const ep = plan.entrypointEdits[0]!
+      expect(ep.before).toBe('node server.js')
+      expect(ep.after).toContain('@opentelemetry/auto-instrumentations-node/register')
+      expect(plan.envEdits.some((e) => e.key === 'OTEL_EXPORTER_OTLP_ENDPOINT')).toBe(true)
+    } finally {
+      await cleanup()
+    }
+  })
+
   it.todo('Python installer plan adds opentelemetry-distro and prefixes entrypoint (ADR-047 #2)')
-  it.todo('no installer plan output references package-lock.json/poetry.lock/Gemfile.lock (ADR-047 #4)')
-  it.todo('plan(dir) returns an empty plan when SDK is already installed (ADR-047 #5)')
-  it.todo('plan output is deterministic across runs (ADR-047 #6)')
-  it.todo('apply failure produces a neat-rollback.patch (ADR-047 #7)')
+
+  it('no installer plan output references package-lock.json/poetry.lock/Gemfile.lock (ADR-047 #4)', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const lockfiles = [
+      'package-lock.json',
+      'pnpm-lock.yaml',
+      'yarn.lock',
+      'poetry.lock',
+      'Pipfile.lock',
+      'Gemfile.lock',
+      'Cargo.lock',
+    ]
+    const { INSTALLERS } = await import('../../src/installers/index.js')
+    const offenders: string[] = []
+    for (const inst of INSTALLERS) {
+      const { dir, cleanup } = await makeNodeService()
+      try {
+        // Drop in everything an installer might detect on, plus a lockfile
+        // for every language. Plans are pure data — no side effects from
+        // calling them, so this is safe across all installers.
+        await fs2.writeFile(
+          path2.join(dir, 'package.json'),
+          JSON.stringify({ name: 'svc', version: '0.0.0', scripts: { start: 'node s.js' } }),
+        )
+        await fs2.writeFile(path2.join(dir, 'pyproject.toml'), '[project]\nname="svc"')
+        await fs2.writeFile(path2.join(dir, 'requirements.txt'), 'flask==3.0.0\n')
+        for (const lock of lockfiles) {
+          await fs2.writeFile(path2.join(dir, lock), '{}')
+        }
+        if (!(await inst.detect(dir))) continue
+        const plan = await inst.plan(dir)
+        const allFiles = [
+          ...plan.dependencyEdits.map((e) => e.file),
+          ...plan.entrypointEdits.map((e) => e.file),
+          ...plan.envEdits.map((e) => e.file).filter((f): f is string => f !== null),
+        ]
+        for (const f of allFiles) {
+          const base = path2.basename(f)
+          if (lockfiles.includes(base)) {
+            offenders.push(`${inst.name}: plan references lockfile ${f}`)
+          }
+        }
+      } finally {
+        await cleanup()
+      }
+    }
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
+
+  it('plan(dir) returns an empty plan when SDK is already installed (ADR-047 #5)', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { dir, cleanup } = await makeNodeService()
+    try {
+      await fs2.writeFile(
+        path2.join(dir, 'package.json'),
+        JSON.stringify({
+          name: 'svc',
+          version: '0.0.0',
+          scripts: {
+            start: 'node --require @opentelemetry/auto-instrumentations-node/register server.js',
+          },
+          dependencies: {
+            '@opentelemetry/api': '^1.9.0',
+            '@opentelemetry/sdk-node': '^0.57.0',
+            '@opentelemetry/auto-instrumentations-node': '^0.55.0',
+          },
+        }),
+      )
+      const { javascriptInstaller, isEmptyPlan } = await import('../../src/installers/index.js')
+      const plan = await javascriptInstaller.plan(dir)
+      expect(isEmptyPlan(plan)).toBe(true)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('plan output is deterministic across runs (ADR-047 #6)', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { dir, cleanup } = await makeNodeService()
+    try {
+      await fs2.writeFile(
+        path2.join(dir, 'package.json'),
+        JSON.stringify(
+          { name: 'svc', version: '0.0.0', scripts: { start: 'node server.js' } },
+          null,
+          2,
+        ),
+      )
+      const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+      const a = await javascriptInstaller.plan(dir)
+      const b = await javascriptInstaller.plan(dir)
+      expect(JSON.stringify(b)).toBe(JSON.stringify(a))
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('apply failure produces a neat-rollback.patch (ADR-047 #7)', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { dir, cleanup } = await makeNodeService()
+    try {
+      const manifest = path2.join(dir, 'package.json')
+      const original = JSON.stringify(
+        { name: 'svc', version: '0.0.0', scripts: { start: 'node server.js' } },
+        null,
+        2,
+      )
+      await fs2.writeFile(manifest, original)
+      const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+      // Construct a plan with a dependencyEdit pointing at a real manifest
+      // (so apply reads originals OK) plus an entrypointEdit pointing at a
+      // file that does not exist — the second pass crashes when reading
+      // originals for that file. The contract: the rollback path triggers
+      // and neat-rollback.patch lands on disk.
+      const ghost = path2.join(dir, 'does-not-exist', 'package.json')
+      await expect(
+        javascriptInstaller.apply({
+          language: 'javascript',
+          serviceDir: dir,
+          dependencyEdits: [{ file: manifest, kind: 'add', name: 'x', version: '1.0.0' }],
+          entrypointEdits: [{ file: ghost, before: 'a', after: 'b' }],
+          envEdits: [],
+        }),
+      ).rejects.toBeInstanceOf(Error)
+      // The real manifest was rolled back (still bears the original bytes).
+      const after = await fs2.readFile(manifest, 'utf8')
+      expect(after).toBe(original)
+      // And neat-rollback.patch lives at the service root.
+      const rollback = await fs2.readFile(path2.join(dir, 'neat-rollback.patch'), 'utf8')
+      expect(rollback).toContain('neat-rollback.patch')
+      expect(rollback).toContain(manifest)
+    } finally {
+      await cleanup()
+    }
+  })
 })
 
 describe('Machine-level project registry contract (ADR-048)', () => {


### PR DESCRIPTION
## Summary

Step 3 of v0.2.5. Adds `packages/core/src/installers/javascript.ts` and registers it in `INSTALLERS` so `neat init` now produces a real SDK install plan for any service that looks like a Node project.

- `detect(serviceDir)` reads `package.json` and returns true when a `name` field is present — same shape `extract/services.ts` uses.
- `plan(serviceDir)` is pure data: adds `@opentelemetry/api`, `@opentelemetry/sdk-node`, and `@opentelemetry/auto-instrumentations-node` to `dependencies` when missing, and prefixes `scripts.start` with `--require @opentelemetry/auto-instrumentations-node/register`. Returns an empty plan when everything is already in place — the idempotency property ADR-047 #5 calls out.
- `apply(plan)` snapshots every manifest before writing, mutates each file under tmp-then-rename, and on failure restores from snapshot and drops `neat-rollback.patch` at the service root listing what got reverted. Missing snapshot reads don't bail early — they let the mutation loop fail naturally so the rollback path covers any file that did already get mutated.
- Lockfiles are never named anywhere in the installer. The forbidden list in `installers/index.ts` is the only place lockfile filenames appear in the codebase, and the lockfile contract test exercises every installer in `INSTALLERS` against every lockfile flavour to prove plans never reference them.

## Contract todos flipped

Six of the seven ADR-047 items in `contracts.test.ts` are now live assertions:

- detect/plan/apply exports (#1)
- Node installer adds sdk-node + entrypoint hook (#2)
- no installer plan output references lockfiles (#4)
- plan returns empty when SDK already installed (#5)
- plan output deterministic across runs (#6)
- apply failure produces `neat-rollback.patch` (#7)

The Python case (#3) stays as `it.todo` for step 4.

## Test plan

- [x] `npx turbo build test lint` green on `20-node-sdk-installer` (333 tests pass; 11 todos remain — down 6)
- [ ] `node packages/core/dist/cli.cjs init <node-repo>` produces a `neat.patch` listing the three OTel deps + entrypoint hook
- [ ] `--apply` against the same repo lands a real edit in `package.json` and prints "run npm install" guidance
- [ ] Re-running with `--apply` produces no further edits (idempotent)

Refs #20