### PR TITLE
ADRs 050-051: v0.2.6 contract batch (#23-#24)

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -32,13 +32,12 @@ This file is the index. Each rule has a short summary and a link to its full per
 | 20 | SDK install | [`contracts/sdk-install.md`](./contracts/sdk-install.md) | Per-language installer modules (Node + Python in MVP). Plan/apply decoupled. Manifests touched, lockfiles never (ADR-047) | ✅ landed (v0.2.5 opens) |
 | 21 | Machine-level project registry | [`contracts/project-registry.md`](./contracts/project-registry.md) | `~/.neat/projects.json` per-user, atomic writes via tmp+rename, flock during writes, path-normalized (ADR-048) | ✅ landed (v0.2.5 opens) |
 | 22 | Daemon | [`contracts/daemon.md`](./contracts/daemon.md) | Single long-lived process, per-project graph isolation, mtime + OTel + policy.json triggers, graceful per-project failure (ADR-049) | ✅ landed (v0.2.5 opens) |
+| 23 | CLI surface | [`contracts/cli-surface.md`](./contracts/cli-surface.md) | Nine `neat <verb>` commands mirroring MCP tools, REST-only data path, `--json` output, exit-code branching (ADR-050) | ✅ landed (v0.2.6 opens) |
+| 24 | Frontend-facing API | [`contracts/frontend-api.md`](./contracts/frontend-api.md) | SSE stream at `/events` with locked 8-type taxonomy, multi-project switcher at `/projects`, WebSocket and per-event filtering deferred (ADR-051) | ✅ landed (v0.2.6 opens) |
 
 ### Future contracts — opened at the start of each milestone
 
-| # | Contract | Milestone | Governs (target) |
-|---|----------|-----------|------------------|
-| 23 | CLI surface | v0.2.6 | CLI verbs mirror MCP tools — nine `neat <verb>` commands calling the same REST client. Output format, exit codes, project scoping. |
-| 24 | Frontend-facing API | v0.2.6 | API surface a local frontend needs that the existing REST + MCP set doesn't already cover — SSE / WebSocket live updates, anything Jed's v0.3.0 track surfaces as a gap. The `(if needed)` qualifier is honest; parts of this contract wait for v0.3.0 to surface concrete demands. |
+_None queued. v0.2.6 is the last milestone in the v0.2.x sequence. Successor contracts (WebSocket transport, per-event filtering, additional language SDK installers, MVP-success-PR experiment) open as their gating work surfaces._
 
 The full reasoning and per-milestone sequencing live in `docs/plans/2026-05-04-v0.2.x-sequencing.md`. The current state of the active milestone lives in `docs/plans/<latest-date>-v0.2.x-status.md`.
 

--- a/docs/contracts/cli-surface.md
+++ b/docs/contracts/cli-surface.md
@@ -1,0 +1,94 @@
+---
+name: cli-surface
+description: Nine `neat <verb>` commands mirroring the MCP tool allowlist. REST-only data path. Two output modes (human + --json). Exit codes branch on misuse vs server error vs daemon-down.
+governs:
+  - "packages/core/src/cli.ts"
+  - "packages/core/src/cli-verbs.ts"
+  - "packages/core/src/cli-client.ts"
+adr: [ADR-050, ADR-039, ADR-026]
+---
+
+# CLI surface contract
+
+The first of two v0.2.6 contracts. Sibling: [`frontend-api.md`](./frontend-api.md).
+
+Closes the terminal-vs-agent gap. Today every reach into the graph goes through MCP. Engineers debugging at a terminal need the same nine tools without a Claude wrapper.
+
+## Nine verbs, locked
+
+```
+neat root-cause <node-id>                            ← get_root_cause
+neat blast-radius <node-id>                          ← get_blast_radius
+neat dependencies <node-id> [--depth N]              ← get_dependencies
+neat observed-dependencies <node-id>                 ← get_observed_dependencies
+neat incidents [--limit N]                           ← get_incident_history
+neat search <query>                                  ← semantic_search
+neat diff [--since <date>]                           ← get_graph_diff
+neat stale-edges                                     ← get_recent_stale_edges
+neat policies [--node <id>] [--hypothetical-action <action>]   ← check_policies
+```
+
+The verb set is locked the same way the MCP allowlist is locked (ADR-039). Adding a tenth verb requires a successor ADR.
+
+## Naming convention
+
+- Drop the `get_` prefix.
+- Kebab-case.
+- Prefer noun verbs (`incidents`, `policies`) over `get-*`.
+- Action-flavored only where the noun would be ambiguous (`search`, `diff`).
+
+## REST-only data path
+
+Every verb hits `NEAT_API_URL` (default `http://localhost:8080`) via a shared client. **No `graph.json` reads at request time.** Same multi-project routing as MCP — `--project <name>` flag → `NEAT_PROJECT` env → `'default'` (ADR-026).
+
+The CLI client and the MCP client share the same REST helper module. One endpoint surface, two consumers.
+
+## Two output modes
+
+**Default (human):** prose summary + plain-text table + `confidence: X.XX · provenance: ...` footer. Mirrors the three-part MCP response from ADR-039 in plain text.
+
+**`--json`:** machine-readable JSON, same three sections as named fields:
+
+```json
+{
+  "summary": "service:checkout fails because pg@7.4.0 is incompatible with PostgreSQL 15.",
+  "block": { ... typed payload ... },
+  "confidence": 0.84,
+  "provenance": "OBSERVED"
+}
+```
+
+Stdout for results. Stderr for diagnostics. Never mix the two.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | success |
+| `1` | server error (4xx / 5xx — body's error message goes to stderr) |
+| `2` | misuse (missing required arg, malformed flag — handled before any network call) |
+| `3` | daemon not reachable (connection refused / timeout) |
+
+`3` is distinct from `1` so scripts can branch on "is the daemon up?" without parsing error text.
+
+## Read-only
+
+Every MCP tool is read-only and so is every CLI verb. Lifecycle commands (`init`, `watch`, `pause`, etc.) keep their existing semantics; mutation never lands behind a query verb.
+
+## No demo-name hardcoding
+
+Same rule as MCP (cross-cutting rule 8). `--help` examples reference real-shape ids (`service:<name>`, `database:<host>`) without committing to specific demo names.
+
+## `--help` is binding documentation
+
+Each verb's `--help` lists args, flags, exit codes, and one example invocation. `neat --help` lists every verb (lifecycle + query) in one block. `--help` text is treated as part of the contract surface — drift between contract and `--help` is a regression.
+
+## Authority
+
+`packages/core/src/cli.ts` extends to dispatch the new verbs. New file `packages/core/src/cli-verbs.ts` for the nine handlers if the surface gets large. REST client at `packages/core/src/cli-client.ts`, shared with `packages/mcp/src/client.ts`.
+
+## Enforcement
+
+`it.todo` for v0.2.6 #23. Regression tests cover: nine verbs registered, REST-only data path, exit-code branching, `--json` shape matches the three-part schema, `--project` propagation matches ADR-026.
+
+Full rationale: [ADR-050](../decisions.md#adr-050--cli-surface-contract).

--- a/docs/contracts/frontend-api.md
+++ b/docs/contracts/frontend-api.md
@@ -1,0 +1,104 @@
+---
+name: frontend-api
+description: SSE event stream at /events for live graph updates. Locked event taxonomy (8 types). Multi-project switcher endpoint at /projects. WebSocket and per-event filtering deferred to successor ADRs.
+governs:
+  - "packages/core/src/api.ts"
+  - "packages/core/src/streaming.ts"
+  - "packages/core/src/events.ts"
+  - "packages/core/src/ingest.ts"
+  - "packages/core/src/extract/index.ts"
+  - "packages/core/src/watch.ts"
+  - "packages/core/src/policy.ts"
+adr: [ADR-051, ADR-040, ADR-026, ADR-048]
+---
+
+# Frontend-facing API contract
+
+The second of two v0.2.6 contracts. Sibling: [`cli-surface.md`](./cli-surface.md).
+
+The existing REST surface (ADR-040) is request-response — fine for initial render, insufficient for live views. Jed's v0.3.0 frontend track needs two things the existing surface doesn't cover: live update streaming, multi-project enumeration. WebSocket-style symmetric subscription is plausibly needed but not surfaced yet.
+
+This contract is **speculative** — it covers the obvious gaps and explicitly defers what isn't surfaced. Sections labeled **(deferred)** wait for v0.3.0 to surface a concrete ask.
+
+## SSE stream at `/events`
+
+Dual-mounted per ADR-026:
+
+```
+GET /events                      ← default project
+GET /projects/:project/events    ← scoped
+```
+
+Content-type `text/event-stream`. Each event line is JSON-encoded, prefixed by `event: <type>` so the EventSource API routes by type:
+
+```
+event: node-added
+data: {"node":{"id":"service:checkout",...}}
+
+event: edge-added
+data: {"edge":{...}}
+```
+
+## Event taxonomy (locked)
+
+Eight event types. New types require a successor ADR — same lock discipline as the nine MCP tools.
+
+| Event | Payload | Trigger |
+|---|---|---|
+| `node-added` | `{ node: GraphNode }` | extract or auto-create in ingest |
+| `node-updated` | `{ id: string, changes: Partial<GraphNode> }` | property change in extract / ingest |
+| `node-removed` | `{ id: string }` | retire path in extract |
+| `edge-added` | `{ edge: GraphEdge }` | any provenance |
+| `edge-removed` | `{ id: string }` | retire / promotion rewire |
+| `extraction-complete` | `{ project, fileCount, nodesAdded, edgesAdded }` | watch.ts re-extract finishes |
+| `policy-violation` | `{ violation: PolicyViolation }` | evaluator emits a new violation |
+| `stale-transition` | `{ edgeId, from: 'OBSERVED', to: 'STALE' }` | staleness loop tick |
+
+## Heartbeat
+
+Every 30 seconds: a comment line (`:heartbeat\n\n`) keeps proxies / load balancers from idle-timing out the connection. EventSource clients ignore comments by spec.
+
+## Multi-project switcher
+
+```
+GET /projects
+```
+
+Returns `Array<{ name, path, status, registeredAt, lastSeenAt?, languages }>` — direct passthrough of `listProjects()` from `registry.ts` (ADR-048). Distinct from the dual-mount routing in ADR-026 (which exposes per-project endpoints); this exposes the registry itself for a project picker UI.
+
+## Backpressure
+
+SSE writes are non-blocking. If a client's socket is slow, events queue up to a per-connection cap (default 1000 messages) before the connection is dropped with `event: error` payload `{ reason: 'backpressure' }`. Independent of OTel span dropping at the ingest layer (ADR-033).
+
+## Error shape unchanged
+
+Same `{ error, status, details? }` envelope from ADR-040. SSE errors land as a final `event: error` payload before the connection closes; non-SSE errors keep the existing JSON-body convention.
+
+## Event emission threading
+
+A single `EventEmitter` singleton in `packages/core/src/events.ts` is the bus. Producers emit:
+
+- `ingest.ts` → `node-added`, `node-updated`, `edge-added`, `edge-removed` (for promotion rewire), `stale-transition`
+- `extract/index.ts` → `node-added`, `node-removed`, `edge-added`, `edge-removed`, `extraction-complete`
+- `watch.ts` → `extraction-complete`
+- `policy.ts` → `policy-violation`
+
+Consumers subscribe inside the SSE handler in `api.ts` / `streaming.ts`. No direct producer-to-handler coupling.
+
+## WebSocket transport (deferred)
+
+Symmetric subscription (client subscribes to specific node ids, sends ping/pong, etc.) waits for a successor ADR. Triggered when v0.3.0 frontend work surfaces a concrete need SSE can't cover. SSE is sufficient for one-way streaming and is the MVP transport.
+
+## Per-event filtering inside SSE (deferred)
+
+The default-project mount streams every event for the default graph; the `/projects/:project/events` mount streams events for that project. Filtering by node id or edge type within a stream is a successor concern.
+
+## Authority
+
+`packages/core/src/api.ts` (extend) for `/projects`. SSE endpoint in `packages/core/src/api.ts` or a new `packages/core/src/streaming.ts` if the surface grows. Event bus in `packages/core/src/events.ts`. Producers in ingest / extract / watch / policy modules emit through the bus.
+
+## Enforcement
+
+`it.todo` for v0.2.6 #24. Regression tests cover: `/events` endpoint with `text/event-stream` content-type, dual-mount per ADR-026, event-type taxonomy locked (eight types), `/projects` endpoint shape, heartbeat interval, backpressure cap.
+
+Full rationale: [ADR-051](../decisions.md#adr-051--frontend-facing-api-contract).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1332,3 +1332,97 @@ Governs the long-lived `neatd` process. Sibling contracts: ADR-046, ADR-047, ADR
 **Authority.** `packages/core/src/daemon.ts`. Composes registry.ts, extract/, ingest.ts, policy.ts, persist.ts.
 
 **Enforcement.** `it.todo` for v0.2.5 #119. Regression test asserts daemon writes `graph.json` only via persist.ts loop and shutdown handlers.
+
+## ADR-050 — CLI surface contract
+
+**Date:** 2026-05-08
+**Status:** Active.
+
+Opens v0.2.6. First of two milestone contracts. Sibling: ADR-051.
+
+**Context.** Today every reach into the graph goes through MCP — fine for Claude Code, awkward for a human at a terminal who wants to ask "what does `get_root_cause` return for `service:checkout`?" The terminal-vs-agent gap is real: an engineer debugging needs the same nine tools the agent has, without the Claude wrapper. The existing `neat` CLI handles lifecycle (`init`, `watch`, `list`, `pause`, `resume`, `uninstall`, `skill`) but exposes no graph queries.
+
+**Decision.**
+
+1. **Nine `neat <verb>` commands, one per MCP tool.** The verb set mirrors the locked allowlist from ADR-039:
+
+   | MCP tool | CLI verb |
+   |---|---|
+   | `get_root_cause` | `neat root-cause <node-id>` |
+   | `get_blast_radius` | `neat blast-radius <node-id>` |
+   | `get_dependencies` | `neat dependencies <node-id> [--depth N]` |
+   | `get_observed_dependencies` | `neat observed-dependencies <node-id>` |
+   | `get_incident_history` | `neat incidents [--limit N]` |
+   | `semantic_search` | `neat search <query>` |
+   | `get_graph_diff` | `neat diff [--since <date>]` |
+   | `get_recent_stale_edges` | `neat stale-edges` |
+   | `check_policies` | `neat policies [--node <id>] [--hypothetical-action <action>]` |
+
+   Naming drops the `get_` prefix and uses kebab-case per UNIX convention. Verbs are nouns where natural (`incidents`, `policies`), action-flavored only when the noun would be ambiguous (`search`, `diff`).
+
+2. **REST-only data path.** Verbs hit `NEAT_API_URL` (default `http://localhost:8080`) via the same client logic the MCP server uses. Never read `graph.json` at request time. Same multi-project routing as MCP — `--project <name>` flag, defaulting to `NEAT_PROJECT` env, defaulting to `'default'`.
+
+3. **Two output modes.** Default human-readable: prose summary + plain-text table + `confidence: X.XX · provenance: ...` footer (mirrors the three-part MCP response per ADR-039). With `--json`: machine-readable JSON with the same three sections as named fields (`{ summary, block, confidence, provenance }`). Stdout for results; stderr for diagnostics.
+
+4. **Exit code conventions.**
+
+   - `0` — success.
+   - `1` — server error (4xx / 5xx response from REST; the body's error message goes to stderr).
+   - `2` — misuse (missing required arg, malformed flag — handled before any network call).
+   - `3` — daemon not reachable (connection refused / timeout). Distinct from `1` so scripts can branch on "is the daemon up?"
+
+5. **No mutation verbs in MVP.** Every MCP tool is read-only and so is every CLI verb. Lifecycle commands (`init`, `watch`, etc.) keep their existing semantics; mutation never lands behind a query verb.
+
+6. **No demo-name hardcoding.** Same rule as MCP (per cross-cutting rule 8). Examples in `--help` text reference real-shape ids (`service:<name>`, `database:<host>`) without committing to specific demo names.
+
+7. **`--help` output is binding documentation.** Each verb's `--help` lists the args, flags, exit codes, and an example invocation. `neat --help` lists every verb (lifecycle + query) in one block.
+
+**Authority.** `packages/core/src/cli.ts` (extends existing parser) or a new `packages/core/src/cli-verbs.ts` if the surface gets large. Implementation choice left to the implementing agent. The REST client lives at `packages/core/src/cli-client.ts` (or similar) and is shared with `packages/mcp/src/client.ts`.
+
+**Enforcement.** `it.todo` block in `contracts.test.ts` for v0.2.6 #23. Regression tests cover: nine verbs registered, REST-only data path (no `graph.json` reads from CLI), exit-code branching, `--json` shape, `--project` propagation.
+
+## ADR-051 — Frontend-facing API contract
+
+**Date:** 2026-05-08
+**Status:** Active. Speculative — sections marked **(deferred)** wait for v0.3.0 to surface concrete asks.
+
+Opens v0.2.6. Second of two milestone contracts. Sibling: ADR-050.
+
+**Context.** Jed's v0.3.0 frontend track builds against the v0.1.2-stable API. The existing REST surface (`/graph`, `/graph/node/:id`, etc., all dual-mounted per ADR-026) is request-response — fine for initial render, insufficient for live views. Two gaps known today: live update streaming, multi-project enumeration. WebSocket-style symmetric subscription is plausibly needed but not surfaced yet.
+
+The `(if needed)` qualifier in the kickoff applies. We draft what's clear and explicitly defer what isn't.
+
+**Decision.**
+
+1. **Server-Sent Events stream at `/events`.** Dual-mounted per ADR-026: `GET /events` (default project) and `GET /projects/:project/events` (scoped). Content-type `text/event-stream`. One JSON-encoded payload per event line, prefixed by `event: <type>` so the EventSource API routes by type.
+
+2. **Event taxonomy (locked).** Eight event types, all derived from existing graph mutations:
+
+   | Event | Payload | Trigger |
+   |---|---|---|
+   | `node-added` | `{ node: GraphNode }` | extract or auto-create in ingest |
+   | `node-updated` | `{ id: string, changes: Partial<GraphNode> }` | property change in extract / ingest |
+   | `node-removed` | `{ id: string }` | retire path in extract |
+   | `edge-added` | `{ edge: GraphEdge }` | any provenance |
+   | `edge-removed` | `{ id: string }` | retire / promotion rewire |
+   | `extraction-complete` | `{ project, fileCount, nodesAdded, edgesAdded }` | watch.ts re-extract finishes |
+   | `policy-violation` | `{ violation: PolicyViolation }` | evaluator emits a new violation |
+   | `stale-transition` | `{ edgeId, from: 'OBSERVED', to: 'STALE' }` | staleness loop tick |
+
+   New event types require a successor ADR. The event taxonomy is locked the same way the nine MCP tools are locked — no quiet additions.
+
+3. **Heartbeat.** Every 30 seconds the server emits a comment line (`:heartbeat\n\n`) to keep proxies / load balancers from idle-timing out the connection. EventSource clients ignore comments.
+
+4. **Multi-project switcher endpoint.** `GET /projects` returns `Array<{ name, path, status, registeredAt, lastSeenAt?, languages }>` — direct passthrough of `listProjects()` from `registry.ts` (ADR-048). Distinct from the dual-mount routing in ADR-026: that exposes per-project endpoints; this exposes the registry itself for a project picker UI.
+
+5. **JSON error shape unchanged.** Same `{ error, status, details? }` envelope from ADR-040. SSE errors land as a final `event: error` payload before the connection closes; non-SSE errors keep the existing JSON-body convention.
+
+6. **WebSocket transport (deferred).** Symmetric subscription (client subscribes to specific node ids, sends ping/pong, etc.) waits for a successor ADR. Triggered when v0.3.0 frontend work surfaces a concrete need SSE can't cover. SSE is sufficient for one-way streaming and is the MVP transport.
+
+7. **Per-event filtering inside SSE (deferred).** The default-project mount streams every event for the default graph; the `/projects/:project/events` mount streams events for that project. Filtering by node id or edge type within a stream is a successor concern.
+
+8. **Backpressure.** SSE writes are non-blocking — if a client's socket is slow, events queue up to a per-connection cap (default 1000 messages) before the connection is dropped with `event: error` payload `{ reason: 'backpressure' }`. Spans dropping at the OTel layer (per ADR-033) is unrelated; this is a separate per-connection guard.
+
+**Authority.** `packages/core/src/api.ts` (extend) for `/projects`. SSE endpoint in `packages/core/src/api.ts` or a new `packages/core/src/streaming.ts` if the surface grows. Event emission threaded through `ingest.ts`, `extract/index.ts`, `watch.ts`, `policy.ts` via a small `EventEmitter` singleton in `packages/core/src/events.ts`.
+
+**Enforcement.** `it.todo` block in `contracts.test.ts` for v0.2.6 #24. Regression tests cover: `/events` endpoint exists with `text/event-stream` content-type, dual-mount per ADR-026, event-type taxonomy locked (eight types, no quiet additions), `/projects` endpoint exists and returns the registry shape, heartbeat interval set, backpressure cap honored.

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -3141,3 +3141,46 @@ describe('Queued contracts (v0.2.1 leftovers — #141, #142, #145)', () => {
   it.todo('ServiceNode.framework populated from package.json (issue #142)')
   it.todo('Drop unused graphology-traversal/-shortest-path deps (issue #145)')
 })
+
+describe('CLI surface contract (ADR-050)', () => {
+  // v0.2.6 #23. Nine `neat <verb>` commands mirroring the MCP allowlist.
+  // Implementation lands the verbs; these todos flip as each verb ships.
+  it.todo('every MCP tool from ADR-039 has a corresponding `neat <verb>` registered (ADR-050 #1)')
+  it.todo('verb names are kebab-case and drop the `get_` prefix (ADR-050 #1 — naming)')
+  it.todo('CLI verbs hit NEAT_API_URL via the shared REST client; no graph.json reads from cli-verbs (ADR-050 #2)')
+  it.todo('`--project <name>` resolution chain matches MCP: flag → NEAT_PROJECT env → `default` (ADR-050 #2)')
+  it.todo('default output is human-readable with NL summary + table + provenance footer (ADR-050 #3)')
+  it.todo('`--json` output schema is `{ summary, block, confidence, provenance }` (ADR-050 #3)')
+  it.todo('stderr carries diagnostics; stdout carries results — no mixing (ADR-050 #3)')
+  it.todo('exit code 0 on success (ADR-050 #4)')
+  it.todo('exit code 1 on server 4xx/5xx with body error message on stderr (ADR-050 #4)')
+  it.todo('exit code 2 on misuse before any network call (ADR-050 #4)')
+  it.todo('exit code 3 distinct from 1 when daemon connection refused / times out (ADR-050 #4)')
+  it.todo('no mutation verbs registered behind the query verb surface (ADR-050 #5)')
+  it.todo('no demo-name hardcoding in `--help` text outside of generic shape examples (ADR-050 #6)')
+  it.todo('every verb has a `--help` block listing args, flags, exit codes, example invocation (ADR-050 #7)')
+  it.todo('`neat --help` lists every verb (lifecycle + query) in one block (ADR-050 #7)')
+})
+
+describe('Frontend-facing API contract (ADR-051)', () => {
+  // v0.2.6 #24. SSE stream + multi-project switcher endpoint. Speculative —
+  // WebSocket transport and per-event filtering deferred to successor ADRs.
+  it.todo('GET /events responds with content-type text/event-stream (ADR-051 #1)')
+  it.todo('GET /events and GET /projects/:project/events are both registered (dual-mount per ADR-026) (ADR-051 #1)')
+  it.todo('SSE event-type taxonomy is exactly the eight locked types — no more, no fewer (ADR-051 #2)')
+  it.todo('node-added event payload matches `{ node: GraphNode }` (ADR-051 #2)')
+  it.todo('node-updated event payload matches `{ id, changes }` (ADR-051 #2)')
+  it.todo('node-removed / edge-removed event payloads carry only `{ id }` (ADR-051 #2)')
+  it.todo('edge-added event payload matches `{ edge: GraphEdge }` (ADR-051 #2)')
+  it.todo('extraction-complete event payload matches `{ project, fileCount, nodesAdded, edgesAdded }` (ADR-051 #2)')
+  it.todo('policy-violation event payload matches `{ violation: PolicyViolation }` (ADR-051 #2)')
+  it.todo('stale-transition event payload matches `{ edgeId, from: "OBSERVED", to: "STALE" }` (ADR-051 #2)')
+  it.todo('SSE heartbeat comment line emitted at most every 30 seconds (ADR-051 #3)')
+  it.todo('GET /projects returns the listProjects() shape from registry.ts (ADR-051 #4)')
+  it.todo('GET /projects shape is Array<{ name, path, status, registeredAt, lastSeenAt?, languages }> (ADR-051 #4)')
+  it.todo('SSE error responses use `event: error` payload before connection close (ADR-051 #5)')
+  it.todo('non-SSE error responses keep the ADR-040 `{ error, status, details? }` envelope (ADR-051 #5)')
+  it.todo('SSE backpressure cap drops connection at 1000 queued messages with `event: error` `{ reason: "backpressure" }` (ADR-051 #8)')
+  it.todo('event bus is a single EventEmitter singleton in packages/core/src/events.ts (ADR-051 — authority)')
+  it.todo('event producers in ingest.ts / extract/ / watch.ts / policy.ts emit through the bus, not directly to handlers (ADR-051 — authority)')
+})


### PR DESCRIPTION
## Summary

Opens v0.2.6 — CLI parity + frontend-API surface — with the same rebuild-against-locked-contract discipline as v0.2.1 onward.

- **ADR-050 (CLI surface)** — nine `neat <verb>` commands mirroring the MCP allowlist (`root-cause`, `blast-radius`, `dependencies`, `observed-dependencies`, `incidents`, `search`, `diff`, `stale-edges`, `policies`). REST-only data path sharing the MCP client, two output modes (default human-readable plus `--json`), exit codes that distinguish misuse / server error / daemon-down (`2` / `1` / `3`). Read-only surface; mutation verbs stay out of the query surface.
- **ADR-051 (frontend-facing API)** — speculative; the `(if needed)` qualifier from the kickoff applies. Covers the two gaps known today: SSE stream at `/events` (dual-mounted per ADR-026) with a locked eight-type taxonomy (node / edge / extraction / policy / stale events) and a multi-project switcher at `/projects` passing through the registry. WebSocket transport and per-event filtering deferred to successor ADRs when v0.3.0 frontend work surfaces a concrete need.

`contracts.md` index promotes rows 23/24 from "Future" to per-topic; the future-contracts table is now empty — v0.2.6 is the last milestone in the v0.2.x sequence.

`contracts.test.ts` gets two new describe blocks: 15 `it.todo` for ADR-050, 18 `it.todo` for ADR-051. They flip to live as the implementation lands.

## Test plan

- [x] `npx turbo build` clean
- [x] `npx turbo lint` clean
- [x] `npx vitest run test/audits/contracts.test.ts` — 125 pass, 37 todo (33 new + 4 v0.2.1 leftovers), 0 fail
- [x] PreToolUse hook surfaces the new contracts when editing files matching `governs:` globs (manual smoke against `cli.ts` and `api.ts`)

## Notes

- Drafted ADR-051 against current best-guess of frontend needs. When Jed's v0.3.0 work surfaces concrete asks SSE can't cover, open a successor ADR rather than amending this one — keeps the lock discipline mechanical.
- After this lands, the implementation queue for v0.2.6 is: build the nine CLI verbs (one PR per verb or one PR for the batch — implementer's call), then the SSE + `/projects` endpoint pair. Existing kickoff doc at `docs/plans/2026-05-07-v0.2.6-kickoff.md` stays valid.

Refs #197