### PR TITLE
ADR-052 #3 — tarball smoke-test gate in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,3 +104,26 @@ jobs:
           else
             echo "Publish complete."
           fi
+
+      - name: Smoke-test the published umbrella tarball
+        if: env.DRY_RUN != 'true'
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./packages/neat.is/package.json').version")
+          echo "Smoke-testing neat.is@${version} from the registry"
+
+          # The registry can be a few seconds behind the publish — retry until
+          # the just-published version is visible, then fail loudly if it never
+          # appears.
+          for i in 1 2 3 4 5; do
+            if npm view "neat.is@${version}" version > /dev/null 2>&1; then break; fi
+            echo "  not yet visible, retrying ($i/5)"
+            sleep 3
+          done
+
+          tmp=$(mktemp -d)
+          cd "$tmp"
+          npm init -y > /dev/null
+          npm install "neat.is@${version}"
+          ./node_modules/.bin/neat --help > /dev/null
+          echo "Smoke test passed — neat --help exited 0 against the published tarball."

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -3297,10 +3297,13 @@ describe('Publish system contract (ADR-052)', () => {
     }
   })
 
-  // The tarball smoke-test step in the publish workflow doesn't exist yet.
-
-  // The tarball smoke-test step in the publish workflow doesn't exist yet.
-  it.todo(
-    'publish workflow installs the just-published umbrella tarball and asserts `neat --help` exits 0 (ADR-052 #3)',
-  )
+  it('publish workflow installs the just-published umbrella tarball and asserts `neat --help` exits 0 (ADR-052 #3)', () => {
+    const yml = readFileSync(join(REPO_ROOT, '.github/workflows/publish.yml'), 'utf8')
+    // Smoke-test step must install the umbrella from the registry and invoke
+    // its bin. Both signals together — installing the tarball and running
+    // `neat --help` — are what make the step a smoke test rather than a
+    // version-existence check.
+    expect(yml).toMatch(/npm install ["']?neat\.is@/)
+    expect(yml).toMatch(/neat --help/)
+  })
 })


### PR DESCRIPTION
## Summary

- After the publish loop succeeds, install `neat.is@<just-published-version>` into a tmp dir from the registry and run `neat --help`. Exit non-zero on failure, skipped on dry-run.
- Catches anything that only surfaces under a real tarball install — the 0.2.6 exports/subpath class, missing dist files, broken shebangs — 30 seconds after CI finishes instead of waiting for someone to hit it via `npm install -g`.
- Flips the last `it.todo` in the publish-system contract test block (ADR-052 #3) to a live assertion that greps `publish.yml` for both the install line and the `neat --help` invocation.

## Test plan

- [ ] CI green on this PR (build + test + lint pass on the branch as a normal `push`-on-PR check)
- [ ] After merge + next tag push, watch the publish run and confirm the new "Smoke-test the published umbrella tarball" step fires after the publish loop, retries cleanly if registry visibility is delayed, and reports "Smoke test passed"
- [ ] Optional sanity: trigger `workflow_dispatch` with `dry_run=true` and confirm the smoke-test step is skipped (the publish loop's dry-run path runs but nothing hits the registry, so skipping is correct)

Refs #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)