### PR TITLE
v0.2.6 kickoff doc — CLI parity + frontend-API surface

### DIFF
--- a/docs/plans/2026-05-07-v0.2.6-kickoff.md
+++ b/docs/plans/2026-05-07-v0.2.6-kickoff.md
@@ -1,0 +1,88 @@
+# v0.2.6 CLI parity + frontend-API surface — kickoff for the implementation agent
+
+**Last updated:** 2026-05-07
+
+This is the "pick up here" doc for v0.2.6 work. Read it first. Supersedes the v0.2.5 kickoff as the active milestone tracker.
+
+## Where we are
+
+- **v0.2.0 Sunrise** — closed, tagged [`v0.2.0`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.0).
+- **v0.2.1 — Tree-sitter rebuild** — closed, tagged [`v0.2.1`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.1).
+- **v0.2.2 — OTel ingest rebuild** — closed, tagged [`v0.2.2`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.2).
+- **v0.2.3 — Traversal rebuild** — closed, tagged [`v0.2.3`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.3).
+- **v0.2.4 — Policies + MCP refresh** — closed on `main`; six implementation PRs (#175 / #177 / #178 / #179 / #180 / #181 / #182) shipped.
+- **v0.2.5 — Distribution layer** — closed, tagged [`v0.2.5`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.5). 28 / 28 contract assertions live; six implementation PRs (#185-#190).
+- **v0.2.6 — CLI parity + frontend-API surface** — **OPEN. Contracts #23 / #24 not yet drafted.**
+
+## What v0.2.6 is
+
+The contract-first batch that closes the v0.2.x sequence. Two contracts queued in [`docs/contracts.md`](../contracts.md):
+
+- **#23 CLI surface** — CLI verbs that mirror the nine MCP tools so a human at a terminal has the same reach as an agent. Output format, exit codes, project scoping (`--project <name>` per ADR-026), JSON vs human output toggle.
+- **#24 Frontend-facing API** — the API surface a local frontend needs that the existing REST + MCP set doesn't already cover. SSE / WebSocket live-updates, multi-project switcher endpoints, anything Jed's v0.3.0 frontend track surfaces as a gap.
+
+The `(if needed)` qualifier on contract #24 is honest — parts of this milestone wait until Jed's track surfaces concrete demands. Contract drafting starts with #23 since that one is fully specifiable from the existing nine MCP tools.
+
+## Why v0.2.6 matters
+
+Two reasons.
+
+1. **The terminal-vs-agent gap closes.** Today every reach into the graph goes through MCP — fine for Claude Code, awkward for a human in a terminal who wants to ask "what does `get_root_cause` return for `service:checkout`?" CLI parity gives the human the same nine tools without the Claude wrapper.
+2. **The frontend track unblocks.** Jed's v0.3.0 work builds against the v0.1.2-stable API today. Live updates (SSE / WebSocket) and multi-project switcher endpoints aren't in the v0.1.2 surface. Contract #24 names what's needed and ships it before v0.3.0 needs it.
+
+## Issues queued
+
+| Issue | Title | Contract |
+|-------|-------|----------|
+| #23 | Open the CLI-surface contract — nine `neat <verb>` commands | CLI surface |
+| #24 | Open the frontend-facing API contract — SSE / WebSocket / multi-project | Frontend-facing API |
+
+Concrete implementation issues will spawn off these once the contracts land. `docs/contracts.md` has the table-of-contracts surface where new entries get added.
+
+## Recommended order of work
+
+The same rebuild-against-locked-contract pattern from v0.2.1 onward. Outside-in:
+
+1. **Draft contract #23 (CLI surface).** Open an ADR (probably ADR-050) plus `docs/contracts/cli.md`. Spec: nine `neat <verb>` commands, REST-client-only data path (no direct graph access), `--project` scoping, `--json` for machine-readable output, exit-code conventions. Land as PR with `it.todo`s queued in `contracts.test.ts`.
+2. **Implement #23.** New file `packages/core/src/cli-verbs.ts` (or extend `cli.ts` since the parser is already there). Each verb wraps a REST call against the running daemon. Flip todos.
+3. **Draft contract #24 (frontend-facing API).** ADR-051 + `docs/contracts/frontend-api.md`. Coordinate with Jed — what's actually needed. SSE via Fastify, WebSocket via `@fastify/websocket`, multi-project switcher endpoints if not already covered by the dual-mount in ADR-026.
+4. **Implement #24.** Endpoints in `packages/core/src/api.ts` (or a new `streaming.ts` if the surface gets large). Flip todos.
+
+Step 1 + 2 are independent of step 3 + 4. Do CLI parity first; pick up #24 after Jed's track surfaces concrete asks.
+
+## Reference points
+
+- **Existing contracts**: [`docs/contracts.md`](../contracts.md) — the index. Each per-topic contract is a file under `docs/contracts/` plus an ADR.
+- **CLI surface today**: `packages/core/src/cli.ts` — has `init`, `watch`, `list`, `pause`, `resume`, `uninstall`, `skill` plus `--project` scoping. v0.2.6 adds the nine verbs that mirror MCP.
+- **MCP tools today** (locked allowlist of nine, ADR-039): `get_root_cause`, `get_blast_radius`, `get_dependencies`, `get_observed_dependencies`, `get_incident_history`, `semantic_search`, `get_graph_diff`, `get_recent_stale_edges`, `check_policies`. Each gets a `neat <verb>` wrapper.
+- **REST API today**: `packages/core/src/api.ts` — dual-mounted per ADR-026 at `/X` and `/projects/:project/X`. v0.2.6 adds SSE / WebSocket on top of this.
+- **v0.3.0 frontend track**: Jed's work, builds against the stable v0.1.2 API. Issues #28-#31 + #106-#108. The list of what's missing comes from there.
+
+## Closing condition
+
+v0.2.6 closes when:
+
+1. Contract #23 (CLI surface) is locked: ADR + per-topic contract markdown + queued `it.todo`s.
+2. Contract #24 (frontend-facing API) is locked, OR explicitly deferred to a later milestone with a documented reason if Jed's track hasn't surfaced concrete asks by close time.
+3. CLI verbs implementation has shipped on `main` — the nine `neat <verb>` commands work end-to-end against `neatd`.
+4. Frontend-API implementation has shipped on `main` for whatever made it into contract #24.
+5. Every `it.todo` keyed to ADR-050 / ADR-051 has flipped to a live assertion.
+6. `npx turbo build test lint` green on `main`.
+7. Tag `v0.2.6` + GitHub release.
+
+## What's not in v0.2.6
+
+- **Live OTel listener inside the daemon** — flagged as deferred during v0.2.5 close. The receiver attachment is a v0.2.6 candidate but only if it falls out of contract #24's frontend-API work; otherwise it stays queued.
+- **TOML-aware `pyproject.toml` editing in the Python installer** — successor ADR, not v0.2.6.
+- **Self-hosting NEAT on the NEAT codebase** — gated behind the MVP-success PR (ADR-027), not a v0.2.6 step.
+- **Java / Ruby / .NET / Go / Rust SDK installers** — each requires its own ADR per ADR-047. Out of scope.
+
+## Carried follow-ups (queued for whichever release window has time)
+
+- **v0.2.1 cleanup** — `#141` source-level DB connection + import detection, `#142` `ServiceNode.framework` population, `#145` drop unused `graphology-traversal` / `-shortest-path` deps. Rolled forward to v0.3.0 prep per the v0.2.5 close decision.
+- **AUDIT-DRIFT amendments** to `docs/audits/verification.md` — surfaced during v0.2.4 close, still open.
+- **#118 example policy library** — carried from v0.2.4, lower priority post-policy-shipped.
+
+## When this file is wrong
+
+Snapshot at kickoff. If `main` has moved since the date at the top, treat the description as historical and check `git log` + `gh release list` for canonical state. New status docs land as `docs/plans/<date>-v0.2.6-status.md` or the eventual `docs/plans/<date>-v0.2.6-close.md`.


### PR DESCRIPTION
Opens the next milestone after the v0.2.5 tag.

Two contracts queued, neither drafted yet — the kickoff doc lays out the recommended outside-in order: draft + implement #23 (CLI surface) first since it's fully specifiable from the existing MCP tool allowlist, then #24 (frontend-facing API) once Jed's v0.3.0 track surfaces what's actually missing from the v0.1.2-stable API.

## Carried forward

- v0.2.1 cleanup (#141, #142, #145) → v0.3.0 prep, per the v0.2.5 close decision.
- AUDIT-DRIFT amendments to `docs/audits/verification.md` — still open from v0.2.4.
- #118 example policy library — lower priority post-policy-shipped.

## Closing condition

Documented inline. Same shape as v0.2.5's: contracts locked, implementation shipped, todos flipped, build/test/lint green, tag + release.