### PR TITLE
ADR-054 — ServiceNode.owner extraction

### DIFF
--- a/packages/core/src/extract/owners.ts
+++ b/packages/core/src/extract/owners.ts
@@ -1,0 +1,101 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { minimatch } from 'minimatch'
+import { exists, readJson } from './shared.js'
+
+export interface CodeownersRule {
+  pattern: string
+  owners: string
+}
+
+export interface CodeownersFile {
+  rules: CodeownersRule[]
+}
+
+interface PackageJsonAuthor {
+  author?: string | { name?: string }
+}
+
+// Read CODEOWNERS at <scanPath>/CODEOWNERS first, then <scanPath>/.github/CODEOWNERS.
+// Returns null when neither exists. ADR-054 #2.1.
+export async function loadCodeowners(scanPath: string): Promise<CodeownersFile | null> {
+  const candidates = [
+    path.join(scanPath, 'CODEOWNERS'),
+    path.join(scanPath, '.github', 'CODEOWNERS'),
+  ]
+  for (const file of candidates) {
+    if (await exists(file)) {
+      const raw = await fs.readFile(file, 'utf8')
+      return parseCodeowners(raw)
+    }
+  }
+  return null
+}
+
+function parseCodeowners(raw: string): CodeownersFile {
+  const rules: CodeownersRule[] = []
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const match = /^(\S+)\s+(.+)$/.exec(trimmed)
+    if (!match) continue
+    rules.push({ pattern: match[1]!, owners: match[2]!.trim() })
+  }
+  return { rules }
+}
+
+// First matching pattern wins; returns the literal RHS or null. ADR-054 #2.1.
+// Pattern matcher is minimal per ADR-054 #6 — handles `*`, `**`, and exact
+// paths; not a full gitignore-style parser.
+export function matchOwner(file: CodeownersFile, repoPath: string): string | null {
+  const normalized = repoPath.split(path.sep).join('/')
+  for (const rule of file.rules) {
+    if (matchesPattern(rule.pattern, normalized)) return rule.owners
+  }
+  return null
+}
+
+function matchesPattern(rawPattern: string, repoPath: string): boolean {
+  let pattern = rawPattern.startsWith('/') ? rawPattern.slice(1) : rawPattern
+  if (pattern === '*') return !repoPath.includes('/')
+  if (pattern === '**' || pattern === '') return true
+  // Trailing slash means "everything in this directory".
+  if (pattern.endsWith('/')) pattern = pattern + '**'
+  if (minimatch(repoPath, pattern, { dot: true })) return true
+  // A pattern that names a directory should match files beneath it too.
+  if (!pattern.includes('*') && minimatch(repoPath, pattern + '/**', { dot: true })) return true
+  return false
+}
+
+// Read <serviceDir>/package.json and return the `author` field as a literal
+// string. Accepts either string form ("Cem D <cem@example.com>") or object
+// form ({ name: 'Cem D' }). Returns null when missing or unparseable.
+// ADR-054 #2.2.
+export async function readPackageJsonAuthor(serviceDir: string): Promise<string | null> {
+  const pkgPath = path.join(serviceDir, 'package.json')
+  if (!(await exists(pkgPath))) return null
+  try {
+    const pkg = await readJson<PackageJsonAuthor>(pkgPath)
+    if (!pkg.author) return null
+    if (typeof pkg.author === 'string') return pkg.author
+    if (typeof pkg.author === 'object' && typeof pkg.author.name === 'string') return pkg.author.name
+    return null
+  } catch {
+    return null
+  }
+}
+
+// Compute owner per ADR-054 priority: CODEOWNERS first, package.json `author`
+// fallback, undefined otherwise. Literal source value, no normalization (#3).
+export async function computeServiceOwner(
+  codeowners: CodeownersFile | null,
+  repoPath: string | undefined,
+  serviceDir: string,
+): Promise<string | undefined> {
+  if (codeowners && repoPath !== undefined) {
+    const owner = matchOwner(codeowners, repoPath)
+    if (owner) return owner
+  }
+  const author = await readPackageJsonAuthor(serviceDir)
+  return author ?? undefined
+}

