### PR TITLE
ADR-054 — ServiceNode.owner extraction rule

### DIFF
--- a/docs/contracts/static-extraction.md
+++ b/docs/contracts/static-extraction.md
@@ -117,6 +117,20 @@ Issue #142 adds `framework?: string` to `ServiceNodeSchema`. This is **schema gr
 
 The table lives in `compat.json` or a sibling data file. Population happens at extract time. The snapshot guard catches schema drift.
 
+## Owner extraction (ADR-054)
+
+`extract/services.ts` populates `ServiceNode.owner` per service. Source priority:
+
+1. **CODEOWNERS file.** Read `<scanPath>/CODEOWNERS` first, then `<scanPath>/.github/CODEOWNERS`. Match each service's `repoPath` against the file's patterns. Use the literal RHS of the first matching line (`@org/team`, `email@addr`, etc.).
+2. **`package.json` `author` field.** If CODEOWNERS doesn't cover the service's path, read `<service.repoPath>/package.json` and use `author` if present (string form or `name` from object form).
+3. **Otherwise undefined.** No git-blame fallback (last-toucher ≠ owner; per-service git invocations are slow).
+
+Format is the literal source value — no normalization in extract. Display-time normalization is the consumer's job.
+
+OTel-auto-created services (per ADR-033) start with `owner: undefined`; static extraction backfills when `extract/services.ts` later discovers source. Property updates on existing nodes are allowed by extract producers per ADR-030.
+
+CODEOWNERS pattern matching in MVP is minimal: support `*`, `**`, and exact paths. No full gitignore-style parser.
+
 ## Enforcement
 
 `packages/core/test/audits/contracts.test.ts` includes:
@@ -124,6 +138,7 @@ The table lives in `compat.json` or a sibling data file. Population happens at e
 - A scan asserting every EXTRACTED-edge construction site in `extract/` includes an `evidence` field with at least `file`. Lands as `it.todo` keyed to #140 and flips when the issue closes.
 - A producer-interface assertion: every `addX` export under `extract/` accepts `(graph, services, scanPath)` (or a strict subset).
 - An idempotency assertion: run a producer twice on the same fixture, expect identical graph state.
+- Owner-extraction block (`it.todo`s for ADR-054): schema includes optional `owner`; CODEOWNERS at root + at `.github/`; package.json `author` fallback; undefined when neither source covers; backfill on existing nodes from OTel ingest.
 
 The PreToolUse hook surfaces this contract whenever any file under `extract/` or `watch.ts` is edited.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1473,3 +1473,51 @@ Documents the load-bearing rules of the npm publish pipeline. The pipeline has b
 **Enforcement.** No mechanized test. Detected by reading: if `CLAUDE.md`'s active-milestone block names a version that's already on the npm registry as a retired or current published version, the milestone needs to be rolled forward.
 
 **First application.** v0.2.6 → v0.2.8 milestone rename, 2026-05-09, see `docs/plans/2026-05-09-milestone-rename.md`.
