### PR TITLE
v0.2.5 close — distribution layer shipped, ready to tag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ v0.2.2 closed on 2026-05-06 — see `docs/plans/2026-05-06-v0.2.2-close.md` for 
 
 **v0.2.5 — `neat init` + SDK install + Claude skill.** Opens with contracts #19-#22 (init, SDK install, machine registry, daemon). Then ships #119.
 
+v0.2.5 closed on 2026-05-07 — see `docs/plans/2026-05-07-v0.2.5-close.md` for the closing snapshot. Six implementation PRs landed in sequence (#185 registry, #186 init mechanics, #187 Node installer, #188 Python installer, #189 daemon, #190 Claude Code skill). Contract scoreboard: 28 / 28 v0.2.5 assertions live in `contracts.test.ts` (25 ADR-046/047/048/049 + 3 Claude-skill packaging). The four remaining `it.todo`s are v0.2.1 cleanup (#141, #142, #145), rolled forward to v0.3.0 prep.
+
 **v0.2.6 — CLI parity + frontend-API surface.** Opens with contracts #23-#24 (CLI surface, frontend-facing API). Ships CLI verbs that mirror the nine MCP tools (so a human at a terminal has the same reach as an agent), plus the API surface a local frontend needs — SSE / WebSocket live-updates, multi-project switcher endpoints, anything else surfaced as v0.3.0 prep work. The `(if that's needed)` qualifier is honest: parts of this milestone wait until Jed's frontend track surfaces concrete API gaps.
 
 After v0.2.6: the MVP-success PR experiment (ADR-027) — point NEAT at an open-source codebase. Self-hosting on the NEAT codebase activates only after that PR closes.

--- a/docs/plans/2026-05-07-v0.2.5-close.md
+++ b/docs/plans/2026-05-07-v0.2.5-close.md
@@ -1,0 +1,109 @@
+# v0.2.5 Distribution layer — close
+
+**Closed:** 2026-05-07
+**Opened with:** PR #184 (ADRs 046–049 re-landed onto current main; #166 was the original contract opener)
+**Kickoff doc:** `docs/plans/2026-05-07-v0.2.5-kickoff.md` (superseded by this doc)
+
+NEAT is now installable. `neat init <repo>` is the one-command bootstrap; `neatd` keeps the graph current; the Claude Code skill drops the nine MCP tools into Claude with a single config merge. This is the milestone that turns NEAT from a local toolchain into something a stranger's repo can actually adopt — the precondition for the MVP-success-PR experiment (ADR-027).
+
+## What landed
+
+| PR | Title | Issue / scope |
+|----|-------|---------------|
+| #185 | Machine-level project registry | #21 — `~/.neat/projects.json` with atomic writes + flock; `neat list / pause / resume / uninstall` |
+| #186 | `neat init` mechanics | #19 — discovery before mutation, registry write, patch-by-default with `--apply` / `--dry-run` / `--no-install` |
+| #187 | Node SDK installer | #20 — `installers/javascript.ts`; OTel deps + entrypoint hook; rollback patch on apply failure |
+| #188 | Python SDK installer | #20 — `installers/python.ts`; `requirements.txt` + Procfile path; mirrors the JS contract |
+| #189 | Daemon | #22 — `neatd start/stop/reload/status`; per-project isolation, SIGHUP reload, PID file |
+| #190 | Claude Code skill | #119 — `packages/claude-skill/` + `neat skill --apply / --print-config` |
+
+This doc is the close artifact, not its own PR — it lands alongside the tracker cleanup and CLAUDE.md status bump.
+
+## Three behaviour changes consumers will feel
+
+1. **`neat init` is the install moment.** One command runs discovery, snapshots the graph, registers the project in `~/.neat/projects.json`, and produces a `neat.patch` listing the SDK install edits. Patch-by-default keeps it safe to run on someone else's repo; `--apply` is the explicit-consent flag that mutates manifests in place (lockfiles never).
+2. **A long-lived daemon owns the graph.** `neatd start` boots one process watching every registered project. Failure in one project marks it `broken` on the registry without taking down the others. `SIGHUP` re-reads the registry; existing projects keep running while new ones get bootstrapped. PID at `~/.neat/neatd.pid` for external supervisors.
+3. **Claude Code wires up with one command.** `neat skill --apply` merges `mcpServers.neat` into `~/.claude.json` without disturbing other entries. After a Claude Code restart, the nine MCP tools are live against the running daemon.
+
+## Contract scoreboard — 28 / 28 v0.2.5 assertions live
+
+| Contract | Live tests | Source |
+|----------|-----------|--------|
+| ADR-046 (`neat init`) | 7 | `describe('neat init contract (ADR-046)')` |
+| ADR-047 (SDK install) | 7 | `describe('SDK install contract (ADR-047)')` |
+| ADR-048 (registry) | 5 | `describe('Machine-level project registry contract (ADR-048)')` |
+| ADR-049 (daemon) | 6 | `describe('Daemon contract (ADR-049)')` |
+| Claude Code skill packaging | 3 | `describe('Claude Code skill packaging')` |
+
+By contract:
+
+- **ADR-046 (`neat init`)** — discovery before mutation; no manifest writes without `--apply`; no lockfile writes ever; `--dry-run` only writes `neat.patch`; idempotent re-runs; registry entry written; non-zero exit on collision.
+- **ADR-047 (SDK install)** — detect/plan/apply exports; Node installer adds sdk-node + entrypoint; Python installer adds opentelemetry-distro + Procfile prefix; no installer plan references lockfiles; empty plan when SDK already installed; deterministic plan output; rollback patch on apply failure.
+- **ADR-048 (registry)** — `registry.ts` is the only module reading/writing the registry file; writes go through `writeAtomically`; writes acquire flock with 5s timeout; paths normalised to resolved absolute; removal does not delete `neat-out/` / `policy.json` / user files.
+- **ADR-049 (daemon)** — mutation authority; per-project isolation under a missing-path failure; OTel routing across active / paused / unknown service.name; missing-registry refusal; PID file present after start, absent after stop; SIGHUP picks up a freshly-added project.
+- **Claude Code skill packaging** — runtime snippet matches the docs copy in `packages/claude-skill/claude_code_config.json` byte-for-byte; snippet wires `@neat/mcp` over stdio with `NEAT_API_URL`; `--apply` merges into `~/.claude.json` without disturbing other entries.
+
+Verification command at tag time:
+
+```bash
+cd packages/core && npx vitest run test/audits/contracts.test.ts \
+  -t "ADR-046|ADR-047|ADR-048|ADR-049|Claude Code skill packaging"
+# Expected: 28 passed, 0 failed
+```
+
+## Remaining `it.todo`s — 4, none v0.2.5 scope
+
+All four are v0.2.1 implementation cleanup carried in `contracts.test.ts`:
+
+- `#141` — source-level DB connection + import detection
+- `#142` — `ServiceNode.framework` populated from package.json (the same todo lives in two describe blocks; both are #142)
+- `#145` — drop unused `graphology-traversal` / `-shortest-path` deps
+
+**Roll-forward decision: v0.3.0 prep.** v0.2.6 is contract-first (CLI parity + frontend-API surface) and these are non-contract-bound implementation cleanup, so tucking them under the v0.3.0 prep window keeps the v0.2.x contract sequence clean. None of them block any milestone today.
+
+## Numbers
+
+- **343 tests passing** across the workspace.
+- **28 / 28 v0.2.5 contract assertions live**, 0 todos at v0.2.5 scope.
+- **4 todos remaining**, all v0.2.1 carry-over per the roll-forward decision above.
+- **6 PRs**, sequenced as the kickoff doc described.
+- **2 new packages**: `@neat/claude-skill` (docs + snippet); the existing `@neat/core` gained `installers/`, `daemon.ts`, `neatd.ts`, `registry.ts`.
+- **2 new bins**: `neat skill` verb on the existing CLI; `neatd` as a separate binary.
+
+## Closing condition (kickoff doc, item by item)
+
+| # | Criterion | Status |
+|---|-----------|--------|
+| 1 | #119 has shipped on main | ✅ #190 merged |
+| 2 | Every ADR-046–049 todo flipped to a live assertion | ✅ 25 / 25 (plus 3 Claude-skill packaging) |
+| 3 | `neat init <some-test-codebase>` produces clean discovery + patch + registry + snapshot end-to-end on a real OSS repo | ⏳ deferred — couples to the MVP-success-PR experiment (ADR-027); runs in its own session |
+| 4 | `neatd start` watches the registry, picks up new projects on `neatd reload`, routes OTel correctly | ✅ unit-tested; live OTel receiver wiring is v0.2.6 work |
+| 5 | Claude Code skill installs in one command and exposes the nine MCP tools | ✅ `neat skill --apply` lands the snippet; tools are the existing v0.2.4 set |
+| 6 | `npx turbo build test lint` green on main | ✅ |
+| 7 | Tag `v0.2.5` + GitHub release | ⏳ this PR is the gate |
+
+Item 3 is honest: the OSS-repo dry run is the bridge into the MVP-success-PR experiment, not a tag-blocker for the milestone itself. Items 4 and 5 are unit-tested at the level the MVP needs; the live receiver attachment in the daemon is queued for v0.2.6.
+
+## What v0.2.5 explicitly didn't do
+
+- **Live OTel receiver inside the daemon.** `routeSpanToProject` is the routing primitive; the actual chokidar / Fastify / OTLP listener wiring per project lands in v0.2.6 alongside the CLI parity work. The single-project `neat watch` flow still works for OTel today.
+- **Policy reload on `policy.json` mtime inside the daemon.** `startWatch` already does this per-project; the daemon-level loop reuses that machinery in a follow-up.
+- **TOML-aware `pyproject.toml` editing.** The Python installer recognises pyproject as a manifest but defers editing it; `requirements.txt` is the full-fidelity path in MVP. Successor ADR will address.
+- **Java / Ruby / .NET / Go / Rust installers.** Per ADR-047, each requires its own ADR. Out of scope here.
+- **Self-hosting NEAT on the NEAT codebase.** Per ADR-027 + ADR-049's "self-hosting gate stays closed" clause, that flips on after the MVP-success PR closes.
+
+## Carried follow-ups
+
+- **AUDIT-DRIFT amendments** to `docs/audits/verification.md` — surfaced during v0.2.4, still open.
+- **#118 example policy library** — carried from v0.2.4, lower priority post-policy-shipped.
+- **v0.2.1 cleanup todos** (#141, #142, #145) — rolled forward to v0.3.0 prep per the decision above.
+
+## What's next
+
+**v0.2.6 — CLI parity + frontend-API surface.** Opens with contracts #23 (CLI surface) and #24 (frontend-facing API). Per the v0.2.x sequencing, this milestone contracts only after seeing how `init` actually shaped up — that signal has now arrived. Contract drafting is the first move.
+
+**MVP-success PR experiment (ADR-027).** Point NEAT at an unfamiliar OSS codebase, run `neat init`, instrument it, find a real divergence-shaped bug where the OBSERVED layer is load-bearing, propose a fix, get the PR merged. The gate that v0.2.x was build-up for. Runs in its own session and is the canonical end-to-end exercise for closing condition #3 above.
+
+## When this file is wrong
+
+Snapshot at close. Treat as historical. Canonical state is `git log` + `gh release list`.


### PR DESCRIPTION
Re-authors the close artifact that was rolled back in #193, with the framing amendments you laid out.

## Two amendments to the original close doc

1. **Contract scoreboard reads 28 / 28, not 25 / 25.** Splits live tests by contract (7 ADR-046 / 7 ADR-047 / 5 ADR-048 / 6 ADR-049 / 3 Claude-skill packaging) and surfaces the verification command that produces those numbers. The skill packaging assertions are v0.2.5 scope even though they live outside the four locked contracts — calling that out explicitly.
2. **The four remaining `it.todo`s are documented as v0.2.1 cleanup, rolled forward to v0.3.0 prep.** `#141` source-level DB/import detection, `#142` `ServiceNode.framework` population, `#145` unused graphology dep cleanup. v0.2.6 stays contract-first; these are non-contract-bound implementation cleanup that doesn't gate any milestone.

## Heads-up on amendment 1's framing

Your original amendment proposed (a) flip 3 Claude-skill todos vs (b) defer to a follow-up. I checked the source — those three assertions landed as live `it(...)` tests in PR #190, not `it.todo`. The (a)/(b) decision was effectively answered when #190 merged. The close doc now states the 28 / 28 number directly to make that visible.

## Verification before tag

```
npx turbo build test lint                                                   # green
cd packages/core && npx vitest run test/audits/contracts.test.ts \
  -t "ADR-046|ADR-047|ADR-048|ADR-049|Claude Code skill packaging"          # 28 / 28
```

Both already run on this branch's HEAD.

## After this lands

1. Close issues #19, #20, #21, #22, #119 (manual, per ADR-005).
2. `git tag -a v0.2.5 <commit> -m "..."` and `git push origin v0.2.5`.
3. `gh release create v0.2.5 --title "v0.2.5 — Distribution layer" --notes-file <file>` with the six-PR summary.
4. `gh api -X PATCH repos/NEAT-Technologies/Neat/milestones/<n> -f state=closed`.
5. v0.2.6 kickoff — confirm `docs/plans/2026-05-07-v0.2.5-kickoff.md` is superseded; draft a new kickoff for v0.2.6 since #183 already merged.

Refs #119