--- a/packages/core/src/extract/services.ts
+++ b/packages/core/src/extract/services.ts
@@ -13,6 +13,7 @@ import {
   type PackageJson,
 } from './shared.js'
 import { discoverPythonService, pythonToPackage } from './python.js'
+import { computeServiceOwner, loadCodeowners } from './owners.js'
 
 const DEFAULT_SCAN_DEPTH = 5
 
@@ -219,6 +220,16 @@ export async function discoverServices(scanPath: string): Promise<DiscoveredServ
     seen.set(service.node.name, dir)
     out.push(service)
   }
+
+  // Owner extraction (ADR-054). CODEOWNERS first, package.json `author`
+  // fallback, undefined otherwise. Read once per discovery pass; the file
+  // is small and parsing it per-service would be wasteful.
+  const codeowners = await loadCodeowners(scanPath)
+  for (const service of out) {
+    const owner = await computeServiceOwner(codeowners, service.node.repoPath, service.dir)
+    if (owner !== undefined) service.node.owner = owner
+  }
+
   return out
 }
 

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -612,26 +612,165 @@ describe('Static-extraction contract (ADR-032)', () => {
 // producers; OTel-auto-created services (per ADR-033 #4) get owner populated
 // when extract/services.ts later discovers their source.
 describe('ServiceNode.owner extraction (ADR-054)', () => {
-  it.todo('ServiceNodeSchema includes optional `owner` field (ADR-054 #1 — schema growth)')
-  it.todo(
-    'extract/services.ts populates ServiceNode.owner from <scanPath>/CODEOWNERS when one exists (ADR-054 #2.1)',
-  )
-  it.todo(
-    'extract/services.ts falls back to <scanPath>/.github/CODEOWNERS when no root CODEOWNERS file (ADR-054 #2.1)',
-  )
-  it.todo(
-    'extract/services.ts falls back to package.json `author` when CODEOWNERS does not cover the path (ADR-054 #2.2)',
-  )
-  it.todo(
-    'extract/services.ts accepts package.json `author` as either string form or `{ name }` object form (ADR-054 #2.2)',
-  )
-  it.todo('extract/services.ts leaves owner undefined when neither source covers (ADR-054 #2.3)')
-  it.todo(
-    'CODEOWNERS pattern matcher supports `*`, `**`, and exact paths only (ADR-054 #6 — minimal MVP)',
-  )
-  it.todo(
-    'OTel-auto-created services with no owner get backfilled when extract/services.ts later discovers source (ADR-054 #5)',
-  )
+  async function scaffold(
+    files: Record<string, string>,
+  ): Promise<string> {
+    const { mkdtempSync, mkdirSync, writeFileSync } = await import('node:fs')
+    const { tmpdir } = await import('node:os')
+    const root = mkdtempSync(join(tmpdir(), 'owner-test-'))
+    for (const [rel, content] of Object.entries(files)) {
+      const full = join(root, rel)
+      mkdirSync(join(full, '..'), { recursive: true })
+      writeFileSync(full, content, 'utf8')
+    }
+    return root
+  }
+
+  it('ServiceNodeSchema includes optional `owner` field (ADR-054 #1 — schema growth)', async () => {
+    const { ServiceNodeSchema } = await import('@neat.is/types')
+    const shape = ServiceNodeSchema.shape
+    expect('owner' in shape).toBe(true)
+    expect(shape.owner.isOptional()).toBe(true)
+    // Round-trip: parses with and without the field present.
+    expect(ServiceNodeSchema.parse({
+      id: 'service:x', type: NodeType.ServiceNode, name: 'x', language: 'javascript',
+    }).owner).toBeUndefined()
+    expect(ServiceNodeSchema.parse({
+      id: 'service:x', type: NodeType.ServiceNode, name: 'x', language: 'javascript',
+      owner: '@neat-tools/backend',
+    }).owner).toBe('@neat-tools/backend')
+  })
+
+  it('extract/services.ts populates ServiceNode.owner from <scanPath>/CODEOWNERS when one exists (ADR-054 #2.1)', async () => {
+    const { discoverServices } = await import('../../src/extract/services.js')
+    const root = await scaffold({
+      'CODEOWNERS': '* @neat-tools/backend\n',
+      'package.json': JSON.stringify({ name: 'svc-a', version: '1.0.0' }),
+    })
+    const services = await discoverServices(root)
+    expect(services).toHaveLength(1)
+    expect(services[0]!.node.owner).toBe('@neat-tools/backend')
+  })
+
+  it('extract/services.ts falls back to <scanPath>/.github/CODEOWNERS when no root CODEOWNERS file (ADR-054 #2.1)', async () => {
+    const { discoverServices } = await import('../../src/extract/services.js')
+    const root = await scaffold({
+      '.github/CODEOWNERS': '* @neat-tools/platform\n',
+      'package.json': JSON.stringify({ name: 'svc-b', version: '1.0.0' }),
+    })
+    const services = await discoverServices(root)
+    expect(services).toHaveLength(1)
+    expect(services[0]!.node.owner).toBe('@neat-tools/platform')
+  })
+
+  it('extract/services.ts falls back to package.json `author` when CODEOWNERS does not cover the path (ADR-054 #2.2)', async () => {
+    const { discoverServices } = await import('../../src/extract/services.js')
+    // CODEOWNERS exists but only matches `apps/web` — the service lives at
+    // packages/api so the root pattern doesn't apply, package.json wins.
+    const root = await scaffold({
+      'CODEOWNERS': 'apps/web @neat-tools/frontend\n',
+      'packages/api/package.json': JSON.stringify({
+        name: 'api',
+        version: '1.0.0',
+        author: 'cem@neat.is',
+      }),
+    })
+    const services = await discoverServices(root)
+    expect(services).toHaveLength(1)
+    expect(services[0]!.node.owner).toBe('cem@neat.is')
+  })
+
+  it('extract/services.ts accepts package.json `author` as either string form or `{ name }` object form (ADR-054 #2.2)', async () => {
+    const { discoverServices } = await import('../../src/extract/services.js')
+
+    const stringRoot = await scaffold({
+      'package.json': JSON.stringify({
+        name: 'svc-string',
+        version: '1.0.0',
+        author: 'Cem D <cem@example.com>',
+      }),
+    })
+    const stringServices = await discoverServices(stringRoot)
+    expect(stringServices[0]!.node.owner).toBe('Cem D <cem@example.com>')
+
+    const objectRoot = await scaffold({
+      'package.json': JSON.stringify({
+        name: 'svc-object',
+        version: '1.0.0',
+        author: { name: 'Deniz D', email: 'deniz@neat.is' },
+      }),
+    })
+    const objectServices = await discoverServices(objectRoot)
+    expect(objectServices[0]!.node.owner).toBe('Deniz D')
+  })
+
+  it('extract/services.ts leaves owner undefined when neither source covers (ADR-054 #2.3)', async () => {
+    const { discoverServices } = await import('../../src/extract/services.js')
+    const root = await scaffold({
+      'package.json': JSON.stringify({ name: 'svc-no-owner', version: '1.0.0' }),
+    })
+    const services = await discoverServices(root)
+    expect(services).toHaveLength(1)
+    expect(services[0]!.node.owner).toBeUndefined()
+  })
+
+  it('CODEOWNERS pattern matcher supports `*`, `**`, and exact paths only (ADR-054 #6 — minimal MVP)', async () => {
+    const { matchOwner } = await import('../../src/extract/owners.js')
+    const file = {
+      rules: [
+        { pattern: 'apps/web', owners: '@team/exact' },
+        { pattern: 'packages/*', owners: '@team/single-star' },
+        { pattern: 'services/**', owners: '@team/double-star' },
+      ],
+    }
+    // Exact path
+    expect(matchOwner(file, 'apps/web')).toBe('@team/exact')
+    expect(matchOwner(file, 'apps/web/src/index.ts')).toBe('@team/exact')
+    // Single * — one segment under packages/
+    expect(matchOwner(file, 'packages/api')).toBe('@team/single-star')
+    // ** — anything below services/
+    expect(matchOwner(file, 'services/checkout')).toBe('@team/double-star')
+    expect(matchOwner(file, 'services/checkout/src/handler.ts')).toBe('@team/double-star')
+    // No match
+    expect(matchOwner(file, 'tools/scripts')).toBeNull()
+    // First match wins
+    const ordered = {
+      rules: [
+        { pattern: 'apps/web', owners: '@first' },
+        { pattern: 'apps/**', owners: '@second' },
+      ],
+    }
+    expect(matchOwner(ordered, 'apps/web')).toBe('@first')
+  })
+
+  it('OTel-auto-created services with no owner get backfilled when extract/services.ts later discovers source (ADR-054 #5)', async () => {
+    const { discoverServices, addServiceNodes } = await import('../../src/extract/services.js')
+
+    // Stage 1: OTel ingest auto-creates a minimal node with no owner.
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:checkout', {
+      id: 'service:checkout',
+      type: NodeType.ServiceNode,
+      name: 'checkout',
+      language: 'unknown',
+      discoveredVia: 'otel',
+    })
+    expect((g.getNodeAttributes('service:checkout') as { owner?: string }).owner).toBeUndefined()
+
+    // Stage 2: static extraction later discovers source with an owner.
+    const root = await scaffold({
+      'CODEOWNERS': '* @neat-tools/backend\n',
+      'package.json': JSON.stringify({ name: 'checkout', version: '1.0.0' }),
+    })
+    const services = await discoverServices(root)
+    expect(services[0]!.node.owner).toBe('@neat-tools/backend')
+
+    addServiceNodes(g, services)
+
+    const merged = g.getNodeAttributes('service:checkout') as { owner?: string; discoveredVia?: string }
+    expect(merged.owner).toBe('@neat-tools/backend')
+    expect(merged.discoveredVia).toBe('merged')
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -270,6 +270,9 @@
             "nodeEngine": {
               "_optional": "_string"
             },
+            "owner": {
+              "_optional": "_string"
+            },
             "repoPath": {
               "_optional": "_string"
             },

--- a/packages/types/src/nodes.ts
+++ b/packages/types/src/nodes.ts
@@ -23,6 +23,7 @@ export const ServiceNodeSchema = z.object({
   version: z.string().optional(),
   dbConnectionTarget: z.string().optional(),
   repoPath: z.string().optional(),
+  owner: z.string().optional(),
   dependencies: z.record(z.string(), z.string()).optional(),
   // Hostnames OTel spans might mention for this service: compose service
   // names, k8s metadata.name (and the cluster-DNS variants), Dockerfile


### PR DESCRIPTION
## Summary

- Adds optional `owner` to `ServiceNodeSchema` (growth per ADR-031; schema-snapshot regenerated as the audit trail).
- New `packages/core/src/extract/owners.ts` reads `<scanPath>/CODEOWNERS` (then `.github/CODEOWNERS`), parses minimal patterns (`*`, `**`, exact paths), and falls back to `package.json` `author` (string or `{ name }` form). No git-blame fallback per ADR-054 #2.3. Literal source value, no normalization (#3).
- `discoverServices` populates `service.node.owner` after candidate discovery; backfill on OTel-auto-created nodes falls out of `addServiceNodes`'s existing merge.
- Eight `it.todo`s in `contracts.test.ts` flip to live assertions; live count 165 → 173.

Refs ADR-054.

## Test plan

- [x] `npx turbo build test lint` green
- [x] `cd packages/core && npx vitest run test/audits/contracts.test.ts` — 173 passed, 4 todo (the v0.2.1 cleanup ones rolled forward)
- [x] Schema snapshot diff committed — `owner: { _optional: _string }` shows up under `ServiceNodeSchema`
- [ ] Contract author / Cem to spot-check the CODEOWNERS pattern matcher against any real-world fixtures they want

🤖 Generated with [Claude Code](https://claude.com/claude-code)