+
+## ADR-054 — `ServiceNode.owner` extraction rule
+
+**Date:** 2026-05-10
+**Status:** Active.
+
+**Context.** The 2026-05-04 audit (`docs/audits/NEAT-audit-types(1).md`) graded the absence of an `owner` field on `ServiceNode` as a FAIL: *"absent. Blocks code-ownership-aware features."* The v0.2.x sequence didn't ship it, didn't track it as a deferred issue, and no contract gated it — it quietly disappeared. The 2026-05-10 pre-v0.3.0 verification pass (`docs/plans/2026-05-10-pre-v0.3.0-verification.md`, Finding 9.1) caught it during the audit-doc re-grade.
+
+`owner` is the difference between diagnostic and actionable. NEAT's value isn't just *"`pg@7.4.0` is incompatible with PostgreSQL 15"* — it's *"and here's who to talk to about fixing it."* Without an owner field, the human consuming the output has to find ownership separately. With it, ADR-027's MVP-success-PR experiment becomes a tighter loop: identify divergence, identify owner, propose fix to that owner.
+
+**Decision.**
+
+1. **Schema.** Add `owner?: string` to `ServiceNodeSchema` in `packages/types/src/nodes.ts`. Optional. Per ADR-031 this is *growth* — commit-and-go, no `persist.ts` migration needed; `schema-snapshot.test.ts` regenerates the fixture as the audit trail.
+
+2. **Source priority during static extraction.** `extract/services.ts` populates `owner` per service in this order:
+
+   1. **CODEOWNERS file.** Read `<scanPath>/CODEOWNERS` or `<scanPath>/.github/CODEOWNERS` (in that order). Match each service's `repoPath` against the patterns; use the first matching line's RHS (the literal owner string, `@org/team` or `email@addr.tld` or whatever the file declares).
+   2. **`package.json` author field.** If CODEOWNERS doesn't cover the service's path, read `<service.repoPath>/package.json` and use the `author` field if present. Accept either string form (`"Cem D <cem@example.com>"`) or object form (use `name` field).
+   3. **Otherwise, leave `owner` undefined.**
+
+   No git-blame fallback. Too noisy (last-toucher ≠ owner), too slow (per-service git invocations), and the failure mode of a wrong owner attribution is worse than no owner attribution.
+
+3. **Format.** Literal value from the source. No normalization in MVP — `@neat-tools/backend` stays `@neat-tools/backend`; `cem@neat.is` stays `cem@neat.is`. The frontend / MCP can normalize for display; the graph stores ground truth.
+
+4. **Trigger.** Population happens during static extraction (`discoverServices` in `extract/services.ts`). Not at OTel ingest time.
+
+5. **OTel-auto-created services.** Per ADR-033 #4, services auto-created from OTel spans (no source path known yet) start with `owner: undefined`. When `extract/services.ts` later discovers the service's source via tree-sitter / file walk, it backfills `owner` per the priority above. Per ADR-030 (lifecycle), property updates on existing nodes are allowed by extract producers; this is a normal property update.
+
+6. **No CODEOWNERS pattern compiler in MVP.** Use a minimal glob match: support `*` and `**` and exact paths. Don't pull in a full CODEOWNERS gitignore-style parser. If real-user signal demands richer patterns, file a successor ADR.
+
+**Authority.** `packages/types/src/nodes.ts` (schema growth), `packages/core/src/extract/services.ts` (extraction logic). The static-extraction contract (`docs/contracts/static-extraction.md`) gets an "Owner extraction" section linking back here.
+
+**Enforcement.** `it.todo` block in `contracts.test.ts`:
+
+- `ServiceNodeSchema` includes optional `owner` field
+- `extract/services.ts` populates `owner` from CODEOWNERS when one exists at repo root
+- `extract/services.ts` populates `owner` from CODEOWNERS at `.github/CODEOWNERS` when no root file
+- `extract/services.ts` falls back to package.json `author` when CODEOWNERS doesn't cover the path
+- `extract/services.ts` leaves `owner` undefined when neither source is available
+- Backfill works: a service auto-created from OTel ingest gets `owner` populated when `discoverServices` later runs
+
+The schema-snapshot test catches the field addition automatically (per ADR-031).
+
+**What this is NOT.**
+
+- Not a node type. Owners aren't first-class graph nodes; they're a property on `ServiceNode`. If real-user demand surfaces a need to query "all services owned by team X" or to wire owner-as-blast-radius-target, that's a successor ADR (probably an `OwnerNode` with `OWNED_BY` edges).
+- Not a runtime concern. The OBSERVED layer doesn't carry owner data; OTel spans don't (and shouldn't) advertise organizational structure. Owner is purely an EXTRACTED-layer property.
+- Not a policy attribute (yet). The `policies` contract (ADRs 042-045) doesn't reference `owner` today. If real-user signal demands ownership-conditioned policies (*"alert team X if their service depends on a deprecated package"*), that's a policy-schema extension, separate work.

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -601,6 +601,40 @@ describe('Static-extraction contract (ADR-032)', () => {
 })
 
 // ──────────────────────────────────────────────────────────────────────────
+// ServiceNode.owner extraction (ADR-054)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Adds optional `owner?: string` to ServiceNodeSchema; populates from
+// CODEOWNERS at <scanPath>/CODEOWNERS or <scanPath>/.github/CODEOWNERS, with
+// package.json `author` fallback, and undefined when neither covers. Per
+// ADR-031 the schema addition is growth — schema-snapshot regenerates as the
+// audit trail. Per ADR-030 backfill on existing nodes is allowed by extract
+// producers; OTel-auto-created services (per ADR-033 #4) get owner populated
+// when extract/services.ts later discovers their source.
+describe('ServiceNode.owner extraction (ADR-054)', () => {
+  it.todo('ServiceNodeSchema includes optional `owner` field (ADR-054 #1 — schema growth)')
+  it.todo(
+    'extract/services.ts populates ServiceNode.owner from <scanPath>/CODEOWNERS when one exists (ADR-054 #2.1)',
+  )
+  it.todo(
+    'extract/services.ts falls back to <scanPath>/.github/CODEOWNERS when no root CODEOWNERS file (ADR-054 #2.1)',
+  )
+  it.todo(
+    'extract/services.ts falls back to package.json `author` when CODEOWNERS does not cover the path (ADR-054 #2.2)',
+  )
+  it.todo(
+    'extract/services.ts accepts package.json `author` as either string form or `{ name }` object form (ADR-054 #2.2)',
+  )
+  it.todo('extract/services.ts leaves owner undefined when neither source covers (ADR-054 #2.3)')
+  it.todo(
+    'CODEOWNERS pattern matcher supports `*`, `**`, and exact paths only (ADR-054 #6 — minimal MVP)',
+  )
+  it.todo(
+    'OTel-auto-created services with no owner get backfilled when extract/services.ts later discovers source (ADR-054 #5)',
+  )
+})
+
+// ──────────────────────────────────────────────────────────────────────────
 // OTel ingest contract — non-blocking, span-time, parent-cache (ADR-033)
 // ──────────────────────────────────────────────────────────────────────────
 describe('OTel ingest contract (ADR-033)', () => {


### PR DESCRIPTION
## Summary

Closes the trail on a FAIL from the 2026-05-04 verification audit (`NEAT-audit-types(1).md`: *"owner on ServiceNode — absent. Blocks code-ownership-aware features."*) that quietly slipped through the v0.2.x sequence. Surfaced again in the 2026-05-10 pre-v0.3.0 verification pass (Finding 9.1) — Contract Author scope to land the contract, Implementation Agent picks up the code work.

## Decision shape

- **Schema:** add `owner?: string` to `ServiceNodeSchema`. Schema growth per ADR-031, no migration; `schema-snapshot.test.ts` regenerates as audit trail.
- **Source priority during static extraction:**
  1. `<scanPath>/CODEOWNERS` (root)
  2. `<scanPath>/.github/CODEOWNERS`
  3. `<service.repoPath>/package.json` `author` field (string or `{name}` object form)
  4. Otherwise `undefined`
- **No git-blame fallback** — last-toucher ≠ owner; per-service git invocations are slow and noisy.
- **Format is literal** — no normalization in extract. Display normalization is the consumer's job.
- **Trigger:** static extraction (`extract/services.ts`). Not OTel ingest.
- **OTel-auto-created services** (per ADR-033) start with `owner: undefined`; static extraction backfills when source is later discovered. Property updates allowed by extract producers per ADR-030.
- **CODEOWNERS pattern matching in MVP** is minimal — `*`, `**`, exact paths. No full gitignore-style parser. Successor ADR if real-user signal demands more.

## What's in this PR

- **`docs/decisions.md`** — ADR-054 appended.
- **`docs/contracts/static-extraction.md`** — new "Owner extraction (ADR-054)" section so the PreToolUse hook surfaces the rule when `extract/services.ts` is edited.
- **`packages/core/test/audits/contracts.test.ts`** — 8 new `it.todo` entries (test count: 165 live + 12 todo, was 4 todo).

## What's NOT in this PR

Per role discipline (Contract Author drafts, Implementation Agent ships):

- `owner?: string` schema addition in `packages/types/src/nodes.ts` — Implementation Agent
- Schema snapshot regeneration (`UPDATE_SNAPSHOT=1`) — Implementation Agent
- CODEOWNERS parser implementation in `packages/core/src/extract/owners.ts` (or wherever) — Implementation Agent
- Wiring into `discoverServices` in `extract/services.ts` — Implementation Agent
- Flipping the 8 `it.todo`s to live — Implementation Agent

A separate Claude Code session picks this up against the locked contract. Handoff prompt is in the conversation history.

## Test plan

- [x] `npx turbo build` clean
- [x] `vitest run test/audits/contracts.test.ts` — 165 pass / 12 todo / 0 fail
- [ ] Post-merge: Implementation Agent ships the schema + extractor + flips the 8 todos
- [ ] Post-implementation: `it.todo`s flip to live and pass against fixture data

Refs #197