### PR TITLE
ADRs 056-059 — frontend contract batch (web shell, multi-project, debugging, bootstrap)

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -35,6 +35,10 @@ This file is the index. Each rule has a short summary and a link to its full per
 | 23 | CLI surface | [`contracts/cli-surface.md`](./contracts/cli-surface.md) | Nine `neat <verb>` commands mirroring MCP tools, REST-only data path, `--json` output, exit-code branching (ADR-050) | ✅ landed (v0.2.8 opens) |
 | 24 | Frontend-facing API | [`contracts/frontend-api.md`](./contracts/frontend-api.md) | SSE stream at `/events` with locked 8-type taxonomy, multi-project switcher at `/projects`, WebSocket and per-event filtering deferred (ADR-051) | ✅ landed (v0.2.8 opens) |
 | 25 | Publish system | [`contracts/publish-system.md`](./contracts/publish-system.md) | Bin-wrapper subpath validity against dependency `exports`, version lockstep across five packages, tarball smoke-test gate, dependency order, npm immutability acknowledged (ADR-052) | ✅ landed (post-0.2.6 broken-publish) |
+| 26 | Web shell completeness | [`contracts/web-completeness.md`](./contracts/web-completeness.md) | No permanent stub UI; every interactive element wired or explicitly disabled; no duplicate components; audit doc is the canonical inventory (ADR-056) | ✅ landed (Track 1 frontend) |
+| 27 | Web shell multi-project routing | [`contracts/web-multi-project.md`](./contracts/web-multi-project.md) | AppShell owns project state; URL → localStorage → /projects → 'default' resolution chain; project change triggers data refresh; no hardcoded project names (ADR-057) | ✅ landed (Track 1 frontend) |
+| 28 | Web shell debugging surface | [`contracts/web-debugging.md`](./contracts/web-debugging.md) | StatusBar shows daemon + SSE connection state; no silent API failures; debug panel toggleable via Ctrl+Shift+D; read-only (ADR-058) | ✅ landed (Track 1 frontend) |
+| 29 | Web UI bootstrap from neatd | [`contracts/web-bootstrap.md`](./contracts/web-bootstrap.md) | `neatd start` launches the web UI on port 6328 (T9 NEAT); `NEAT_WEB_PORT` overrides; fail-loud on collision; `@neat.is/web` joins the lockstep (ADR-059) | ✅ landed (Track 1 frontend) |
 
 ### Future contracts — opened at the start of each milestone
 

