### PR TITLE
Rename milestone v0.2.6 → v0.2.8 + ADR-053 milestone-naming convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,9 +64,11 @@ v0.2.2 closed on 2026-05-06 — see `docs/plans/2026-05-06-v0.2.2-close.md` for 
 
 v0.2.5 closed on 2026-05-07 — see `docs/plans/2026-05-07-v0.2.5-close.md` for the closing snapshot. Six implementation PRs landed in sequence (#185 registry, #186 init mechanics, #187 Node installer, #188 Python installer, #189 daemon, #190 Claude Code skill). Contract scoreboard: 28 / 28 v0.2.5 assertions live in `contracts.test.ts` (25 ADR-046/047/048/049 + 3 Claude-skill packaging). The four remaining `it.todo`s are v0.2.1 cleanup (#141, #142, #145), rolled forward to v0.3.0 prep.
 
-**v0.2.6 — CLI parity + frontend-API surface.** Opens with contracts #23-#24 (CLI surface, frontend-facing API). Ships CLI verbs that mirror the nine MCP tools (so a human at a terminal has the same reach as an agent), plus the API surface a local frontend needs — SSE / WebSocket live-updates, multi-project switcher endpoints, anything else surfaced as v0.3.0 prep work. The `(if that's needed)` qualifier is honest: parts of this milestone wait until Jed's frontend track surfaces concrete API gaps.
+**v0.2.8 — CLI parity + frontend-API surface.** Opens with contracts #23-#24 (CLI surface, frontend-facing API). Ships CLI verbs that mirror the nine MCP tools (so a human at a terminal has the same reach as an agent), plus the API surface a local frontend needs — SSE live-updates, multi-project switcher endpoints, anything else surfaced as v0.3.0 prep work. The `(if that's needed)` qualifier is honest: parts of this milestone wait until Jed's frontend track surfaces concrete API gaps.
 
-After v0.2.6: the MVP-success PR experiment (ADR-027) — point NEAT at an open-source codebase. Self-hosting on the NEAT codebase activates only after that PR closes.
+This milestone was originally named v0.2.6 when its contract batch (ADRs 050/051) opened on 2026-05-08, projecting that 0.2.6 would be the npm version when implementation shipped. Two publish-fix releases (0.2.5 → 0.2.6 → 0.2.7, both retired npm slots) consumed those numbers, so the milestone rolls forward to v0.2.8 per ADR-053. ADRs and contracts retain their original numbers; only the milestone label changed.
+
+After v0.2.8: the MVP-success PR experiment (ADR-027) — point NEAT at an open-source codebase. Self-hosting on the NEAT codebase activates only after that PR closes.
 
 ### Track 1 — v0.3.0 Frontend (Jed)
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -32,13 +32,13 @@ This file is the index. Each rule has a short summary and a link to its full per
 | 20 | SDK install | [`contracts/sdk-install.md`](./contracts/sdk-install.md) | Per-language installer modules (Node + Python in MVP). Plan/apply decoupled. Manifests touched, lockfiles never (ADR-047) | ✅ landed (v0.2.5 opens) |
 | 21 | Machine-level project registry | [`contracts/project-registry.md`](./contracts/project-registry.md) | `~/.neat/projects.json` per-user, atomic writes via tmp+rename, flock during writes, path-normalized (ADR-048) | ✅ landed (v0.2.5 opens) |
 | 22 | Daemon | [`contracts/daemon.md`](./contracts/daemon.md) | Single long-lived process, per-project graph isolation, mtime + OTel + policy.json triggers, graceful per-project failure (ADR-049) | ✅ landed (v0.2.5 opens) |
-| 23 | CLI surface | [`contracts/cli-surface.md`](./contracts/cli-surface.md) | Nine `neat <verb>` commands mirroring MCP tools, REST-only data path, `--json` output, exit-code branching (ADR-050) | ✅ landed (v0.2.6 opens) |
-| 24 | Frontend-facing API | [`contracts/frontend-api.md`](./contracts/frontend-api.md) | SSE stream at `/events` with locked 8-type taxonomy, multi-project switcher at `/projects`, WebSocket and per-event filtering deferred (ADR-051) | ✅ landed (v0.2.6 opens) |
+| 23 | CLI surface | [`contracts/cli-surface.md`](./contracts/cli-surface.md) | Nine `neat <verb>` commands mirroring MCP tools, REST-only data path, `--json` output, exit-code branching (ADR-050) | ✅ landed (v0.2.8 opens) |
+| 24 | Frontend-facing API | [`contracts/frontend-api.md`](./contracts/frontend-api.md) | SSE stream at `/events` with locked 8-type taxonomy, multi-project switcher at `/projects`, WebSocket and per-event filtering deferred (ADR-051) | ✅ landed (v0.2.8 opens) |
 | 25 | Publish system | [`contracts/publish-system.md`](./contracts/publish-system.md) | Bin-wrapper subpath validity against dependency `exports`, version lockstep across five packages, tarball smoke-test gate, dependency order, npm immutability acknowledged (ADR-052) | ✅ landed (post-0.2.6 broken-publish) |
 
 ### Future contracts — opened at the start of each milestone
 
-_None queued. v0.2.6 is the last milestone in the v0.2.x sequence. Successor contracts (WebSocket transport, per-event filtering, additional language SDK installers, MVP-success-PR experiment) open as their gating work surfaces._
+_None queued. v0.2.8 is the last milestone in the v0.2.x sequence. Successor contracts (WebSocket transport, per-event filtering, additional language SDK installers, MVP-success-PR experiment) open as their gating work surfaces._
 
 The full reasoning and per-milestone sequencing live in `docs/plans/2026-05-04-v0.2.x-sequencing.md`. The current state of the active milestone lives in `docs/plans/<latest-date>-v0.2.x-status.md`.
 

--- a/docs/contracts/cli-surface.md
+++ b/docs/contracts/cli-surface.md
@@ -10,7 +10,7 @@ adr: [ADR-050, ADR-039, ADR-026]
 
 # CLI surface contract
 
-The first of two v0.2.6 contracts. Sibling: [`frontend-api.md`](./frontend-api.md).
+The first of two v0.2.8 contracts. Sibling: [`frontend-api.md`](./frontend-api.md).
 
 Closes the terminal-vs-agent gap. Today every reach into the graph goes through MCP. Engineers debugging at a terminal need the same nine tools without a Claude wrapper.
 
@@ -89,6 +89,6 @@ Each verb's `--help` lists args, flags, exit codes, and one example invocation. 
 
 ## Enforcement
 
-`it.todo` for v0.2.6 #23. Regression tests cover: nine verbs registered, REST-only data path, exit-code branching, `--json` shape matches the three-part schema, `--project` propagation matches ADR-026.
+`it.todo` for v0.2.8 #23. Regression tests cover: nine verbs registered, REST-only data path, exit-code branching, `--json` shape matches the three-part schema, `--project` propagation matches ADR-026.
 
 Full rationale: [ADR-050](../decisions.md#adr-050--cli-surface-contract).

--- a/docs/contracts/frontend-api.md
+++ b/docs/contracts/frontend-api.md
@@ -14,7 +14,7 @@ adr: [ADR-051, ADR-040, ADR-026, ADR-048]
 
 # Frontend-facing API contract
 
-The second of two v0.2.6 contracts. Sibling: [`cli-surface.md`](./cli-surface.md).
+The second of two v0.2.8 contracts. Sibling: [`cli-surface.md`](./cli-surface.md).
 
 The existing REST surface (ADR-040) is request-response — fine for initial render, insufficient for live views. Jed's v0.3.0 frontend track needs two things the existing surface doesn't cover: live update streaming, multi-project enumeration. WebSocket-style symmetric subscription is plausibly needed but not surfaced yet.
 
@@ -99,6 +99,6 @@ The default-project mount streams every event for the default graph; the `/proje
 
 ## Enforcement
 
-`it.todo` for v0.2.6 #24. Regression tests cover: `/events` endpoint with `text/event-stream` content-type, dual-mount per ADR-026, event-type taxonomy locked (eight types), `/projects` endpoint shape, heartbeat interval, backpressure cap.
+`it.todo` for v0.2.8 #24. Regression tests cover: `/events` endpoint with `text/event-stream` content-type, dual-mount per ADR-026, event-type taxonomy locked (eight types), `/projects` endpoint shape, heartbeat interval, backpressure cap.
 
 Full rationale: [ADR-051](../decisions.md#adr-051--frontend-facing-api-contract).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1338,7 +1338,7 @@ Governs the long-lived `neatd` process. Sibling contracts: ADR-046, ADR-047, ADR
 **Date:** 2026-05-08
 **Status:** Active.
 
-Opens v0.2.6. First of two milestone contracts. Sibling: ADR-051.
+Opens v0.2.8 (contract drafted under the milestone's original v0.2.6 name; renamed per ADR-053 after publish-fix releases consumed those version slots — the contract content is unchanged). First of two milestone contracts. Sibling: ADR-051.
 
 **Context.** Today every reach into the graph goes through MCP — fine for Claude Code, awkward for a human at a terminal who wants to ask "what does `get_root_cause` return for `service:checkout`?" The terminal-vs-agent gap is real: an engineer debugging needs the same nine tools the agent has, without the Claude wrapper. The existing `neat` CLI handles lifecycle (`init`, `watch`, `list`, `pause`, `resume`, `uninstall`, `skill`) but exposes no graph queries.
 
@@ -1379,14 +1379,14 @@ Opens v0.2.6. First of two milestone contracts. Sibling: ADR-051.
 
 **Authority.** `packages/core/src/cli.ts` (extends existing parser) or a new `packages/core/src/cli-verbs.ts` if the surface gets large. Implementation choice left to the implementing agent. The REST client lives at `packages/core/src/cli-client.ts` (or similar) and is shared with `packages/mcp/src/client.ts`.
 
-**Enforcement.** `it.todo` block in `contracts.test.ts` for v0.2.6 #23. Regression tests cover: nine verbs registered, REST-only data path (no `graph.json` reads from CLI), exit-code branching, `--json` shape, `--project` propagation.
+**Enforcement.** `it.todo` block in `contracts.test.ts` for v0.2.8 #23. Regression tests cover: nine verbs registered, REST-only data path (no `graph.json` reads from CLI), exit-code branching, `--json` shape, `--project` propagation.
 
 ## ADR-051 — Frontend-facing API contract
 
 **Date:** 2026-05-08
 **Status:** Active. Speculative — sections marked **(deferred)** wait for v0.3.0 to surface concrete asks.
 
-Opens v0.2.6. Second of two milestone contracts. Sibling: ADR-050.
+Opens v0.2.8 (contract drafted under the milestone's original v0.2.6 name; renamed per ADR-053 after publish-fix releases consumed those version slots — the contract content is unchanged). Second of two milestone contracts. Sibling: ADR-050.
 
 **Context.** Jed's v0.3.0 frontend track builds against the v0.1.2-stable API. The existing REST surface (`/graph`, `/graph/node/:id`, etc., all dual-mounted per ADR-026) is request-response — fine for initial render, insufficient for live views. Two gaps known today: live update streaming, multi-project enumeration. WebSocket-style symmetric subscription is plausibly needed but not surfaced yet.
 
@@ -1425,7 +1425,7 @@ The `(if needed)` qualifier in the kickoff applies. We draft what's clear and ex
 
 **Authority.** `packages/core/src/api.ts` (extend) for `/projects`. SSE endpoint in `packages/core/src/api.ts` or a new `packages/core/src/streaming.ts` if the surface grows. Event emission threaded through `ingest.ts`, `extract/index.ts`, `watch.ts`, `policy.ts` via a small `EventEmitter` singleton in `packages/core/src/events.ts`.
 
-**Enforcement.** `it.todo` block in `contracts.test.ts` for v0.2.6 #24. Regression tests cover: `/events` endpoint exists with `text/event-stream` content-type, dual-mount per ADR-026, event-type taxonomy locked (eight types, no quiet additions), `/projects` endpoint exists and returns the registry shape, heartbeat interval set, backpressure cap honored.
+**Enforcement.** `it.todo` block in `contracts.test.ts` for v0.2.8 #24. Regression tests cover: `/events` endpoint exists with `text/event-stream` content-type, dual-mount per ADR-026, event-type taxonomy locked (eight types, no quiet additions), `/projects` endpoint exists and returns the registry shape, heartbeat interval set, backpressure cap honored.
 
 ## ADR-052 — Publish system contract
 
@@ -1450,3 +1450,26 @@ Documents the load-bearing rules of the npm publish pipeline. The pipeline has b
 **Authority.** `.github/workflows/publish.yml` (CI publish), `scripts/publish.sh` (local fallback), `docs/runbook-publish.md` (process), `packages/neat.is/bin/{neat,neatd,neat-mcp}` (the wrappers under contract), `packages/core/package.json` and `packages/mcp/package.json` (the `exports` fields the wrappers reach through).
 
 **Enforcement.** New describe block in `contracts.test.ts`. Live assertions for rules 2 (version lockstep), 4 (dependency order encoded in scripts), 8 (engines field). Rule 1 (subpath validity) ships as live but depends on the 0.2.7 exports fix being on `main` first; until then, the assertion would fail because main reflects the broken 0.2.6 state. Rule 3 (tarball smoke-test) is an `it.todo` until the workflow step lands. Rules 5, 6, 7 are documented invariants without test mechanization (5 is exercised by every re-run of the workflow; 6 and 7 are policy, not verifiable in CI).
+
+## ADR-053 — Milestone naming convention
+
+**Date:** 2026-05-09
+**Status:** Active.
+
+**Context.** Until now NEAT milestones have been named after the npm version they're projected to ship under (`v0.2.0 — Sunrise`, `v0.2.1 — Tree-sitter rebuild`, etc.). This worked because every milestone shipped exactly one npm version, with no publish-fix releases intervening. The 0.2.6 broken-publish saga broke that assumption: between the v0.2.6 milestone opening (2026-05-08) and any implementation work, two publish-fix releases (`0.2.6` retired, `0.2.7` shipped) consumed the version slot the milestone name implied. Calling the unshipped milestone "v0.2.6" while the next npm publish would actually be `0.2.8` created persistent terminology drift across CLAUDE.md, contracts.md, the kickoff doc, ADR-050/051, and the contracts test suite.
+
+**Decision.**
+
+1. **Milestone name = projected next npm version at kickoff time.** Same convention as before.
+2. **If publish-fix releases consume the projected version before the milestone implementation ships, the milestone name updates to match the new projected version.** Rolling forward, not staying anchored. The rename is mechanical: every forward-looking reference (CLAUDE.md "Where you are in the build", contracts.md status fields, ADR "Opens v0.X.Y" lines, kickoff doc filenames, contracts.test.ts comment headers) updates in one PR. Historical references (commit messages, closed status docs, PR descriptions, retired npm versions) stay as they were — those reflect the world as it was at the time, and rewriting them would be revisionism.
+3. **ADR and contract numbers do not change.** ADR-050 stays ADR-050 even if the milestone it opens is renamed v0.2.6 → v0.2.8. Contract numbering is independent of milestone naming. Same for `it.todo` issue references in contracts.test.ts — those are tracker issue numbers, not milestone version numbers.
+4. **The rename is documented in a status doc.** `docs/plans/<date>-milestone-rename.md` captures what changed and why, so the trail back to the original name stays discoverable.
+5. **Old kickoff docs get a deprecation header.** `docs/plans/<old-date>-v0.X.Y-kickoff.md` gets a one-block redirect to the new kickoff at the top, preserving the body as historical record.
+
+**Why not decouple milestone names from version numbers entirely?** Considered. Descriptive milestone names (`M-CLI-API`, `M-Frontend-Surface`) would prevent any version-name drift forever, but they also break the existing v0.X.Y → version → npm convention NEAT has used since v0.1.0, and they require updating every status doc and runbook reference at once. The roll-forward rule preserves the existing convention while handling the rare case where it slips. If milestone-version drift recurs more than twice in v0.3.x or beyond, revisit.
+
+**Authority.** Process rule, no code authority. Enforced by the rename PR pattern when drift is detected.
+
+**Enforcement.** No mechanized test. Detected by reading: if `CLAUDE.md`'s active-milestone block names a version that's already on the npm registry as a retired or current published version, the milestone needs to be rolled forward.
+
+**First application.** v0.2.6 → v0.2.8 milestone rename, 2026-05-09, see `docs/plans/2026-05-09-milestone-rename.md`.

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -12,9 +12,9 @@ Source of truth for sprint status. Update this file at the end of every session.
 
 ## 🚩 Pick up here
 
-**Last session ended:** 2026-05-09. v0.2.0 through v0.2.5 milestones closed and tagged. v0.2.6 contracts (ADRs 050/051 — CLI surface + frontend-facing API) landed on `main`; implementation is queued. The publish system contract (ADR-052) landed alongside the npm pipeline rebuild. npm packages at 0.2.6 on the registry — a broken `exports` field shipped, 0.2.7 fix-only patch in flight.
+**Last session ended:** 2026-05-09. v0.2.0 through v0.2.5 milestones closed and tagged. v0.2.8 contracts (ADRs 050/051 — CLI surface + frontend-facing API) landed on `main`; implementation is queued. The publish system contract (ADR-052) landed alongside the npm pipeline rebuild, and ADR-053 codifies the milestone-naming rule that produced the v0.2.6 → v0.2.8 rename. npm packages at 0.2.7 on the registry; the 0.2.5 and 0.2.6 slots are permanently retired (broken publishes that forced patch bumps per npm policy).
 
-**For current operational state of the active milestone, read `docs/plans/2026-05-07-v0.2.6-kickoff.md` first.** That doc is the canonical handoff; this file describes the long-term shape.
+**For current operational state of the active milestone, read `docs/plans/2026-05-09-v0.2.8-kickoff.md` first.** That doc is the canonical handoff; this file describes the long-term shape.
 
 **Two parallel tracks share `main`:**
 
@@ -27,9 +27,9 @@ Source of truth for sprint status. Update this file at the end of every session.
   - **v0.2.3 — Traversal rebuild.** Opens with contracts #9-#11. Ships #136-#139, #123.
   - **v0.2.4 — Policies + MCP refresh.** Opens with contracts #12-#18. Ships #115-#118, #143, #144.
   - **v0.2.5 — `neat init` + SDK install + Claude skill.** Opens with contracts #19-#22. Ships #119.
-  - **v0.2.6 — CLI parity + frontend-API surface.** Opens with contracts #23-#24. CLI verbs mirroring the nine MCP tools (so a human at a terminal has the same reach as an agent), plus whatever API surface Jed's v0.3.0 frontend track surfaces as a gap. The `(if needed)` qualifier is honest — parts of this milestone wait until v0.3.0 starts pulling on concrete demands.
+  - **v0.2.8 — CLI parity + frontend-API surface.** Opens with contracts #23-#24. CLI verbs mirroring the nine MCP tools (so a human at a terminal has the same reach as an agent), plus whatever API surface Jed's v0.3.0 frontend track surfaces as a gap. The `(if needed)` qualifier is honest — parts of this milestone wait until v0.3.0 starts pulling on concrete demands. Originally named v0.2.6; renamed per ADR-053 after two publish-fix patches consumed the 0.2.6 and 0.2.7 npm version slots.
 
-After v0.2.6: the MVP-success PR experiment (ADR-027). Self-hosting on the NEAT codebase activates only after that PR closes — until then NEAT is the target of construction, not the tool.
+After v0.2.8: the MVP-success PR experiment (ADR-027). Self-hosting on the NEAT codebase activates only after that PR closes — until then NEAT is the target of construction, not the tool.
 
 ### Active work — start here
 

--- a/docs/plans/2026-05-04-v0.2.x-sequencing.md
+++ b/docs/plans/2026-05-04-v0.2.x-sequencing.md
@@ -30,7 +30,10 @@ The architecture-first surface from the neat.is manifesto, finally buildable bec
 Distribution layer. Init owns SDK install (Node + Python first), codemod with `--apply` opt-in, machine-level `~/.neat/projects.json` registry, daemon model. Comes after the layers below it in the dependency stack are stable because init has to know what NEAT supports.
 **Output:** `neat install` + `neat init <repo>` + Claude skill. End-to-end usable on an arbitrary codebase.
 
-### v0.2.6 — CLI parity + frontend-API surface
+### v0.2.8 — CLI parity + frontend-API surface
+
+(Originally named v0.2.6 when this sequencing doc was written; renamed per ADR-053 after publish-fix releases consumed the 0.2.6 and 0.2.7 npm version slots.)
+
 The last engineering milestone before the MVP-success PR experiment. Two contracts open it:
 - **#23 CLI surface.** Nine `neat <verb>` commands mirroring the MCP tool set (root-cause, blast-radius, dependencies, observed-dependencies, incidents, search, diff, stale-edges, policies). Each calls the same REST client the MCP tools use — single source of truth. Project-scoped via `--project`. Exit codes for CI use.
 - **#24 Frontend-facing API.** API surface a local frontend needs that the existing REST + MCP set doesn't already cover — SSE / WebSocket live updates from `neatd`, multi-project switcher endpoints, anything Jed's v0.3.0 track surfaces as a real gap. The `(if needed)` qualifier is honest: parts of this contract wait for v0.3.0 to start pulling on concrete demands.

--- a/docs/plans/2026-05-07-v0.2.6-kickoff.md
+++ b/docs/plans/2026-05-07-v0.2.6-kickoff.md
@@ -1,8 +1,10 @@
 # v0.2.6 CLI parity + frontend-API surface — kickoff for the implementation agent
 
-**Last updated:** 2026-05-07
+> **⚠️ Superseded — historical record only.** This kickoff was written when the milestone was named v0.2.6, projecting that 0.2.6 would be the npm version when implementation shipped. Two publish-fix releases (v0.2.5 and v0.2.6 broken on npm, v0.2.7 latest working) consumed those slots, so the milestone rolled forward to **v0.2.8** per ADR-053. The active canonical kickoff is **[`docs/plans/2026-05-09-v0.2.8-kickoff.md`](./2026-05-09-v0.2.8-kickoff.md)** — read that instead. The body below is preserved as historical context.
 
-This is the "pick up here" doc for v0.2.6 work. Read it first. Supersedes the v0.2.5 kickoff as the active milestone tracker.
+**Last updated:** 2026-05-07 (renamed-and-superseded note added 2026-05-09)
+
+This was the "pick up here" doc for what is now v0.2.8 work. Read the new kickoff first. Supersedes the v0.2.5 kickoff as the active milestone tracker.
 
 ## Where we are
 

--- a/docs/plans/2026-05-09-milestone-rename.md
+++ b/docs/plans/2026-05-09-milestone-rename.md
@@ -1,0 +1,63 @@
+# Milestone rename — v0.2.6 → v0.2.8
+
+**Date:** 2026-05-09
+**ADR:** [ADR-053 — Milestone naming convention](../decisions.md#adr-053--milestone-naming-convention)
+
+## What happened
+
+The milestone whose contract batch is ADRs 050/051 (CLI parity + frontend-API surface, contracts #23/#24) was originally named **v0.2.6**, projecting that 0.2.6 would be the npm version when its implementation shipped. Two publish-fix releases consumed the projected version:
+
+- **0.2.5** broken — umbrella shipped without a `bin` field, so `npm install -g neat.is` didn't put binaries on PATH. Fixed by 0.2.6.
+- **0.2.6** broken — umbrella's bin wrappers `require()`ed dist subpaths that `@neat.is/core` and `@neat.is/mcp` didn't expose in their `exports` field. Fixed by 0.2.7.
+- **0.2.7** working. Latest published.
+
+Both broken slots are permanently sealed on the npm registry per [npm's unpublish policy](https://docs.npmjs.com/policies/unpublish). The milestone, when its implementation ships, will publish as **0.2.8** — diverging from the milestone name by two patch versions.
+
+ADR-053 codified the rule: when publish-fix releases consume the projected version before milestone implementation ships, the milestone name rolls forward to match the new projected version. This PR is the first application.
+
+## What was renamed
+
+Forward-looking references only. Historical references (commits, retired npm versions, closed status docs, PR descriptions) stay as they were — those reflect the world at the time and rewriting them would be revisionism.
+
+| File | Change |
+|------|--------|
+| `CLAUDE.md` | "Where you are in the build" Track 2 block — `v0.2.6` → `v0.2.8`, plus a one-paragraph note explaining the rename |
+| `docs/contracts.md` | Status fields on rows 23 / 24 — "v0.2.6 opens" → "v0.2.8 opens"; future-contracts footer updated |
+| `docs/decisions.md` | ADR-050 and ADR-051 "Opens v0.2.6" lines → "Opens v0.2.8" with rename note; their `it.todo` enforcement references — `v0.2.6 #23` / `v0.2.6 #24` → `v0.2.8 #23` / `v0.2.8 #24` |
+| `docs/contracts/cli-surface.md` | Body and enforcement section — `v0.2.6` → `v0.2.8` |
+| `docs/contracts/frontend-api.md` | Same shape |
+| `docs/milestones.md` | "Last session ended" block, Track 2 milestone list, "After v0.2.6" line — all updated; rename note added |
+| `docs/plans/2026-05-04-v0.2.x-sequencing.md` | Section heading `### v0.2.6 — CLI parity...` → `### v0.2.8 — CLI parity...` with rename note |
+| `docs/plans/2026-05-07-v0.2.6-kickoff.md` | Deprecation header at top redirecting to the new kickoff. File otherwise preserved as historical record. |
+| `packages/core/test/audits/contracts.test.ts` | Comment headers in CLI surface and frontend-API describe blocks — `v0.2.6 #23` / `v0.2.6 #24` → `v0.2.8 #23` / `v0.2.8 #24` |
+
+## What was NOT renamed
+
+These references are historical fact and should not change:
+
+- **`docs/decisions.md` ADR-052** body — references "0.2.6 broken-publish bug", "0.2.6 class failure", etc. These are real npm version refs to the broken release.
+- **`docs/contracts/publish-system.md`** — same shape; refers to the 0.2.6 broken publish as historical context.
+- **`docs/plans/2026-05-07-v0.2.5-close.md`** — written when the milestone was still named v0.2.6; preserves that historical state.
+- **`docs/plans/2026-05-07-v0.2.5-kickoff.md`** — same.
+- **`docs/plans/2026-05-07-v0.2.6-kickoff.md`** body — preserved as the historical kickoff under its original name; only the header gets a redirect note.
+- **Commit messages** in `git log` — historical record. Future commits can reference v0.2.8.
+- **Retired npm versions** (`0.2.5`, `0.2.6`) — those literal version numbers stay correct.
+
+## What was added
+
+- **ADR-053 — Milestone naming convention** — codifies the roll-forward rule.
+- **`docs/plans/2026-05-09-v0.2.8-kickoff.md`** — canonical kickoff doc for the (renamed) milestone.
+- **This file** — historical record of the rename itself.
+
+## What didn't change
+
+- **ADR numbers** — ADR-050, ADR-051, ADR-052 keep their numbers regardless of the milestone name.
+- **Contract numbers** — contracts #23, #24, #25 keep their numbers.
+- **Issue references** — `it.todo` annotations like `(ADR-050 #1)` stay; tracker issue numbers are independent of milestone naming.
+- **Implementation queue** — contracts already drafted, regression tests already in place. The rename is purely cosmetic to documentation; no code or test changes that affect behavior.
+
+## Verification
+
+- `npx turbo build test lint` — green
+- `vitest run test/audits/contracts.test.ts` — 132 live, 37 todo, 0 fail (unchanged from pre-rename state)
+- `grep -rn "v0\.2\.6" docs/ CLAUDE.md packages/core/test/audits/contracts.test.ts` — only historical references remain (npm 0.2.6 retired version, deprecation header on old kickoff, the rename docs themselves)

--- a/docs/plans/2026-05-09-v0.2.8-kickoff.md
+++ b/docs/plans/2026-05-09-v0.2.8-kickoff.md
@@ -1,0 +1,104 @@
+# v0.2.8 — CLI parity + frontend-API surface — kickoff for the implementation agent
+
+**Last updated:** 2026-05-09
+
+This is the canonical "pick up here" doc for v0.2.8 work. Read it first. Supersedes the v0.2.5 close doc and the now-historical v0.2.6 kickoff (`docs/plans/2026-05-07-v0.2.6-kickoff.md`).
+
+## A note on the milestone name
+
+This milestone was originally named `v0.2.6` when its contract batch (ADRs 050/051, contracts #23/#24) opened on 2026-05-08, projecting that 0.2.6 would be the npm version when the implementation shipped. Two publish-fix releases consumed the 0.2.6 and 0.2.7 npm version slots before any implementation landed, so the milestone rolls forward to **v0.2.8** per [ADR-053](../decisions.md#adr-053--milestone-naming-convention). The contract content is unchanged — ADR-050, ADR-051, and contracts #23/#24 keep their numbers. Only the milestone label moved.
+
+## Where we are
+
+- **v0.2.0 — Sunrise** — closed, tagged [`v0.2.0`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.0).
+- **v0.2.1 — Tree-sitter rebuild** — closed, tagged [`v0.2.1`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.1).
+- **v0.2.2 — OTel ingest rebuild** — closed, tagged [`v0.2.2`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.2).
+- **v0.2.3 — Traversal rebuild** — closed, tagged [`v0.2.3`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.3).
+- **v0.2.4 — Policies + MCP refresh** — closed on `main`; six implementation PRs (#175 / #177 / #178 / #179 / #180 / #181 / #182) shipped.
+- **v0.2.5 — Distribution layer** — closed, tagged [`v0.2.5`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.5). Six implementation PRs (#185-#190).
+- **npm 0.2.5, 0.2.6** — retired (broken publishes, permanently sealed by npm).
+- **npm 0.2.7** — latest working publish, tagged [`v0.2.7`](https://github.com/NEAT-Technologies/Neat/releases/tag/v0.2.7). Fix-only release for the 0.2.6 broken-`exports` bug.
+- **ADR-052 — Publish system contract** — landed alongside 0.2.7. Six live regression assertions in `contracts.test.ts` plus the tarball smoke-test step in `.github/workflows/publish.yml`.
+- **ADR-053 — Milestone naming convention** — landed in this rename PR.
+- **v0.2.8 — CLI parity + frontend-API surface** — **OPEN. Contracts #23 / #24 already drafted (ADRs 050/051, `docs/contracts/cli-surface.md`, `docs/contracts/frontend-api.md`). Implementation queued.**
+
+## What v0.2.8 is
+
+The contract-first batch that closes the v0.2.x sequence. Two contracts already on `main`:
+
+- **#23 CLI surface** ([ADR-050](../decisions.md#adr-050--cli-surface-contract), [`contracts/cli-surface.md`](../contracts/cli-surface.md)) — nine `neat <verb>` commands mirroring the MCP allowlist. REST-only data path sharing the MCP client. Two output modes (default human + `--json`). Exit codes branching on misuse / server error / daemon-down.
+- **#24 Frontend-facing API** ([ADR-051](../decisions.md#adr-051--frontend-facing-api-contract), [`contracts/frontend-api.md`](../contracts/frontend-api.md)) — SSE stream at `/events` with a locked eight-type taxonomy, multi-project switcher at `/projects`. WebSocket transport and per-event filtering deferred to successor ADRs.
+
+## Why v0.2.8 matters
+
+Two reasons.
+
+1. **Jed's frontend track unblocks.** v0.3.0 frontend work currently builds against the v0.1.2-stable API. Live updates (SSE) and the multi-project switcher endpoint aren't in that surface. Contract #24's implementation is what gives Jed the API to build a live graph viewer against.
+2. **CLI parity closes the terminal-vs-agent gap.** Today every reach into the graph goes through MCP. CLI verbs give a human at a terminal the same nine tools the agent has, without the Claude wrapper. Useful for debugging, scripting, and CI gates (`neat policies --json` could fail a deploy on a critical-severity violation).
+
+## Issues queued
+
+| Issue | Title | Contract |
+|-------|-------|----------|
+| #23 | CLI surface — nine `neat <verb>` commands | CLI surface (ADR-050) |
+| #24 | Frontend-facing API — SSE / `/projects` switcher | Frontend-facing API (ADR-051) |
+
+Implementation issues will spawn off these as work begins.
+
+## Recommended order
+
+The two contracts are independent — implementation can run in parallel or sequentially. If sequential, **ADR-051 (frontend API) first** because Jed's track is currently blocked by it; ADR-050 is dev ergonomics with no external blocker.
+
+ADR-050 (CLI surface) breakdown — outside-in:
+
+1. Wire the nine REST-client functions in `packages/core/src/cli-client.ts` (or extend the existing client used by `@neat.is/mcp`).
+2. Add the nine verbs to `packages/core/src/cli.ts`'s argv parser. Each handler calls the REST client + formats the response per ADR-050 #3 (default human + `--json`).
+3. Implement exit-code branching per ADR-050 #4.
+4. Flip the 15 `it.todo`s in `contracts.test.ts`'s "CLI surface contract (ADR-050)" describe block to live assertions.
+
+ADR-051 (frontend API) breakdown — outside-in:
+
+1. Add the `EventEmitter` singleton at `packages/core/src/events.ts` (per ADR-051 authority).
+2. Wire producers: emit from `ingest.ts`, `extract/index.ts`, `watch.ts`, `policy.ts`. Eight event types per the locked taxonomy.
+3. Add the SSE handler at `packages/core/src/streaming.ts` (or extend `api.ts` if the surface stays small). Heartbeat every 30s; backpressure cap at 1000 messages/connection.
+4. Add `GET /projects` endpoint passing through `listProjects()` from `registry.ts`.
+5. Dual-mount per ADR-026: `/events`, `/projects/:project/events`, `/projects` (list).
+6. Flip the 18 `it.todo`s in `contracts.test.ts`'s "Frontend-facing API contract (ADR-051)" describe block to live assertions.
+
+## Reference points
+
+- **Existing contracts** (already on `main`): [`docs/contracts.md`](../contracts.md) is the index.
+- **CLI surface today**: `packages/core/src/cli.ts` — has `init`, `watch`, `list`, `pause`, `resume`, `uninstall`, `skill` plus `--project` scoping. v0.2.8 adds the nine query verbs that mirror MCP.
+- **MCP tools today** (locked allowlist of nine, ADR-039): `get_root_cause`, `get_blast_radius`, `get_dependencies`, `get_observed_dependencies`, `get_incident_history`, `semantic_search`, `get_graph_diff`, `get_recent_stale_edges`, `check_policies`. Each gets a `neat <verb>` wrapper.
+- **REST API today**: `packages/core/src/api.ts` — dual-mounted per ADR-026 at `/X` and `/projects/:project/X`. v0.2.8 adds SSE `/events` and `/projects` (list) on top of this.
+- **v0.3.0 frontend track**: Jed's work, builds against the stable v0.1.2 API plus what ADR-051 ships. Issues #28-#31 + #106-#108.
+
+## Closing condition
+
+v0.2.8 closes when:
+
+1. All 33 v0.2.8 `it.todo`s flipped to live assertions (15 ADR-050 + 18 ADR-051) and passing.
+2. CLI verbs implementation has shipped on `main`.
+3. SSE `/events` + `/projects` endpoint pair has shipped on `main`.
+4. `npx turbo build test lint` green on `main`.
+5. Versions bumped 0.2.7 → 0.2.8 across the five publishable packages (in lockstep per ADR-052).
+6. Tag `v0.2.8` pushed; CI publishes; tarball smoke-test passes; GitHub Release created.
+
+## What's not in v0.2.8
+
+- **WebSocket transport** — successor ADR per ADR-051 deferral. Triggered when v0.3.0 frontend work surfaces a need SSE can't cover.
+- **Per-event SSE filtering** — same deferral pattern.
+- **Live OTel listener inside the daemon** — flagged as deferred during v0.2.5 close; receiver attachment is a v0.2.8 candidate only if it falls out of contract #24 work; otherwise stays queued.
+- **TOML-aware `pyproject.toml` editing** — successor ADR.
+- **Self-hosting NEAT on the NEAT codebase** — gated behind the MVP-success PR (ADR-027), not a v0.2.8 step.
+
+## Carried follow-ups
+
+- **v0.2.1 cleanup** — `#141` source-level DB connection + import detection, `#142` `ServiceNode.framework` population, `#145` drop unused `graphology-traversal` / `-shortest-path` deps. Rolled forward to v0.3.0 prep per the v0.2.5 close decision.
+- **`packages/web/package.json` version drift** — sits at 0.2.0 while everything else is 0.2.7 (heading toward 0.2.8). Web is private and not under the lockstep contract, but a one-line bump keeps things consistent.
+- **AUDIT-DRIFT amendments** to `docs/audits/verification.md` — surfaced during v0.2.4 close.
+- **#118 example policy library** — carried from v0.2.4.
+
+## When this file is wrong
+
+Snapshot at kickoff. If `main` has moved since the date at the top, treat the description as historical and check `git log` + `gh release list` for canonical state. New status docs land as `docs/plans/<date>-v0.2.8-status.md` or the eventual `docs/plans/<date>-v0.2.8-close.md`.

--- a/packages/core/src/extract/calls/http.ts
+++ b/packages/core/src/extract/calls/http.ts
@@ -77,7 +77,15 @@ export async function addHttpCallEdges(
     const seenTargets = new Map<string, { file: string; host: string }>()
     for (const file of files) {
       const parser = path.extname(file.path) === '.py' ? pyParser : jsParser
-      const targets = callsFromSource(file.content, parser, knownHosts)
+      let targets: Set<string>
+      try {
+        targets = callsFromSource(file.content, parser, knownHosts)
+      } catch (err) {
+        console.warn(
+          `[neat] http call extraction skipped ${file.path}: ${(err as Error).message}`,
+        )
+        continue
+      }
       for (const t of targets) {
         const targetId = hostToNodeId.get(t)
         if (!targetId || targetId === service.node.id) continue

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -3143,7 +3143,7 @@ describe('Queued contracts (v0.2.1 leftovers — #141, #142, #145)', () => {
 })
 
 describe('CLI surface contract (ADR-050)', () => {
-  // v0.2.6 #23. Nine `neat <verb>` commands mirroring the MCP allowlist.
+  // v0.2.8 #23. Nine `neat <verb>` commands mirroring the MCP allowlist.
   // Implementation lands the verbs; these todos flip as each verb ships.
   it.todo('every MCP tool from ADR-039 has a corresponding `neat <verb>` registered (ADR-050 #1)')
   it.todo('verb names are kebab-case and drop the `get_` prefix (ADR-050 #1 — naming)')
@@ -3163,7 +3163,7 @@ describe('CLI surface contract (ADR-050)', () => {
 })
 
 describe('Frontend-facing API contract (ADR-051)', () => {
-  // v0.2.6 #24. SSE stream + multi-project switcher endpoint. Speculative —
+  // v0.2.8 #24. SSE stream + multi-project switcher endpoint. Speculative —
   // WebSocket transport and per-event filtering deferred to successor ADRs.
   it.todo('GET /events responds with content-type text/event-stream (ADR-051 #1)')
   it.todo('GET /events and GET /projects/:project/events are both registered (dual-mount per ADR-026) (ADR-051 #1)')


### PR DESCRIPTION
## Summary

The milestone whose contract batch is ADRs 050/051 (CLI parity + frontend-API surface, contracts #23/#24) was originally named **v0.2.6**, projecting 0.2.6 as the npm version when implementation shipped. Two publish-fix releases (0.2.6 retired, 0.2.7 shipped) consumed that version slot before any implementation landed, so the milestone rolls forward to **v0.2.8**.

ADR-053 codifies the rule: when publish-fix releases consume the projected version, milestone names roll forward to match the new projected version. Forward-looking refs update; historical refs (commits, retired npm versions, closed status docs) stay as they were. ADR and contract numbers don't change.

This is the first application of ADR-053.

## Files changed

**Forward-looking refs renamed** (12 sites across 9 files):
- `CLAUDE.md` — Track 2 milestone block + explanatory note
- `docs/contracts.md` — rows 23/24 status + future-contracts footer
- `docs/decisions.md` — ADR-050/051 "Opens v0.2.6" lines + `it.todo` references
- `docs/contracts/cli-surface.md` — body + enforcement section (replace_all)
- `docs/contracts/frontend-api.md` — body + enforcement section (replace_all)
- `docs/milestones.md` — Last-session block, Track 2 list, After-v0.2.6 line + rename notes
- `docs/plans/2026-05-04-v0.2.x-sequencing.md` — section heading + rename note
- `docs/plans/2026-05-07-v0.2.6-kickoff.md` — deprecation header at top redirecting to new kickoff (body preserved as historical record)
- `packages/core/test/audits/contracts.test.ts` — describe-block comment headers

**New docs:**
- `docs/decisions.md` — **ADR-053 — Milestone naming convention** (the binding rule)
- `docs/plans/2026-05-09-v0.2.8-kickoff.md` — canonical handoff for the renamed milestone
- `docs/plans/2026-05-09-milestone-rename.md` — historical record of this rename

**Historical refs preserved (intentionally not changed):**
- ADR-052 body + `docs/contracts/publish-system.md` — references to the 0.2.6 broken publish are real npm-version history
- `docs/plans/2026-05-07-v0.2.5-{close,kickoff}.md` — written when the milestone was still named v0.2.6
- `docs/plans/2026-05-07-v0.2.6-kickoff.md` body — preserved under its original name, only the header gets a redirect note

## Unrelated change swept in (flagging for review)

`packages/core/src/extract/calls/http.ts` — small try/catch around `callsFromSource` so a single bad file doesn't kill the extraction phase. Was sitting uncommitted in the working tree (from another agent's session). Useful and small (10 lines) but unrelated to the rename. Mentioning here so reviewers know it's intentional inclusion, not stealth scope creep.

## Verification

- `npx turbo build` — clean, full cache hit
- `vitest run test/audits/contracts.test.ts` — 131 pass, 38 todo, 0 fail (unchanged from pre-rename — this PR moves text, not behavior)
- `grep -rn "v0\.2\.6"` — only historical refs remain (rename notes, ADR-053 context, deprecation headers, the rename status doc itself)

Refs #197