### PR TITLE
v0.2.7 — fix umbrella bin wrappers + publish system contract (ADR-052)

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -34,6 +34,7 @@ This file is the index. Each rule has a short summary and a link to its full per
 | 22 | Daemon | [`contracts/daemon.md`](./contracts/daemon.md) | Single long-lived process, per-project graph isolation, mtime + OTel + policy.json triggers, graceful per-project failure (ADR-049) | ✅ landed (v0.2.5 opens) |
 | 23 | CLI surface | [`contracts/cli-surface.md`](./contracts/cli-surface.md) | Nine `neat <verb>` commands mirroring MCP tools, REST-only data path, `--json` output, exit-code branching (ADR-050) | ✅ landed (v0.2.6 opens) |
 | 24 | Frontend-facing API | [`contracts/frontend-api.md`](./contracts/frontend-api.md) | SSE stream at `/events` with locked 8-type taxonomy, multi-project switcher at `/projects`, WebSocket and per-event filtering deferred (ADR-051) | ✅ landed (v0.2.6 opens) |
+| 25 | Publish system | [`contracts/publish-system.md`](./contracts/publish-system.md) | Bin-wrapper subpath validity against dependency `exports`, version lockstep across five packages, tarball smoke-test gate, dependency order, npm immutability acknowledged (ADR-052) | ✅ landed (post-0.2.6 broken-publish) |
 
 ### Future contracts — opened at the start of each milestone
 

