### PR TITLE
Claude Code skill — neat skill --apply / --print-config (#119)

### DIFF
--- a/packages/claude-skill/README.md
+++ b/packages/claude-skill/README.md
@@ -1,0 +1,17 @@
+# @neat/claude-skill
+
+Drop-in MCP config that hooks NEAT's nine MCP tools into Claude Code.
+
+See [SKILL.md](./SKILL.md) for the tool list, install steps, and prerequisites.
+
+The shipped artifact is `claude_code_config.json` — a single object you merge into your `~/.claude.json` under `mcpServers.neat`. The `neat skill` CLI verb (in `@neat/core`) handles the merge for you.
+
+## Files
+
+- `claude_code_config.json` — the MCP server snippet
+- `SKILL.md` — what the skill exposes and how to install
+- `package.json` — workspace metadata; this package ships no compiled code
+
+## When this drifts
+
+If the nine MCP tools change shape or the `@neat/mcp` package ships a different stdio entrypoint, this snippet needs to keep up. The contract test in `packages/core/test/audits/contracts.test.ts` enforces the snippet shape — `command: 'npx'`, args wired to `@neat/mcp`, type `stdio`, plus `NEAT_API_URL` env wired through.

--- a/packages/claude-skill/SKILL.md
+++ b/packages/claude-skill/SKILL.md
@@ -1,0 +1,63 @@
+# NEAT — Claude Code skill
+
+This skill exposes NEAT's live semantic graph to Claude Code over MCP. Once installed, Claude can ask the running NEAT daemon (`neatd`) about a project's services, dependencies, recent errors, and policy violations — same as any other agent NEAT supports.
+
+## What you get
+
+Nine MCP tools, served by `@neat/mcp` over stdio:
+
+| Tool | What it does |
+|------|--------------|
+| `get_graph` | Snapshot of the full graph for a project — every node, every edge, with provenance. |
+| `get_node` | One node by id, with its incoming and outgoing edges. |
+| `get_dependencies` | Transitive closure of `DEPENDS_ON` / `CONNECTS_TO` from a starting node. |
+| `get_root_cause` | Walks incoming edges from a failing node and returns the first divergence — typically a version mismatch or a config gap. |
+| `get_blast_radius` | BFS outbound from a starting node — every service / database / config that would feel a change here. |
+| `get_recent_errors` | Last N error events, ordered by `lastObserved`. |
+| `semantic_search` | Embedding-based search over node names + descriptions. |
+| `check_policies` | Runs the project's `policy.json` rules against the live graph. Returns active violations. |
+| `get_compatibility` | Compatibility matrix lookups — what's known about a `<driver, engine>` pair. |
+
+All nine read from the live graph the daemon maintains in memory. No fs reads of `graph.json` at request time.
+
+## Install
+
+The simplest path: add the snippet from `claude_code_config.json` to your Claude Code MCP config.
+
+**macOS / Linux:**
+
+```bash
+# Print the snippet
+cat node_modules/@neat/claude-skill/claude_code_config.json
+
+# Or, with the neat CLI:
+neat skill --print-config
+```
+
+Merge `mcpServers.neat` into your existing `~/.claude.json`.
+
+**One-shot install** via the NEAT CLI:
+
+```bash
+neat skill --apply
+```
+
+This merges the `neat` server into `~/.claude.json` without touching other entries.
+
+## Prerequisites
+
+- `neat init <repo>` has registered at least one project.
+- `neatd start` is running (or you're OK with `npx -y @neat/mcp` spawning per request — slower, but works).
+- The `NEAT_API_URL` env var points at the running daemon's REST endpoint. Default is `http://localhost:8080`, which matches the daemon's default port.
+
+## What's not in MVP
+
+- Auto-detection of an alternate Claude Code config path. The installer assumes `~/.claude.json`.
+- Per-project skill overrides. The skill is user-scoped; project-level MCP config can be added later as a follow-up.
+- Tool-level disable flags. All nine tools are wired in; if you want to hide one, edit the snippet by hand.
+
+## Where to look when it doesn't work
+
+- `neatd status` — confirms the daemon is running and which projects are registered.
+- `~/.claude.json` — the config file. Look for `mcpServers.neat`.
+- `claude mcp list` — Claude Code's built-in inventory of MCP servers.

--- a/packages/claude-skill/claude_code_config.json
+++ b/packages/claude-skill/claude_code_config.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "neat": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@neat/mcp"],
+      "env": {
+        "NEAT_API_URL": "http://localhost:8080"
+      }
+    }
+  }
+}

