### PR TITLE
Frontend-facing API — SSE /events + /projects switcher (ADR-051)

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -32,6 +32,8 @@ import { computeGraphDiff, loadSnapshotForDiff } from './diff.js'
 import type { SearchIndex } from './search.js'
 import type { Projects, ProjectContext } from './projects.js'
 import { Projects as ProjectsClass, pathsForProject } from './projects.js'
+import { listProjects as listRegistryProjects } from './registry.js'
+import { handleSse } from './streaming.js'
 
 export interface BuildApiOptions {
   // Multi-project shape. Optional — when absent we synthesise a single-
@@ -131,6 +133,16 @@ interface RouteContext {
 // same handlers run when the URL names a project explicitly.
 function registerRoutes(scope: FastifyInstance, ctx: RouteContext): void {
   const { registry, startedAt, errorsPathFor, staleEventsPathFor } = ctx
+
+  // SSE event stream (ADR-051 #1). Dual-mounted: hits /events for default
+  // project and /projects/:project/events when scoped. The handler keeps
+  // the connection open and writes one frame per bus envelope whose
+  // `project` matches.
+  scope.get<{ Params: { project?: string } }>('/events', (req, reply) => {
+    const proj = resolveProject(registry, req, reply)
+    if (!proj) return
+    handleSse(req, reply, { project: proj.name })
+  })
 
   scope.get<{ Params: { project?: string } }>('/health', async (req, reply) => {
     const proj = resolveProject(registry, req, reply)
@@ -501,18 +513,20 @@ export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> 
     policyFilePathFor,
   }
 
-  // Top-level discovery — only meaningful at the root.
-  app.get('/projects', async () => ({
-    projects: registry.list().map((name) => {
-      const proj = registry.get(name) as ProjectContext
-      return {
-        name,
-        nodeCount: proj.graph.order,
-        edgeCount: proj.graph.size,
-        scanPath: proj.scanPath,
-      }
-    }),
-  }))
+  // Multi-project switcher (ADR-051 #4). Direct passthrough of the
+  // machine-level registry from registry.ts (ADR-048) — distinct from the
+  // dual-mount routing in ADR-026, which exposes per-project endpoints.
+  // Returns Array<{ name, path, status, registeredAt, lastSeenAt?, languages }>.
+  app.get('/projects', async (_req, reply) => {
+    try {
+      return await listRegistryProjects()
+    } catch (err) {
+      return reply.code(500).send({
+        error: 'failed to read project registry',
+        details: (err as Error).message,
+      })
+    }
+  })
 
   // Default mount: /health, /graph, /incidents, etc. all hit project=default.
   registerRoutes(app, routeCtx)

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,0 +1,171 @@
+// Frontend-facing event bus (ADR-051). The single in-process EventEmitter
+// every producer (ingest / extract / watch / policy) emits through and the
+// only thing the SSE handler in streaming.ts subscribes to.
+//
+// Direct producer-to-handler coupling is a contract violation — every event
+// goes through `eventBus.emit('event', envelope)` so the SSE layer is the
+// only consumer that has to know the wire taxonomy.
+//
+// The taxonomy is locked at eight types (ADR-051 #2). Adding a ninth type
+// requires a successor ADR.
+
+import { EventEmitter } from 'node:events'
+import type { GraphEdge, GraphNode, PolicyViolation, Provenance } from '@neat.is/types'
+import type { NeatGraph } from './graph.js'
+
+// Locked event taxonomy. Eight values. Tests assert the array shape
+// directly, so adding here without updating the contract is a regression.
+export const NEAT_EVENT_TYPES = [
+  'node-added',
+  'node-updated',
+  'node-removed',
+  'edge-added',
+  'edge-removed',
+  'extraction-complete',
+  'policy-violation',
+  'stale-transition',
+] as const
+
+export type NeatEventType = (typeof NEAT_EVENT_TYPES)[number]
+
+// Per-type payload shapes. The wire layer (SSE) writes the payload as the
+// `data` field; producers use `emit*` helpers below for type safety.
+export interface NodeAddedPayload {
+  node: GraphNode
+}
+export interface NodeUpdatedPayload {
+  id: string
+  changes: Partial<GraphNode>
+}
+export interface NodeRemovedPayload {
+  id: string
+}
+export interface EdgeAddedPayload {
+  edge: GraphEdge
+}
+export interface EdgeRemovedPayload {
+  id: string
+}
+export interface ExtractionCompletePayload {
+  project: string
+  fileCount: number
+  nodesAdded: number
+  edgesAdded: number
+}
+export interface PolicyViolationPayload {
+  violation: PolicyViolation
+}
+export interface StaleTransitionPayload {
+  edgeId: string
+  from: typeof Provenance.OBSERVED
+  to: typeof Provenance.STALE
+}
+
+export type NeatEventPayload = {
+  'node-added': NodeAddedPayload
+  'node-updated': NodeUpdatedPayload
+  'node-removed': NodeRemovedPayload
+  'edge-added': EdgeAddedPayload
+  'edge-removed': EdgeRemovedPayload
+  'extraction-complete': ExtractionCompletePayload
+  'policy-violation': PolicyViolationPayload
+  'stale-transition': StaleTransitionPayload
+}
+
+// What the bus carries internally. Project is metadata used by the SSE
+// handler to route between /events and /projects/:project/events; it never
+// lands in the wire payload.
+export interface NeatEventEnvelope<T extends NeatEventType = NeatEventType> {
+  type: T
+  project: string
+  payload: NeatEventPayload[T]
+}
+
+// Single event channel — listeners filter by `envelope.type` and
+// `envelope.project`. Using one channel keeps the contract surface narrow
+// and matches the SSE handler's needs (one subscription, fan out).
+export const EVENT_BUS_CHANNEL = 'event'
+
+class NeatEventBus extends EventEmitter {}
+
+// Singleton. Process-wide so producers in ingest / extract / watch / policy
+// can emit without threading a bus instance through every call site.
+export const eventBus: NeatEventBus = new NeatEventBus()
+
+// EventEmitter defaults to 10 listeners; SSE clients add up quickly under a
+// browser refresh storm, so lift the cap.
+eventBus.setMaxListeners(0)
+
+export function emitNeatEvent<T extends NeatEventType>(envelope: NeatEventEnvelope<T>): void {
+  eventBus.emit(EVENT_BUS_CHANNEL, envelope)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Graph subscription — one place to wire graphology mutation events into
+// the bus so producers don't have to instrument every addNode/addEdge.
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface AttachOptions {
+  project: string
+}
+
+// Subscribes to a NeatGraph and re-emits node/edge add/remove + node/edge
+// attribute updates as bus envelopes scoped to `project`. Returns a detach
+// fn that removes every listener it installed.
+//
+// Stale-transition is NOT routed through here — a provenance flip is just an
+// attribute update from graphology's view, and we'd lose the OBSERVED→STALE
+// semantic. ingest.ts emits stale-transition itself.
+export function attachGraphToEventBus(graph: NeatGraph, opts: AttachOptions): () => void {
+  const { project } = opts
+
+  const onNodeAdded = (payload: { key: string; attributes: GraphNode }): void => {
+    emitNeatEvent({
+      type: 'node-added',
+      project,
+      payload: { node: payload.attributes },
+    })
+  }
+  const onNodeDropped = (payload: { key: string }): void => {
+    emitNeatEvent({
+      type: 'node-removed',
+      project,
+      payload: { id: payload.key },
+    })
+  }
+  const onEdgeAdded = (payload: { key: string; attributes: GraphEdge }): void => {
+    emitNeatEvent({
+      type: 'edge-added',
+      project,
+      payload: { edge: payload.attributes },
+    })
+  }
+  const onEdgeDropped = (payload: { key: string }): void => {
+    emitNeatEvent({
+      type: 'edge-removed',
+      project,
+      payload: { id: payload.key },
+    })
+  }
+  const onNodeAttrsUpdated = (payload: { key: string; attributes: GraphNode }): void => {
+    emitNeatEvent({
+      type: 'node-updated',
+      project,
+      payload: { id: payload.key, changes: payload.attributes },
+    })
+  }
+
+  graph.on('nodeAdded', onNodeAdded)
+  graph.on('nodeDropped', onNodeDropped)
+  graph.on('edgeAdded', onEdgeAdded)
+  graph.on('edgeDropped', onEdgeDropped)
+  graph.on('nodeAttributesUpdated', onNodeAttrsUpdated)
+
+  return () => {
+    graph.off('nodeAdded', onNodeAdded)
+    graph.off('nodeDropped', onNodeDropped)
+    graph.off('edgeAdded', onEdgeAdded)
+    graph.off('edgeDropped', onEdgeDropped)
+    graph.off('nodeAttributesUpdated', onNodeAttrsUpdated)
+  }
+}

--- a/packages/core/src/extract/index.ts
+++ b/packages/core/src/extract/index.ts
@@ -11,8 +11,10 @@
 //     dependencies; engine names from compat.json via compatPairs().
 //   * Rule 14 — ConfigNodes record file existence only; never the contents.
 import type { NeatGraph } from '../graph.js'
+import { DEFAULT_PROJECT } from '../graph.js'
 import { promoteFrontierNodes } from '../ingest.js'
 import { ensureCompatLoaded } from '../compat.js'
+import { emitNeatEvent } from '../events.js'
 import { addServiceNodes, discoverServices } from './services.js'
 import { addServiceAliases } from './aliases.js'
 import { addDatabasesAndCompat } from './databases/index.js'
@@ -31,6 +33,9 @@ export interface ExtractOptions {
   // so policies see the final post-pass graph state. Daemons wire this to
   // evaluateAllPolicies + PolicyViolationsLog.append.
   onPolicyTrigger?: (graph: NeatGraph) => Promise<void> | void
+  // Project tag for the extraction-complete event (ADR-051). Defaults to
+  // DEFAULT_PROJECT when omitted.
+  project?: string
 }
 
 export async function extractFromDirectory(
@@ -54,7 +59,7 @@ export async function extractFromDirectory(
   // upgrades that just landed).
   if (opts.onPolicyTrigger) await opts.onPolicyTrigger(graph)
 
-  return {
+  const result: ExtractResult = {
     nodesAdded:
       phase1Nodes +
       phase2.nodesAdded +
@@ -65,4 +70,20 @@ export async function extractFromDirectory(
       phase2.edgesAdded + phase3.edgesAdded + phase4.edgesAdded + phase5.edgesAdded,
     frontiersPromoted,
   }
+
+  // extraction-complete (ADR-051). fileCount is the number of services
+  // discovered — the closest proxy we have for "how much source did this
+  // pass touch" without a per-phase file accountant.
+  emitNeatEvent({
+    type: 'extraction-complete',
+    project: opts.project ?? DEFAULT_PROJECT,
+    payload: {
+      project: opts.project ?? DEFAULT_PROJECT,
+      fileCount: services.length,
+      nodesAdded: result.nodesAdded,
+      edgesAdded: result.edgesAdded,
+    },
+  })
+
+  return result
 }

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -24,7 +24,9 @@ import {
   type EdgeTypeValue,
 } from '@neat.is/types'
 import type { NeatGraph } from './graph.js'
+import { DEFAULT_PROJECT } from './graph.js'
 import type { ParsedSpan } from './otel.js'
+import { emitNeatEvent } from './events.js'
 
 // Maps OTel spans to graph signal:
 //   * Cross-service span → upsert CALLS edge.
@@ -45,6 +47,9 @@ import type { ParsedSpan } from './otel.js'
 export interface IngestContext {
   graph: NeatGraph
   errorsPath: string
+  // Project name for event-bus routing (ADR-051). Defaults to DEFAULT_PROJECT
+  // when omitted — keeps single-project tests / scripts wire-compatible.
+  project?: string
   now?: () => number
   // Set to false when the receiver already wrote the ErrorEvent synchronously
   // (production daemons via watch.ts wire this). When true or omitted, handleSpan
@@ -761,6 +766,8 @@ export interface MarkStaleOptions {
   // line. Skipped if undefined — tests and embedded use cases don't need a
   // log.
   staleEventsPath?: string
+  // Project tag for event-bus routing (ADR-051). Defaults to DEFAULT_PROJECT.
+  project?: string
 }
 
 // Demote OBSERVED edges that haven't been seen in a while. Per-edge-type
@@ -774,6 +781,7 @@ export async function markStaleEdges(
   const now = options.now ?? Date.now()
   const events: StaleEvent[] = []
 
+  const project = options.project ?? DEFAULT_PROJECT
   graph.forEachEdge((id, attrs) => {
     const e = attrs as GraphEdge
     if (e.provenance !== Provenance.OBSERVED) return
@@ -792,6 +800,19 @@ export async function markStaleEdges(
         ageMs: age,
         lastObserved: e.lastObserved,
         transitionedAt: new Date(now).toISOString(),
+      })
+      // Stale-transition fires through the bus (ADR-051). The graph
+      // subscription in events.ts can't see the OBSERVED→STALE semantic on
+      // its own — a provenance flip is just an attribute update from
+      // graphology's view.
+      emitNeatEvent({
+        type: 'stale-transition',
+        project,
+        payload: {
+          edgeId: id,
+          from: Provenance.OBSERVED,
+          to: Provenance.STALE,
+        },
       })
     }
   })
@@ -826,6 +847,8 @@ export interface StalenessLoopOptions {
   thresholds?: Record<string, number>
   intervalMs?: number
   staleEventsPath?: string
+  // Project tag for event-bus routing (ADR-051).
+  project?: string
   // Post-stale-transition policy trigger (ADR-043). Fires after each tick of
   // markStaleEdges so policies see the new STALE state. Daemons wire this to
   // evaluateAllPolicies + PolicyViolationsLog.append.
@@ -845,6 +868,7 @@ export function startStalenessLoop(
         await markStaleEdges(graph, {
           thresholds: options.thresholds,
           staleEventsPath: options.staleEventsPath,
+          project: options.project,
         })
         if (options.onPolicyTrigger) await options.onPolicyTrigger(graph)
       } catch (err) {

--- a/packages/core/src/policy.ts
+++ b/packages/core/src/policy.ts
@@ -18,6 +18,7 @@ import {
   Provenance,
 } from '@neat.is/types'
 import type { NeatGraph } from './graph.js'
+import { DEFAULT_PROJECT } from './graph.js'
 import {
   checkCompatibility,
   checkDeprecatedApi,
@@ -28,6 +29,7 @@ import {
   nodeEngineConstraints,
   packageConflicts,
 } from './compat.js'
+import { emitNeatEvent } from './events.js'
 import { getBlastRadius } from './traverse.js'
 
 // Policy evaluation engine (ADR-043). The entry point evaluateAllPolicies is
@@ -415,10 +417,12 @@ export async function loadPolicyFile(policyPath: string): Promise<Policy[]> {
 // — startups that load an existing log don't lose dedup state.
 export class PolicyViolationsLog {
   private readonly path: string
+  private readonly project: string
   private seen: Set<string> | null = null
 
-  constructor(logPath: string) {
+  constructor(logPath: string, project: string = DEFAULT_PROJECT) {
     this.path = logPath
+    this.project = project
   }
 
   async append(v: PolicyViolation): Promise<boolean> {
@@ -427,6 +431,14 @@ export class PolicyViolationsLog {
     this.seen!.add(v.id)
     await fs.mkdir(path.dirname(this.path), { recursive: true })
     await fs.appendFile(this.path, JSON.stringify(v) + '\n', 'utf8')
+    // Emit policy-violation only on first sighting (post-dedup) so SSE
+    // consumers don't see the same violation again on every evaluation
+    // cycle (ADR-051 #2).
+    emitNeatEvent({
+      type: 'policy-violation',
+      project: this.project,
+      payload: { violation: v },
+    })
     return true
   }
 

--- a/packages/core/src/streaming.ts
+++ b/packages/core/src/streaming.ts
@@ -1,0 +1,84 @@
+// SSE handler for the frontend-facing event stream (ADR-051 #1).
+// Subscribes to the bus in events.ts, filters by project, writes
+// `event: <type>\ndata: <json>\n\n` frames to the client.
+//
+// Backpressure: per-connection queue cap of 1000 outstanding writes; once
+// hit, the connection is dropped with `event: error data: { reason:
+// 'backpressure' }` per ADR-051 #8. Heartbeat: comment line every 30s
+// keeps proxies from idle-timing out (ADR-051 #3).
+
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import {
+  EVENT_BUS_CHANNEL,
+  eventBus,
+  type NeatEventEnvelope,
+} from './events.js'
+
+export const SSE_HEARTBEAT_MS = 30_000
+export const SSE_BACKPRESSURE_CAP = 1000
+
+export interface HandleSseOptions {
+  project: string
+  heartbeatMs?: number
+  backpressureCap?: number
+}
+
+export function handleSse(
+  req: FastifyRequest,
+  reply: FastifyReply,
+  opts: HandleSseOptions,
+): void {
+  const heartbeatMs = opts.heartbeatMs ?? SSE_HEARTBEAT_MS
+  const backpressureCap = opts.backpressureCap ?? SSE_BACKPRESSURE_CAP
+
+  reply.raw.setHeader('Content-Type', 'text/event-stream')
+  reply.raw.setHeader('Cache-Control', 'no-cache, no-transform')
+  reply.raw.setHeader('Connection', 'keep-alive')
+  reply.raw.setHeader('X-Accel-Buffering', 'no')
+  reply.raw.flushHeaders?.()
+
+  let pending = 0
+  let dropped = false
+
+  const closeConnection = (): void => {
+    if (dropped) return
+    dropped = true
+    eventBus.off(EVENT_BUS_CHANNEL, listener)
+    clearInterval(heartbeat)
+    if (!reply.raw.writableEnded) reply.raw.end()
+  }
+
+  const writeFrame = (frame: string): void => {
+    if (dropped) return
+    if (pending >= backpressureCap) {
+      // Past the cap — emit one final error frame and drop. Don't try to
+      // gracefully drain; a slow consumer that's already 1000 frames behind
+      // is not going to catch up.
+      const errFrame = `event: error\ndata: ${JSON.stringify({ reason: 'backpressure' })}\n\n`
+      reply.raw.write(errFrame)
+      closeConnection()
+      return
+    }
+    pending++
+    reply.raw.write(frame, () => {
+      pending = Math.max(0, pending - 1)
+    })
+  }
+
+  const listener = (envelope: NeatEventEnvelope): void => {
+    if (envelope.project !== opts.project) return
+    writeFrame(`event: ${envelope.type}\ndata: ${JSON.stringify(envelope.payload)}\n\n`)
+  }
+
+  eventBus.on(EVENT_BUS_CHANNEL, listener)
+
+  const heartbeat = setInterval(() => {
+    if (dropped) return
+    reply.raw.write(':heartbeat\n\n')
+  }, heartbeatMs)
+  if (typeof heartbeat.unref === 'function') heartbeat.unref()
+
+  req.raw.on('close', closeConnection)
+  reply.raw.on('close', closeConnection)
+  reply.raw.on('error', closeConnection)
+}

--- a/packages/core/src/watch.ts
+++ b/packages/core/src/watch.ts
@@ -29,6 +29,7 @@ import { loadGraphFromDisk, startPersistLoop } from './persist.js'
 import { buildSearchIndex, type SearchIndex } from './search.js'
 import { DEFAULT_PROJECT } from './graph.js'
 import { Projects, pathsForProject } from './projects.js'
+import { attachGraphToEventBus, emitNeatEvent } from './events.js'
 
 export type ExtractPhase =
   | 'services'
@@ -125,7 +126,12 @@ export async function runExtractPhases(
   graph: NeatGraph,
   scanPath: string,
   phases: Set<ExtractPhase>,
+  // Project tag passed through for the runtime event bus (ADR-051) — not
+  // required for extraction logic itself but threaded for parity with
+  // extractFromDirectory's project option.
+  project: string = DEFAULT_PROJECT,
 ): Promise<RunPhasesResult> {
+  void project
   const started = Date.now()
   await ensureCompatLoaded()
   // Discovery is cheap and every phase needs the same DiscoveredService list,
@@ -215,8 +221,13 @@ export async function startWatch(
   opts: WatchOptions,
 ): Promise<WatchHandle> {
   const debounceMs = opts.debounceMs ?? 1000
+  const projectName = opts.project ?? DEFAULT_PROJECT
 
   await loadGraphFromDisk(graph, opts.outPath)
+
+  // Wire graph mutations into the event bus (ADR-051) before extract begins
+  // so the initial pass also produces node/edge events. Detached on stop().
+  const detachEventBus = attachGraphToEventBus(graph, { project: projectName })
 
   // Load policies + open the violations log once at startup. policy.json
   // lives at the project root per ADR-042 §File location; absent file is
@@ -233,7 +244,7 @@ export async function startWatch(
   } catch (err) {
     console.warn(`policies: failed to load ${policyFilePath} — ${(err as Error).message}`)
   }
-  const policyLog = new PolicyViolationsLog(policyViolationsPath)
+  const policyLog = new PolicyViolationsLog(policyViolationsPath, projectName)
 
   // Single shared trigger callback wired into post-ingest, post-extract, and
   // post-stale per ADR-043. Failures append to console.warn but don't kill
@@ -253,15 +264,34 @@ export async function startWatch(
   // startup before the receiver opens. Subsequent watch-driven re-extract
   // passes go through runExtractPhases which doesn't take the hook directly
   // — we run it after each flush() instead.
-  const initial = await runExtractPhases(graph, opts.scanPath, new Set(ALL_PHASES))
+  const initial = await runExtractPhases(
+    graph,
+    opts.scanPath,
+    new Set(ALL_PHASES),
+    projectName,
+  )
   console.log(
     `extract: ${initial.nodesAdded} new nodes, ${initial.edgesAdded} new edges (graph total ${graph.order}/${graph.size})`,
   )
+  // extraction-complete for the initial pass (ADR-051). runExtractPhases
+  // doesn't emit on its own — the event lives at the watch / orchestrator
+  // boundary so the daemon can swap in its own emission shape.
+  emitNeatEvent({
+    type: 'extraction-complete',
+    project: projectName,
+    payload: {
+      project: projectName,
+      fileCount: 0,
+      nodesAdded: initial.nodesAdded,
+      edgesAdded: initial.edgesAdded,
+    },
+  })
   await onPolicyTrigger(graph)
 
   const stopPersist = startPersistLoop(graph, opts.outPath)
   const stopStaleness = startStalenessLoop(graph, {
     staleEventsPath: opts.staleEventsPath,
+    project: projectName,
     onPolicyTrigger,
   })
 
@@ -281,7 +311,6 @@ export async function startWatch(
     )
   }
 
-  const projectName = opts.project ?? DEFAULT_PROJECT
   const registry = new Projects()
   registry.set(projectName, {
     graph,
@@ -313,6 +342,7 @@ export async function startWatch(
   const onSpan = makeSpanHandler({
     graph,
     errorsPath: opts.errorsPath,
+    project: projectName,
     writeErrorEventInline: false,
     onPolicyTrigger,
   })
@@ -331,6 +361,7 @@ export async function startWatch(
     const onSpanGrpc = makeSpanHandler({
       graph,
       errorsPath: opts.errorsPath,
+      project: projectName,
       onPolicyTrigger,
     })
     const r = await startOtelGrpcReceiver({ onSpan: onSpanGrpc, host, port: grpcPort })
@@ -359,10 +390,23 @@ export async function startWatch(
       // (docs/contracts/static-extraction.md §Ghost-edge cleanup).
       let retired = 0
       for (const p of paths) retired += retireEdgesByFile(graph, p)
-      const result = await runExtractPhases(graph, opts.scanPath, phases)
+      const result = await runExtractPhases(graph, opts.scanPath, phases, projectName)
       console.log(
         `[watch] re-extract phases=${result.phases.join(',')} retired=${retired} +${result.nodesAdded}n/+${result.edgesAdded}e in ${result.durationMs}ms`,
       )
+      // extraction-complete after every re-extract pass (ADR-051). fileCount
+      // is the number of paths that drove the pass — closest signal we have
+      // for "how much source moved" without per-phase accounting.
+      emitNeatEvent({
+        type: 'extraction-complete',
+        project: projectName,
+        payload: {
+          project: projectName,
+          fileCount: paths.size,
+          nodesAdded: result.nodesAdded,
+          edgesAdded: result.edgesAdded,
+        },
+      })
       if (searchIndex) {
         try {
           await searchIndex.refresh(graph)
@@ -434,6 +478,7 @@ export async function startWatch(
     await watcher.close()
     stopStaleness()
     stopPersist()
+    detachEventBus()
     await api.close()
     await otelHttp.close()
     if (grpcReceiver) await grpcReceiver.stop()

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -3165,24 +3165,533 @@ describe('CLI surface contract (ADR-050)', () => {
 describe('Frontend-facing API contract (ADR-051)', () => {
   // v0.2.8 #24. SSE stream + multi-project switcher endpoint. Speculative —
   // WebSocket transport and per-event filtering deferred to successor ADRs.
-  it.todo('GET /events responds with content-type text/event-stream (ADR-051 #1)')
-  it.todo('GET /events and GET /projects/:project/events are both registered (dual-mount per ADR-026) (ADR-051 #1)')
-  it.todo('SSE event-type taxonomy is exactly the eight locked types — no more, no fewer (ADR-051 #2)')
-  it.todo('node-added event payload matches `{ node: GraphNode }` (ADR-051 #2)')
-  it.todo('node-updated event payload matches `{ id, changes }` (ADR-051 #2)')
-  it.todo('node-removed / edge-removed event payloads carry only `{ id }` (ADR-051 #2)')
-  it.todo('edge-added event payload matches `{ edge: GraphEdge }` (ADR-051 #2)')
-  it.todo('extraction-complete event payload matches `{ project, fileCount, nodesAdded, edgesAdded }` (ADR-051 #2)')
-  it.todo('policy-violation event payload matches `{ violation: PolicyViolation }` (ADR-051 #2)')
-  it.todo('stale-transition event payload matches `{ edgeId, from: "OBSERVED", to: "STALE" }` (ADR-051 #2)')
-  it.todo('SSE heartbeat comment line emitted at most every 30 seconds (ADR-051 #3)')
-  it.todo('GET /projects returns the listProjects() shape from registry.ts (ADR-051 #4)')
-  it.todo('GET /projects shape is Array<{ name, path, status, registeredAt, lastSeenAt?, languages }> (ADR-051 #4)')
-  it.todo('SSE error responses use `event: error` payload before connection close (ADR-051 #5)')
-  it.todo('non-SSE error responses keep the ADR-040 `{ error, status, details? }` envelope (ADR-051 #5)')
-  it.todo('SSE backpressure cap drops connection at 1000 queued messages with `event: error` `{ reason: "backpressure" }` (ADR-051 #8)')
-  it.todo('event bus is a single EventEmitter singleton in packages/core/src/events.ts (ADR-051 — authority)')
-  it.todo('event producers in ingest.ts / extract/ / watch.ts / policy.ts emit through the bus, not directly to handlers (ADR-051 — authority)')
+
+  it('GET /events responds with content-type text/event-stream (ADR-051 #1)', async () => {
+    const { Projects } = await import('../../src/projects.js')
+    const { buildApi } = await import('../../src/api.js')
+    const { DEFAULT_PROJECT, getGraph, resetGraph } = await import('../../src/graph.js')
+    resetGraph(DEFAULT_PROJECT)
+    const registry = new Projects()
+    const fs2 = await import('node:fs/promises')
+    const os2 = await import('node:os')
+    const path2 = await import('node:path')
+    const tmp = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-sse-events-'))
+    registry.set(DEFAULT_PROJECT, {
+      graph: getGraph(DEFAULT_PROJECT),
+      paths: {
+        snapshotPath: path2.join(tmp, 'graph.json'),
+        errorsPath: path2.join(tmp, 'errors.ndjson'),
+        staleEventsPath: path2.join(tmp, 'stale-events.ndjson'),
+        embeddingsCachePath: path2.join(tmp, 'embeddings.json'),
+        policyViolationsPath: path2.join(tmp, 'policy-violations.ndjson'),
+      },
+    })
+    const app = await buildApi({ projects: registry })
+    try {
+      const address = await app.listen({ port: 0, host: '127.0.0.1' })
+      const ctrl = new AbortController()
+      const res = await fetch(`${address}/events`, { signal: ctrl.signal })
+      expect(res.headers.get('content-type')).toMatch(/text\/event-stream/)
+      ctrl.abort()
+      await res.body?.cancel().catch(() => {})
+    } finally {
+      await app.close()
+      await fs2.rm(tmp, { recursive: true, force: true })
+      resetGraph(DEFAULT_PROJECT)
+    }
+  })
+
+  it('GET /events and GET /projects/:project/events are both registered (dual-mount per ADR-026) (ADR-051 #1)', () => {
+    // Source-grep: the /events route is registered inside registerRoutes,
+    // which is called both at the root scope and inside the
+    // /projects/:project plugin. One registration site → both mounts.
+    const api = readFileSync(join(CORE_SRC, 'api.ts'), 'utf8')
+    const m = api.match(/scope\.get<[^>]*>\s*\(\s*['"]\/events['"]/)
+    expect(m, 'expected `/events` registered on registerRoutes scope').not.toBeNull()
+    // Dual-mount machinery: registerRoutes is invoked at both root and the
+    // /projects/:project prefix.
+    expect(api).toMatch(/registerRoutes\(app, routeCtx\)/)
+    expect(api).toMatch(/prefix:\s*['"]\/projects\/:project['"]/)
+  })
+
+  it('SSE event-type taxonomy is exactly the eight locked types — no more, no fewer (ADR-051 #2)', async () => {
+    const { NEAT_EVENT_TYPES } = await import('../../src/events.js')
+    expect([...NEAT_EVENT_TYPES].sort()).toEqual(
+      [
+        'edge-added',
+        'edge-removed',
+        'extraction-complete',
+        'node-added',
+        'node-removed',
+        'node-updated',
+        'policy-violation',
+        'stale-transition',
+      ].sort(),
+    )
+  })
+
+  it('node-added event payload matches `{ node: GraphNode }` (ADR-051 #2)', async () => {
+    const { eventBus, EVENT_BUS_CHANNEL, attachGraphToEventBus } = await import(
+      '../../src/events.js'
+    )
+    const captured: unknown[] = []
+    const listener = (env: { type: string; payload: unknown }): void => {
+      if (env.type === 'node-added') captured.push(env.payload)
+    }
+    eventBus.on(EVENT_BUS_CHANNEL, listener)
+    try {
+      const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({
+        allowSelfLoops: false,
+      })
+      const detach = attachGraphToEventBus(g, { project: 'tester' })
+      const node = {
+        id: 'service:probe',
+        type: NodeType.ServiceNode,
+        name: 'probe',
+        language: 'javascript',
+      } as GraphNode
+      g.addNode(node.id, node)
+      detach()
+      expect(captured).toHaveLength(1)
+      expect(captured[0]).toEqual({ node })
+    } finally {
+      eventBus.off(EVENT_BUS_CHANNEL, listener)
+    }
+  })
+
+  it('node-updated event payload matches `{ id, changes }` (ADR-051 #2)', async () => {
+    const { eventBus, EVENT_BUS_CHANNEL, attachGraphToEventBus } = await import(
+      '../../src/events.js'
+    )
+    const captured: { id: string; changes: unknown }[] = []
+    const listener = (env: { type: string; payload: { id: string; changes: unknown } }): void => {
+      if (env.type === 'node-updated') captured.push(env.payload)
+    }
+    eventBus.on(EVENT_BUS_CHANNEL, listener)
+    try {
+      const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({
+        allowSelfLoops: false,
+      })
+      const detach = attachGraphToEventBus(g, { project: 'tester' })
+      const node = {
+        id: 'service:probe',
+        type: NodeType.ServiceNode,
+        name: 'probe',
+        language: 'javascript',
+      } as GraphNode
+      g.addNode(node.id, node)
+      g.replaceNodeAttributes(node.id, { ...node, name: 'renamed' } as GraphNode)
+      detach()
+      const update = captured.find((p) => p.id === 'service:probe')
+      expect(update).toBeDefined()
+      expect(update!.id).toBe('service:probe')
+      expect(update!.changes).toEqual(expect.objectContaining({ name: 'renamed' }))
+    } finally {
+      eventBus.off(EVENT_BUS_CHANNEL, listener)
+    }
+  })
+
+  it('node-removed / edge-removed event payloads carry only `{ id }` (ADR-051 #2)', async () => {
+    const { eventBus, EVENT_BUS_CHANNEL, attachGraphToEventBus } = await import(
+      '../../src/events.js'
+    )
+    const captured: { type: string; payload: unknown }[] = []
+    const listener = (env: { type: string; payload: unknown }): void => {
+      if (env.type === 'node-removed' || env.type === 'edge-removed') {
+        captured.push({ type: env.type, payload: env.payload })
+      }
+    }
+    eventBus.on(EVENT_BUS_CHANNEL, listener)
+    try {
+      const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({
+        allowSelfLoops: false,
+      })
+      const detach = attachGraphToEventBus(g, { project: 'tester' })
+      g.addNode('service:a', {
+        id: 'service:a',
+        type: NodeType.ServiceNode,
+        name: 'a',
+        language: 'javascript',
+      } as GraphNode)
+      g.addNode('service:b', {
+        id: 'service:b',
+        type: NodeType.ServiceNode,
+        name: 'b',
+        language: 'javascript',
+      } as GraphNode)
+      const eid = `${EdgeType.CALLS}:service:a->service:b`
+      g.addEdgeWithKey(eid, 'service:a', 'service:b', {
+        id: eid,
+        source: 'service:a',
+        target: 'service:b',
+        type: EdgeType.CALLS,
+        provenance: Provenance.EXTRACTED,
+      } as GraphEdge)
+      g.dropEdge(eid)
+      g.dropNode('service:b')
+      detach()
+
+      const edgeRemoved = captured.find((c) => c.type === 'edge-removed')
+      const nodeRemoved = captured.find((c) => c.type === 'node-removed')
+      expect(edgeRemoved?.payload).toEqual({ id: eid })
+      expect(nodeRemoved?.payload).toEqual({ id: 'service:b' })
+      // Strict shape — only `id`, nothing else (Object.keys returns ['id']).
+      expect(Object.keys(edgeRemoved!.payload as object)).toEqual(['id'])
+      expect(Object.keys(nodeRemoved!.payload as object)).toEqual(['id'])
+    } finally {
+      eventBus.off(EVENT_BUS_CHANNEL, listener)
+    }
+  })
+
+  it('edge-added event payload matches `{ edge: GraphEdge }` (ADR-051 #2)', async () => {
+    const { eventBus, EVENT_BUS_CHANNEL, attachGraphToEventBus } = await import(
+      '../../src/events.js'
+    )
+    const captured: { edge: unknown }[] = []
+    const listener = (env: { type: string; payload: { edge: unknown } }): void => {
+      if (env.type === 'edge-added') captured.push(env.payload)
+    }
+    eventBus.on(EVENT_BUS_CHANNEL, listener)
+    try {
+      const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({
+        allowSelfLoops: false,
+      })
+      const detach = attachGraphToEventBus(g, { project: 'tester' })
+      g.addNode('service:a', {
+        id: 'service:a',
+        type: NodeType.ServiceNode,
+        name: 'a',
+        language: 'javascript',
+      } as GraphNode)
+      g.addNode('service:b', {
+        id: 'service:b',
+        type: NodeType.ServiceNode,
+        name: 'b',
+        language: 'javascript',
+      } as GraphNode)
+      const edge = {
+        id: `${EdgeType.CALLS}:service:a->service:b`,
+        source: 'service:a',
+        target: 'service:b',
+        type: EdgeType.CALLS,
+        provenance: Provenance.EXTRACTED,
+      } as GraphEdge
+      g.addEdgeWithKey(edge.id, 'service:a', 'service:b', edge)
+      detach()
+      const found = captured.find((p) => (p.edge as GraphEdge).id === edge.id)
+      expect(found).toBeDefined()
+      expect(found!.edge).toEqual(edge)
+    } finally {
+      eventBus.off(EVENT_BUS_CHANNEL, listener)
+    }
+  })
+
+  it('extraction-complete event payload matches `{ project, fileCount, nodesAdded, edgesAdded }` (ADR-051 #2)', async () => {
+    const { eventBus, EVENT_BUS_CHANNEL, emitNeatEvent } = await import('../../src/events.js')
+    const captured: unknown[] = []
+    const listener = (env: { type: string; payload: unknown }): void => {
+      if (env.type === 'extraction-complete') captured.push(env.payload)
+    }
+    eventBus.on(EVENT_BUS_CHANNEL, listener)
+    try {
+      emitNeatEvent({
+        type: 'extraction-complete',
+        project: 'tester',
+        payload: { project: 'tester', fileCount: 3, nodesAdded: 1, edgesAdded: 2 },
+      })
+      expect(captured[0]).toEqual({
+        project: 'tester',
+        fileCount: 3,
+        nodesAdded: 1,
+        edgesAdded: 2,
+      })
+    } finally {
+      eventBus.off(EVENT_BUS_CHANNEL, listener)
+    }
+  })
+
+  it('policy-violation event payload matches `{ violation: PolicyViolation }` (ADR-051 #2)', async () => {
+    const { eventBus, EVENT_BUS_CHANNEL } = await import('../../src/events.js')
+    const { PolicyViolationsLog } = await import('../../src/policy.js')
+    const fs2 = await import('node:fs/promises')
+    const os2 = await import('node:os')
+    const path2 = await import('node:path')
+    const tmp = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-pol-violation-'))
+    const captured: unknown[] = []
+    const listener = (env: { type: string; payload: unknown }): void => {
+      if (env.type === 'policy-violation') captured.push(env.payload)
+    }
+    eventBus.on(EVENT_BUS_CHANNEL, listener)
+    try {
+      const log = new PolicyViolationsLog(path2.join(tmp, 'pv.ndjson'), 'tester')
+      const violation = {
+        id: 'p1:n1',
+        policyId: 'p1',
+        policyName: 'pol',
+        severity: 'error' as const,
+        onViolation: 'alert' as const,
+        ruleType: 'ownership' as const,
+        subject: { nodeId: 'service:x' },
+        message: 'missing owner',
+        observedAt: new Date().toISOString(),
+      }
+      await log.append(violation)
+      expect(captured[0]).toEqual({ violation })
+    } finally {
+      eventBus.off(EVENT_BUS_CHANNEL, listener)
+      await fs2.rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('stale-transition event payload matches `{ edgeId, from: "OBSERVED", to: "STALE" }` (ADR-051 #2)', async () => {
+    const { eventBus, EVENT_BUS_CHANNEL } = await import('../../src/events.js')
+    const { markStaleEdges } = await import('../../src/ingest.js')
+    const captured: unknown[] = []
+    const listener = (env: { type: string; payload: unknown }): void => {
+      if (env.type === 'stale-transition') captured.push(env.payload)
+    }
+    eventBus.on(EVENT_BUS_CHANNEL, listener)
+    try {
+      const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({
+        allowSelfLoops: false,
+      })
+      g.addNode('service:a', {
+        id: 'service:a',
+        type: NodeType.ServiceNode,
+        name: 'a',
+        language: 'javascript',
+      } as GraphNode)
+      g.addNode('service:b', {
+        id: 'service:b',
+        type: NodeType.ServiceNode,
+        name: 'b',
+        language: 'javascript',
+      } as GraphNode)
+      const eid = `${EdgeType.CALLS}:OBSERVED:service:a->service:b`
+      g.addEdgeWithKey(eid, 'service:a', 'service:b', {
+        id: eid,
+        source: 'service:a',
+        target: 'service:b',
+        type: EdgeType.CALLS,
+        provenance: Provenance.OBSERVED,
+        confidence: 1,
+        lastObserved: new Date(0).toISOString(),
+        callCount: 1,
+      } as GraphEdge)
+      await markStaleEdges(g, { now: Date.now(), project: 'tester' })
+      expect(captured[0]).toEqual({
+        edgeId: eid,
+        from: Provenance.OBSERVED,
+        to: Provenance.STALE,
+      })
+    } finally {
+      eventBus.off(EVENT_BUS_CHANNEL, listener)
+    }
+  })
+
+  it('SSE heartbeat comment line emitted at most every 30 seconds (ADR-051 #3)', async () => {
+    // Default heartbeat interval is 30s — exposed as SSE_HEARTBEAT_MS so the
+    // contract value is reachable by anything that needs it (proxies, tests).
+    const streaming = readFileSync(join(CORE_SRC, 'streaming.ts'), 'utf8')
+    const { SSE_HEARTBEAT_MS } = await import('../../src/streaming.js')
+    expect(SSE_HEARTBEAT_MS).toBe(30_000)
+    expect(streaming).toMatch(/:heartbeat\\n\\n/)
+  })
+
+  it('GET /projects returns the listProjects() shape from registry.ts (ADR-051 #4)', async () => {
+    const { Projects } = await import('../../src/projects.js')
+    const { buildApi } = await import('../../src/api.js')
+    const { DEFAULT_PROJECT, getGraph, resetGraph } = await import('../../src/graph.js')
+    const fs2 = await import('node:fs/promises')
+    const os2 = await import('node:os')
+    const path2 = await import('node:path')
+    const home = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-projects-list-'))
+    const projDir = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-projects-pdir-'))
+    const projReal = await fs2.realpath(projDir)
+    const prevHome = process.env.NEAT_HOME
+    process.env.NEAT_HOME = home
+    resetGraph(DEFAULT_PROJECT)
+    try {
+      const { addProject, listProjects: listRegistry } = await import('../../src/registry.js')
+      await addProject({ name: 'p', path: projReal, languages: ['javascript'] })
+      const expected = await listRegistry()
+      const reg = new Projects()
+      reg.set(DEFAULT_PROJECT, {
+        graph: getGraph(DEFAULT_PROJECT),
+        paths: {
+          snapshotPath: path2.join(home, 'graph.json'),
+          errorsPath: path2.join(home, 'errors.ndjson'),
+          staleEventsPath: path2.join(home, 'stale-events.ndjson'),
+          embeddingsCachePath: path2.join(home, 'embeddings.json'),
+          policyViolationsPath: path2.join(home, 'policy-violations.ndjson'),
+        },
+      })
+      const app = await buildApi({ projects: reg })
+      const res = await app.inject({ method: 'GET', url: '/projects' })
+      expect(res.statusCode).toBe(200)
+      expect(res.json()).toEqual(expected)
+      await app.close()
+    } finally {
+      if (prevHome === undefined) delete process.env.NEAT_HOME
+      else process.env.NEAT_HOME = prevHome
+      await fs2.rm(home, { recursive: true, force: true })
+      await fs2.rm(projDir, { recursive: true, force: true })
+      resetGraph(DEFAULT_PROJECT)
+    }
+  })
+
+  it('GET /projects shape is Array<{ name, path, status, registeredAt, lastSeenAt?, languages }> (ADR-051 #4)', async () => {
+    const { Projects } = await import('../../src/projects.js')
+    const { buildApi } = await import('../../src/api.js')
+    const { DEFAULT_PROJECT, getGraph, resetGraph } = await import('../../src/graph.js')
+    const fs2 = await import('node:fs/promises')
+    const os2 = await import('node:os')
+    const path2 = await import('node:path')
+    const home = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-projects-shape-'))
+    const projDir = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-projects-shape-p-'))
+    const projReal = await fs2.realpath(projDir)
+    const prevHome = process.env.NEAT_HOME
+    process.env.NEAT_HOME = home
+    resetGraph(DEFAULT_PROJECT)
+    try {
+      const { addProject } = await import('../../src/registry.js')
+      await addProject({
+        name: 'shape-test',
+        path: projReal,
+        languages: ['python'],
+      })
+      const reg = new Projects()
+      reg.set(DEFAULT_PROJECT, {
+        graph: getGraph(DEFAULT_PROJECT),
+        paths: {
+          snapshotPath: path2.join(home, 'graph.json'),
+          errorsPath: path2.join(home, 'errors.ndjson'),
+          staleEventsPath: path2.join(home, 'stale-events.ndjson'),
+          embeddingsCachePath: path2.join(home, 'embeddings.json'),
+          policyViolationsPath: path2.join(home, 'policy-violations.ndjson'),
+        },
+      })
+      const app = await buildApi({ projects: reg })
+      const res = await app.inject({ method: 'GET', url: '/projects' })
+      expect(res.statusCode).toBe(200)
+      const body = res.json() as Array<{
+        name: string
+        path: string
+        status: string
+        registeredAt: string
+        lastSeenAt?: string
+        languages: string[]
+      }>
+      expect(Array.isArray(body)).toBe(true)
+      expect(body).toHaveLength(1)
+      const entry = body[0]!
+      expect(entry.name).toBe('shape-test')
+      expect(entry.path).toBe(projReal)
+      expect(entry.status).toBe('active')
+      expect(typeof entry.registeredAt).toBe('string')
+      expect(entry.languages).toEqual(['python'])
+      await app.close()
+    } finally {
+      if (prevHome === undefined) delete process.env.NEAT_HOME
+      else process.env.NEAT_HOME = prevHome
+      await fs2.rm(home, { recursive: true, force: true })
+      await fs2.rm(projDir, { recursive: true, force: true })
+      resetGraph(DEFAULT_PROJECT)
+    }
+  })
+
+  it('SSE error responses use `event: error` payload before connection close (ADR-051 #5)', () => {
+    // Backpressure cap is the only error path that closes the connection
+    // mid-stream; the streaming source emits exactly one `event: error`
+    // frame before calling end() in that case.
+    const streaming = readFileSync(join(CORE_SRC, 'streaming.ts'), 'utf8')
+    expect(streaming).toMatch(/event:\s*error/)
+    expect(streaming).toMatch(/closeConnection/)
+  })
+
+  it('non-SSE error responses keep the ADR-040 `{ error, status, details? }` envelope (ADR-051 #5)', async () => {
+    const { Projects } = await import('../../src/projects.js')
+    const { buildApi } = await import('../../src/api.js')
+    const { DEFAULT_PROJECT, getGraph, resetGraph } = await import('../../src/graph.js')
+    const fs2 = await import('node:fs/promises')
+    const os2 = await import('node:os')
+    const path2 = await import('node:path')
+    const tmp = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-err-shape-'))
+    resetGraph(DEFAULT_PROJECT)
+    try {
+      const reg = new Projects()
+      reg.set(DEFAULT_PROJECT, {
+        graph: getGraph(DEFAULT_PROJECT),
+        paths: {
+          snapshotPath: path2.join(tmp, 'graph.json'),
+          errorsPath: path2.join(tmp, 'errors.ndjson'),
+          staleEventsPath: path2.join(tmp, 'stale-events.ndjson'),
+          embeddingsCachePath: path2.join(tmp, 'embeddings.json'),
+          policyViolationsPath: path2.join(tmp, 'policy-violations.ndjson'),
+        },
+      })
+      const app = await buildApi({ projects: reg })
+      const res = await app.inject({ method: 'GET', url: '/projects/missing/graph' })
+      expect(res.statusCode).toBe(404)
+      const body = res.json() as { error: string }
+      expect(typeof body.error).toBe('string')
+      expect(body).toEqual({ error: 'project not found', project: 'missing' })
+      await app.close()
+    } finally {
+      await fs2.rm(tmp, { recursive: true, force: true })
+      resetGraph(DEFAULT_PROJECT)
+    }
+  })
+
+  it('SSE backpressure cap drops connection at 1000 queued messages with `event: error` `{ reason: "backpressure" }` (ADR-051 #8)', async () => {
+    const { SSE_BACKPRESSURE_CAP } = await import('../../src/streaming.js')
+    expect(SSE_BACKPRESSURE_CAP).toBe(1000)
+    const streaming = readFileSync(join(CORE_SRC, 'streaming.ts'), 'utf8')
+    expect(streaming).toMatch(/reason:\s*['"]backpressure['"]/)
+    expect(streaming).toMatch(/backpressureCap/)
+  })
+
+  it('event bus is a single EventEmitter singleton in packages/core/src/events.ts (ADR-051 — authority)', async () => {
+    const events = await import('../../src/events.js')
+    const { EventEmitter } = await import('node:events')
+    expect(events.eventBus).toBeInstanceOf(EventEmitter)
+    // Singleton: re-importing returns the same instance.
+    const again = await import('../../src/events.js')
+    expect(again.eventBus).toBe(events.eventBus)
+    // No competing EventEmitter exported as a public bus — the named export
+    // is exactly `eventBus` and there's only one.
+    const src = readFileSync(join(CORE_SRC, 'events.ts'), 'utf8')
+    expect(src.match(/export const eventBus/g)).toHaveLength(1)
+  })
+
+  it('event producers in ingest.ts / extract/ / watch.ts / policy.ts emit through the bus, not directly to handlers (ADR-051 — authority)', () => {
+    // Each producer module must import from events.ts. None may construct a
+    // private EventEmitter for graph-mutation broadcast.
+    const ingest = readFileSync(join(CORE_SRC, 'ingest.ts'), 'utf8')
+    const extractIdx = readFileSync(join(CORE_SRC, 'extract', 'index.ts'), 'utf8')
+    const watch = readFileSync(join(CORE_SRC, 'watch.ts'), 'utf8')
+    const policy = readFileSync(join(CORE_SRC, 'policy.ts'), 'utf8')
+    for (const [name, src] of [
+      ['ingest.ts', ingest],
+      ['extract/index.ts', extractIdx],
+      ['watch.ts', watch],
+      ['policy.ts', policy],
+    ] as const) {
+      expect(src, `${name} must import from events.ts`).toMatch(/from\s+['"]\.\.?\/events\.js['"]|from\s+['"]\.\/events\.js['"]/)
+    }
+    // Negative: no producer constructs its own EventEmitter for runtime
+    // events. The bus is the only one.
+    for (const [name, src] of [
+      ['ingest.ts', ingest],
+      ['extract/index.ts', extractIdx],
+      ['policy.ts', policy],
+    ] as const) {
+      expect(
+        src,
+        `${name} must not construct a private EventEmitter`,
+      ).not.toMatch(/new\s+EventEmitter/)
+    }
+  })
 })
 
 describe('Publish system contract (ADR-052)', () => {

--- a/packages/core/test/projects.test.ts
+++ b/packages/core/test/projects.test.ts
@@ -168,21 +168,30 @@ describe('buildApi multi-project routing', () => {
     await app.close()
   })
 
-  it('GET /projects lists every registered project', async () => {
+  it('GET /projects passes through the machine-level registry (ADR-051 #4)', async () => {
+    // ADR-051 changed /projects from "in-memory project map with node/edge
+    // counts" to a passthrough of registry.listProjects() — that shape is what
+    // a project-picker UI needs. Seed an empty NEAT_HOME so the response is
+    // an empty array; behaviour with seeded registry entries is covered by
+    // the contracts test suite.
     seedDefault()
-    seedAlpha()
     const registry = new Projects()
     registry.set(DEFAULT_PROJECT, { paths: pathsForProject(DEFAULT_PROJECT, tmpDir) })
-    registry.set('alpha', { paths: pathsForProject('alpha', tmpDir) })
 
-    const app = await buildApi({ projects: registry })
-    const res = await app.inject({ method: 'GET', url: '/projects' })
-    expect(res.statusCode).toBe(200)
-    const body = res.json() as { projects: { name: string; nodeCount: number }[] }
-    const byName = Object.fromEntries(body.projects.map((p) => [p.name, p]))
-    expect(byName.default.nodeCount).toBe(1)
-    expect(byName.alpha.nodeCount).toBe(2)
-    await app.close()
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-projects-home-'))
+    const prevHome = process.env.NEAT_HOME
+    process.env.NEAT_HOME = home
+    try {
+      const app = await buildApi({ projects: registry })
+      const res = await app.inject({ method: 'GET', url: '/projects' })
+      expect(res.statusCode).toBe(200)
+      expect(res.json()).toEqual([])
+      await app.close()
+    } finally {
+      if (prevHome === undefined) delete process.env.NEAT_HOME
+      else process.env.NEAT_HOME = prevHome
+      await fs.rm(home, { recursive: true, force: true })
+    }
   })
 
   it('returns 404 with the project name when an unknown project is requested', async () => {


### PR DESCRIPTION
## Summary

The frontend-facing half of the v0.2.8 contract batch. Closes the surface that Jed's v0.3.0 frontend track is currently blocked on:

- **`packages/core/src/events.ts`** — single in-process `EventEmitter` + locked taxonomy of eight event types. Every graph-mutation producer (ingest / extract / watch / policy) emits through it; the SSE handler is the only consumer. `attachGraphToEventBus(graph, { project })` re-emits graphology's node/edge add/remove + attribute-update events with a project tag, so producers don't have to instrument every `addNode` / `addEdge` call.
- **`packages/core/src/streaming.ts`** — the SSE handler. 30s heartbeat (`:heartbeat\n\n`), per-connection backpressure cap of 1000 outstanding writes; past that the connection is dropped with `event: error data: { reason: 'backpressure' }`.
- **`/events` is dual-mounted** alongside the rest of the REST surface, so `/events` streams the default project and `/projects/:project/events` scopes per ADR-026.
- **`/projects`** is now a passthrough of `registry.listProjects()` — the shape a project-picker UI needs. Old `{ name, nodeCount, edgeCount, scanPath }` shape replaced by `{ name, path, status, registeredAt, lastSeenAt?, languages }` per ADR-051 #4.

Stale-transition fires from `markStaleEdges` directly because a provenance flip is a bare attribute update from graphology's view. `policy-violation` comes out of `PolicyViolationsLog.append` on first sighting, after the existing dedup gate.

All 18 ADR-051 `it.todo`s in `contracts.test.ts` flip to live assertions. Tests cover content-type, dual-mount, the locked taxonomy, every event payload shape, the heartbeat / backpressure constants, the `/projects` shape, and the bus-singleton authority rule.

## Test plan

- [x] `npx turbo build test lint` green
- [x] `npx vitest run test/audits/contracts.test.ts` — 18 new live ADR-051 tests, 0 fail
- [x] Existing `/projects` test in `projects.test.ts` updated to match the new registry-passthrough shape
- [ ] Manual smoke: `curl -N http://localhost:8080/events` keeps the connection open, prints heartbeats, and emits frames for graph mutations during a `neat watch` session

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)