--- a/docs/contracts/publish-system.md
+++ b/docs/contracts/publish-system.md
@@ -1,0 +1,119 @@
+---
+name: publish-system
+description: Bin-wrapper subpath validity, version lockstep, tarball smoke-test gate, dependency order, idempotency, npm immutability, engines field. Catches the 0.2.6 broken-publish failure shape mechanically.
+governs:
+  - "packages/neat.is/bin/**"
+  - "packages/neat.is/package.json"
+  - "packages/core/package.json"
+  - "packages/mcp/package.json"
+  - "packages/types/package.json"
+  - "packages/claude-skill/package.json"
+  - ".github/workflows/publish.yml"
+  - "scripts/publish.sh"
+adr: [ADR-052]
+---
+
+# Publish system contract
+
+The npm publish pipeline. Five packages ship to the registry on every release; the system has been load-bearing since 0.2.5 but had no contract coverage, which is how the 0.2.6 broken-publish bug shipped. This contract closes that gap.
+
+## Five packages, dependency-ordered
+
+```
+@neat.is/types  →  @neat.is/core  →  @neat.is/mcp  →  @neat.is/claude-skill  →  neat.is
+```
+
+The umbrella has no code of its own — three bin wrappers in `packages/neat.is/bin/` that delegate to dist files in `core` and `mcp` via `require()`. That delegation is what `npm install -g neat.is` relies on to put `neat` / `neatd` / `neat-mcp` on PATH.
+
+## Bin-wrapper subpath validity
+
+Every `require('@scope/pkg/subpath')` in `packages/neat.is/bin/*` must resolve to a path exposed in the target package's `exports` field.
+
+Today's wrappers (post-0.2.7):
+
+| Wrapper | `require()` target | Must appear in |
+|---|---|---|
+| `bin/neat` | `@neat.is/core/dist/cli.cjs` | `core/package.json` exports |
+| `bin/neatd` | `@neat.is/core/dist/neatd.cjs` | `core/package.json` exports |
+| `bin/neat-mcp` | `@neat.is/mcp/dist/index.cjs` | `mcp/package.json` exports |
+
+**Why this matters:** in monorepo dev, workspace symlinks bypass Node's `exports` enforcement, so a wrapper can `require()` any path inside a sibling package and it works. Tarball installs don't have that escape hatch — Node refuses any subpath not listed in `exports`. The 0.2.6 publish broke exactly here: wrappers worked locally, failed for everyone who ran `npm install -g neat.is`.
+
+A contract test parses each wrapper file, extracts the require target via regex, splits into `@scope/pkg` + `subpath`, walks the target package.json's `exports`, and asserts the subpath is exposed. Literal-key match for MVP; wildcard patterns are successor work.
+
+## Version lockstep
+
+All five publishable packages carry the same `version` string in their `package.json` on `main`. Cross-package dep ranges in the four packages that depend on others (`core` → `types`, `mcp` → `types`, `umbrella` → `core`/`mcp`/`claude-skill`) must match the same `X.Y.Z` exactly.
+
+Half-bumped state on `main` is a contract violation. The CI workflow's "Verify versions are in lockstep" step blocks publish; a contract test on `main` blocks merge.
+
+## Tarball smoke-test gate
+
+The publish workflow must install the just-published umbrella tarball into a tmp dir and invoke `neat --help`, asserting exit code 0, before declaring success. Catches any failure shape that only surfaces under a real tarball install (the 0.2.6 class).
+
+Implementation: a workflow step after the publish loop that does roughly:
+
+```bash
+TMP=$(mktemp -d)
+cd "$TMP"
+npm init -y > /dev/null
+npm install "neat.is@${VERSION}"
+./node_modules/.bin/neat --help > /dev/null
+```
+
+Exit non-zero on any failure. Fails the workflow run; the broken version stays on the registry (npm immutability) but the tag is suspect and the operator knows immediately.
+
+## Dependency order
+
+Publish proceeds in this order, never another:
+
+```
+types → core → mcp → claude-skill → neat.is
+```
+
+Out of order produces 404s — npm rejects publishes whose deps aren't on the registry yet. Encoded in both `.github/workflows/publish.yml` and `scripts/publish.sh`.
+
+## Idempotency
+
+Re-running the publish workflow after partial failure must skip packages already at the target version. Implementation: `npm view <pkg>@<version>` returns non-zero if the version isn't published; if it returns zero, skip. Re-runs after a 401 / network blip don't 409 on the packages that already landed.
+
+## npm immutability
+
+Once `name@version` is published, that slot is permanently sealed. `npm unpublish` does not free it for re-publish — the version number is reserved forever. Therefore:
+
+- Publishing a broken version forces a patch-version bump (e.g. 0.2.6 broken → 0.2.7 fix).
+- No tooling around `npm unpublish` recovery exists or should be built; npm policy makes the obvious recovery shape impossible.
+
+Documented in `docs/runbook-publish.md`'s troubleshooting table.
+
+## `engines.node: ">=20"`
+
+Every publishable package and the umbrella. Older Node fails at install, not at runtime. The 20+ floor is what `chokidar@4`, modern `fastify@5`, and the rest of the dep tree assume.
+
+## Authority
+
+- **Bin wrappers**: `packages/neat.is/bin/{neat,neatd,neat-mcp}`
+- **Package metadata**: each publishable `package.json`
+- **CI publish**: `.github/workflows/publish.yml`
+- **Local fallback**: `scripts/publish.sh`
+- **Process docs**: `docs/runbook-publish.md`
+
+## Enforcement
+
+`describe` block in `contracts.test.ts`. Live assertions:
+
+- **Subpath validity** — parses wrappers, walks exports, asserts every required subpath is exposed.
+- **Version lockstep** — reads all five package.jsons, asserts versions match and cross-package dep ranges match the version.
+- **`engines.node: ">=20"`** — every publishable package + umbrella has the field.
+- **Dependency order** — the publish loop in `.github/workflows/publish.yml` and `scripts/publish.sh` references the five packages in `types → core → mcp → claude-skill → neat.is` order.
+
+`it.todo` until the corresponding work lands:
+
+- **Tarball smoke-test gate** — depends on the workflow step landing.
+
+Documented invariants without mechanized tests (policy, not code):
+
+- npm immutability and the no-unpublish-recovery rule (rules 6, 7).
+- Idempotency (rule 5) — exercised by every re-run; failure mode is a re-publish 409 which is loud enough.
+
+Full rationale: [ADR-052](../decisions.md#adr-052--publish-system-contract).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1426,3 +1426,27 @@ The `(if needed)` qualifier in the kickoff applies. We draft what's clear and ex
 **Authority.** `packages/core/src/api.ts` (extend) for `/projects`. SSE endpoint in `packages/core/src/api.ts` or a new `packages/core/src/streaming.ts` if the surface grows. Event emission threaded through `ingest.ts`, `extract/index.ts`, `watch.ts`, `policy.ts` via a small `EventEmitter` singleton in `packages/core/src/events.ts`.
 
 **Enforcement.** `it.todo` block in `contracts.test.ts` for v0.2.6 #24. Regression tests cover: `/events` endpoint exists with `text/event-stream` content-type, dual-mount per ADR-026, event-type taxonomy locked (eight types, no quiet additions), `/projects` endpoint exists and returns the registry shape, heartbeat interval set, backpressure cap honored.
+
+## ADR-052 — Publish system contract
+
+**Date:** 2026-05-09
+**Status:** Active.
+
+Documents the load-bearing rules of the npm publish pipeline. The pipeline has been in production since 0.2.5 but had no contract coverage, which is how the 0.2.6 broken-publish bug shipped: the `neat.is` umbrella's bin wrappers `require()`ed subpaths into `@neat.is/core` and `@neat.is/mcp` that those packages didn't expose through their `exports` field, and nothing caught it before the tarballs went live on the registry.
+
+**Context.** Five packages ship to npm: `@neat.is/types`, `@neat.is/core`, `@neat.is/mcp`, `@neat.is/claude-skill`, and the `neat.is` umbrella. The umbrella's whole job is to put `neat`, `neatd`, `neat-mcp` on PATH after `npm install -g neat.is` — it has no code of its own, only three bin wrappers that delegate via `require('@neat.is/core/dist/cli.cjs')` etc. Local monorepo dev uses workspace symlinks where Node bypasses `exports` enforcement; npm-installed tarballs do not. The first release that exercised the wrappers through real tarballs was 0.2.6, and that's when the failure surfaced.
+
+**Decision.**
+
+1. **Bin-wrapper subpath validity.** Every `require('@scope/pkg/subpath')` line in `packages/neat.is/bin/*` must resolve to a path exposed in the target package's `exports` field. Literal-key match for MVP; wildcard pattern matching is a successor concern. Enforced as a contract-test assertion that parses the wrapper files and walks each target package.json.
+2. **Version lockstep.** All five publishable packages (`types`, `core`, `mcp`, `claude-skill`, `neat.is`) carry the same `version` string in their `package.json` at all times on `main`. Cross-package dep ranges (`@neat.is/types: ^X.Y.Z` in core/mcp, three of those in the umbrella) must match the same `X.Y.Z`. Half-bumped state is a contract violation. Enforced both by the publish workflow's verify-versions step and by a contract test on `main`.
+3. **Tarball smoke-test gate.** The publish workflow must run `neat --help` against the just-published umbrella tarball before declaring success. Specifically: install `neat.is@<published-version>` into a tmp dir, invoke the `neat` bin, assert exit code 0. Catches any failure shape that only surfaces under a real tarball install (the 0.2.6 class).
+4. **Dependency order is fixed.** Publish proceeds `types → core → mcp → claude-skill → neat.is`. Out of order means a downstream 404 because npm rejects publishes whose deps aren't on the registry yet. Encoded in both the CI workflow and `scripts/publish.sh`.
+5. **Idempotency per package.** Re-running the publish workflow after a partial failure must skip packages already at the target version (`npm view <pkg>@<version>` check) rather than 409. Already implemented; this contract locks it as a binding rule.
+6. **npm immutability acknowledged.** Once `name@version` is published, that slot is permanently sealed — `npm unpublish` does not free it for re-publish. Therefore: publishing a broken version forces a patch-version bump, never a same-version republish. Documented in `docs/runbook-publish.md`'s troubleshooting section.
+7. **No engineering of an unpublish recovery.** When a broken release ships, the response is a fix-only patch release at the next version (e.g. 0.2.6 broken → 0.2.7 fix). Don't build tooling around `npm unpublish` because npm won't let it work the way that tooling would imply.
+8. **`engines.node: ">=20"`** on every publishable package and the umbrella. Older Node fails at install, not at runtime. Already in place; this contract locks it.
+
+**Authority.** `.github/workflows/publish.yml` (CI publish), `scripts/publish.sh` (local fallback), `docs/runbook-publish.md` (process), `packages/neat.is/bin/{neat,neatd,neat-mcp}` (the wrappers under contract), `packages/core/package.json` and `packages/mcp/package.json` (the `exports` fields the wrappers reach through).
+
+**Enforcement.** New describe block in `contracts.test.ts`. Live assertions for rules 2 (version lockstep), 4 (dependency order encoded in scripts), 8 (engines field). Rule 1 (subpath validity) ships as live but depends on the 0.2.7 exports fix being on `main` first; until then, the assertion would fail because main reflects the broken 0.2.6 state. Rule 3 (tarball smoke-test) is an `it.todo` until the workflow step lands. Rules 5, 6, 7 are documented invariants without test mechanization (5 is exercised by every re-run of the workflow; 6 and 7 are policy, not verifiable in CI).

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -12,9 +12,9 @@ Source of truth for sprint status. Update this file at the end of every session.
 
 ## 🚩 Pick up here
 
-**Last session ended:** 2026-05-05. v0.1.2 + v0.1.3 shipped. v0.2.0 Sunrise nearly closed — three PRs stacked on `main` carry the data-layer foundation (see "Open PRs awaiting merge" below).
+**Last session ended:** 2026-05-09. v0.2.0 through v0.2.5 milestones closed and tagged. v0.2.6 contracts (ADRs 050/051 — CLI surface + frontend-facing API) landed on `main`; implementation is queued. The publish system contract (ADR-052) landed alongside the npm pipeline rebuild. npm packages at 0.2.6 on the registry — a broken `exports` field shipped, 0.2.7 fix-only patch in flight.
 
-**For current operational state of the active milestone, read `docs/plans/2026-05-05-v0.2.0-status.md` first.** That doc is updated per session; this file describes the long-term shape.
+**For current operational state of the active milestone, read `docs/plans/2026-05-07-v0.2.6-kickoff.md` first.** That doc is the canonical handoff; this file describes the long-term shape.
 
 **Two parallel tracks share `main`:**
 
@@ -346,9 +346,11 @@ A second failing demo service (mysql2/mysql, mongoose/mongo) would prove the sam
 
 ---
 
-## v0.2.0 — Frontend
+## v0.3.0 — Frontend (Track 1, Jed)
 
 **End state:** `packages/web/` is no longer a shell. Graph explorer renders the live graph; node inspector shows attrs + signal + outbound edges; incident log surfaces recent errors and stale-edge transitions; multi-project switcher routes every call through the right `/projects/:project/*` URL; semantic search bar lives in the top chrome; the explorer hot-updates when `neat watch` re-extracts.
+
+Builds against the stable v0.1.2 API plus the SSE event stream + `/projects` endpoint specified by ADR-051 (frontend-facing API contract). Independent of the v0.2.x engineering track — Jed should not block on engineering work.
 
 **Status:** NOT_STARTED.
 

--- a/packages/claude-skill/package.json
+++ b/packages/claude-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/claude-skill",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Claude Code skill drop-in for NEAT — wires the @neat.is/mcp server into Claude's MCP config",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/core",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "NEAT graph engine: tree-sitter extraction, OTel ingest, REST API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -24,7 +24,9 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
-    }
+    },
+    "./dist/cli.cjs": "./dist/cli.cjs",
+    "./dist/neatd.cjs": "./dist/neatd.cjs"
   },
   "bin": {
     "neat": "./dist/cli.cjs",
@@ -48,7 +50,7 @@
     "@fastify/cors": "^10.0.0",
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
-    "@neat.is/types": "^0.2.6",
+    "@neat.is/types": "^0.2.7",
     "chokidar": "^4.0.3",
     "fastify": "^5.0.0",
     "graphology": "^0.25.4",

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -3184,3 +3184,123 @@ describe('Frontend-facing API contract (ADR-051)', () => {
   it.todo('event bus is a single EventEmitter singleton in packages/core/src/events.ts (ADR-051 — authority)')
   it.todo('event producers in ingest.ts / extract/ / watch.ts / policy.ts emit through the bus, not directly to handlers (ADR-051 — authority)')
 })
+
+describe('Publish system contract (ADR-052)', () => {
+  // The publish pipeline. Five packages ship in lockstep; bin wrappers in
+  // the umbrella `require()` subpaths into core and mcp that must be
+  // exposed in those packages' `exports` field. The 0.2.6 release shipped
+  // with broken exports — the wrappers worked under monorepo symlinks
+  // (which bypass exports enforcement) but failed for `npm install -g`
+  // users. This block locks the failure shape so it can't recur.
+
+  const REPO_ROOT = join(__dirname, '../../../..')
+  const PUBLISHABLE_PACKAGES = ['types', 'core', 'mcp', 'claude-skill', 'neat.is'] as const
+
+  function readPackageJson(pkgDirName: string): Record<string, unknown> {
+    return JSON.parse(
+      readFileSync(join(REPO_ROOT, 'packages', pkgDirName, 'package.json'), 'utf8'),
+    ) as Record<string, unknown>
+  }
+
+  it('all five publishable packages share the same version (ADR-052 #2 — lockstep)', () => {
+    const versions = PUBLISHABLE_PACKAGES.map((p) => readPackageJson(p).version as string)
+    const unique = [...new Set(versions)]
+    expect(unique).toHaveLength(1)
+  })
+
+  it('cross-package dep ranges match the lockstep version (ADR-052 #2 — lockstep)', () => {
+    const version = readPackageJson('types').version as string
+
+    const core = readPackageJson('core') as { dependencies: Record<string, string> }
+    expect(core.dependencies['@neat.is/types']).toBe(`^${version}`)
+
+    const mcp = readPackageJson('mcp') as { dependencies: Record<string, string> }
+    expect(mcp.dependencies['@neat.is/types']).toBe(`^${version}`)
+
+    const umbrella = readPackageJson('neat.is') as { dependencies: Record<string, string> }
+    expect(umbrella.dependencies['@neat.is/core']).toBe(`^${version}`)
+    expect(umbrella.dependencies['@neat.is/mcp']).toBe(`^${version}`)
+    expect(umbrella.dependencies['@neat.is/claude-skill']).toBe(`^${version}`)
+  })
+
+  it('every publishable package declares engines.node: ">=20" (ADR-052 #8)', () => {
+    for (const pkg of PUBLISHABLE_PACKAGES) {
+      const json = readPackageJson(pkg) as { engines?: { node?: string } }
+      expect(json.engines?.node, `${pkg} missing engines.node`).toBe('>=20')
+    }
+  })
+
+  it('publish workflow encodes the canonical dependency order (ADR-052 #4)', () => {
+    const yml = readFileSync(join(REPO_ROOT, '.github/workflows/publish.yml'), 'utf8')
+    // Workflow lists `publish_one "packages/<name>"` once per package.
+    // The first occurrence of each marks its position; assert they appear
+    // in canonical order.
+    const positions = PUBLISHABLE_PACKAGES.map((pkg) => {
+      const idx = yml.indexOf(`publish_one "packages/${pkg}"`)
+      expect(idx, `${pkg} not referenced in publish.yml`).toBeGreaterThan(-1)
+      return idx
+    })
+    const sorted = [...positions].sort((a, b) => a - b)
+    expect(positions).toEqual(sorted)
+  })
+
+  it('local publish script encodes the canonical dependency order (ADR-052 #4)', () => {
+    const sh = readFileSync(join(REPO_ROOT, 'scripts/publish.sh'), 'utf8')
+    // Same shape as the workflow check — assert positions appear in order.
+    const positions = PUBLISHABLE_PACKAGES.map((pkg) => {
+      const idx = sh.indexOf(`"packages/${pkg}"`)
+      expect(idx, `${pkg} not referenced in scripts/publish.sh`).toBeGreaterThan(-1)
+      return idx
+    })
+    const sorted = [...positions].sort((a, b) => a - b)
+    expect(positions).toEqual(sorted)
+  })
+
+  it('every require() in packages/neat.is/bin/* resolves to a path exposed in the target package exports (ADR-052 #1)', () => {
+    // Parses each wrapper, extracts the `require('@scope/pkg/subpath')`
+    // target, walks the target package's `exports` field, and asserts
+    // the subpath is a literal exports key. Wildcard pattern matching
+    // is a successor concern. Catches the 0.2.6-class failure where
+    // wrappers worked under monorepo symlinks but failed for
+    // `npm install -g neat.is` users because exports enforcement only
+    // kicks in for tarball installs.
+    const binDir = join(REPO_ROOT, 'packages/neat.is/bin')
+    const wrappers = readdirSync(binDir).filter(
+      (f) => !f.startsWith('.') && statSync(join(binDir, f)).isFile(),
+    )
+    expect(wrappers.length, 'no wrapper scripts found').toBeGreaterThan(0)
+
+    const requireRe = /require\(\s*['"]([^'"]+)['"]\s*\)/g
+    const scopedRe = /^(@[^/]+\/[^/]+)\/(.+)$/
+
+    for (const wrapper of wrappers) {
+      const content = readFileSync(join(binDir, wrapper), 'utf8')
+      const matches = [...content.matchAll(requireRe)]
+      expect(matches.length, `${wrapper} has no require() call`).toBeGreaterThan(0)
+
+      for (const m of matches) {
+        const target = m[1] as string
+        const parsed = scopedRe.exec(target)
+        if (!parsed) continue // bare specifier like 'fs' — not what this rule covers
+
+        const [, pkgName, subpath] = parsed as unknown as [string, string, string]
+        const pkgDirName = pkgName.replace('@neat.is/', '')
+        const pkg = readPackageJson(pkgDirName) as { exports?: Record<string, unknown> }
+        const exports = pkg.exports ?? {}
+        const subpathKey = `./${subpath}`
+
+        expect(
+          Object.keys(exports),
+          `${wrapper} requires ${target} but ${pkgName} exports ${subpathKey} not exposed`,
+        ).toContain(subpathKey)
+      }
+    }
+  })
+
+  // The tarball smoke-test step in the publish workflow doesn't exist yet.
+
+  // The tarball smoke-test step in the publish workflow doesn't exist yet.
+  it.todo(
+    'publish workflow installs the just-published umbrella tarball and asserts `neat --help` exits 0 (ADR-052 #3)',
+  )
+})

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/mcp",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "NEAT MCP server: exposes graph queries to AI agents over stdio",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -24,7 +24,8 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
-    }
+    },
+    "./dist/index.cjs": "./dist/index.cjs"
   },
   "bin": {
     "neat-mcp": "./dist/index.cjs"
@@ -41,7 +42,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@neat.is/types": "^0.2.6",
+    "@neat.is/types": "^0.2.7",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/neat.is/package.json
+++ b/packages/neat.is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neat.is",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "NEAT — live semantic graph of a software system, queryable from AI agents over MCP. Install once, get the neat / neatd / neat-mcp CLIs.",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -22,8 +22,8 @@
   },
   "files": ["bin", "README.md"],
   "dependencies": {
-    "@neat.is/core": "^0.2.6",
-    "@neat.is/mcp": "^0.2.6",
-    "@neat.is/claude-skill": "^0.2.6"
+    "@neat.is/core": "^0.2.7",
+    "@neat.is/mcp": "^0.2.7",
+    "@neat.is/claude-skill": "^0.2.7"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/types",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Shared Zod schemas, types, and runtime constants for NEAT",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",


### PR DESCRIPTION
## Summary

Combined PR carrying both the 0.2.7 fix-only release for the broken 0.2.6 publish AND the new publish-system contract that locks the failure shape so it can't recur.

Two commits on this branch:

1. **`0.2.7 — fix umbrella bin wrappers`** — by the publisher agent. Adds the dist subpaths to `exports` in `@neat.is/core` and `@neat.is/mcp` so the umbrella's bin wrappers resolve under tarball installs (they did not under 0.2.6 — `npm install -g neat.is` users hit `ERR_PACKAGE_PATH_NOT_EXPORTED` on `neat init`). Bumps all five packages 0.2.6 → 0.2.7. Verified locally by packing all five tarballs and running `neat --help` from a clean tmp install.
2. **`ADR-052 regression tests + milestones.md drift cleanup`** — six live contract assertions encoding the publish-system rules, plus drift fixes from the audit pass.

## What ADR-052 covers

The publish pipeline has been load-bearing since 0.2.5 but had zero contract coverage, which is exactly how 0.2.6 shipped broken. ADR-052 + `docs/contracts/publish-system.md` codify:

- Bin-wrapper subpath validity against dependency `exports` fields
- Version lockstep across the five publishable packages
- Tarball smoke-test gate (still queued — workflow step pending)
- Dependency order (`types → core → mcp → claude-skill → neat.is`)
- npm immutability — published versions can't be re-minted; broken releases force a patch bump
- `engines.node: ">=20"` everywhere

Six live regression assertions, one `it.todo` for the tarball smoke-test step.

## Drift fixes from the audit

- `docs/milestones.md` "Last session ended" was 2026-05-05; updated to 2026-05-09 with the v0.2.x summary current to the 0.2.7 publish.
- `docs/milestones.md` had a section labeled "v0.2.0 — Frontend" that actually described the v0.3.0 frontend track (issues #28-31 + #106-108). Corrected.

## Out of scope (audit-flagged but deferred)

- `packages/web/package.json` is at 0.2.0 while everything else is 0.2.7. Web is private and never published, so it's not under the lockstep contract. Bumping for consistency is reasonable but not load-bearing. Recommend folding into a future cleanup pass.

## Test plan

- [x] `npx turbo build` clean
- [x] `npx vitest run test/audits/contracts.test.ts` — 131 pass, 38 todo, 0 fail
- [x] All six new ADR-052 assertions pass against the 0.2.7 exports fix
- [x] `npm whoami` + dry-run via `gh workflow run "Publish" -f dry_run=true` passes
- [ ] Post-merge: tag `v0.2.7` and push; CI publishes
- [ ] Smoke test: clean shell `npm install -g neat.is@0.2.7 && neat --help` exits 0

## Release notes draft (for the GitHub Release after publish)

```
v0.2.7 — fix-only patch

The 0.2.6 publish shipped umbrella bin wrappers that require()'d into
@neat.is/core and @neat.is/mcp via dist/ subpaths, but those packages'
`exports` fields didn't expose them. Worked under monorepo dev (workspace
symlinks bypass exports enforcement); failed for `npm install -g neat.is`
users with ERR_PACKAGE_PATH_NOT_EXPORTED.

0.2.7 fixes the exports field. The 0.2.6 slot is permanently retired on
the npm registry per npm policy. Anyone who installed 0.2.6 should
upgrade to 0.2.7.

Plus ADR-052 (publish system contract) lands the regression tests that
catch this failure shape mechanically going forward.
```

Refs #197