### PR TITLE
Daemon — neatd start/stop/reload/status (#22)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,8 @@
     }
   },
   "bin": {
-    "neat": "./dist/cli.cjs"
+    "neat": "./dist/cli.cjs",
+    "neatd": "./dist/neatd.cjs"
   },
   "files": [
     "dist",

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -1,0 +1,242 @@
+/**
+ * Multi-project daemon (ADR-049).
+ *
+ * Single long-lived process watching every project in the machine-level registry.
+ * Per-project graph isolation: each registered project owns its own
+ * `MultiDirectedGraph` slot keyed by name (ADR-026), and a failure during
+ * one project's bootstrap is logged + marked `broken` without taking down
+ * the rest of the daemon.
+ *
+ * MVP scope (v0.2.5):
+ *  - Read registry; refuse to boot when it's missing.
+ *  - Write PID at `~/.neat/neatd.pid` for external supervisors.
+ *  - Per project: load any existing snapshot, run initial extraction,
+ *    start a per-project persist loop.
+ *  - SIGHUP triggers a reload — re-reads the registry, picks up new
+ *    projects, drops removed ones, leaves untouched ones in place.
+ *  - Provide `routeSpanToProject(serviceName, projects)` for OTel ingest
+ *    to dispatch by `service.name` across registered projects, falling
+ *    back to `default` for unknown services per ADR-033.
+ *
+ * Out of MVP scope (deferred):
+ *  - Live OTel listener wiring per project — daemon exposes the routing
+ *    primitive; the actual receiver attachment lands alongside v0.2.6.
+ *  - Policy reload on `policy.json` mtime — `startWatch` already does this
+ *    per-project; the daemon-level loop reuses that machinery in a follow-up.
+ *  - Auto-restart on crash. PID file is the supervisor handoff.
+ */
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { DEFAULT_PROJECT, getGraph, resetGraph, type NeatGraph } from './graph.js'
+import { extractFromDirectory } from './extract.js'
+import { loadGraphFromDisk, startPersistLoop } from './persist.js'
+import { pathsForProject } from './projects.js'
+import {
+  listProjects,
+  registryPath,
+  setStatus,
+  touchLastSeen,
+  writeAtomically,
+} from './registry.js'
+import type { RegistryEntry } from '@neat/types'
+
+export interface DaemonOptions {
+  // Defaults to `~/.neat/`. Honors NEAT_HOME the same way registry.ts does.
+  // Tests override via NEAT_HOME and don't pass this directly.
+  neatHome?: string
+}
+
+export interface ProjectSlot {
+  entry: RegistryEntry
+  graph: NeatGraph
+  outPath: string
+  stopPersist: () => void
+  status: 'active' | 'broken'
+  errorReason?: string
+}
+
+export interface DaemonHandle {
+  // The slots currently being managed, keyed by project name. Tests inspect
+  // this to assert isolation properties.
+  slots: Map<string, ProjectSlot>
+  // Re-read the registry. New entries get bootstrapped, removed ones get
+  // their persist loops stopped, existing ones stay running.
+  reload: () => Promise<void>
+  // Graceful shutdown — stop every project's persist loop and remove the
+  // PID file.
+  stop: () => Promise<void>
+  // Path to the PID file the daemon owns. Useful for test assertions.
+  pidPath: string
+}
+
+function neatHomeFor(opts: DaemonOptions): string {
+  if (opts.neatHome && opts.neatHome.length > 0) return path.resolve(opts.neatHome)
+  const env = process.env.NEAT_HOME
+  if (env && env.length > 0) return path.resolve(env)
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? ''
+  return path.join(home, '.neat')
+}
+
+/**
+ * Resolve which project's graph an OTel span belongs to. Looks up the
+ * `service.name` against the registry and returns the matching project's
+ * name, or `DEFAULT_PROJECT` for unknown services so the FrontierNode
+ * auto-creation flow keeps working per ADR-033.
+ *
+ * Pure function. Daemon callers pass a snapshot of the registry to avoid
+ * per-span fs reads.
+ */
+export function routeSpanToProject(
+  serviceName: string | undefined,
+  projects: ReadonlyArray<RegistryEntry>,
+): string {
+  if (!serviceName) return DEFAULT_PROJECT
+  for (const entry of projects) {
+    if (entry.status !== 'active') continue
+    if (entry.languages.length === 0) {
+      // No language data yet — still acceptable to match by name.
+    }
+    if (entry.name === serviceName) return entry.name
+  }
+  return DEFAULT_PROJECT
+}
+
+async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
+  // Path missing on disk → mark broken and surface the reason. Daemon
+  // continues with the rest of the registry.
+  try {
+    const stat = await fs.stat(entry.path)
+    if (!stat.isDirectory()) {
+      throw new Error(`registered path ${entry.path} is not a directory`)
+    }
+  } catch (err) {
+    await setStatus(entry.name, 'broken').catch(() => {})
+    return {
+      entry,
+      // Empty graph is fine — `slots` keeps the entry visible in `status`
+      // output; nothing routes to it because it's not 'active'.
+      graph: getGraph(`__broken__:${entry.name}`),
+      outPath: '',
+      stopPersist: () => {},
+      status: 'broken',
+      errorReason: (err as Error).message,
+    }
+  }
+
+  // Use the project name as the in-memory graph key. Any prior contents
+  // are wiped because the daemon owns the slot for the lifetime of this
+  // bootstrap (ADR-030 — mutation authority).
+  resetGraph(entry.name)
+  const graph = getGraph(entry.name)
+  const outPath = pathsForProject(
+    entry.name,
+    path.join(entry.path, 'neat-out'),
+  ).snapshotPath
+
+  await loadGraphFromDisk(graph, outPath)
+  await extractFromDirectory(graph, entry.path)
+  const stopPersist = startPersistLoop(graph, outPath)
+  await touchLastSeen(entry.name).catch(() => {})
+
+  return {
+    entry,
+    graph,
+    outPath,
+    stopPersist,
+    status: 'active',
+  }
+}
+
+export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandle> {
+  const home = neatHomeFor(opts)
+  const regPath = registryPath()
+  // Graceful degradation per ADR-049 #6: missing registry refuses to boot
+  // with a clear error rather than silently coming up empty.
+  try {
+    await fs.access(regPath)
+  } catch {
+    throw new Error(
+      `neatd: registry not found at ${regPath}. Run \`neat init <path>\` to register a project before starting the daemon.`,
+    )
+  }
+
+  const pidPath = path.join(home, 'neatd.pid')
+  await writeAtomically(pidPath, `${process.pid}\n`)
+
+  const slots = new Map<string, ProjectSlot>()
+
+  async function loadAll(): Promise<void> {
+    const projects = await listProjects()
+    const seen = new Set<string>()
+    for (const entry of projects) {
+      seen.add(entry.name)
+      if (slots.has(entry.name)) continue
+      try {
+        const slot = await bootstrapProject(entry)
+        slots.set(entry.name, slot)
+        if (slot.status === 'broken') {
+          console.warn(`neatd: project "${entry.name}" broken — ${slot.errorReason}`)
+        } else {
+          console.log(`neatd: project "${entry.name}" active (${entry.path})`)
+        }
+      } catch (err) {
+        console.warn(
+          `neatd: project "${entry.name}" failed to bootstrap — ${(err as Error).message}`,
+        )
+        await setStatus(entry.name, 'broken').catch(() => {})
+      }
+    }
+    // Drop entries the registry no longer carries.
+    for (const [name, slot] of [...slots.entries()]) {
+      if (seen.has(name)) continue
+      try {
+        slot.stopPersist()
+      } catch {
+        // best-effort
+      }
+      slots.delete(name)
+      console.log(`neatd: project "${name}" removed from registry — stopped`)
+    }
+  }
+
+  await loadAll()
+
+  let reloading: Promise<void> | null = null
+  const reload = async (): Promise<void> => {
+    if (reloading) return reloading
+    reloading = (async () => {
+      try {
+        await loadAll()
+      } finally {
+        reloading = null
+      }
+    })()
+    return reloading
+  }
+
+  // SIGHUP — external "reload your config" signal. ADR-049 #2.
+  const sighupHandler = (): void => {
+    void reload().catch((err) => {
+      console.warn(`neatd: SIGHUP reload failed — ${(err as Error).message}`)
+    })
+  }
+  process.on('SIGHUP', sighupHandler)
+
+  let stopped = false
+  const stop = async (): Promise<void> => {
+    if (stopped) return
+    stopped = true
+    process.off('SIGHUP', sighupHandler)
+    for (const slot of slots.values()) {
+      try {
+        slot.stopPersist()
+      } catch {
+        // best-effort
+      }
+    }
+    await fs.unlink(pidPath).catch(() => {})
+  }
+
+  return { slots, reload, stop, pidPath }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,6 +44,13 @@ export {
   type PersistedSnapshot,
 } from './diff.js'
 export {
+  routeSpanToProject,
+  startDaemon,
+  type DaemonHandle,
+  type DaemonOptions,
+  type ProjectSlot,
+} from './daemon.js'
+export {
   addProject,
   getProject,
   listProjects,

--- a/packages/core/src/neatd.ts
+++ b/packages/core/src/neatd.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * `neatd` — distribution-layer daemon CLI (ADR-049).
+ *
+ * Subcommands:
+ *   neatd start [--foreground]    boot the daemon and watch the registry
+ *   neatd stop                    signal the running daemon to shut down
+ *   neatd reload                  signal the running daemon to re-read the registry
+ *   neatd status                  print PID + per-project last-seen timestamps
+ *
+ * MVP runs in foreground only. Backgrounding is the supervisor's job
+ * (launchd / systemd / nohup) — `neatd start` blocks until SIGINT/SIGTERM.
+ */
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { startDaemon } from './daemon.js'
+import { listProjects, registryPath } from './registry.js'
+
+function neatHome(): string {
+  if (process.env.NEAT_HOME && process.env.NEAT_HOME.length > 0) {
+    return path.resolve(process.env.NEAT_HOME)
+  }
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? ''
+  return path.join(home, '.neat')
+}
+
+async function readPid(): Promise<number | null> {
+  try {
+    const raw = await fs.readFile(path.join(neatHome(), 'neatd.pid'), 'utf8')
+    const n = Number.parseInt(raw.trim(), 10)
+    return Number.isFinite(n) ? n : null
+  } catch {
+    return null
+  }
+}
+
+function usage(): void {
+  console.log('usage: neatd <start|stop|reload|status> [--foreground]')
+}
+
+async function cmdStart(): Promise<void> {
+  const handle = await startDaemon()
+  console.log(`neatd: started, PID ${process.pid}, ${handle.slots.size} project(s)`)
+  console.log(`neatd: registry at ${registryPath()}`)
+  console.log('neatd: SIGHUP reloads, SIGTERM/SIGINT stops')
+
+  let stopping = false
+  const shutdown = (signal: NodeJS.Signals): void => {
+    if (stopping) return
+    stopping = true
+    console.log(`neatd: ${signal} received, stopping…`)
+    void handle
+      .stop()
+      .catch((err) => console.error(`neatd: shutdown error — ${(err as Error).message}`))
+      .finally(() => process.exit(0))
+  }
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+
+  // Block forever — supervisors keep us in the foreground.
+  await new Promise<void>(() => {})
+}
+
+async function cmdStop(): Promise<void> {
+  const pid = await readPid()
+  if (pid === null) {
+    console.error('neatd: no running daemon found (no PID file)')
+    process.exit(1)
+  }
+  try {
+    process.kill(pid, 'SIGTERM')
+    console.log(`neatd: SIGTERM sent to PID ${pid}`)
+  } catch (err) {
+    console.error(`neatd: failed to signal PID ${pid} — ${(err as Error).message}`)
+    process.exit(1)
+  }
+}
+
+async function cmdReload(): Promise<void> {
+  const pid = await readPid()
+  if (pid === null) {
+    console.error('neatd: no running daemon found (no PID file)')
+    process.exit(1)
+  }
+  try {
+    process.kill(pid, 'SIGHUP')
+    console.log(`neatd: SIGHUP sent to PID ${pid}`)
+  } catch (err) {
+    console.error(`neatd: failed to signal PID ${pid} — ${(err as Error).message}`)
+    process.exit(1)
+  }
+}
+
+async function cmdStatus(): Promise<void> {
+  const pid = await readPid()
+  console.log(`pid:      ${pid ?? '(not running)'}`)
+  console.log(`registry: ${registryPath()}`)
+  const projects = await listProjects().catch(() => [])
+  if (projects.length === 0) {
+    console.log('projects: (none)')
+    return
+  }
+  console.log('projects:')
+  for (const p of projects) {
+    const seen = p.lastSeenAt ?? 'never'
+    console.log(`  ${p.name}\t${p.status}\t${p.path}\tlast-seen=${seen}`)
+  }
+}
+
+async function main(): Promise<void> {
+  const cmd = process.argv[2]
+  if (!cmd || cmd === '-h' || cmd === '--help') {
+    usage()
+    process.exit(cmd ? 0 : 2)
+  }
+
+  if (cmd === 'start') return cmdStart()
+  if (cmd === 'stop') return cmdStop()
+  if (cmd === 'reload') return cmdReload()
+  if (cmd === 'status') return cmdStatus()
+
+  console.error(`neatd: unknown command "${cmd}"`)
+  usage()
+  process.exit(1)
+}
+
+const entry = process.argv[1] ?? ''
+if (/[\\/]neatd\.(?:cjs|js)$/.test(entry) || entry.endsWith('/neatd')) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -2761,12 +2761,242 @@ describe('Machine-level project registry contract (ADR-048)', () => {
 })
 
 describe('Daemon contract (ADR-049)', () => {
-  it.todo('daemon writes only via persist.ts loop and shutdown handlers (ADR-049 — mutation authority)')
-  it.todo('per-project graph isolation: failure in one project does not affect others (ADR-049 #4)')
-  it.todo('OTel span routing matches by service.name across registered projects (ADR-049 #5)')
-  it.todo('graceful degradation: missing registry → boot refuses with clear error (ADR-049 #6)')
-  it.todo('daemon writes PID to ~/.neat/neatd.pid (ADR-049 #7)')
-  it.todo('SIGHUP triggers registry re-read (ADR-049 #2)')
+  // Sandbox helper: tmp NEAT_HOME with a registry pre-seeded by addProject,
+  // optionally with one or more registered projects. Returns a cleanup that
+  // unwinds env mutations + tmp dirs.
+  async function setupDaemonSandbox(opts: {
+    projects?: Array<{ name: string; missingPath?: boolean }>
+  } = {}): Promise<{
+    home: string
+    cleanup: () => Promise<void>
+    addedPaths: Map<string, string>
+  }> {
+    const os2 = await import('node:os')
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const home = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neatd-home-'))
+    const addedPaths = new Map<string, string>()
+    const cleanups: Array<() => Promise<void>> = []
+    const prevHome = process.env.NEAT_HOME
+    process.env.NEAT_HOME = home
+
+    const { addProject, setStatus } = await import('../../src/registry.js')
+    for (const p of opts.projects ?? []) {
+      const dir = await fs2.mkdtemp(path2.join(os2.tmpdir(), `neatd-project-${p.name}-`))
+      const real = await fs2.realpath(dir)
+      await fs2.writeFile(
+        path2.join(real, 'package.json'),
+        JSON.stringify({ name: p.name, version: '0.0.0' }),
+      )
+      await addProject({ name: p.name, path: real, languages: ['javascript'] })
+      addedPaths.set(p.name, real)
+      cleanups.push(() => fs2.rm(dir, { recursive: true, force: true }))
+      if (p.missingPath) {
+        // Yank the dir after registration so the daemon sees a registered
+        // project whose disk has vanished — the broken-path graceful path.
+        await fs2.rm(real, { recursive: true, force: true })
+      }
+      // setStatus call is implicit here — addProject defaults to 'active'.
+      void setStatus
+    }
+
+    return {
+      home,
+      addedPaths,
+      cleanup: async () => {
+        if (prevHome === undefined) delete process.env.NEAT_HOME
+        else process.env.NEAT_HOME = prevHome
+        for (const c of cleanups) await c().catch(() => {})
+        await fs2.rm(home, { recursive: true, force: true })
+      },
+    }
+  }
+
+  it('daemon writes only via persist.ts loop and shutdown handlers (ADR-049 — mutation authority)', () => {
+    // Source-grep: daemon.ts has no direct fs writes against project graph
+    // files. Persistence flows through startPersistLoop (which lives in
+    // persist.ts), and the only fs.unlink/writeAtomically calls are for
+    // the PID file at ~/.neat/neatd.pid.
+    const daemon = readFileSync(join(CORE_SRC, 'daemon.ts'), 'utf8')
+    expect(daemon).toMatch(/startPersistLoop\(/)
+    // No raw fs.writeFile or fs.write to a graph snapshot. The two allowed
+    // writes are writeAtomically for the PID file (registry-helper) and
+    // fs.unlink for cleanup of that same PID file.
+    const offenders: string[] = []
+    daemon.split('\n').forEach((line, i) => {
+      if (/fs\.writeFile\(/.test(line)) offenders.push(`${i + 1}: ${line.trim()}`)
+      if (/fs\.appendFile\(/.test(line)) offenders.push(`${i + 1}: ${line.trim()}`)
+    })
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
+
+  it('per-project graph isolation: failure in one project does not affect others (ADR-049 #4)', async () => {
+    const { home, cleanup } = await setupDaemonSandbox({
+      projects: [
+        { name: 'good', missingPath: false },
+        { name: 'broken', missingPath: true },
+      ],
+    })
+    const prevWarn = console.warn
+    const prevLog = console.log
+    console.warn = () => {}
+    console.log = () => {}
+    try {
+      const { startDaemon } = await import('../../src/daemon.js')
+      const handle = await startDaemon()
+      try {
+        // Both projects appear in slots; the missing-path one is marked
+        // broken, the surviving one is active and producing a snapshot.
+        const good = handle.slots.get('good')
+        const broken = handle.slots.get('broken')
+        expect(good, 'good slot present').toBeDefined()
+        expect(broken, 'broken slot present').toBeDefined()
+        expect(good!.status).toBe('active')
+        expect(broken!.status).toBe('broken')
+      } finally {
+        await handle.stop()
+      }
+      // Confirm setStatus on the registry actually ran for the broken one.
+      const { listProjects } = await import('../../src/registry.js')
+      const projects = await listProjects()
+      const brokenEntry = projects.find((p) => p.name === 'broken')
+      expect(brokenEntry?.status).toBe('broken')
+      void home
+    } finally {
+      console.warn = prevWarn
+      console.log = prevLog
+      await cleanup()
+    }
+  })
+
+  it('OTel span routing matches by service.name across registered projects (ADR-049 #5)', async () => {
+    const { routeSpanToProject } = await import('../../src/daemon.js')
+    const { DEFAULT_PROJECT } = await import('../../src/graph.js')
+    const projects = [
+      {
+        name: 'checkout',
+        path: '/tmp/checkout',
+        registeredAt: '2026-05-07T00:00:00.000Z',
+        languages: ['javascript'],
+        status: 'active' as const,
+      },
+      {
+        name: 'inventory',
+        path: '/tmp/inventory',
+        registeredAt: '2026-05-07T00:00:00.000Z',
+        languages: ['python'],
+        status: 'active' as const,
+      },
+      {
+        name: 'paused-svc',
+        path: '/tmp/paused-svc',
+        registeredAt: '2026-05-07T00:00:00.000Z',
+        languages: [],
+        status: 'paused' as const,
+      },
+    ]
+    expect(routeSpanToProject('checkout', projects)).toBe('checkout')
+    expect(routeSpanToProject('inventory', projects)).toBe('inventory')
+    // Paused entries are not active routing targets.
+    expect(routeSpanToProject('paused-svc', projects)).toBe(DEFAULT_PROJECT)
+    // Unknown service.name falls back per ADR-033's FrontierNode flow.
+    expect(routeSpanToProject('unknown-mystery-service', projects)).toBe(DEFAULT_PROJECT)
+    expect(routeSpanToProject(undefined, projects)).toBe(DEFAULT_PROJECT)
+  })
+
+  it('graceful degradation: missing registry → boot refuses with clear error (ADR-049 #6)', async () => {
+    const os2 = await import('node:os')
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const home = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neatd-empty-home-'))
+    const prevHome = process.env.NEAT_HOME
+    process.env.NEAT_HOME = home
+    try {
+      const { startDaemon } = await import('../../src/daemon.js')
+      await expect(startDaemon()).rejects.toThrow(/registry not found/)
+    } finally {
+      if (prevHome === undefined) delete process.env.NEAT_HOME
+      else process.env.NEAT_HOME = prevHome
+      await fs2.rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('daemon writes PID to ~/.neat/neatd.pid (ADR-049 #7)', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { home, cleanup } = await setupDaemonSandbox({
+      projects: [{ name: 'pid-test' }],
+    })
+    const prevWarn = console.warn
+    const prevLog = console.log
+    console.warn = () => {}
+    console.log = () => {}
+    try {
+      const { startDaemon } = await import('../../src/daemon.js')
+      const handle = await startDaemon()
+      try {
+        expect(handle.pidPath).toBe(path2.join(home, 'neatd.pid'))
+        const pidRaw = await fs2.readFile(handle.pidPath, 'utf8')
+        expect(Number.parseInt(pidRaw.trim(), 10)).toBe(process.pid)
+      } finally {
+        await handle.stop()
+      }
+      // Stop removes the PID file.
+      await expect(fs2.access(handle.pidPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    } finally {
+      console.warn = prevWarn
+      console.log = prevLog
+      await cleanup()
+    }
+  })
+
+  it('SIGHUP triggers registry re-read (ADR-049 #2)', async () => {
+    const { home, cleanup } = await setupDaemonSandbox({
+      projects: [{ name: 'first' }],
+    })
+    const prevWarn = console.warn
+    const prevLog = console.log
+    console.warn = () => {}
+    console.log = () => {}
+    try {
+      const { startDaemon } = await import('../../src/daemon.js')
+      const handle = await startDaemon()
+      try {
+        expect(handle.slots.has('first')).toBe(true)
+        expect(handle.slots.has('second')).toBe(false)
+
+        // Add a second project to the registry while the daemon is running.
+        const os2 = await import('node:os')
+        const fs2 = await import('node:fs/promises')
+        const path2 = await import('node:path')
+        const dir = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neatd-second-'))
+        const real = await fs2.realpath(dir)
+        await fs2.writeFile(
+          path2.join(real, 'package.json'),
+          JSON.stringify({ name: 'second', version: '0.0.0' }),
+        )
+        const { addProject } = await import('../../src/registry.js')
+        await addProject({ name: 'second', path: real, languages: ['javascript'] })
+
+        // Send SIGHUP and wait for the reload to settle. The handler is
+        // fire-and-forget so we poll the slots map briefly.
+        process.kill(process.pid, 'SIGHUP')
+        const deadline = Date.now() + 2000
+        while (Date.now() < deadline && !handle.slots.has('second')) {
+          await new Promise((r) => setTimeout(r, 25))
+        }
+        expect(handle.slots.has('second')).toBe(true)
+        await fs2.rm(dir, { recursive: true, force: true })
+      } finally {
+        await handle.stop()
+      }
+      void home
+    } finally {
+      console.warn = prevWarn
+      console.log = prevLog
+      await cleanup()
+    }
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/server.ts', 'src/cli.ts'],
+  entry: ['src/index.ts', 'src/server.ts', 'src/cli.ts', 'src/neatd.ts'],
   format: ['esm', 'cjs'],
   dts: true,
   clean: true,


### PR DESCRIPTION
## Summary

Step 5 of v0.2.5. Adds `packages/core/src/daemon.ts` and a `neatd` bin so a single long-lived process can manage every project the machine-level registry knows about.

- `startDaemon()` reads the registry through `registry.ts` helpers (no direct fs on `projects.json`), refuses to boot when the registry file is missing, and writes a PID at `~/.neat/neatd.pid` via the same `writeAtomically` helper init uses.
- Per registered project: load any existing snapshot, run static extraction, hand the graph to `startPersistLoop`. A project whose disk path has vanished is flagged `status: 'broken'` on the registry and the rest of the daemon keeps running.
- `SIGHUP` triggers a reload that re-reads the registry, bootstraps new projects, and stops persist loops for entries the user removed. Existing slots are left running.
- `stop()` unwinds every persist loop, unsubscribes from `SIGHUP`, and unlinks the PID file.
- `routeSpanToProject(serviceName, projects)` — pure-function OTel routing primitive. Looks up `service.name` across active registry entries, falls back to `DEFAULT_PROJECT` for unknown services (FrontierNode auto-creation per ADR-033) and for paused entries. Receiver wiring lands alongside v0.2.6.

Mutation authority stays with `persist.ts` and the registry helpers. The daemon source has no `fs.writeFile` or `fs.appendFile` against project graph files — the regression test source-greps for that.

The `neatd` bin (`packages/core/src/neatd.ts` → `dist/neatd.cjs`) wires the four lifecycle verbs. `start` blocks in the foreground; `stop` sends SIGTERM by PID; `reload` sends SIGHUP; `status` prints the PID, the registry path, and per-project last-seen timestamps.

## Contract todos flipped

All six queued ADR-049 items in `contracts.test.ts` are now live assertions:

- mutation authority — daemon writes only via `persist.ts` loop and shutdown handlers
- per-project isolation under a missing-path failure (#4)
- OTel span routing across active / paused / unknown service names (#5)
- missing-registry refusal with a clear error (#6)
- PID file present after start, absent after stop (#7)
- SIGHUP picks up a freshly-added project (#2)

ADR-049 is fully landed.

## Test plan

- [x] `npx turbo build test lint` green on `22-daemon` (340 tests pass; 4 todos remain — down 6, all v0.2.1 leftovers)
- [ ] `node packages/core/dist/neatd.cjs status` prints registry path + project list
- [ ] `node packages/core/dist/neatd.cjs start` blocks, writes PID, picks up registered projects
- [ ] `kill -HUP <pid>` makes the daemon log a reload + new projects appear in `slots`
- [ ] `node packages/core/dist/neatd.cjs stop` shuts the daemon down cleanly

Refs #22