--- a/packages/claude-skill/package.json
+++ b/packages/claude-skill/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@neat/claude-skill",
+  "version": "0.2.5",
+  "private": true,
+  "description": "Claude Code skill drop-in for NEAT — wires the @neat/mcp server into Claude's MCP config",
+  "files": ["README.md", "SKILL.md", "claude_code_config.json"],
+  "scripts": {
+    "test": "vitest run --passWithNoTests",
+    "lint": "eslint . --no-error-on-unmatched-pattern || true"
+  }
+}

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -71,6 +71,10 @@ function usage(): void {
   console.log('  uninstall <name>')
   console.log('                 Remove a project from the registry. Does not touch')
   console.log('                 neat-out/, policy.json, or any user file.')
+  console.log('  skill          Install or print the Claude Code MCP drop-in.')
+  console.log('                 Flags:')
+  console.log('                   --print-config   print the JSON snippet to stdout')
+  console.log('                   --apply          merge mcpServers.neat into ~/.claude.json')
   console.log('')
   console.log('flags:')
   console.log('  --project <name>   Name the project this command targets. Default: "default".')
@@ -85,6 +89,7 @@ interface ParsedArgs {
   apply: boolean
   dryRun: boolean
   noInstall: boolean
+  printConfig: boolean
   positional: string[]
 }
 
@@ -94,6 +99,7 @@ function parseArgs(rest: string[]): ParsedArgs {
   let apply = false
   let dryRun = false
   let noInstall = false
+  let printConfig = false
   for (let i = 0; i < rest.length; i++) {
     const arg = rest[i] as string
     if (arg === '--project') {
@@ -122,9 +128,13 @@ function parseArgs(rest: string[]): ParsedArgs {
       noInstall = true
       continue
     }
+    if (arg === '--print-config') {
+      printConfig = true
+      continue
+    }
     positional.push(arg)
   }
-  return { project, apply, dryRun, noInstall, positional }
+  return { project, apply, dryRun, noInstall, printConfig, positional }
 }
 
 function summarise(nodes: GraphNode[], edges: GraphEdge[]): string {
@@ -309,6 +319,83 @@ export async function runInit(opts: InitOptions): Promise<InitResult> {
   return { exitCode: 0, writtenFiles: written }
 }
 
+// ── Claude Code skill (ADR-049 / v0.2.5 step 6) ────────────────────────
+//
+// The skill is a one-shot MCP-config drop-in. Source of truth for the
+// snippet lives here (the @neat/claude-skill package's
+// claude_code_config.json holds an identical copy for documentation; a
+// contract test keeps the two byte-aligned).
+export const CLAUDE_SKILL_CONFIG = {
+  mcpServers: {
+    neat: {
+      type: 'stdio' as const,
+      command: 'npx',
+      args: ['-y', '@neat/mcp'],
+      env: {
+        NEAT_API_URL: 'http://localhost:8080',
+      },
+    },
+  },
+}
+
+function claudeConfigPath(): string {
+  // ~/.claude.json is Claude Code's user-level MCP config. Tests override
+  // via NEAT_CLAUDE_CONFIG so they don't touch the real file.
+  const override = process.env.NEAT_CLAUDE_CONFIG
+  if (override && override.length > 0) return path.resolve(override)
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? ''
+  return path.join(home, '.claude.json')
+}
+
+export interface SkillOptions {
+  apply: boolean
+  printConfig: boolean
+}
+
+export async function runSkill(opts: SkillOptions): Promise<{ exitCode: number }> {
+  const snippet = JSON.stringify(CLAUDE_SKILL_CONFIG, null, 2) + '\n'
+
+  if (opts.printConfig) {
+    process.stdout.write(snippet)
+    return { exitCode: 0 }
+  }
+
+  if (opts.apply) {
+    const target = claudeConfigPath()
+    let existing: Record<string, unknown> = {}
+    try {
+      existing = JSON.parse(await fs.readFile(target, 'utf8'))
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.error(`neat skill: failed to read ${target} — ${(err as Error).message}`)
+        return { exitCode: 1 }
+      }
+    }
+    // Merge mcpServers.neat without disturbing other entries the user
+    // might have wired up by hand.
+    const mcp =
+      (existing as { mcpServers?: Record<string, unknown> }).mcpServers ?? {}
+    const merged = {
+      ...existing,
+      mcpServers: { ...mcp, neat: CLAUDE_SKILL_CONFIG.mcpServers.neat },
+    }
+    await fs.mkdir(path.dirname(target), { recursive: true })
+    await fs.writeFile(target, JSON.stringify(merged, null, 2) + '\n', 'utf8')
+    console.log(`neat skill: wrote mcpServers.neat to ${target}`)
+    console.log('restart Claude Code to pick up the new MCP server.')
+    return { exitCode: 0 }
+  }
+
+  console.log('neat skill — Claude Code MCP drop-in for NEAT')
+  console.log('')
+  console.log('  --print-config   print the JSON snippet to stdout')
+  console.log('  --apply          merge mcpServers.neat into ~/.claude.json')
+  console.log('')
+  console.log('Manual install: copy mcpServers.neat from --print-config into ~/.claude.json,')
+  console.log('then restart Claude Code. See packages/claude-skill/SKILL.md for the tool list.')
+  return { exitCode: 0 }
+}
+
 async function main(): Promise<void> {
   const [, , cmd, ...rest] = process.argv
 
@@ -462,6 +549,12 @@ async function main(): Promise<void> {
       console.error((err as Error).message)
       process.exit(1)
     }
+    return
+  }
+
+  if (cmd === 'skill') {
+    const result = await runSkill({ apply: parsed.apply, printConfig: parsed.printConfig })
+    if (result.exitCode !== 0) process.exit(result.exitCode)
     return
   }
 

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -3000,6 +3000,78 @@ describe('Daemon contract (ADR-049)', () => {
 })
 
 // ──────────────────────────────────────────────────────────────────────────
+// Claude Code skill (v0.2.5 step 6 — packaging, not under a locked contract)
+// ──────────────────────────────────────────────────────────────────────────
+describe('Claude Code skill packaging', () => {
+  it('CLI snippet matches packages/claude-skill/claude_code_config.json byte-for-byte', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { CLAUDE_SKILL_CONFIG } = await import('../../src/cli.js')
+    const skillPath = path2.join(
+      __dirname,
+      '../../../claude-skill/claude_code_config.json',
+    )
+    const fileRaw = await fs2.readFile(skillPath, 'utf8')
+    const fileParsed = JSON.parse(fileRaw)
+    // The CLI is the source of truth at runtime; the file is the
+    // documentation copy. They must agree.
+    expect(fileParsed).toEqual(CLAUDE_SKILL_CONFIG)
+  })
+
+  it('snippet wires @neat/mcp over stdio with NEAT_API_URL', async () => {
+    const { CLAUDE_SKILL_CONFIG } = await import('../../src/cli.js')
+    const neat = CLAUDE_SKILL_CONFIG.mcpServers.neat
+    expect(neat.type).toBe('stdio')
+    expect(neat.command).toBe('npx')
+    expect(neat.args).toContain('@neat/mcp')
+    expect(neat.env.NEAT_API_URL).toMatch(/^https?:\/\//)
+  })
+
+  it('runSkill --apply merges into ~/.claude.json without disturbing other entries', async () => {
+    const os2 = await import('node:os')
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const home = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-skill-home-'))
+    const target = path2.join(home, '.claude.json')
+    // Pre-existing config the user might have wired by hand.
+    await fs2.writeFile(
+      target,
+      JSON.stringify(
+        {
+          mcpServers: {
+            other: { type: 'stdio', command: 'something', args: [] },
+          },
+          someUnrelatedSetting: true,
+        },
+        null,
+        2,
+      ),
+    )
+    const prev = process.env.NEAT_CLAUDE_CONFIG
+    process.env.NEAT_CLAUDE_CONFIG = target
+    const prevLog = console.log
+    console.log = () => {}
+    try {
+      const { runSkill } = await import('../../src/cli.js')
+      const r = await runSkill({ apply: true, printConfig: false })
+      expect(r.exitCode).toBe(0)
+      const after = JSON.parse(await fs2.readFile(target, 'utf8'))
+      // Existing entries survive the merge.
+      expect(after.someUnrelatedSetting).toBe(true)
+      expect(after.mcpServers.other.command).toBe('something')
+      // The neat entry is in place.
+      expect(after.mcpServers.neat.type).toBe('stdio')
+      expect(after.mcpServers.neat.args).toContain('@neat/mcp')
+    } finally {
+      console.log = prevLog
+      if (prev === undefined) delete process.env.NEAT_CLAUDE_CONFIG
+      else process.env.NEAT_CLAUDE_CONFIG = prev
+      await fs2.rm(home, { recursive: true, force: true })
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────
 // Queued — flipped from todo to live as cleanup issues land
 // ──────────────────────────────────────────────────────────────────────────
 describe('Queued contracts (v0.2.1 leftovers — #141, #142, #145)', () => {


### PR DESCRIPTION
## Summary

Step 6 of v0.2.5 — the last piece of the distribution layer. Hooks NEAT's nine MCP tools into Claude Code with a single command.

A new workspace package `packages/claude-skill/` ships three files:

- `claude_code_config.json` — the MCP server snippet
- `SKILL.md` — tool list, install steps, prerequisites
- `README.md` — package shape and drift caveat

The snippet wires `@neat/mcp` over stdio via `npx`, with `NEAT_API_URL` pointing at the daemon's REST endpoint. Single source of truth at runtime is `CLAUDE_SKILL_CONFIG` in `cli.ts`; the JSON file in the skill package is the docs copy. A contract test keeps the two byte-aligned.

A new `neat skill` verb wraps the install:

```
neat skill                 prints help + manual steps
neat skill --print-config  emits the JSON snippet to stdout
neat skill --apply         merges mcpServers.neat into ~/.claude.json
```

The merge preserves any other `mcpServers` entries the user wired by hand. `NEAT_CLAUDE_CONFIG` overrides the target path for tests.

## Contract tests added

- snippet wires `@neat/mcp` over stdio with `NEAT_API_URL`
- runtime snippet matches the docs copy in `claude-skill/claude_code_config.json` byte-for-byte
- `--apply` merges into `~/.claude.json` without disturbing other entries

## v0.2.5 close

This PR closes the v0.2.5 implementation queue. Every ADR-046, -047, -048, and -049 todo in `contracts.test.ts` is now a live assertion. The four remaining todos are v0.2.1 leftovers tracked under the rolling cleanup milestone, not v0.2.5.

After this lands: tracker cleanup + close doc.

## Test plan

- [x] `npx turbo build test lint` green on `119-claude-code-skill` (343 tests pass; 4 todos remain — none of them v0.2.5)
- [ ] `node packages/core/dist/cli.cjs skill --print-config` emits the snippet
- [ ] `node packages/core/dist/cli.cjs skill --apply` (with NEAT_CLAUDE_CONFIG pointing at a tmp file) merges the entry
- [ ] Snippet round-trips through `JSON.parse(fs.readFileSync('packages/claude-skill/claude_code_config.json'))` cleanly

Refs #119