### PR TITLE
0.2.6 publish fix — umbrella bin wrappers + engines field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10889,18 +10889,21 @@
     },
     "packages/claude-skill": {
       "name": "@neat.is/claude-skill",
-      "version": "0.2.5",
-      "license": "BUSL-1.1"
+      "version": "0.2.6",
+      "license": "BUSL-1.1",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "packages/core": {
       "name": "@neat.is/core",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "BUSL-1.1",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
         "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
-        "@neat.is/types": "^0.2.5",
+        "@neat.is/types": "^0.2.6",
         "chokidar": "^4.0.3",
         "fastify": "^5.0.0",
         "graphology": "^0.25.4",
@@ -10930,17 +10933,20 @@
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"
       },
+      "engines": {
+        "node": ">=20"
+      },
       "optionalDependencies": {
         "@xenova/transformers": "^2.17.2"
       }
     },
     "packages/mcp": {
       "name": "@neat.is/mcp",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "BUSL-1.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@neat.is/types": "^0.2.5",
+        "@neat.is/types": "^0.2.6",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -10952,20 +10958,31 @@
         "tsx": "^4.19.0",
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "packages/neat.is": {
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "BUSL-1.1",
       "dependencies": {
-        "@neat.is/claude-skill": "^0.2.5",
-        "@neat.is/core": "^0.2.5",
-        "@neat.is/mcp": "^0.2.5"
+        "@neat.is/claude-skill": "^0.2.6",
+        "@neat.is/core": "^0.2.6",
+        "@neat.is/mcp": "^0.2.6"
+      },
+      "bin": {
+        "neat": "bin/neat",
+        "neat-mcp": "bin/neat-mcp",
+        "neatd": "bin/neatd"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "packages/types": {
       "name": "@neat.is/types",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "BUSL-1.1",
       "dependencies": {
         "zod": "^3.23.8"
@@ -10974,6 +10991,9 @@
         "tsup": "^8.3.0",
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "packages/web": {

--- a/packages/claude-skill/package.json
+++ b/packages/claude-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/claude-skill",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Claude Code skill drop-in for NEAT — wires the @neat.is/mcp server into Claude's MCP config",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -11,6 +11,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node": ">=20"
   },
   "files": ["README.md", "SKILL.md", "claude_code_config.json"],
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/core",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "NEAT graph engine: tree-sitter extraction, OTel ingest, REST API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -11,6 +11,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node": ">=20"
   },
   "type": "module",
   "main": "./dist/index.cjs",
@@ -45,7 +48,7 @@
     "@fastify/cors": "^10.0.0",
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
-    "@neat.is/types": "^0.2.5",
+    "@neat.is/types": "^0.2.6",
     "chokidar": "^4.0.3",
     "fastify": "^5.0.0",
     "graphology": "^0.25.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/mcp",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "NEAT MCP server: exposes graph queries to AI agents over stdio",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -11,6 +11,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node": ">=20"
   },
   "type": "module",
   "main": "./dist/index.cjs",
@@ -38,7 +41,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@neat.is/types": "^0.2.5",
+    "@neat.is/types": "^0.2.6",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/neat.is/README.md
+++ b/packages/neat.is/README.md
@@ -2,15 +2,26 @@
 
 NEAT keeps a live semantic graph of a software system — code, infrastructure, runtime — and exposes it to AI agents over MCP.
 
+## Prerequisites
+
+- **Node.js 20 or newer.** Enforced via `engines`; older versions fail at install.
+- **A C toolchain**, because `@neat.is/core` builds native bindings for `tree-sitter` (JS, TS, Python parsers) at install time:
+  - macOS: Xcode Command Line Tools (`xcode-select --install`)
+  - Debian/Ubuntu: `build-essential` plus `python3` (for `node-gyp`)
+  - Alpine: `build-base python3`
+  - Windows: Visual Studio Build Tools with the "Desktop development with C++" workload
+
+If `npm install -g neat.is` fails partway through with a `gyp` error, the toolchain is the cause. Install it and re-run.
+
 ## Install
 
 ```bash
 npm install -g neat.is
 ```
 
-That gives you three binaries:
+That puts three binaries on your PATH:
 
-- `neat` — CLI (init, watch, list, skill, etc.)
+- `neat` — CLI (init, watch, list, skill, plus the nine query verbs that mirror the MCP tool surface)
 - `neatd` — daemon (start, stop, status, reload)
 - `neat-mcp` — MCP stdio server for Claude Code and other agents
 
@@ -21,7 +32,7 @@ neat init /path/to/your/repo --project myrepo
 neatd start
 ```
 
-Snapshot lands at `<repo>/neat-out/myrepo.json`. The daemon watches for file changes and OTel traces and keeps the graph live.
+Snapshot lands at `<repo>/neat-out/myrepo.json`. The daemon watches for file changes and OTel traces (`:4318` HTTP by default) and keeps the graph live.
 
 ## What's in the box
 

--- a/packages/neat.is/bin/neat
+++ b/packages/neat.is/bin/neat
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+// Bin shim — `npm install -g neat.is` puts this on PATH as `neat`.
+// argv[1] ends in `/neat`, which @neat.is/core/dist/cli.cjs's existing
+// entry detection already matches; requiring the file is enough to fire main().
+require('@neat.is/core/dist/cli.cjs')

--- a/packages/neat.is/bin/neat-mcp
+++ b/packages/neat.is/bin/neat-mcp
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+// Bin shim — `npm install -g neat.is` puts this on PATH as `neat-mcp`.
+// @neat.is/mcp/dist/index.cjs unconditionally calls main() at module load,
+// so requiring it fires the stdio MCP server.
+require('@neat.is/mcp/dist/index.cjs')

--- a/packages/neat.is/bin/neatd
+++ b/packages/neat.is/bin/neatd
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+// Bin shim — `npm install -g neat.is` puts this on PATH as `neatd`.
+// argv[1] ends in `/neatd`, which @neat.is/core/dist/neatd.cjs's existing
+// entry detection already matches; requiring the file is enough to fire main().
+require('@neat.is/core/dist/neatd.cjs')

--- a/packages/neat.is/package.json
+++ b/packages/neat.is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neat.is",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "NEAT — live semantic graph of a software system, queryable from AI agents over MCP. Install once, get the neat / neatd / neat-mcp CLIs.",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -12,10 +12,18 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": ["README.md"],
+  "engines": {
+    "node": ">=20"
+  },
+  "bin": {
+    "neat": "./bin/neat",
+    "neatd": "./bin/neatd",
+    "neat-mcp": "./bin/neat-mcp"
+  },
+  "files": ["bin", "README.md"],
   "dependencies": {
-    "@neat.is/core": "^0.2.5",
-    "@neat.is/mcp": "^0.2.5",
-    "@neat.is/claude-skill": "^0.2.5"
+    "@neat.is/core": "^0.2.6",
+    "@neat.is/mcp": "^0.2.6",
+    "@neat.is/claude-skill": "^0.2.6"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/types",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Shared Zod schemas, types, and runtime constants for NEAT",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -11,6 +11,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node": ">=20"
   },
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

The 0.2.5 publish put `neat.is` on the registry with no `bin` field — `npm install -g neat.is` would install the package but the `neat` / `neatd` / `neat-mcp` bins never landed on PATH because npm only globally links bins from the directly-installed package, not transitive dependencies. This patches the umbrella, bumps every publishable package to 0.2.6, and documents the prerequisites.

## Changes

- **`packages/neat.is/bin/{neat,neatd,neat-mcp}`** — three-line `require()` shims. argv[1] passes through to the dist file's existing entry detection (`endsWith('/neat')`, `endsWith('/neatd')`), so `main()` fires naturally. Zero source-code touched.
- **`packages/neat.is/package.json`** — adds `bin` field mapping the three shims, adds `bin/` to `files`, bumps to 0.2.6, dep ranges bump to `^0.2.6`.
- **`packages/neat.is/README.md`** — adds a Prerequisites block (Node 20+, C toolchain for tree-sitter native bindings) so first-touch installs on a clean machine see a hint instead of just a gyp error.
- **`packages/{core,mcp,types,claude-skill}/package.json`** — version bump to 0.2.6, `engines.node: ">=20"` everywhere. `core` and `mcp` also bump their `@neat.is/types` dep to `^0.2.6`.

## Out of scope

Moving `@grpc/grpc-js` and `@grpc/proto-loader` to `optionalDependencies`. The current top-level static imports in `server.ts` / `watch.ts` / `index.ts` would crash if the deps weren't installed. Successor work — needs a refactor to lazy-load the gRPC receiver behind `NEAT_OTLP_GRPC=true`.

Postinstall script for native-build error messaging is also skipped — too noisy on every install. The README prerequisites cover the same ground at lower cost.

## Test plan

- [x] `npm install` clean across the workspace
- [x] `npx turbo build` clean — all four publishable packages compile
- [x] `npx turbo test` — full suite stays green; 125 live tests pass, 37 todo, 0 fail
- [x] `cd packages/neat.is && npm pack --dry-run` shows the three bin scripts (`bin/neat`, `bin/neatd`, `bin/neat-mcp`) included in the tarball
- [ ] **Post-merge publish.** Five tarballs in dependency order:
  ```
  cd packages/types         && npm publish
  cd ../core                && npm publish
  cd ../mcp                 && npm publish
  cd ../claude-skill        && npm publish
  cd ../neat.is             && npm publish
  ```
- [ ] **Post-publish smoke.** From a clean machine: `npm install -g neat.is`, then `which neat`, `which neatd`, `which neat-mcp` — all should resolve. `neat --help` should print the usage block.

## Note on versioning

This bump (0.2.5 → 0.2.6) is purely a publish-fix release. The v0.2.6 milestone (CLI parity + frontend-API surface, ADR-050 / ADR-051) is contracts-only on `main` so far; its implementation will land later under whatever version is current then (likely 0.2.7). npm patch versions don't have to map 1:1 to milestone names.

Refs #197