--- a/docs/contracts/web-bootstrap.md
+++ b/docs/contracts/web-bootstrap.md
@@ -1,0 +1,109 @@
+---
+name: web-bootstrap
+description: neatd start launches the web UI on port 6328 by default. NEAT_WEB_PORT overrides. Fail loudly on collision. Web UI inherits NEAT_API_URL from the parent daemon. Shutdown cascades.
+governs:
+  - "packages/core/src/neatd.ts"
+  - "packages/web/package.json"
+  - "packages/neat.is/package.json"
+adr: [ADR-059, ADR-049, ADR-052]
+---
+
+# Web UI bootstrap contract
+
+The fourth of four web-shell contracts. Sibling contracts: [`web-completeness.md`](./web-completeness.md), [`web-multi-project.md`](./web-multi-project.md), [`web-debugging.md`](./web-debugging.md).
+
+Closes the operational gap that bites every external user: today, `neatd start` boots the daemon but doesn't bring up the web UI. The user has to know the right `npm run dev --workspace @neat.is/web` invocation, fight the Next.js default port 3000 (which collides with everything else they have running), and configure `NEAT_API_URL` themselves.
+
+For ADR-027's MVP-success-PR experiment, this is a non-starter. The fix is for `neatd start` to launch everything the operator needs in one command, on a port designed not to clash.
+
+## Binding rules
+
+### 1. `neatd start` launches the web UI
+
+After the REST API and OTel receivers are listening, `neatd` spawns the web UI as a child process. Web UI runs in production mode (`next start`), not dev mode. Lifecycle is tied to the parent daemon.
+
+### 2. Default port: `6328`
+
+NEAT in T9 phone keypad (N=6, E=3, A=2, T=8). Memorable, narratable, not in `/etc/services` or any common-port list. Avoids the universal collisions on `3000`, `5000`, `8000`, `8080`.
+
+### 3. Port override: `NEAT_WEB_PORT`
+
+Env variable; reads at start time. CI environments, port-already-in-use scenarios, multi-instance setups — set this. neatd respects it.
+
+### 4. Fail loudly on collision
+
+If port 6328 (or `NEAT_WEB_PORT`) is already in use and the parent process can't bind, `neatd start` aborts with the clear-error pattern from ADR-049:
+
+```
+neatd: web UI port 6328 in use; set NEAT_WEB_PORT to override or stop the conflicting process
+```
+
+No silent fallback to a random port — the user has to know what URL to open.
+
+### 5. Port table
+
+| Service | Default port | Env override |
+|---|---|---|
+| REST API (neat-core) | `8080` | `PORT` |
+| OTel HTTP receiver | `4318` | `OTEL_PORT` |
+| OTel gRPC receiver (opt-in) | `4317` | `NEAT_OTLP_GRPC_PORT` |
+| Web UI | `6328` | `NEAT_WEB_PORT` |
+
+Each port has one job. Each is overridable independently.
+
+### 6. `NEAT_API_URL` inheritance
+
+When neatd spawns the web UI process, it sets `NEAT_API_URL=http://localhost:${restPort}` in the child's environment. The web shell consumes that env var to point its proxy routes at the same daemon that launched it. The user doesn't configure this twice.
+
+If `NEAT_API_URL` is already set in the parent's env (operator pre-configured), neatd respects it and forwards.
+
+### 7. Shutdown cascades
+
+When `neatd stop` is invoked or `SIGTERM` reaches the daemon, the spawned web UI process is also stopped. Process group kill or explicit child termination. No orphaned web UI processes.
+
+### 8. Distribution: `@neat.is/web` becomes publishable
+
+The web package is currently `private: true` and stays at version `0.2.0`, out of lockstep. To ship it as part of `npm install -g neat.is`, this changes:
+
+- Flip `private: false` and add `publishConfig.access: public` to `packages/web/package.json`.
+- Bring `@neat.is/web` into the publish-system contract's lockstep set (per ADR-052 #2). The five-package lockstep becomes six-package.
+- Add `@neat.is/web` to the `neat.is` umbrella's `dependencies` so `npm install -g neat.is` pulls it.
+- Update CI publish workflow `.github/workflows/publish.yml`'s dependency-order list: `types → core → mcp → claude-skill → web → neat.is`.
+- Update `scripts/publish.sh` similarly.
+
+This is a structural change to the publish surface. ADR-052 amendment may be needed, or a successor ADR — flag in implementation PR.
+
+### 9. Distribution: `neatd` resolves the web UI's location
+
+`neatd.ts` uses `require.resolve('@neat.is/web/package.json')` to find the installed web UI's location. Spawns its `start` script (`next start --port ${webPort}`). This works whether neatd is run from the monorepo (`packages/web/` is a workspace symlink) or from a global install (`@neat.is/web` is a regular dependency).
+
+## Out of scope
+
+- **Static-export bundling into `@neat.is/core`.** Considered (single port, single process, simpler). Rejected for MVP because it would require rewriting Jed's existing Next.js API routes as direct fetches to the backend (loses the proxy abstraction layer), and forks Jed's existing dev workflow (`next dev` for live-reload). The child-process approach preserves Jed's track unchanged. If real-user signal demands single-port simplicity, that's a successor ADR.
+- **Process supervision / restart-on-crash for the web UI.** Per ADR-049, the daemon doesn't auto-restart on crash; same rule applies to the spawned web UI.
+- **Authentication on the web UI.** Localhost-only, MVP. Future ADR if multi-user / hosted instances become a thing.
+- **HTTPS for the web UI.** Localhost-only HTTP is sufficient for MVP. Reverse-proxy for HTTPS is the operator's job in deployed environments.
+
+## Authority
+
+- **Spawn logic:** `packages/core/src/neatd.ts` (`cmdStart`)
+- **Web UI start script:** `packages/web/package.json` `scripts.start` (`next start`)
+- **Distribution / lockstep:** `packages/neat.is/package.json` (`dependencies`), publish workflow + script
+- **Port collision check:** new helper in `neatd.ts` or `server.ts` — best-effort `net.createServer().listen()` test before spawning
+
+## Enforcement
+
+`it.todo` block in `contracts.test.ts` for ADR-059:
+
+- `neatd.ts` spawns a web UI child process during `cmdStart`.
+- The child process runs on `process.env.NEAT_WEB_PORT ?? '6328'`.
+- The child inherits `NEAT_API_URL=http://localhost:${restPort}` (or respects pre-existing parent env).
+- Port collision on the configured web port aborts neatd with a clear error and non-zero exit.
+- `neatd stop` (and SIGTERM / SIGINT) kills the spawned web UI process.
+- `@neat.is/web` is no longer `private: true` and version-matches the lockstep.
+- The `neat.is` umbrella's `dependencies` includes `@neat.is/web`.
+- The publish workflow + local script include `@neat.is/web` in their dependency order.
+
+The publish-system regression tests (ADR-052) need updating to expect a six-package lockstep, not five. That change is queued for the implementing agent — flag for Contract Author review whether it warrants an ADR-052 amendment or a successor ADR.
+
+Full rationale: [ADR-059](../decisions.md#adr-059--web-ui-bootstrap-from-neatd).

--- a/docs/contracts/web-completeness.md
+++ b/docs/contracts/web-completeness.md
@@ -1,0 +1,73 @@
+---
+name: web-completeness
+description: No permanent stub UI in packages/web/. Every interactive element either maps to a real action or is explicitly disabled with affordance. No duplicate components. Audit doc tracks the inventory.
+governs:
+  - "packages/web/app/components/**"
+  - "packages/web/app/**/page.tsx"
+  - "packages/web/audit/09-gaps-and-stubs.md"
+adr: [ADR-056]
+---
+
+# Web shell completeness contract
+
+The first of four web-shell contracts (ADRs 056-059). Sibling contracts: [`web-multi-project.md`](./web-multi-project.md), [`web-debugging.md`](./web-debugging.md), [`web-bootstrap.md`](./web-bootstrap.md).
+
+Permanent stub UI is its own credibility leak. The user clicks a button, expecting an action, gets silence, concludes NEAT is half-built. Worse for an MVP that's supposed to be diagnostic itself.
+
+## Binding rules
+
+### 1. No permanent stubs
+
+Every interactive element rendered to the user — button, tab, link, menu item, keyboard shortcut — is one of:
+
+- **Wired:** has an `onClick` / `onKeyDown` / equivalent handler that produces an observable change in UI or backend state.
+- **Explicitly disabled:** `disabled` attribute set, lower opacity, tooltip / badge ("Coming soon", "v0.3.x", etc.) so the user perceives the affordance as unavailable, not broken.
+
+Anything else (rendered, looks active, does nothing) is a contract violation.
+
+### 2. No empty handlers
+
+`onClick={() => {}}` or `onClick={undefined}` on a rendered, non-disabled component is the most common stub shape and the most disorienting failure mode for users. Forbidden.
+
+### 3. Component uniqueness
+
+No two files in `packages/web/app/components/` may export a default component with the same name. If extension is needed (filtered view, grouped variant, etc.), extend the existing file — don't fork. Prevents the kind of `GraphView.tsx` / `GraphCanvas.tsx` confusion that already led to a deletion in prior commits.
+
+### 4. Audit doc tracks the inventory
+
+`packages/web/audit/09-gaps-and-stubs.md` is the canonical inventory of known-stub elements. As stubs get wired or explicitly disabled, the audit doc updates. The contract test reads the doc and asserts no stub appears in source code without a matching entry — drift in either direction (audit-says-stub-but-code-is-wired, or code-has-stub-but-audit-doesn't-list-it) is a finding.
+
+## Today's inventory (the work to do)
+
+Per `audit/09-gaps-and-stubs.md` at the time this contract landed:
+
+| Component | Stub elements |
+|---|---|
+| TopBar | History, Share buttons |
+| Rail | Layers, Find, NeatScript, Time travel, Blast radius, Diff, Comments, Agents, Settings buttons |
+| GraphCanvas toolbar | Layout: cose, Locked toggles |
+| Inspector | Owners tab, History tab |
+
+Thirteen elements total. Each must either be wired (handler implemented, action observable) or explicitly disabled with affordance. Implementation Agent flips the corresponding `it.todo`s as each element ships.
+
+## What's NOT covered
+
+- Visual / interaction design choices — the contract says wire-or-disable, not "what should the History panel look like."
+- Component naming conventions — the contract says no duplicates, not "use suffix `Panel` for overlays."
+- Accessibility — separate concern, separate contract if/when needed.
+
+## Authority
+
+`packages/web/app/components/` is the primary scope. `packages/web/app/**/page.tsx` covers route-level rendering. `packages/web/audit/09-gaps-and-stubs.md` is the inventory the contract reads.
+
+## Enforcement
+
+`it.todo` block in `contracts.test.ts` for ADR-056. Three regression scans:
+
+1. No empty `onClick={() => {}}` or `onClick={undefined}` in `packages/web/app/components/**`.
+2. No two files under `packages/web/app/components/` export default components with the same name.
+3. Every entry in `audit/09-gaps-and-stubs.md`'s "Stub buttons" table corresponds to a button in source code, and vice versa (drift in either direction fails the test).
+
+The thirteen-element inventory above is the per-element checklist. Each element's todo flips to live as it's wired or disabled.
+
+Full rationale: [ADR-056](../decisions.md#adr-056--web-shell-completeness).

--- a/docs/contracts/web-debugging.md
+++ b/docs/contracts/web-debugging.md
@@ -1,0 +1,85 @@
+---
+name: web-debugging
+description: Web shell exposes connection state, daemon URL, last API calls and SSE events. No silent API failures. Read-only debug surface — observes, doesn't mutate.
+governs:
+  - "packages/web/app/components/StatusBar.tsx"
+  - "packages/web/app/components/TopBar.tsx"
+  - "packages/web/app/components/DebugPanel.tsx"
+  - "packages/web/lib/proxy.ts"
+adr: [ADR-058]
+---
+
+# Web shell debugging surface contract
+
+The third of four web-shell contracts. Sibling contracts: [`web-completeness.md`](./web-completeness.md), [`web-multi-project.md`](./web-multi-project.md), [`web-bootstrap.md`](./web-bootstrap.md).
+
+NEAT is a diagnostic tool. The web shell can't be the part that fails silently. When the daemon is down, when SSE is reconnecting, when a proxy returns 5xx — the user needs to see it without opening devtools.
+
+## Binding rules
+
+### 1. Daemon connection state is visible
+
+StatusBar renders a small indicator (green / yellow / red dot) reflecting whether `GET /health` against `NEAT_API_URL` succeeded recently:
+
+- **Green:** healthy, response < N seconds since last check
+- **Yellow:** slow (response > N seconds) or retrying
+- **Red:** failed for ≥ M consecutive attempts
+
+Heartbeat default 5s. State exposed as `data-connection-state="ok|slow|down"` on the indicator element.
+
+### 2. SSE connection state is visible
+
+When the EventSource connection to `/events` is open, healthy, or reconnecting, the StatusBar (or another component) reflects it. EventSource auto-reconnects per spec; the UI tells the user that updates are flowing or paused, not just that nothing's happening.
+
+State exposed as `data-sse-state="connected|reconnecting|disconnected"`.
+
+### 3. No silent API errors
+
+Every fetch that returns a non-2xx status surfaces a transient toast or banner with the error envelope from ADR-040 (`{ error, status, details? }`). User sees what failed, not just nothing. Errors don't crash the app — they're caught at the proxy layer and converted to user-visible signals.
+
+### 4. Debug panel keyboard shortcut
+
+`Ctrl+Shift+D` (or `Cmd+Shift+D` on macOS) toggles a debug panel overlay showing:
+
+- Current `project` and `NEAT_API_URL`
+- Last 10 API calls (path, status code, duration ms, timestamp)
+- Last 10 SSE events (event type, timestamp, payload size)
+- Daemon health-check history (last 20 heartbeats)
+
+Panel exists as a separate component (`DebugPanel.tsx` or equivalent), reachable only via the shortcut (not in any visible menu — keeps it out of the user's way until needed).
+
+### 5. Daemon URL is visible somewhere
+
+TopBar or StatusBar renders the value of `NEAT_API_URL` (or its public-facing equivalent). Multi-daemon environments will eventually exist; the user always knows which backend they're querying.
+
+For localhost: shows `localhost:8080`. For other targets: shows the hostname.
+
+### 6. Read-only
+
+The debugging surface observes; it does not mutate. No buttons in the debug panel that POST to the backend. No "force refresh" that bypasses the normal proxy. Per the existing role discipline (ADR-039 MCP read-only, ADR-050 CLI verbs read-only), debugging follows the same rule.
+
+## Authority
+
+- **Connection indicator + SSE state:** `packages/web/app/components/StatusBar.tsx`
+- **Daemon URL display:** `packages/web/app/components/TopBar.tsx` or `StatusBar.tsx`
+- **Error capture + toast emission:** `packages/web/lib/proxy.ts`
+- **Debug panel overlay:** `packages/web/app/components/DebugPanel.tsx` (new component to add)
+
+## Enforcement
+
+`it.todo` block in `contracts.test.ts` for ADR-058:
+
+- StatusBar.tsx renders an element with a `data-connection-state` attribute.
+- StatusBar.tsx renders an element with a `data-sse-state` attribute.
+- proxy.ts emits a toast / banner on non-2xx response (regex-check for the emission shape, or a runtime test if React Testing Library is available).
+- A `DebugPanel.tsx` (or equivalent) component file exists in `packages/web/app/components/`.
+- TopBar.tsx or StatusBar.tsx renders the daemon URL string.
+- The debug panel doesn't include `<button onClick={...POST...}>` patterns — read-only enforcement.
+
+## Out of scope
+
+- **Telemetry / analytics.** Not collecting user actions, not phoning home. The debug panel is local-only.
+- **Permission gating on the debug panel.** Localhost-only; no auth in MVP per ADR-058 #6 + cross-cutting "no auth in MVP".
+- **Performance metrics dashboard.** Last 10 calls is intentional minimalism. Full metrics live in the future telemetry layer (out-of-scope for this contract).
+
+Full rationale: [ADR-058](../decisions.md#adr-058--web-shell-debugging-surface).

--- a/docs/contracts/web-multi-project.md
+++ b/docs/contracts/web-multi-project.md
@@ -1,0 +1,87 @@
+---
+name: web-multi-project
+description: Web shell scopes every backend call to the user-selected project. AppShell owns project state. Project changes trigger data refresh. No hardcoded project names. The runtime corollary of ADR-026.
+governs:
+  - "packages/web/app/components/AppShell.tsx"
+  - "packages/web/app/components/TopBar.tsx"
+  - "packages/web/app/components/GraphCanvas.tsx"
+  - "packages/web/app/components/Inspector.tsx"
+  - "packages/web/app/components/StatusBar.tsx"
+  - "packages/web/app/components/Rail.tsx"
+  - "packages/web/lib/proxy.ts"
+  - "packages/web/lib/fixtures.ts"
+  - "packages/web/app/api/**"
+adr: [ADR-057, ADR-026, ADR-051]
+---
+
+# Web shell multi-project routing contract
+
+The second of four web-shell contracts. Sibling contracts: [`web-completeness.md`](./web-completeness.md), [`web-debugging.md`](./web-debugging.md), [`web-bootstrap.md`](./web-bootstrap.md).
+
+When NEAT runs against an unfamiliar codebase (medusa, the canonical MVP-success-PR target), the web shell must show *that codebase's* graph. The backend already supports multi-project routing per ADR-026; this contract makes the frontend honor it consistently.
+
+Today's gap (per `audit/09-gaps-and-stubs.md`): *"Multi-project — graph not re-fetched on project change."*
+
+## Binding rules
+
+### 1. Single source of truth
+
+`AppShell.tsx` owns the `project` state via `useState<string>`. Every component that fetches backend data accepts `project` as a prop or reads it from a context. No component manages its own project state.
+
+### 2. Initial project resolution chain
+
+In order, first non-empty wins:
+
+1. URL query param: `?project=X`
+2. `localStorage.getItem('neat:lastProject')` — survives reload
+3. First entry from `GET /projects` if registry is non-empty
+4. `'default'` fallback (only allowed value of `'default'` in branching logic)
+
+### 3. Project change triggers data refresh
+
+When `project` changes — switcher click, URL update, deep link — every component that depends on it re-fetches via `useEffect(..., [project])`. No stale data from the previous project carries over. GraphCanvas, Inspector, StatusBar, Incidents page — all of them.
+
+### 4. URL stays in sync
+
+Updating the project state writes the new value to the URL (`?project=X`) so the page can be shared / bookmarked / deep-linked. Reading the URL on load is the first step of the resolution chain (rule #2).
+
+### 5. API proxy routes accept `project`
+
+All routes under `packages/web/app/api/` accept `?project=X` as a query param (or path-scoped `/projects/:project/X` if the proxy uses that shape). The route forwards to the matching backend endpoint per ADR-026's dual-mount.
+
+### 6. TopBar surfaces the active project
+
+The user always knows which codebase NEAT is currently graphing — no ambiguity, no implicit defaults. TopBar renders the project name visibly. The switcher (uses `GET /projects` per ADR-051) is reachable via at most one click.
+
+### 7. Project switcher is a real control
+
+Not a stub. Clicking an entry calls `setProject(name)` and updates the URL. Per ADR-056 (web-completeness), no empty handler permitted.
+
+### 8. No hardcoded project names in branching logic
+
+`'default'` is allowed only as the explicit fallback in `AppShell.tsx`'s state initializer. No `'medusa'`, no `'neat'`, no `if (project === 'demo')` anywhere in `packages/web/`. Same rule as the cross-cutting "no demo-name hardcoding" (cross-cutting rule 8) but extended to the web track.
+
+Allowed locations for project-name string literals:
+
+- `'default'` in `AppShell.tsx` state initializer
+- Test fixtures (`packages/web/lib/fixtures.ts` — though even there, "demo" is a fixture name, not a code branch)
+- Comments and docstrings
+
+## Authority
+
+- **State owner:** `packages/web/app/components/AppShell.tsx`
+- **Display + switcher:** `packages/web/app/components/TopBar.tsx`
+- **Project-aware proxy:** `packages/web/lib/proxy.ts`
+- **Project-aware API routes:** `packages/web/app/api/**/route.ts`
+
+## Enforcement
+
+`it.todo` block in `contracts.test.ts` for ADR-057:
+
+- AppShell.tsx initializes project from URL → localStorage → /projects → 'default' (regex-check the source for the resolution chain).
+- Every component file that imports `proxy.ts` or fetches from `/api/` accepts `project: string` as a prop.
+- Every API proxy route under `packages/web/app/api/` forwards `project` query/path to the backend.
+- No hardcoded project names (`medusa`, `neat`, `demo`, etc.) in branching logic under `packages/web/app/components/` or `packages/web/lib/` (excluding fixtures.ts).
+- Multi-project re-fetch test: render AppShell with `project=A`, change to `B`, assert all data-fetching hooks re-ran. Requires Vitest + React Testing Library — new tooling for the web track. Flag in PR.
+
+Full rationale: [ADR-057](../decisions.md#adr-057--web-shell-multi-project-routing).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1574,3 +1574,137 @@ The scan is regex-based and approximate but sufficient for the failure shape —
 - **Size pre-filter on parse inputs** (debugger agent item 4). Skipping files > 1 MB before parse would reduce log noise from minified bundles. Optional, not required for correctness.
 - **Asynchronous-error escalation.** A producer can't `process.exit(1)` on a parse failure even if every file fails. The phase must always complete, even with zero successful parses. Logging volume from a `node_modules`-leaking scan is a separate UX concern.
 - **Sentry-style structured error reporting.** Plain `console.warn` is sufficient for MVP. Wrap-at-call-site keeps the message contextual; future telemetry can hook into `console.warn` without changing the contract.
+
+## ADR-056 — Web shell completeness
+
+**Date:** 2026-05-10
+**Status:** Active.
+
+**Context.** Jed's v0.3.0 frontend track has been pushing `packages/web/` to main since the v0.2.5 close. The audit at `packages/web/audit/09-gaps-and-stubs.md` self-identifies thirteen UI elements that render visibly but do nothing on click — eleven buttons in TopBar / Rail, two Inspector tabs. Every one of them is a credibility leak: a user clicks the button, expecting the action, gets silence, concludes NEAT is half-built.
+
+The frontend audit is comprehensive and Jed's track is independent (Track 1 per CLAUDE.md), but the contract surface didn't cover it. Permanent stub UI is its own failure mode — the kind that bites the MVP-success-PR experiment when the OSS user clicks "Time travel" expecting a panel and gets nothing.
+
+**Decision.**
+
+1. **No permanent stub UI.** Every interactive element rendered to the user — button, tab, link, menu item, keyboard shortcut — must either:
+   - **Map to a real action** (an `onClick` / `onKeyDown` handler that produces an observable change in the UI or backend state), OR
+   - **Be explicitly disabled** with visual affordance: `disabled` attribute set, lower opacity, and a tooltip / badge ("Coming soon", "Not yet available", "v0.3.x") so the user doesn't perceive a malfunction.
+2. **No `onClick={() => {}}` or `onClick={undefined}` on rendered components.** Empty handlers are the most common stub shape and the most disorienting for users.
+3. **Component uniqueness.** No two files in `packages/web/app/components/` may export a component with the same name. If a component needs extension (filter view, grouped variant, etc.), extend the existing one — don't fork. Helps prevent the `GraphView.tsx` / `GraphCanvas.tsx` confusion that already happened (the old `GraphView.tsx` was deleted in a recent commit; the contract codifies "don't do this again").
+4. **Inventory tied to the audit doc.** `packages/web/audit/09-gaps-and-stubs.md` is the canonical list of known stubs. As stubs are removed or wired, the audit doc updates. The contract test reads the audit doc and asserts no stub appears in code without a matching entry — drift in either direction is a finding.
+
+**Authority.** `packages/web/app/components/**` (component library), `packages/web/app/**/page.tsx` (route surfaces), `packages/web/audit/09-gaps-and-stubs.md` (the canonical inventory). Web track is Jed's; this contract sets binding rules but doesn't dictate visual or interaction design.
+
+**Enforcement.** `it.todo` block in `contracts.test.ts` for ADR-056. Regression scans:
+
+- No empty `onClick={() => {}}` or `onClick={undefined}` in `packages/web/app/components/**`.
+- No two files under `packages/web/app/components/` export `default` components with the same name.
+- Every entry in `audit/09-gaps-and-stubs.md`'s "Stub buttons" table corresponds to a button in source code (audit-vs-code consistency).
+
+`it.todo` initially because all thirteen stubs from the audit currently exist in source. As they wire or get explicitly disabled, the corresponding todos flip to live, and the global empty-handler scan flips last.
+
+## ADR-057 — Web shell multi-project routing
+
+**Date:** 2026-05-10
+**Status:** Active.
+
+**Context.** When NEAT runs against an unfamiliar codebase (e.g., medusa, the canonical MVP-success-PR target), the web shell must show *that codebase's* graph, not the default project's. Jed's audit already flags this as an open gap: *"Multi-project — graph not re-fetched on project change."* The current `AppShell.tsx` initializes `project = 'default'` and accepts a setter, but the downstream components (GraphCanvas, Inspector, StatusBar, the proxy routes) don't all re-fetch when the project changes.
+
+This is the runtime corollary of ADR-026 (multi-project dual-mount). The backend already supports it; the frontend has to honor it consistently.
+
+**Decision.**
+
+1. **Single source of truth.** `AppShell.tsx` owns the `project` state. Every component that fetches backend data reads it as a prop and re-fetches on change.
+2. **Initial project resolution chain (in order):**
+   1. URL query param: `?project=X`
+   2. `localStorage.getItem('neat:lastProject')` — survives reload
+   3. First entry from `GET /projects` if registry is non-empty
+   4. `'default'` fallback
+3. **Project change triggers data refresh.** When `project` changes (user picks from switcher, URL updates, etc.), every component that depends on it re-fetches via its own `useEffect([project])` hook. No stale data carries over.
+4. **API proxy routes accept `project` consistently.** All routes under `packages/web/app/api/` accept `?project=X` or path-scoped `/projects/:project/X` and forward to the matching backend endpoint per ADR-026. New routes use the helper from day one (proxy.ts pattern).
+5. **TopBar surfaces the active project visibly.** The user always knows which codebase NEAT is currently graphing — no ambiguity, no implicit defaults.
+6. **Project switcher is a real control.** Uses `GET /projects` (per ADR-051) to populate; clicking an entry calls `setProject(name)` and updates the URL. Not a stub.
+7. **No hardcoded project names in branching logic.** `'default'` is allowed only as the explicit fallback in `AppShell.tsx`'s state initializer. No `'medusa'`, no `'neat'`, no `if (project === 'demo')` anywhere in `packages/web/`. Same rule as the cross-cutting "no demo-name hardcoding" but extended to the web track.
+
+**Authority.** `packages/web/app/components/AppShell.tsx` (state owner), `packages/web/app/components/TopBar.tsx` (display + switcher), `packages/web/app/components/GraphCanvas.tsx` (consumes project prop), `packages/web/lib/proxy.ts` (project-aware fetcher), `packages/web/app/api/**/route.ts` (project-aware proxies).
+
+**Enforcement.** `it.todo` block in `contracts.test.ts`:
+
+- AppShell.tsx initializes `project` from URL → localStorage → /projects → 'default' (read source, regex check).
+- Every component file that imports `proxy.ts` or fetches from `/api/` accepts `project: string` as a prop or reads it from a context.
+- Every API proxy route forwards `project` query/path to the backend.
+- No hardcoded project names (`medusa`, `neat`, `demo`, etc.) in branching logic under `packages/web/app/components/` or `packages/web/lib/`.
+- Multi-project re-fetch test: render AppShell with project=A, change to B, assert all data-fetching hooks re-ran (uses Vitest + React Testing Library — a new-tooling addition for the web track).
+
+## ADR-058 — Web shell debugging surface
+
+**Date:** 2026-05-10
+**Status:** Active.
+
+**Context.** When NEAT misbehaves in production — daemon down, registry stale, SSE reconnecting, proxy returning 5xx — the web shell currently fails silently. The user clicks something, nothing happens, no indication why. This is the worst failure mode for an MVP that's supposed to be diagnostic itself.
+
+The fix is observable connection state plus loud-not-silent error surfaces. Not a debug-only feature — debugging IS the product, and the user shouldn't need to open devtools to see why a query failed.
+
+**Decision.**
+
+1. **StatusBar shows daemon connection state.** A small indicator (green / yellow / red dot) reflecting whether `GET /health` against `NEAT_API_URL` succeeded recently. Yellow = slow / retrying; red = failed for ≥ N attempts. Updated on a heartbeat (default 5s).
+2. **SSE connection state visible.** When the `/events` EventSource is open, healthy, or reconnecting, the StatusBar reflects it. EventSource auto-reconnects per spec; a UI indicator tells the user *that* it's reconnecting, not just that updates have stopped flowing.
+3. **No silent API errors.** Every fetch that returns a non-2xx status surfaces a transient toast or banner with the error envelope from ADR-040 (`{ error, status, details? }`). User sees what failed, not just nothing.
+4. **Debug panel keyboard shortcut.** `Ctrl+Shift+D` (or `Cmd+Shift+D`) toggles a debug panel overlay showing:
+   - Current `project` and `NEAT_API_URL`
+   - Last 10 API calls with status code + duration
+   - Last 10 SSE events with type + timestamp
+   - Daemon health-check history
+5. **Daemon URL is visible.** TopBar or StatusBar shows the value of `NEAT_API_URL` (or its public-facing equivalent) so the user knows which backend they're querying. Not a debug-only feature — multi-daemon environments will exist eventually.
+6. **Read-only.** The debugging surface doesn't mutate state. It observes. Per the existing role discipline (ADR-039 MCP is read-only; ADR-040 REST has only two write endpoints; ADR-050 CLI verbs are read-only), the web debugging panel matches.
+
+**Authority.** `packages/web/app/components/StatusBar.tsx` (connection indicator), `packages/web/app/components/TopBar.tsx` (URL surface), `packages/web/lib/proxy.ts` (error capture + toast emission), a new `packages/web/app/components/DebugPanel.tsx` (or similar) for the keyboard-shortcut overlay.
+
+**Enforcement.** `it.todo` in `contracts.test.ts`:
+
+- StatusBar.tsx renders a connection indicator element with a state attribute (`data-connection-state="ok|slow|down"`).
+- StatusBar.tsx renders an SSE indicator with a state attribute.
+- proxy.ts emits a toast / banner on non-2xx response.
+- A `DebugPanel.tsx` (or equivalent) component exists and is keyboard-shortcut-toggleable.
+- TopBar or StatusBar renders the daemon URL.
+
+## ADR-059 — Web UI bootstrap from `neatd`
+
+**Date:** 2026-05-10
+**Status:** Active.
+
+**Context.** Today running NEAT against an unfamiliar codebase requires three terminals: one for `neatd start` (REST + OTel), one for `npm run dev --workspace @neat.is/web` (the Next.js dev server), and a third for the user's own work. The user has to know the right `dev` invocation, and the Next.js port (currently the Next.js default `3000`) collides with every other Node project they may have running.
+
+For the MVP-success-PR experiment, this is a non-starter: the operator runs `neatd start` against medusa, expects to be able to view the graph, and there's no obvious way. The web shell that ADRs 056-058 govern is unreachable.
+
+The fix is for `neatd start` to launch the web UI alongside the REST + OTel listeners, on a port that's narratable and unlikely to clash.
+
+**Decision.**
+
+1. **`neatd start` launches the web UI.** As part of the daemon's startup, after the REST API and OTel receivers are listening, `neatd` spawns the web UI as a child process. The web UI runs in production mode (`next start`), not dev mode.
+2. **Default port: `6328`.** This is NEAT in T9 phone keypad (N=6, E=3, A=2, T=8). Memorable, narratable, and not in `/etc/services` or any common-port list. The number doesn't carry a stronger semantic; it's chosen to avoid the universal collisions on `3000`, `5000`, `8000`, `8080`.
+3. **Override via `NEAT_WEB_PORT` env var.** If the user wants a different port (CI environments, port already in use locally, multi-instance setups), they set it. neatd reads the env at start time.
+4. **Fail loudly on port collision.** If port 6328 is already in use and no override is provided, `neatd start` aborts with a clear error message: `port 6328 in use; set NEAT_WEB_PORT to override or stop the conflicting process.` No silent fallback to a random port — the user needs to know what URL to open.
+5. **Port relationship.** REST API on `8080`. OTel HTTP on `4318`. OTel gRPC on `4317` (opt-in). Web UI on `6328`. Each port has one job; each is overridable via its own env var (`PORT` for REST, `OTEL_PORT` for OTel HTTP, `NEAT_OTLP_GRPC_PORT` for OTel gRPC, `NEAT_WEB_PORT` for the web UI).
+6. **Web UI inherits `NEAT_API_URL` automatically.** When neatd spawns the web UI process, it sets `NEAT_API_URL=http://localhost:<rest-port>` so the web shell points at the same daemon that launched it. The user doesn't configure this twice.
+7. **Shutdown cascades.** When `neatd stop` is invoked or `SIGTERM` reaches the daemon, the spawned web UI process is also stopped (process group kill or explicit child termination). No orphaned web UI processes.
+8. **Distribution.** The `@neat.is/web` package is published to npm as part of the umbrella (along with core / mcp / claude-skill / types). `neatd` resolves the web UI's location via `require.resolve('@neat.is/web/package.json')` and runs its production-mode start script. This requires bumping `@neat.is/web` from `private: true` to publishable and including it in the lockstep version bump going forward.
+
+**Out of scope.**
+
+- **Static-export bundling into `@neat.is/core`.** Considered (single port, single process, simpler). Rejected for MVP because it requires rewriting Jed's existing Next.js API routes as direct fetches to the backend (lose proxy abstraction), and it forks the web track's existing development workflow (`next dev` for live-reload). The child-process approach preserves Jed's track unchanged. If real-user signal demands single-port simplicity, that's a successor ADR.
+- **Process supervision / restart-on-crash for the web UI.** Per ADR-049 the daemon doesn't auto-restart on crash; same rule applies to the spawned web UI. External supervisors (launchd, systemd) can wrap the whole thing if needed.
+- **Authentication on the web UI.** Localhost-only, MVP. Future ADR if multi-user / hosted instances become a thing.
+
+**Authority.** `packages/core/src/neatd.ts` (spawning logic), `packages/web/package.json` (publishability + start script), `@neat.is/web` distribution (becomes part of the umbrella).
+
+**Enforcement.** `it.todo` block in `contracts.test.ts`:
+
+- `neatd.ts` spawns a web UI child process during `cmdStart`.
+- The child process runs on `process.env.NEAT_WEB_PORT ?? 6328`.
+- The child inherits `NEAT_API_URL=http://localhost:${restPort}`.
+- Port collision on the configured web port aborts neatd with the exit-3 / clear-error pattern from ADR-049.
+- `neatd stop` kills the spawned web UI process.
+- `@neat.is/web` is no longer `private: true` and is included in the umbrella's lockstep version bump (publish-system contract gets a fifth-package-becomes-six update).
+
+The publishability change touches the publish-system contract (ADR-052) and the umbrella's `dependencies` list. That's a structural change to the publish surface — flag for the implementing agent, may warrant a successor ADR amendment to ADR-052 if the lockstep set grows from five to six.

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -4569,3 +4569,149 @@ describe('Publish system contract (ADR-052)', () => {
     expect(yml).toMatch(/neat --help/)
   })
 })
+
+// ──────────────────────────────────────────────────────────────────────────
+// Web shell completeness (ADR-056)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// No permanent stub UI in packages/web/. Every interactive element is wired
+// or explicitly disabled; no duplicate components; audit doc tracks the
+// inventory. All scans flip from todo to live as Jed wires the thirteen
+// known stubs from packages/web/audit/09-gaps-and-stubs.md.
+describe('Web shell completeness (ADR-056)', () => {
+  it.todo(
+    'no empty onClick={() => {}} or onClick={undefined} in packages/web/app/components/** (ADR-056 #2)',
+  )
+  it.todo(
+    'no two files under packages/web/app/components/ export default components with the same name (ADR-056 #3)',
+  )
+  it.todo(
+    'every entry in audit/09-gaps-and-stubs.md "Stub buttons" tables corresponds to a button in source (ADR-056 #4)',
+  )
+  // Per-element todos — flip as each is wired or explicitly disabled.
+  it.todo('TopBar: History button wired or disabled (ADR-056 #1)')
+  it.todo('TopBar: Share button wired or disabled (ADR-056 #1)')
+  it.todo('Rail: Layers button wired or disabled (ADR-056 #1)')
+  it.todo('Rail: Find button wired or disabled (ADR-056 #1)')
+  it.todo('Rail: NeatScript button wired or disabled (ADR-056 #1)')
+  it.todo('Rail: Time travel button wired or disabled (ADR-056 #1)')
+  it.todo('Rail: Blast radius button wired or disabled (ADR-056 #1)')
+  it.todo('Rail: Diff button wired or disabled (ADR-056 #1)')
+  it.todo('Rail: Comments button wired or disabled (ADR-056 #1)')
+  it.todo('Rail: Agents button wired or disabled (ADR-056 #1)')
+  it.todo('Rail: Settings button wired or disabled (ADR-056 #1)')
+  it.todo('GraphCanvas toolbar: Layout: cose toggle wired or disabled (ADR-056 #1)')
+  it.todo('GraphCanvas toolbar: Locked toggle wired or disabled (ADR-056 #1)')
+  it.todo('Inspector: Owners tab wired or disabled (ADR-056 #1)')
+  it.todo('Inspector: History tab wired or disabled (ADR-056 #1)')
+})
+
+// ──────────────────────────────────────────────────────────────────────────
+// Web shell multi-project routing (ADR-057)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// AppShell.tsx owns project state. URL → localStorage → /projects → 'default'
+// resolution chain. Project change triggers data refresh. No hardcoded
+// project names. Runtime corollary of ADR-026.
+describe('Web shell multi-project routing (ADR-057)', () => {
+  it.todo(
+    'AppShell.tsx initializes project from URL ?project=X first (ADR-057 #2.1)',
+  )
+  it.todo(
+    'AppShell.tsx falls back to localStorage `neat:lastProject` (ADR-057 #2.2)',
+  )
+  it.todo(
+    'AppShell.tsx falls back to first entry from GET /projects when registry is non-empty (ADR-057 #2.3)',
+  )
+  it.todo(
+    'AppShell.tsx falls back to "default" when registry is empty (ADR-057 #2.4)',
+  )
+  it.todo(
+    'Project change triggers data refresh — every component using project re-fetches (ADR-057 #3)',
+  )
+  it.todo(
+    'URL stays in sync — setProject(name) writes ?project=X (ADR-057 #4)',
+  )
+  it.todo(
+    'Every API proxy route under packages/web/app/api/** forwards `project` (ADR-057 #5)',
+  )
+  it.todo(
+    'TopBar.tsx renders the active project name visibly (ADR-057 #6)',
+  )
+  it.todo(
+    'Project switcher in TopBar.tsx uses GET /projects and calls setProject(name) (ADR-057 #7)',
+  )
+  it.todo(
+    'No hardcoded project names (medusa, neat, demo) in branching logic under packages/web/app/components/ or packages/web/lib/ (ADR-057 #8)',
+  )
+})
+
+// ──────────────────────────────────────────────────────────────────────────
+// Web shell debugging surface (ADR-058)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// StatusBar shows daemon + SSE connection state. No silent API failures.
+// Debug panel keyboard-shortcut toggleable. Read-only.
+describe('Web shell debugging surface (ADR-058)', () => {
+  it.todo(
+    'StatusBar.tsx renders an element with data-connection-state attribute (ADR-058 #1)',
+  )
+  it.todo(
+    'StatusBar.tsx renders an element with data-sse-state attribute (ADR-058 #2)',
+  )
+  it.todo(
+    'proxy.ts emits a toast or banner on non-2xx response (ADR-058 #3)',
+  )
+  it.todo(
+    'A DebugPanel.tsx (or equivalent) component file exists in packages/web/app/components/ (ADR-058 #4)',
+  )
+  it.todo(
+    'Debug panel toggleable via Ctrl+Shift+D / Cmd+Shift+D keyboard shortcut (ADR-058 #4)',
+  )
+  it.todo(
+    'TopBar.tsx or StatusBar.tsx renders the daemon URL string (ADR-058 #5)',
+  )
+  it.todo(
+    'DebugPanel does not include POST/PUT/DELETE buttons — read-only enforcement (ADR-058 #6)',
+  )
+})
+
+// ──────────────────────────────────────────────────────────────────────────
+// Web UI bootstrap from neatd (ADR-059)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// neatd start launches the web UI on port 6328 (T9 NEAT). NEAT_WEB_PORT
+// overrides. Fail loudly on collision. @neat.is/web joins the publish-system
+// lockstep — six packages instead of five going forward.
+describe('Web UI bootstrap from neatd (ADR-059)', () => {
+  it.todo(
+    'neatd.ts spawns a web UI child process during cmdStart (ADR-059 #1)',
+  )
+  it.todo(
+    'web UI port defaults to 6328 (NEAT in T9 keypad) (ADR-059 #2)',
+  )
+  it.todo(
+    'NEAT_WEB_PORT env var overrides the default port (ADR-059 #3)',
+  )
+  it.todo(
+    'port collision aborts neatd with a clear error and non-zero exit (ADR-059 #4)',
+  )
+  it.todo(
+    'spawned web UI inherits NEAT_API_URL=http://localhost:${restPort} (ADR-059 #6)',
+  )
+  it.todo(
+    'neatd stop / SIGTERM kills the spawned web UI process (no orphans) (ADR-059 #7)',
+  )
+  it.todo(
+    '@neat.is/web is no longer private:true and version-matches the lockstep (ADR-059 #8)',
+  )
+  it.todo(
+    'neat.is umbrella package.json includes @neat.is/web in dependencies (ADR-059 #8)',
+  )
+  it.todo(
+    '.github/workflows/publish.yml dependency order includes @neat.is/web before neat.is (ADR-059 #8)',
+  )
+  it.todo(
+    'scripts/publish.sh dependency order includes packages/web before packages/neat.is (ADR-059 #8)',
+  )
+})


### PR DESCRIPTION
## Summary

Four contracts governing `packages/web/` — same shape as the v0.2.6 contract batch (#199) and the v0.2.x publish-system contract (#203), but for the frontend track. Brings Jed's web shell under contract discipline, codifies what's already working, closes known gaps, and adds the daemon→web-UI bootstrap that's been missing.

The headline finding from your prompt — **"running neatd doesn't kick off the localhost"** — is ADR-059. Picks port `6328` (NEAT in T9 phone keypad) so it doesn't clash with the universal `3000`/`5000`/`8000`/`8080` collisions.

## What's in this PR

### ADR-056 — Web shell completeness
No permanent stub UI. Every button / tab / link / shortcut wired or explicitly disabled with affordance. No empty `onClick={() => {}}`. No duplicate components. `audit/09-gaps-and-stubs.md` is the canonical inventory; contract test asserts audit-vs-code consistency in both directions.

**Today's inventory (Jed's audit):** 13 stub elements — TopBar (History, Share), Rail (Layers, Find, NeatScript, Time travel, Blast radius, Diff, Comments, Agents, Settings), GraphCanvas (Layout, Locked), Inspector (Owners, History tabs).

### ADR-057 — Web shell multi-project routing
AppShell owns project state. Resolution chain: URL `?project=X` → `localStorage` → `GET /projects` → `'default'`. Project change triggers data refresh in every dependent component. URL stays in sync (`setProject(name)` writes `?project=X`). No hardcoded project names in branching logic.

**Closes Jed's audit gap:** *"graph not re-fetched on project change."* Runtime corollary of ADR-026 (multi-project dual-mount).

### ADR-058 — Web shell debugging surface
StatusBar shows daemon + SSE connection state via `data-connection-state` / `data-sse-state` attributes. No silent API failures (non-2xx surfaces as toast/banner). Debug panel toggleable via `Ctrl+Shift+D` shows last 10 API calls, last 10 SSE events, daemon URL, current project. Read-only — observes, doesn't mutate.

### ADR-059 — Web UI bootstrap from neatd
`neatd start` launches the web UI as a child process on port **`6328`** (default). `NEAT_WEB_PORT` overrides. Fail loudly on collision (no random-port fallback — user has to know the URL). Web UI inherits `NEAT_API_URL` from the parent so the web shell points at the same daemon that launched it. Shutdown cascades.

Distribution change: `@neat.is/web` flips from `private: true` to publishable, joins the publish-system lockstep. Five publishable packages becomes six. Touches ADR-052 — the implementing agent should flag whether this warrants an amendment to ADR-052 or a successor ADR.

## Files changed

- **`docs/decisions.md`** — ADRs 056-059 appended (~134 lines)
- **`docs/contracts/web-completeness.md`** — new (ADR-056)
- **`docs/contracts/web-multi-project.md`** — new (ADR-057)
- **`docs/contracts/web-debugging.md`** — new (ADR-058)
- **`docs/contracts/web-bootstrap.md`** — new (ADR-059)
- **`docs/contracts.md`** — index rows 26-29 added; 25 contracts → 29
- **`packages/core/test/audits/contracts.test.ts`** — four new describe blocks, 45 new `it.todo`s (test count: 180 live + 49 todo, was 180 + 4)

## Verification

- [x] `npx turbo build` clean
- [x] `vitest run test/audits/contracts.test.ts` — 180 pass / 49 todo / 0 fail
- [x] All four per-topic contracts have `governs:` frontmatter; PreToolUse hook will surface them when `packages/web/` files are edited (manual smoke test by reading the hook script's glob matching against representative web file paths)

## Out of scope

Per the ADRs' own "Out of scope" sections:

- **Static-export bundling into `@neat.is/core`.** Considered, rejected for MVP — would fork Jed's existing Next.js dev workflow and require rewriting the proxy routes. Successor ADR if real-user signal demands single-port simplicity.
- **Visual / interaction design.** Jed's domain. Contracts say wire-or-disable, not "what should the History panel look like."
- **Authentication on the web UI.** Localhost-only, MVP. Future ADR if multi-user / hosted instances become a thing.
- **HTTPS for the web UI.** Operator's job in deployed environments.
- **Process supervision / restart-on-crash for the web UI.** Per ADR-049's existing rule, no auto-restart.

## What's NOT in this PR

Per role discipline (Contract Author drafts; Implementation Agent ships):

- Wiring the 13 stub buttons → Implementation Agent (frontend track, Jed or a designated frontend implementer)
- The `useEffect([project])` re-fetch wiring → Implementation Agent
- The `DebugPanel.tsx` component → Implementation Agent
- The `neatd.ts` spawn logic for the web UI child process → Implementation Agent (touches `packages/core/src/neatd.ts`)
- Flipping `@neat.is/web` from `private: true` and bumping it into the lockstep → Publisher / Contract Author (touches the publish system; coordinate to avoid merge collision with the next release)
- Flipping any of the 45 `it.todo`s to live → Implementation Agent as work ships

A separate Claude Code session picks each up against the locked contracts. Handoff prompts available in conversation.

Refs #197