### PR TITLE
Publish infrastructure (re-PR after stacking accident) — CI workflow, local fallback, runbook

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,106 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run — verify everything but do not publish'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+# Single-flight publish. A second tag push waits rather than racing — partial
+# failure leaves a known state to recover from, not a registry made up of
+# whichever job won.
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npx turbo build test lint
+
+      - name: Verify versions are in lockstep
+        run: |
+          set -euo pipefail
+          versions=$(node -e "
+            const fs = require('fs')
+            const pkgs = ['types', 'core', 'mcp', 'claude-skill', 'neat.is']
+            const vs = pkgs.map(p => JSON.parse(fs.readFileSync('packages/' + p + '/package.json', 'utf8')).version)
+            console.log(vs.join(' '))
+          ")
+          unique=$(echo "$versions" | tr ' ' '\n' | sort -u | wc -l | tr -d ' ')
+          echo "Versions: $versions"
+          if [ "$unique" != "1" ]; then
+            echo "::error::Publishable packages have mismatched versions. All five must match."
+            exit 1
+          fi
+
+      - name: Publish in dependency order
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          publish_one() {
+            local pkg_dir="$1"
+            local pkg_name
+            pkg_name=$(node -p "require('./${pkg_dir}/package.json').name")
+            local pkg_version
+            pkg_version=$(node -p "require('./${pkg_dir}/package.json').version")
+
+            echo
+            echo "── ${pkg_name}@${pkg_version} ──"
+
+            # Idempotency: skip if this exact version is already on the registry.
+            # `npm view` exits non-zero if the version isn't published.
+            if npm view "${pkg_name}@${pkg_version}" version > /dev/null 2>&1; then
+              echo "  already on registry, skipping"
+              return 0
+            fi
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "  DRY RUN — would publish"
+              ( cd "$pkg_dir" && npm publish --dry-run )
+              return 0
+            fi
+
+            ( cd "$pkg_dir" && npm publish )
+            echo "  published"
+          }
+
+          publish_one "packages/types"
+          publish_one "packages/core"
+          publish_one "packages/mcp"
+          publish_one "packages/claude-skill"
+          publish_one "packages/neat.is"
+
+          echo
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry run complete. No packages were published."
+          else
+            echo "Publish complete."
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@ The Railway gates from M6 are still informational. AWS is the more likely produc
 - Commits and PRs read like a colleague wrote them. No "this commit introduces" or release-notes-y bullets. See ADR-008.
 - Stack γ PRs on top of merged β work, not on each other. `main` rebase is the easier merge story.
 - Every package emits ESM + CJS + DTS via tsup. Don't ship ESM-only.
+- npm publishes go through CI on tag push (`.github/workflows/publish.yml`). Process + troubleshooting in [`docs/runbook-publish.md`](docs/runbook-publish.md). Local publishes via `bash scripts/publish.sh` are a fallback, not the default.
 
 ## Don't do
 

--- a/docs/runbook-publish.md
+++ b/docs/runbook-publish.md
@@ -1,0 +1,126 @@
+# Runbook — publishing to npm
+
+Five packages ship to the npm registry on every release: `@neat.is/types`, `@neat.is/core`, `@neat.is/mcp`, `@neat.is/claude-skill`, and the `neat.is` umbrella. They publish in dependency order — npm rejects the umbrella if its deps aren't already on the registry.
+
+The preferred path is **CI on tag push**. Local publish is a fallback for when CI isn't an option.
+
+## One-time setup
+
+### 1. npm account + 2FA
+
+The owning account is `denizdogan-neat`. Confirm 2FA is enabled at https://www.npmjs.com/settings/denizdogan-neat/profile so any token rotation requires explicit auth, not just login credentials.
+
+### 2. Granular npm token
+
+Create at https://www.npmjs.com/settings/denizdogan-neat/tokens with these settings:
+
+- **Type:** Granular access token
+- **Expiration:** 1 year (or longer; rotate on calendar)
+- **Packages and scopes:** read+write to the `@neat.is` scope and to the unscoped `neat.is` package
+- **Organizations:** read+write to `neat.is` (if the org exists; otherwise leave blank — scope-level write is sufficient)
+
+Copy the token. It's shown once.
+
+### 3. GitHub Actions secret
+
+Add the token as `NPM_TOKEN`:
+
+```bash
+gh secret set NPM_TOKEN --repo NEAT-Technologies/Neat
+# paste token at the prompt
+```
+
+Or via the web UI: repo Settings → Secrets and variables → Actions → New repository secret.
+
+The publish workflow at `.github/workflows/publish.yml` references this secret as `NODE_AUTH_TOKEN` and won't run without it.
+
+## Routine publish (CI path)
+
+Five steps from a clean working tree on `main`:
+
+```bash
+# 1. Bump versions in lockstep across all five publishable packages.
+#    Edit by hand or use a small script — we don't have changesets.
+#    Files: packages/{types,core,mcp,claude-skill,neat.is}/package.json
+#    Don't forget the cross-package deps (`@neat.is/types: ^X.Y.Z` in core/mcp,
+#    `@neat.is/core: ^X.Y.Z` in neat.is).
+
+# 2. Commit + push.
+git commit -am "Bump to X.Y.Z"
+git push origin main
+
+# 3. Tag.
+git tag -a vX.Y.Z -m "vX.Y.Z"
+
+# 4. Push the tag — this triggers the publish workflow.
+git push origin vX.Y.Z
+
+# 5. Watch it ship.
+gh run watch --repo NEAT-Technologies/Neat
+```
+
+The workflow:
+
+1. Checks out the tagged commit.
+2. Runs `npm ci` + `npx turbo build test lint` (gates the publish on green).
+3. Verifies all five package versions match (catches a half-bumped state).
+4. Publishes in dependency order. Skips any package whose target version is already on the registry — re-runs after partial failure are safe.
+
+A successful run produces five new package versions visible at https://www.npmjs.com/package/neat.is and the four scoped packages.
+
+## Dry run via CI
+
+To verify everything without publishing:
+
+1. Go to repo Actions tab → Publish workflow → Run workflow.
+2. Set `dry_run` input to `true`.
+3. Run.
+
+Same checks fire; `npm publish --dry-run` runs per package; nothing actually ships.
+
+## Local fallback
+
+When CI isn't an option (offline, hotfix, debugging the workflow itself):
+
+```bash
+# Make sure your local token is fresh.
+npm whoami
+# If 401, run `npm login` and retry.
+
+# Then:
+bash scripts/publish.sh             # publish for real
+bash scripts/publish.sh --dry-run   # preflight + simulate
+```
+
+The script preflights aggressively:
+
+- Verifies `npm whoami`. Fails fast on 401.
+- Refuses to run if you're not on `main` (overridable with a confirm prompt).
+- Refuses to run if the working tree has uncommitted changes.
+- Verifies all five package versions are in lockstep before publishing anything.
+- Skips packages already at the target version (idempotent re-runs).
+
+## Troubleshooting
+
+| npm error | Cause | Fix |
+|---|---|---|
+| `E401 Unauthorized` from `npm whoami` or publish | Local auth token expired or revoked. | `npm login` to refresh. Verify with `npm whoami`. |
+| `E404 Not Found - PUT https://registry.npmjs.org/...` | Misleading error — usually means **auth failure** for an existing scoped package. npm hides 401/403 as 404 for some publish operations. | Same fix as 401. Run `npm whoami` first; re-login if needed. Verify scope membership: `npm access list packages` should include `@neat.is/*`. |
+| `E403 Forbidden` | Token doesn't have publish scope on `@neat.is/*`, or 2FA `--otp` was required and not provided. | Recreate the granular token with the right scope, or pass `--otp=<code>` on a publish that requires it. |
+| `E409 Conflict — version already published` | Trying to republish an existing immutable version. | Bump the version in all five package.jsons; tag a new vX.Y.Z. The local script auto-skips this case; you'd only see it in the CI workflow if version-sync check passed but a previous run already shipped this version. |
+| Workflow runs but no packages publish | The version-sync check found mismatched versions, OR every package was already at the target version (no-op publish). | Look at the workflow log for the "Verify versions are in lockstep" step output. |
+| `gyp ERR! find Python` or similar build errors during `prepublishOnly` | C toolchain missing on the runner. | CI runners come with build tools; locally install Xcode CLT (macOS), `build-essential` (Ubuntu), or MSVS Build Tools (Windows). |
+
+## What ships and what doesn't
+
+**Published:** `@neat.is/types`, `@neat.is/core`, `@neat.is/mcp`, `@neat.is/claude-skill`, `neat.is`.
+
+**Not published:** `@neat.is/web` (private; lives in the monorepo for the v0.3.0 frontend track but isn't a runtime dep of anything else).
+
+**Not in the umbrella:** anything outside the four core/mcp/claude-skill/types packages. The `neat.is` umbrella's job is to put `neat`, `neatd`, and `neat-mcp` on PATH — nothing else.
+
+## When this runbook is wrong
+
+- npm changes their token UI or 2FA flow — update the "One-time setup" section.
+- Provenance attestations get added (`npm publish --provenance`) — update the workflow + setup section.
+- A successor scope or org structure replaces `@neat.is` — update everywhere, including the publish workflow's idempotency check (`npm view <pkg>@<version>`).

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -99,6 +99,21 @@ NEAT_SCAN_PATH=./demo \
 - **README CI badge 404s** — the workflow path changed. The badge URL must match `/.github/workflows/<file>.yml`.
 - **`npm install` adds 80 packages out of nowhere** — someone added `demo/*` back into root `workspaces` before M2 is ready. Drop it again until docker-compose actually launches the services.
 
+## Publishing to npm
+
+CI does the publish on tag push. From a clean working tree on `main`:
+
+```bash
+# Bump versions across all five publishable packages, then:
+git commit -am "Bump to X.Y.Z" && git push origin main
+git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z
+gh run watch --repo NEAT-Technologies/Neat
+```
+
+`.github/workflows/publish.yml` handles the rest. Local fallback: `bash scripts/publish.sh` (or `--dry-run` to simulate).
+
+Full process + troubleshooting tree: [`runbook-publish.md`](./runbook-publish.md).
+
 ## Branch / commit / PR flow
 
 - One issue → one branch `<num>-<slug>` → one PR.

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Local fallback for publishing the five NEAT packages to npm.
+#
+# Preferred path: tag push to GitHub triggers `.github/workflows/publish.yml`.
+# Use this script only when CI isn't an option (offline, hotfix, debugging).
+#
+# Usage:
+#   bash scripts/publish.sh              # publish for real
+#   bash scripts/publish.sh --dry-run    # preflight + simulate, no publish
+#
+# Exits non-zero on any error. Idempotent — already-published versions are
+# skipped, so re-running after a partial failure is safe.
+
+set -euo pipefail
+
+DRY_RUN="false"
+if [ "${1:-}" = "--dry-run" ]; then
+  DRY_RUN="true"
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PACKAGES=(
+  "packages/types"
+  "packages/core"
+  "packages/mcp"
+  "packages/claude-skill"
+  "packages/neat.is"
+)
+
+# ── Preflight ────────────────────────────────────────────────────────────
+echo "── preflight ──"
+
+if ! npm whoami > /dev/null 2>&1; then
+  echo
+  echo "ERROR: not logged in to npm."
+  echo "Run \`npm login\` (or refresh your token) and try again."
+  echo "See docs/runbook-publish.md for one-time setup."
+  exit 1
+fi
+
+WHOAMI=$(npm whoami)
+echo "  npm user: ${WHOAMI}"
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+  echo
+  echo "WARNING: not on main (you're on ${CURRENT_BRANCH})."
+  echo "Publishing from a feature branch ships the wrong commit."
+  read -r -p "Continue anyway? [y/N] " confirm
+  if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+    exit 1
+  fi
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo
+  echo "ERROR: working tree has uncommitted changes."
+  echo "Commit or stash before publishing — published artifacts must match git state."
+  exit 1
+fi
+
+# ── Version sync check ──────────────────────────────────────────────────
+echo
+echo "── versions ──"
+VERSIONS=()
+for pkg_dir in "${PACKAGES[@]}"; do
+  v=$(node -p "require('./${pkg_dir}/package.json').version")
+  name=$(node -p "require('./${pkg_dir}/package.json').name")
+  echo "  ${name}: ${v}"
+  VERSIONS+=("$v")
+done
+
+UNIQUE_COUNT=$(printf '%s\n' "${VERSIONS[@]}" | sort -u | wc -l | tr -d ' ')
+if [ "$UNIQUE_COUNT" != "1" ]; then
+  echo
+  echo "ERROR: package versions are not in lockstep."
+  echo "All five packages must share the same version. Bump and try again."
+  exit 1
+fi
+
+TARGET_VERSION="${VERSIONS[0]}"
+
+# ── Build + test gate ───────────────────────────────────────────────────
+echo
+echo "── build / test / lint ──"
+npx turbo build test lint
+
+# ── Publish ─────────────────────────────────────────────────────────────
+echo
+echo "── publish ──"
+PUBLISHED=()
+SKIPPED=()
+
+for pkg_dir in "${PACKAGES[@]}"; do
+  pkg_name=$(node -p "require('./${pkg_dir}/package.json').name")
+
+  echo
+  echo "${pkg_name}@${TARGET_VERSION}"
+
+  if npm view "${pkg_name}@${TARGET_VERSION}" version > /dev/null 2>&1; then
+    echo "  already on registry, skipping"
+    SKIPPED+=("$pkg_name")
+    continue
+  fi
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "  DRY RUN — would publish"
+    ( cd "$pkg_dir" && npm publish --dry-run )
+    continue
+  fi
+
+  ( cd "$pkg_dir" && npm publish )
+  echo "  published"
+  PUBLISHED+=("$pkg_name")
+done
+
+# ── Summary ─────────────────────────────────────────────────────────────
+echo
+echo "── summary ──"
+if [ "$DRY_RUN" = "true" ]; then
+  echo "  dry run complete (no packages published)"
+else
+  echo "  published: ${#PUBLISHED[@]}"
+  for p in "${PUBLISHED[@]}"; do echo "    - $p"; done
+  echo "  skipped:   ${#SKIPPED[@]}"
+  for p in "${SKIPPED[@]}"; do echo "    - $p"; done
+fi


### PR DESCRIPTION
## Summary

Same content as the now-stranded PR #201 — re-opened against `main` after a stacking accident.

PR #200 was squash-merged into `main` at 00:47:09 UTC, then PR #201 was merged into the `npm-0.2.6-publish-fix` branch (PR #200's now-dead base) 35 seconds later. The publish-infrastructure work never made it to `main`.

This PR cherry-picks the same commit onto a fresh branch from `main` so the work actually lands.

## What's in here (unchanged from #201)

- **`.github/workflows/publish.yml`** — CI publishes on `v*.*.*` tag push or manual `workflow_dispatch` (with optional `dry_run`). Auth via `NPM_TOKEN` secret. Idempotent — already-published versions are skipped.
- **`scripts/publish.sh`** — local fallback. Preflights `npm whoami`, refuses dirty trees, verifies version sync, idempotent skip per package.
- **`docs/runbook-publish.md`** — one-time setup, routine flow, troubleshooting tree (404-is-actually-auth gets explicit treatment).
- **`CLAUDE.md`** + **`docs/runbook.md`** — pointers at the new runbook.

## Test plan

Same as #201:

- [x] `bash -n scripts/publish.sh` clean
- [x] YAML structurally valid
- [x] `npx turbo build test lint` clean
- [ ] Post-merge: workflow_dispatch with `dry_run: true` to verify auth + version-sync + ordering without shipping
- [ ] First real release: tag `v0.2.6`, push, watch with `gh run watch`

Refs #197 #201