### PR TITLE
ADR-055 — Producer per-file parse-failure isolation

### DIFF
--- a/docs/contracts/static-extraction.md
+++ b/docs/contracts/static-extraction.md
@@ -117,6 +117,29 @@ Issue #142 adds `framework?: string` to `ServiceNodeSchema`. This is **schema gr
 
 The table lives in `compat.json` or a sibling data file. Population happens at extract time. The snapshot guard catches schema drift.
 
+## Per-file parse-failure isolation (ADR-055)
+
+Every producer that parses per-file content wraps the parse in `try / catch`. On failure: `console.warn` with the producer name, file path, and error message; `continue` to the next file. The phase completes even if some files are unparseable.
+
+```ts
+for (const file of files) {
+  let parsed: T
+  try {
+    parsed = await readJson<T>(file)
+  } catch (err) {
+    console.warn(`[neat] <phase> skipped ${file}: ${(err as Error).message}`)
+    continue
+  }
+  // … use `parsed` …
+}
+```
+
+Wrap at the call site, not in shared helpers. `readJson` and `readYaml` in `extract/shared.ts` continue to throw on malformed input; producers wrap their call. Keeps warning messages contextual (producer name, file path, failure mode).
+
+File reads that don't parse follow the same pattern when they sit inside a per-file walk — a permission error on one file shouldn't kill the phase.
+
+Conformant sites today: `calls/http.ts`, `owners.ts`, `infra/k8s.ts`, `databases/*`. Sites needing the fix: `services.ts` (×2), `aliases.ts` (×2), `infra/docker-compose.ts`, `infra/dockerfile.ts`. See ADR-055 for the full enumeration and the implementation hand-off.
+
 ## Owner extraction (ADR-054)
 
 `extract/services.ts` populates `ServiceNode.owner` per service. Source priority:

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1521,3 +1521,56 @@ The schema-snapshot test catches the field addition automatically (per ADR-031).
 - Not a node type. Owners aren't first-class graph nodes; they're a property on `ServiceNode`. If real-user demand surfaces a need to query "all services owned by team X" or to wire owner-as-blast-radius-target, that's a successor ADR (probably an `OwnerNode` with `OWNED_BY` edges).
 - Not a runtime concern. The OBSERVED layer doesn't carry owner data; OTel spans don't (and shouldn't) advertise organizational structure. Owner is purely an EXTRACTED-layer property.
 - Not a policy attribute (yet). The `policies` contract (ADRs 042-045) doesn't reference `owner` today. If real-user signal demands ownership-conditioned policies (*"alert team X if their service depends on a deprecated package"*), that's a policy-schema extension, separate work.
+
+## ADR-055 — Producer per-file parse-failure isolation
+
+**Date:** 2026-05-10
+**Status:** Active.
+
+**Context.** Run NEAT against an unfamiliar codebase (in this case `medusa` per the debugger agent's session) and a single file with malformed-but-parseable-by-tree-sitter syntax can throw inside `callsFromSource`, propagating up through the producer's `for (const file of files)` loop and aborting the entire HTTP-call extraction phase. The pattern recurs across producers: a `JSON.parse` on a malformed `package.json`, a `parseAllDocuments` on a broken Compose file, a tree-sitter parse on an exotic JS variant — any one bad file kills the phase.
+
+This violates the implicit assumption everywhere else in the system (OTel ingest backpressure per ADR-033, traversal per ADR-036's clean returns) that NEAT degrades gracefully on partial input. The static-extraction layer was the last piece without an explicit rule.
+
+The debugger agent shipped the fix on `extract/calls/http.ts` (try/catch with `console.warn` + `continue`); ADR-054's implementation independently arrived at the same shape on `extract/owners.ts`; `extract/infra/k8s.ts` already had it; `extract/databases/*` already had it. Four producer files still don't.
+
+**Decision.**
+
+1. **Every producer that parses per-file content wraps the parse in try/catch.** The wrap covers the parse call itself (`readYaml`, `readJson`, `parseAllDocuments`, `callsFromSource`, etc.) and any narrow logic that depends on its return value being well-formed.
+2. **On failure: warn and continue.** `console.warn(\`[neat] <phase> skipped <file>: <err.message>\`)`, then `continue` to the next file. Don't throw; don't abort the phase.
+3. **The phase completes even if some files are unparseable.** A single broken `.compose.yml` doesn't kill all infra extraction; a single bad `package.json` doesn't kill service discovery; a single bad `.js` file doesn't kill HTTP-call extraction.
+4. **Wrap at the call site, not in shared helpers.** `readJson` and `readYaml` in `extract/shared.ts` continue to throw on malformed input; producers wrap their call. This keeps warnings contextual (the message can name the producer, the file path, and the failure mode) and lets pure callers (e.g. `loadCodeowners`, which already wraps) keep their own shape.
+5. **File reads that don't parse follow the same pattern when they sit inside a per-file walk.** `fs.readFile` in `infra/dockerfile.ts` and `infra/terraform.ts` doesn't itself throw on content shape, but a permission error on one file shouldn't kill the phase. Same try/catch + skip discipline.
+
+**Sites already conformant (no work needed):**
+
+- `extract/calls/http.ts` — debugger agent's fix
+- `extract/owners.ts` — ADR-054 implementation
+- `extract/infra/k8s.ts:51-55` — `parseAllDocuments` wrapped
+- `extract/databases/*` — debugger agent confirmed
+
+**Sites needing the fix:**
+
+- `extract/services.ts:125` — `readJson<PackageJson>(pkgPath)` unwrapped (per-service `package.json` read)
+- `extract/services.ts:173` — `readJson<RootPackageJson>(rootPkgPath)` unwrapped (workspace root read)
+- `extract/aliases.ts:98` — `readYaml<ComposeFile>(composePath)` unwrapped
+- `extract/aliases.ts:149` — Dockerfile `fs.readFile` unwrapped (parse-by-regex, but file read can still fail)
+- `extract/infra/docker-compose.ts:58` — `readYaml<ComposeFile>(composePath)` unwrapped
+- `extract/infra/dockerfile.ts:42` — `fs.readFile` unwrapped
+
+Six call sites across four producer modules.
+
+**Authority.** `packages/core/src/extract/**` (every producer). The static-extraction contract (`docs/contracts/static-extraction.md`) gets a new "Per-file parse-failure isolation" section linking back here.
+
+**Enforcement.** `it.todo` block in `contracts.test.ts`:
+
+- A producer-resilience scan that walks every file under `packages/core/src/extract/`, finds every parse-like call (`readYaml`, `readJson`, `parseAllDocuments`, `callsFromSource`), and asserts it's surrounded by a `try { ... } catch { ... }` block.
+- One `it.todo` per known unfixed call site (six total) that flips to live as the implementation agent ships each fix.
+
+The scan is regex-based and approximate but sufficient for the failure shape — a missing try/catch around a `readJson` call shows up as a clean grep miss.
+
+**Out of scope.**
+
+- **Replacing tree-sitter substring scan in `callsFromSource` with regex** (debugger agent item 3). Performance / robustness rewrite; defer until performance becomes the gating concern.
+- **Size pre-filter on parse inputs** (debugger agent item 4). Skipping files > 1 MB before parse would reduce log noise from minified bundles. Optional, not required for correctness.
+- **Asynchronous-error escalation.** A producer can't `process.exit(1)` on a parse failure even if every file fails. The phase must always complete, even with zero successful parses. Logging volume from a `node_modules`-leaking scan is a separate UX concern.
+- **Sentry-style structured error reporting.** Plain `console.warn` is sufficient for MVP. Wrap-at-call-site keeps the message contextual; future telemetry can hook into `console.warn` without changing the contract.

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -774,6 +774,40 @@ describe('ServiceNode.owner extraction (ADR-054)', () => {
 })
 
 // ──────────────────────────────────────────────────────────────────────────
+// Producer per-file parse-failure isolation (ADR-055)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Surfaced 2026-05-10 by the debugger agent's medusa-codebase session: a
+// single malformed file in a producer's per-file walk could throw inside the
+// parse call and abort the entire phase. ADR-055 codifies the rule — every
+// producer wraps each per-file parse in try/catch, warns on failure, and
+// continues. Six call sites needed the fix at ADR time. The first assertion
+// is a live regression scan; the six per-site todos flip as each call site
+// is wrapped.
+describe('Producer per-file parse-failure isolation (ADR-055)', () => {
+  // Global scan ships as `it.todo` until the six per-site fixes land. Once
+  // every site is wrapped, the implementation agent flips this from todo to
+  // live; the assertion then catches any future regression mechanically.
+  // The scan walks producer files under extract/, finds every parse-like
+  // call (`readJson`, `readYaml`, `parseAllDocuments`, `callsFromSource`),
+  // and asserts the file contains at least one try/catch block. Whole-file
+  // presence of try/catch is sufficient evidence — per-call-site precision
+  // lives in the six todos below.
+  it.todo(
+    'every producer file under extract/ that calls a parse-like function wraps it in try/catch (ADR-055 — global scan, flips after the six per-site fixes ship)',
+  )
+
+  // Per-site todos. Each flips when its call site is wrapped per the
+  // canonical pattern (try { parse } catch { console.warn(...); continue }).
+  it.todo('extract/services.ts:125 — readJson<PackageJson>(pkgPath) wrapped (ADR-055 #1)')
+  it.todo('extract/services.ts:173 — readJson<RootPackageJson>(rootPkgPath) wrapped (ADR-055 #1)')
+  it.todo('extract/aliases.ts:98 — readYaml<ComposeFile>(composePath) wrapped (ADR-055 #1)')
+  it.todo('extract/aliases.ts:149 — Dockerfile fs.readFile wrapped (ADR-055 #5)')
+  it.todo('extract/infra/docker-compose.ts:58 — readYaml<ComposeFile>(composePath) wrapped (ADR-055 #1)')
+  it.todo('extract/infra/dockerfile.ts:42 — fs.readFile wrapped (ADR-055 #5)')
+})
+
+// ──────────────────────────────────────────────────────────────────────────
 // OTel ingest contract — non-blocking, span-time, parent-cache (ADR-033)
 // ──────────────────────────────────────────────────────────────────────────
 describe('OTel ingest contract (ADR-033)', () => {


### PR DESCRIPTION
## Summary

Closes the contract gap surfaced by the debugger agent's medusa-codebase session. The fix on `extract/calls/http.ts` already shipped to main; this PR codifies the rule, audits the rest of the producers, and queues the regression tests so the failure shape can't recur.

**Item 1 from the debugger agent's hand-off** — Contract Author scope. Items 3-5 are out of scope per ADR-055 ("Out of scope" section). Item 5 (publish decision) — flagging back to user: the debugger agent's note said "you're at 0.2.7 now" but **0.2.8 just shipped**, so the publish question is whether to bundle the eventual implementation fix into a 0.2.9 patch on its own or roll into the next milestone.

## Decision shape

Every producer that parses per-file content wraps the parse in `try / catch`. On failure: `console.warn` with producer name, file path, error message; `continue`. The phase completes even if some files are unparseable.

```ts
for (const file of files) {
  let parsed: T
  try {
    parsed = await readJson<T>(file)
  } catch (err) {
    console.warn(`[neat] <phase> skipped ${file}: ${(err as Error).message}`)
    continue
  }
  // … use parsed …
}
```

**Wrap at the call site, not in shared helpers.** `readJson` and `readYaml` in `extract/shared.ts` keep throwing on malformed input; producers wrap their call. This keeps warning messages contextual.

## Producer audit (the read-only delivery for debugger item 2)

**Sites already conformant — no work needed:**

- `extract/calls/http.ts` — debugger agent's fix
- `extract/owners.ts` — independently arrived at the same shape during ADR-054 implementation
- `extract/infra/k8s.ts:51-55` — `parseAllDocuments` wrapped
- `extract/databases/*` — debugger agent confirmed

**Sites needing the fix:**

| File | Site | Risk |
|---|---|---|
| `extract/services.ts:125` | `readJson<PackageJson>(pkgPath)` | malformed `package.json` kills service discovery |
| `extract/services.ts:173` | `readJson<RootPackageJson>(rootPkgPath)` | malformed root `package.json` kills monorepo expansion |
| `extract/aliases.ts:98` | `readYaml<ComposeFile>(composePath)` | malformed compose YAML kills alias collection |
| `extract/aliases.ts:149` | Dockerfile `fs.readFile` | unreadable Dockerfile kills alias collection |
| `extract/infra/docker-compose.ts:58` | `readYaml<ComposeFile>(composePath)` | malformed compose YAML kills infra extraction |
| `extract/infra/dockerfile.ts:42` | `fs.readFile` | unreadable Dockerfile kills Dockerfile-as-infra extraction |

Six call sites across four files.

## What's in this PR

- **`docs/decisions.md`** — ADR-055 appended with the full audit
- **`docs/contracts/static-extraction.md`** — new "Per-file parse-failure isolation (ADR-055)" section so the PreToolUse hook surfaces the rule when any `extract/` file is edited
- **`packages/core/test/audits/contracts.test.ts`** — 7 new `it.todo` entries (1 global scan + 6 per-site). Test count: 173 live + 11 todo

## What's NOT in this PR

Per role discipline (Contract Author drafts; Implementation Agent ships):

- The actual try/catch wraps in the six producer files — Implementation Agent
- Flipping the 7 `it.todo`s to live as each wrap lands — Implementation Agent
- The `callsFromSource` regex rewrite (debugger item 3) — explicit deferral in ADR-055
- File-size pre-filter (debugger item 4) — explicit deferral in ADR-055
- Decision on standalone 0.2.9 patch vs. bundle into next milestone — User

## Test plan

- [x] `npx turbo build` clean
- [x] `vitest run test/audits/contracts.test.ts` — 173 pass / 11 todo / 0 fail
- [ ] Post-merge: Implementation Agent ships the six wraps, flips the 6 per-site todos, then flips the global scan todo to live
- [ ] User decides publish cadence (standalone 0.2.9 vs. bundled)

## Implementation handoff prompt

Available in the conversation history if needed for a fresh agent. Outline:
1. For each of the 6 sites, wrap parse call in `try/catch`. Pattern matches `extract/calls/http.ts`.
2. `console.warn` with `[neat] <phase> skipped <file>: <err>`.
3. Flip the corresponding `it.todo` to live.
4. After all 6 land, flip the global scan from `it.todo` to live; the regex check enforces the rule mechanically going forward.

Refs #197