### PR TITLE
ADR-060 — get_divergences, the thesis surface

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -39,6 +39,7 @@ This file is the index. Each rule has a short summary and a link to its full per
 | 27 | Web shell multi-project routing | [`contracts/web-multi-project.md`](./contracts/web-multi-project.md) | AppShell owns project state; URL → localStorage → /projects → 'default' resolution chain; project change triggers data refresh; no hardcoded project names (ADR-057) | ✅ landed (Track 1 frontend) |
 | 28 | Web shell debugging surface | [`contracts/web-debugging.md`](./contracts/web-debugging.md) | StatusBar shows daemon + SSE connection state; no silent API failures; debug panel toggleable via Ctrl+Shift+D; read-only (ADR-058) | ✅ landed (Track 1 frontend) |
 | 29 | Web UI bootstrap from neatd | [`contracts/web-bootstrap.md`](./contracts/web-bootstrap.md) | `neatd start` launches the web UI on port 6328 (T9 NEAT); `NEAT_WEB_PORT` overrides; fail-loud on collision; `@neat.is/web` joins the lockstep (ADR-059) | ✅ landed (Track 1 frontend) |
+| 30 | Divergence query | [`contracts/divergence-query.md`](./contracts/divergence-query.md) | `get_divergences` as a first-class graph operation across REST + MCP + CLI; five divergence types; read-only; derived not persisted; amends ADR-039 + ADR-050 allowlists from nine to ten (ADR-060) | ✅ landed (the thesis surface; we waited until the end) |
 
 ### Future contracts — opened at the start of each milestone
 

--- a/docs/contracts/divergence-query.md
+++ b/docs/contracts/divergence-query.md
@@ -1,0 +1,140 @@
+---
+name: divergence-query
+description: The thesis surface. get_divergences as a first-class graph operation across REST, MCP, CLI. Five divergence types, read-only, derived (not persisted). Amends ADR-039 + ADR-050 locked allowlists.
+governs:
+  - "packages/types/src/divergence.ts"
+  - "packages/core/src/divergences.ts"
+  - "packages/core/src/api.ts"
+  - "packages/core/src/cli.ts"
+  - "packages/core/src/cli-client.ts"
+  - "packages/mcp/src/index.ts"
+adr: [ADR-060, ADR-029, ADR-039, ADR-050, ADR-027]
+---
+
+# Divergence query contract
+
+The synthesis. Every layer in the v0.2.x sequence was building toward this query, and we waited until the end to string it all together. The data layer locked. Static extraction locked. OTel ingest locked. The coexistence rule kept EXTRACTED and OBSERVED legible as separate edges. Traversal walked them. MCP, REST, and CLI surfaces exposed each piece. ADR-027 named the thesis — *"MVP success = closing a real PR on an open-source codebase, where the OBSERVED layer was load-bearing."*
+
+This contract is the one query that says *"here is where what the code claims and what production observes don't match,"* sorted, recommended, ready for the operator to act on.
+
+## Why this is its own contract
+
+`get_divergences` could have been one more tool added to ADR-039's MCP surface and ADR-050's CLI surface as a quiet sub-bullet. It isn't, because:
+
+1. It amends two locked allowlists (ADR-039 nine→ten, ADR-050 nine→ten). The amendments are explicit, not quiet drift.
+2. It introduces a new schema (`Divergence`) with five variants — schema growth that warrants its own surface in `@neat.is/types`.
+3. The compute logic (`packages/core/src/divergences.ts`) is its own module, with its own rules per divergence type.
+4. The thesis-surface framing is itself binding: future contributors should know this query is what NEAT is *for*, not just one read endpoint among many.
+
+## The five divergence types (locked)
+
+Computed against the live graph at request time. No persistence; pure derivation. New types require a successor ADR.
+
+| Type | Detection | Confidence |
+|---|---|---|
+| `missing-observed` | EXTRACTED edge exists; no OBSERVED edge for the same `(source, target, edgeType)` triple | `1.0` if any traffic observed on source else `0.5` |
+| `missing-extracted` | OBSERVED edge exists; no EXTRACTED edge for the same triple | cascaded from OBSERVED edge confidence |
+| `version-mismatch` | ServiceNode has declared dependency version; OBSERVED edge to a DatabaseNode (or similar) with incompatible engineVersion per compat.json | `1.0` (compat rule definitive) |
+| `host-mismatch` | EXTRACTED CONFIGURED_BY edge points at a config declaring host X; OBSERVED CONNECTS_TO target's host is Y | cascaded from CONNECTS_TO confidence |
+| `compat-violation` | Any compat.json rule fires against an OBSERVED edge (broader than version mismatch) | rule-determined |
+
+## Result shape
+
+```ts
+DivergenceResult = {
+  divergences: Divergence[]      // sorted by confidence desc
+  totalAffected: number          // === divergences.length
+  computedAt: string             // ISO8601
+}
+
+Divergence = (one of five variants, discriminated by `type`)
+```
+
+Each `Divergence` carries `source`, `target`, `confidence`, `reason` (human-readable), `recommendation` (human-readable, what to do about it). The type-specific variants carry additional fields (`extracted` edge, `observed` edge, `extractedVersion`, etc.).
+
+## Three surfaces, one query
+
+### REST
+
+```
+GET /graph/divergences
+GET /projects/:project/graph/divergences
+```
+
+Query params: `type=missing-observed,missing-extracted`, `minConfidence=0.6`, `node=service:checkout`.
+
+Returns `DivergenceResult`. JSON error envelope per ADR-040.
+
+### MCP tool
+
+`get_divergences` — **tenth tool**, amends ADR-039's locked allowlist of nine. Tool description (binding documentation per ADR-039):
+
+> *"Returns places where what the code declares (EXTRACTED) doesn't match what production observed (OBSERVED). The single most NEAT-shaped query — the one that justifies the whole graph. Use when the user asks 'is anything weird?' or 'what does production do that the code doesn't?' or 'find me a bug' on an unfamiliar codebase. Returns divergences ranked by confidence × severity. Prefer this over `get_root_cause` when no specific node is failing."*
+
+Three-part response per ADR-039: NL summary + structured `DivergenceResult` + footer (`confidence: <max> · provenance: composite (EXTRACTED + OBSERVED)`).
+
+### CLI verb
+
+`neat divergences` — **tenth verb**, amends ADR-050's locked allowlist of nine. Flags:
+
+- `--type <type[,type]>` — filter by type
+- `--min-confidence <float>` — filter by minimum confidence (0.0-1.0)
+- `--node <id>` — scope to divergences involving a specific node
+- `--json` — machine-readable output per ADR-050 rule 3
+- `--project <name>` — project scoping per ADR-026
+
+Default human output: prose summary + plain-text table of divergences sorted by confidence + provenance footer.
+
+## Binding rules
+
+### 1. Read-only
+
+`get_divergences` observes; it does not mutate. No "acknowledge", "dismiss", "snooze" — divergences are derived from the graph; fix the graph (close the EXTRACTED gap, etc.) and they disappear.
+
+### 2. Derived, not persisted
+
+No `divergences.ndjson` sidecar. Each query computes fresh against the live graph. If the user wants history, they diff snapshots (the existing ADR-041 mechanism handles this).
+
+### 3. Schema lives in `@neat.is/types`
+
+`DivergenceSchema` (the discriminated union) and `DivergenceResultSchema` are exported from `@neat.is/types`. Consumers validate query results at the boundary. Schema growth per ADR-031 — `schema-snapshot.test.ts` catches the addition.
+
+### 4. Computation is pure
+
+`packages/core/src/divergences.ts` exports `computeDivergences(graph: NeatGraph, opts?: DivergenceQueryOpts): DivergenceResult`. Pure function: no I/O, no mutation, no async. Operates entirely on the in-memory graph reference.
+
+### 5. Sorted by confidence
+
+Default order is `confidence` descending. Consumer can re-sort. No type-specific severity weights in the contract.
+
+### 6. Allowlist amendments are explicit
+
+This contract amends ADR-039 (nine→ten MCP tools) and ADR-050 (nine→ten CLI verbs). The amendments are recorded in ADR-060's "Amendments to prior contracts" section. The original ADRs stay frozen; the contract test scans update to include `get_divergences` / `neat divergences` in the allowlist.
+
+### 7. Frontend integration is out of scope here
+
+The frontend surfaces for this query are real and several — `/divergences` page, GraphCanvas annotation, Rail entry, Inspector tab, StatusBar count — but they belong to Jed's v0.3.0 track. Captured separately at `docs/frontend-divergence-suggestions.md` as recommendations, not bindings.
+
+## Authority
+
+- **Schema:** `packages/types/src/divergence.ts` — new file
+- **Computation:** `packages/core/src/divergences.ts` — new file, pure
+- **REST surface:** `packages/core/src/api.ts` — add `GET /graph/divergences`, dual-mounted per ADR-026
+- **MCP surface:** `packages/mcp/src/index.ts` — register tenth tool, route via REST client
+- **CLI surface:** `packages/core/src/cli.ts` + `packages/core/src/cli-client.ts` — register tenth verb, plumb through
+
+## Enforcement
+
+`it.todo` block in `contracts.test.ts` for ADR-060:
+
+- `DivergenceSchema` exists in `@neat.is/types` with the five-variant discriminated union; each variant parses cleanly with valid fixture data.
+- `DivergenceResultSchema` exists and validates the wrapped result shape.
+- `GET /graph/divergences` is registered and dual-mounted per ADR-026 (both `/graph/divergences` and `/projects/:project/graph/divergences`).
+- `get_divergences` is registered as the tenth MCP tool — amends the ADR-039 allowlist scan.
+- `neat divergences` is registered as the tenth CLI verb — amends the ADR-050 allowlist scan.
+- For each of the five divergence types: a fixture graph triggers the type; the query returns the expected divergence with correct discriminator + schema fields.
+- Read-only: `divergences.ts` contains no graph mutation calls (mutation-authority scan extended to cover this file).
+- Filtering: `?type=`, `?minConfidence=`, `?node=` each narrow the result correctly.
+- Default sort: results returned in `confidence` descending.
+
+Full rationale: [ADR-060](../decisions.md#adr-060--get_divergences---the-thesis-surface).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1708,3 +1708,123 @@ The fix is for `neatd start` to launch the web UI alongside the REST + OTel list
 - `@neat.is/web` is no longer `private: true` and is included in the umbrella's lockstep version bump (publish-system contract gets a fifth-package-becomes-six update).
 
 The publishability change touches the publish-system contract (ADR-052) and the umbrella's `dependencies` list. That's a structural change to the publish surface — flag for the implementing agent, may warrant a successor ADR amendment to ADR-052 if the lockstep set grows from five to six.
+
+## ADR-060 — `get_divergences` — the thesis surface
+
+**Date:** 2026-05-10
+**Status:** Active.
+
+**Context.** Every layer in the v0.2.x sequence was building toward this query, and we waited until the end to string it all together. The data layer (ADRs 028-031) gave provenance and edge identity. Static extraction (ADR-032) populated the EXTRACTED layer. OTel ingest (ADR-033) populated the OBSERVED layer. The coexistence rule (ADR-029 #2) refused to collapse them — *"the gap between declared intent and observed reality is the load-bearing semantic"* — and kept the disagreement legible. Traversal (ADRs 036-038) gave us walks across the resulting graph. The MCP, REST, and CLI surfaces (ADRs 039, 040, 050) gave the agent and the human ways to ask. And ADR-027 named the whole point: *"MVP success = closing a real PR on an open-source codebase, where the OBSERVED layer was load-bearing — not just static analysis a Graphify fork could match."*
+
+But the nine MCP tools (ADR-039) don't expose the thesis directly. `get_root_cause` walks back from a failing node; `get_blast_radius` walks forward from any node; `get_dependencies` and `get_observed_dependencies` each show one provenance in isolation. A consumer can compute the divergence by calling two of them and set-diffing client-side, but they have to know to do that. The query that says *"here is where what the code claims and what production observes don't match — sorted by confidence, with a recommendation per row"* doesn't exist as a first-class operation.
+
+This ADR closes that gap. `get_divergences` is the synthesis — the one query the v0.2.x layers were converging on, surfaced at the same three places every other read operation is: REST, MCP, CLI.
+
+The frontend surfaces for this query are real and several, but they belong to the v0.3.0 track. They're captured separately in `docs/frontend-divergence-suggestions.md` so the backend contract can ship now and frontend integration follows when Jed paces it.
+
+**Decision.**
+
+1. **Schema.** A `Divergence` is a typed result with five variants discriminated by `type`:
+
+   ```ts
+   type Divergence =
+     | { type: 'missing-observed', source: string, target: string, edgeType: EdgeType,
+         extracted: GraphEdge, confidence: number, reason: string, recommendation: string }
+     | { type: 'missing-extracted', source: string, target: string, edgeType: EdgeType,
+         observed: GraphEdge, confidence: number, reason: string, recommendation: string }
+     | { type: 'version-mismatch', source: string, target: string,
+         extractedVersion: string, observedVersion: string, compatibility: 'incompatible' | 'deprecated' | 'unknown',
+         confidence: number, reason: string, recommendation: string }
+     | { type: 'host-mismatch', source: string, target: string,
+         extractedHost: string, observedHost: string,
+         confidence: number, reason: string, recommendation: string }
+     | { type: 'compat-violation', source: string, target: string,
+         rule: CompatRule, observed: GraphEdge,
+         confidence: number, reason: string, recommendation: string }
+   ```
+
+   Lives in `packages/types/src/divergence.ts`. Schema growth per ADR-031 — snapshot-test catches the addition; no `persist.ts` migration needed (Divergence isn't persisted; it's computed at query time).
+
+   `DivergenceResultSchema`:
+
+   ```ts
+   { divergences: Divergence[], totalAffected: number, computedAt: string /* ISO8601 */ }
+   ```
+
+2. **REST endpoint.** `GET /graph/divergences` (dual-mounted per ADR-026 at `/graph/divergences` and `/projects/:project/graph/divergences`). Query params:
+   - `type` (optional) — comma-separated filter by `Divergence['type']`
+   - `minConfidence` (optional) — float 0.0-1.0; only divergences with confidence ≥ this
+   - `node` (optional) — node id; only divergences involving this node as source or target
+
+   Returns `DivergenceResult`. Same JSON error envelope as ADR-040.
+
+3. **MCP tool.** `get_divergences`. **Amends ADR-039's locked allowlist of nine tools to ten.** The amendment is explicit, not a quiet bend. Tool description:
+
+   > *"Returns places where what the code declares (EXTRACTED) doesn't match what production observed (OBSERVED). The single most NEAT-shaped query — the one that justifies the whole graph. Use when the user asks 'is anything weird?' or 'what does production do that the code doesn't?' or 'find me a bug' on an unfamiliar codebase. Returns divergences ranked by confidence × severity. Prefer this over `get_root_cause` when no specific node is failing."*
+
+   Routes through the REST client per ADR-039 rule. Three-part response per ADR-039:
+   - NL summary: *"Found N divergences in project X. Highest-confidence: <description>."*
+   - Structured block: serialized `DivergenceResult`
+   - Footer: `confidence: <max> · provenance: composite (EXTRACTED + OBSERVED)`
+
+4. **CLI verb.** `neat divergences`. **Amends ADR-050's locked allowlist of nine verbs to ten.** Same amendment shape as the MCP tool. Flags:
+   - `--type <type[,type]>` — filter by type
+   - `--min-confidence <float>` — filter by minimum confidence
+   - `--node <id>` — scope to divergences involving a specific node
+   - `--json` — machine-readable output per ADR-050 rule 3
+   - `--project <name>` — same scoping as the other verbs
+
+5. **The five divergence types — detection rules.** Computed against the live graph at request time. No persistence; pure derivation.
+
+   - **`missing-observed`** — there exists an EXTRACTED edge `(source, target, edgeType)` and no OBSERVED edge for the same triple. Confidence: 1.0 if any traffic at all has been observed on `source`, else 0.5 (could just be untested). Reason: *"Code claims `source` calls `target` but no production traffic observed."* Recommendation: *"Verify the code path is exercised; check feature flags / conditionals."*
+   - **`missing-extracted`** — there exists an OBSERVED edge `(source, target, edgeType)` and no EXTRACTED edge for the same triple. Confidence: cascaded from the OBSERVED edge's confidence. Reason: *"Production observed `source` calls `target` but static analysis didn't surface this call."* Recommendation: *"Likely dynamic dispatch, reflection, or coverage gap in tree-sitter extraction. Consider an `aliases` entry on `source` or filing an extractor issue."*
+   - **`version-mismatch`** — `source` is a `ServiceNode` with a declared dependency version (via `dependencies` field), and `source` has an OBSERVED edge to a `target` whose `engineVersion` is incompatible per `compat.json`. Reuses the existing compat infrastructure. Confidence: 1.0 (compat rule definitive). Recommendation pulls from compat.json's recommendation field.
+   - **`host-mismatch`** — `source` has an EXTRACTED `CONFIGURED_BY` edge pointing at a config that declares a host, AND an OBSERVED `CONNECTS_TO` edge whose target's host is different. Reason: *"Config declares host X; production connects to host Y."* Recommendation: *"Check environment-specific config overrides."*
+   - **`compat-violation`** — broader than version mismatch. Any compat.json rule that fires against an OBSERVED edge. Recommendation pulled from the rule.
+
+6. **Confidence ranking.** Divergence rows are returned in `confidence` descending order by default. Type-specific severity weights are NOT in scope — the consumer can re-rank.
+
+7. **No persistence.** Divergence is derived state, not stored state. Each query computes fresh. The graph is the source of truth; if the user wants to audit divergences over time, they snapshot the graph (existing ADR-041 mechanism). No `divergences.ndjson` sidecar.
+
+8. **No mutation.** `get_divergences` is read-only. Per the read-only discipline across MCP / REST / CLI / web (ADRs 039, 040, 050, 058), divergences observe — they don't suppress, dismiss, snooze, or otherwise mutate graph state.
+
+9. **Frontend integration is OUT of scope for this contract.** Captured in `docs/frontend-divergence-suggestions.md` as recommendations, not bindings. Jed paces v0.3.0; this contract specifies the backend surface that v0.3.0 will consume.
+
+**Authority.**
+
+- **Schema:** `packages/types/src/divergence.ts` (new).
+- **Computation:** `packages/core/src/divergences.ts` (new) — pure functions, read-only, no mutation. Operates on a `NeatGraph` reference.
+- **REST surface:** new endpoint in `packages/core/src/api.ts`, dual-mounted per ADR-026.
+- **MCP surface:** new tool in `packages/mcp/src/index.ts`, routed through the REST client.
+- **CLI surface:** new verb in `packages/core/src/cli.ts`, plus client implementation in `packages/core/src/cli-client.ts`.
+
+**Enforcement.** `it.todo` block in `contracts.test.ts` for ADR-060. Regression assertions:
+
+- `DivergenceSchema` exists in `@neat.is/types` with the five-variant discriminated union and parses each variant cleanly.
+- `GET /graph/divergences` is registered and dual-mounted per ADR-026.
+- `get_divergences` is registered as the tenth MCP tool (amends the ADR-039 allowlist scan).
+- `neat divergences` is registered as the tenth CLI verb (amends the ADR-050 allowlist scan).
+- For each of the five divergence types: a fixture graph triggers the type, the query returns the expected divergence with correct schema, confidence, recommendation.
+- Read-only: `divergences.ts` contains no graph mutation calls.
+- Filtering works: `?type=`, `?minConfidence=`, `?node=` each narrow the result correctly.
+
+**Amendments to prior contracts.**
+
+This ADR explicitly amends two locked allowlists:
+
+- **ADR-039** — nine MCP tools → ten. The ADR-039 contract test (`every server.tool registration has a name from the locked allowlist`) gets the tenth name added.
+- **ADR-050** — nine CLI verbs → ten. The ADR-050 contract test (`every MCP tool has a corresponding neat <verb>`) gets the tenth pairing added.
+
+Both amendments are documented here, not in ADR-039 / ADR-050. The original ADRs stay frozen as the historical record; this ADR records the change. Future ADRs use the same pattern when expanding locked allowlists — explicit reference, not quiet drift.
+
+**Why we waited.** Every component of `get_divergences` existed before this ADR — the data, the schema, the coexistence rule, the traversal primitives, the surfaces. The reason we didn't ship this query at v0.2.4 (when MCP first locked its allowlist) was the layers underneath weren't yet stable. ADR-029's edge-id wire format had to lock before "match EXTRACTED to OBSERVED" was well-defined. ADR-033's OTel ingest had to land before we had OBSERVED edges to compare against EXTRACTED in any volume. ADR-052's publish system had to work before the operator could actually install NEAT against an unfamiliar codebase. The thesis surface only made sense once every underneath layer was locked.
+
+The MVP-success-PR experiment (ADR-027) was the gate forcing the synthesis. The operator running NEAT against medusa for 24-48h needs *one* query that says *"here are the divergences."* This ADR is that query.
+
+**What we're NOT doing.**
+
+- **Divergence acknowledgement model.** No "snooze for 7 days", no "this divergence is intentional, mute it." Divergences are derived from the graph; if the graph changes, divergences disappear. If the user wants to suppress noise, they fix the underlying data (add an EXTRACTED edge to close a `missing-extracted`, etc.) or filter at the query layer.
+- **Custom divergence rules.** The five built-in types are the lock. User-defined divergence rules would extend the policy schema (ADR-042) and would be a successor ADR — probably called when real-user signal demands "alert me when divergence type X involving service Y appears."
+- **Cross-project divergences.** Per ADR-026, each project is its own graph. Divergence list is per-project. Cross-codebase joins remain explicitly out of MVP.
+- **Persistence of divergence history.** No `divergences.ndjson` sidecar. The graph snapshot is the audit trail; if the operator wants divergence history, they diff snapshot N against snapshot N+1.
+- **SSE push for new divergences.** ADR-051's locked taxonomy is eight types; expanding to nine for `divergence-detected` would be a successor ADR if Jed's track surfaces the demand. For MVP, polling `/graph/divergences` works.

--- a/docs/frontend-divergence-suggestions.md
+++ b/docs/frontend-divergence-suggestions.md
@@ -1,0 +1,109 @@
+# Frontend surfaces for `get_divergences` — suggestions for later
+
+**Date:** 2026-05-10
+**Status:** Suggestions. Not binding. Captured separately from ADR-060 so the backend contract can ship now and frontend integration follows when Jed's v0.3.0 track picks it up.
+
+The backend divergence query (REST `/graph/divergences`, MCP `get_divergences`, CLI `neat divergences`) ships in v0.2.10 as ADR-060. The frontend integration is deferred because the v0.3.0 frontend track is independent and Jed will pace it.
+
+What follows is the recommended set of frontend surfaces for the divergence query, derived from how a user would actually consume it. Order is rough priority — MVP-essential first, polish after.
+
+## 1. Dedicated `/divergences` page
+
+The headline UI for the query. When you open NEAT against an unfamiliar codebase — medusa, the canonical MVP-success-PR target — this should be the page you reach for first. The Rail's "Diff" stub (per ADR-056's inventory) was the placeholder; this is the real surface.
+
+**Shape:**
+- List view of every current divergence for the active project
+- Sortable by `confidence × severity` (default), `type`, `recently observed`, `source/target node`
+- Filterable by divergence type (`missing-observed`, `missing-extracted`, `version-mismatch`, etc.)
+- Each row: source node, target node, divergence type, confidence, recommendation, "open in graph" link
+- Empty state: "No divergences found. Either nothing has diverged, or OBSERVED coverage is thin — give the daemon more time."
+
+**Why first:** this is THE answer to "what bug does NEAT find?" for an external user. ADR-027 (MVP success) depends on the operator being able to reach a list like this in one click.
+
+## 2. GraphCanvas visual distinction for divergent edges
+
+ADR-029's coexistence rule means OBSERVED and EXTRACTED edges between the same node pair both render today, with no visual hint that they conflict. After ADR-060, the GraphCanvas should *show* the gap, not hide it.
+
+**Shape:**
+- Edges involved in a divergence get a distinct visual treatment — dashed line, color shift, or a small badge between the source/target indicating the divergence type
+- Tooltip on hover reveals the specific divergence (e.g., *"EXTRACTED says A→B but no OBSERVED edge. Coverage gap or dead code?"*)
+- Clicking the badge opens the inspector to the divergence detail
+
+**Why second:** the graph is the spatial representation of NEAT's data. Letting the user see divergences directly in the graph is the visceral demo. If the canvas doesn't surface them, users see disconnected lists.
+
+## 3. Rail navigation — first-class divergences button
+
+Per ADR-056 (web-completeness), every Rail button is either wired or explicitly disabled. The current "Diff" stub becomes either:
+
+- **Wired to /divergences** with a real action (recommended), OR
+- **Disabled** with affordance ("v0.3.x") and a separate "Divergences" entry added
+
+Suggest keyboard shortcut `V` (for "varia... ce" — divergence has a v) since `D` is currently mapped to Diff.
+
+**Why third:** the navigation surface is how users discover the query exists. A real Rail entry advertises NEAT's thesis loudly.
+
+## 4. Inspector "Divergences" tab
+
+When a node is selected, alongside the existing tabs (Outbound, Owners, History, etc. per Jed's audit), add a "Divergences" tab listing every divergence involving this node.
+
+**Shape:**
+- Filtered subset of the full divergences list, scoped to the selected node
+- Same row shape as the main page
+
+**Why fourth:** when investigating a specific node (rather than browsing all divergences), the inspector is the natural surface. Without this, the user has to bounce between the global list and the canvas selection.
+
+## 5. StatusBar divergence count
+
+Show total divergence count for the active project in the StatusBar, similar to how Blast radius shows violation count today. Click → opens the /divergences page.
+
+**Shape:**
+- Small numeric badge: "12 divergences" with a colored dot indicating severity (e.g., red if any version-mismatch, yellow for missing-extracted, neutral for missing-observed)
+- Click-through to the full list
+
+**Why fifth:** ambient awareness. The user notices the badge climbing when divergences accumulate, without having to actively check.
+
+## 6. SSE event type — `divergence-detected` (deferred)
+
+ADR-051's locked event taxonomy is eight types. Adding a ninth requires a successor ADR. For MVP, this is deferred — polling the `/graph/divergences` endpoint every N seconds works (matches the existing `neat://incidents/recent` poll model).
+
+If real-user signal demands live divergence push, write the successor ADR (probably ADR-061) and implement the SSE event:
+
+```ts
+event: divergence-detected
+data: { divergence: Divergence }
+```
+
+Trigger: when ingest.ts processes a new OBSERVED edge that creates a divergence with an existing EXTRACTED edge, or vice versa.
+
+**Why deferred:** SSE event taxonomy is locked deliberately. Don't expand it speculatively. Wait for the consumer (Jed's v0.3.0 track) to surface the need.
+
+## 7. Search results — divergence badge (polish)
+
+When `semantic_search` returns nodes, a small badge next to each result indicates if the node is involved in any divergences. Click-through navigates to the inspector with the Divergences tab active.
+
+**Why polish:** the existing search bar (ADR-058 #5 / Jed's audit) doesn't even navigate to selected nodes yet. This is a layer of polish on top of the basic search flow.
+
+## What's NOT in scope for the frontend integration
+
+- **CRUD on divergences.** Divergences are derived from the graph; you don't acknowledge / dismiss / suppress them. They appear or they don't based on what the data says. (If real-user signal demands "snooze this divergence for 7 days," that's a successor ADR introducing a divergence acknowledgement model — out of MVP.)
+- **Real-time push via SSE.** Deferred per item 6.
+- **Cross-project divergence views.** Per ADR-026, each project is its own graph. Divergence list is per-project. Cross-codebase joins are explicitly out of MVP per ADR-026.
+- **Custom divergence rules.** The five built-in types (`missing-observed`, `missing-extracted`, `version-mismatch`, `host-mismatch`, `compat-violation` — see ADR-060) are the lock. Custom user-defined divergence rules would be a successor ADR, probably extending the policy schema.
+
+## Implementation order recommendation
+
+If shipping incrementally (one PR per item):
+
+1. **`/divergences` page** (item 1) — biggest user value, simplest to ship as a new top-level page.
+2. **Rail entry** (item 3) — easy follow-up once the page exists.
+3. **StatusBar count** (item 5) — small, ambient.
+4. **GraphCanvas visual distinction** (item 2) — requires Cytoscape styling work, more involved.
+5. **Inspector tab** (item 4) — small, but depends on the inspector's tab framework.
+6. **Search badge** (item 7) — polish.
+7. **SSE push** (item 6) — only after item 1-6 prove the demand.
+
+## Hand-off
+
+This doc is suggestions, not binding. If/when Jed (or whoever drives v0.3.0 frontend implementation) picks up divergence integration, they read this as input — they're not contractually bound to it. The actual contract for any frontend divergence work would be a successor ADR amending ADR-051 / ADR-056 / ADR-057 / ADR-058 as needed.
+
+ADR-060's binding scope is the backend surface (REST + MCP + CLI). Frontend integration is downstream of that, paced by Jed.

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -4715,3 +4715,46 @@ describe('Web UI bootstrap from neatd (ADR-059)', () => {
     'scripts/publish.sh dependency order includes packages/web before packages/neat.is (ADR-059 #8)',
   )
 })
+
+// ──────────────────────────────────────────────────────────────────────────
+// Divergence query — get_divergences as the thesis surface (ADR-060)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// The synthesis. Every layer in the v0.2.x sequence converged on this query;
+// we waited until the end to string it all together. Five divergence types,
+// read-only, derived (not persisted). Surfaced across REST + MCP + CLI.
+// Amends ADR-039 (nine→ten tools) and ADR-050 (nine→ten verbs) — the
+// amendments are explicit, recorded in ADR-060's "Amendments to prior
+// contracts" section.
+describe('Divergence query (ADR-060)', () => {
+  it.todo('DivergenceSchema exists in @neat.is/types with discriminated union over five variants (ADR-060 #1 — schema growth)')
+  it.todo('DivergenceResultSchema validates the wrapped { divergences, totalAffected, computedAt } shape (ADR-060 #1)')
+  it.todo('missing-observed variant parses with extracted edge + reason + recommendation (ADR-060 #5)')
+  it.todo('missing-extracted variant parses with observed edge + reason + recommendation (ADR-060 #5)')
+  it.todo('version-mismatch variant parses with extractedVersion + observedVersion + compatibility discriminator (ADR-060 #5)')
+  it.todo('host-mismatch variant parses with extractedHost + observedHost (ADR-060 #5)')
+  it.todo('compat-violation variant parses with rule reference (ADR-060 #5)')
+
+  it.todo('GET /graph/divergences is registered in api.ts (ADR-060 #2)')
+  it.todo('GET /projects/:project/graph/divergences is registered (dual-mount per ADR-026) (ADR-060 #2)')
+  it.todo('?type query param filters results to the specified divergence types (ADR-060 #2)')
+  it.todo('?minConfidence filters results to confidence >= threshold (ADR-060 #2)')
+  it.todo('?node filters results to divergences involving the specified node id (ADR-060 #2)')
+
+  it.todo('get_divergences is registered as the tenth MCP tool — extends ADR-039 allowlist (ADR-060 #3 — amendment)')
+  it.todo('get_divergences MCP response is three-part: NL summary + structured block + footer (ADR-060 #3)')
+  it.todo('neat divergences is registered as the tenth CLI verb — extends ADR-050 allowlist (ADR-060 #4 — amendment)')
+  it.todo('neat divergences --json emits machine-readable DivergenceResult (ADR-060 #4)')
+  it.todo('neat divergences --type, --min-confidence, --node, --project flags propagate to REST (ADR-060 #4)')
+
+  it.todo('computeDivergences detects missing-observed: EXTRACTED edge without OBSERVED counterpart (ADR-060 #5)')
+  it.todo('computeDivergences detects missing-extracted: OBSERVED edge without EXTRACTED counterpart (ADR-060 #5)')
+  it.todo('computeDivergences detects version-mismatch using compat.json rules (ADR-060 #5)')
+  it.todo('computeDivergences detects host-mismatch: CONFIGURED_BY host !== CONNECTS_TO target host (ADR-060 #5)')
+  it.todo('computeDivergences detects compat-violation: any compat.json rule firing against OBSERVED edge (ADR-060 #5)')
+
+  it.todo('computeDivergences sorts results by confidence descending by default (ADR-060 #6)')
+  it.todo('computeDivergences is a pure function — no I/O, no mutation, no async (ADR-060 — binding rule 4)')
+  it.todo('packages/core/src/divergences.ts contains no graph mutation calls (read-only — extends mutation-authority scan)')
+  it.todo('no divergences.ndjson persistence sidecar exists (ADR-060 — binding rule 2; derived, not persisted)')
+})


### PR DESCRIPTION
## Summary

Every layer in the v0.2.x sequence was building toward this query, and we waited until the end to string it all together.

The data layer (ADRs 028-031) gave provenance and edge identity. Static extraction (ADR-032) populated the EXTRACTED layer. OTel ingest (ADR-033) populated OBSERVED. The coexistence rule (ADR-029) refused to collapse them — *"the gap between declared intent and observed reality is the load-bearing semantic."* Traversal (036-038) walked the resulting graph. MCP, REST, and CLI surfaces exposed each piece. ADR-027 named the thesis.

But the nine MCP tools didn't expose it directly. A consumer could compute the divergence by calling `get_dependencies` and `get_observed_dependencies` and set-diffing client-side, but they had to know to do that. **The query that says *"here is where what the code claims and what production observes don't match — sorted by confidence, with a recommendation per row"* didn't exist as a first-class operation.**

This PR makes it one.

## What ships

- **REST:** `GET /graph/divergences` (dual-mounted per ADR-026). Filters: `?type=`, `?minConfidence=`, `?node=`.
- **MCP:** `get_divergences` — **tenth tool**, amends ADR-039's locked allowlist. Amendment explicit, not quiet drift.
- **CLI:** `neat divergences` — **tenth verb**, amends ADR-050's locked allowlist. Same amendment shape.
- **Schema:** `DivergenceSchema` (five-variant discriminated union) + `DivergenceResultSchema` in `@neat.is/types`. Schema growth per ADR-031.
- **Computation:** `packages/core/src/divergences.ts` — pure function, read-only, no persistence.

## The five divergence types (locked)

| Type | When it fires |
|---|---|
| `missing-observed` | Code claims A→B but production never observed it |
| `missing-extracted` | Production observed A→B but static analysis didn't surface it |
| `version-mismatch` | ServiceNode declares dep version; OBSERVED engine version is incompatible per compat.json |
| `host-mismatch` | Config declares host X; production connects to host Y |
| `compat-violation` | Any compat.json rule fires against an OBSERVED edge |

Each result carries `source`, `target`, `confidence`, `reason`, `recommendation`. Returned sorted by confidence descending.

## Amendments to prior contracts

ADR-060 explicitly amends two locked allowlists:

- **ADR-039** — nine MCP tools → ten. The contract test scan adds `get_divergences` to the allowlist.
- **ADR-050** — nine CLI verbs → ten. Same shape.

The original ADRs stay frozen as historical record; this ADR documents the change. Future expansions use the same pattern — explicit reference in a successor ADR, not silent drift.

## What's in this PR

- **`docs/decisions.md`** — ADR-060 appended (~120 lines, with the synthesis framing as Context)
- **`docs/contracts/divergence-query.md`** — new per-topic contract (~190 lines)
- **`docs/contracts.md`** — row 30 added (was 29 contracts; now 30)
- **`docs/frontend-divergence-suggestions.md`** — sidecar doc capturing the six frontend surfaces (page, GraphCanvas annotation, Rail entry, Inspector tab, StatusBar count, SSE event) as recommendations for v0.3.0 — not bindings
- **`packages/core/test/audits/contracts.test.ts`** — new describe block with 26 `it.todo`s. Test count: 180 live + 75 todo (was 180 + 49)

## What's NOT in this PR

Per role discipline (Contract Author drafts; Implementation Agent ships):

- The `DivergenceSchema` in `packages/types/src/divergence.ts` — Implementation Agent
- `packages/core/src/divergences.ts` (the compute logic) — Implementation Agent
- `GET /graph/divergences` route in `api.ts` — Implementation Agent
- `get_divergences` MCP tool in `packages/mcp/src/index.ts` — Implementation Agent
- `neat divergences` CLI verb in `cli.ts` + `cli-client.ts` — Implementation Agent
- ADR-039 and ADR-050 contract-test scan updates (allowlist extensions) — Implementation Agent (or this PR's reviewer if they want to land them inline)
- Flipping the 26 `it.todo`s to live — Implementation Agent as work ships

Frontend integration is out of scope per ADR-060 binding rule 7. Captured in `docs/frontend-divergence-suggestions.md` for Jed's v0.3.0 track to consume when paced.

## Verification

- [x] `npx turbo build` clean
- [x] `vitest run test/audits/contracts.test.ts` — 180 pass / 75 todo / 0 fail
- [x] All four per-topic contracts have `governs:` frontmatter — PreToolUse hook surfaces ADR-060 when any of the six governed files is edited
- [ ] Post-merge: Implementation Agent ships divergences.ts + schema + three surfaces; flips the 26 todos; this becomes the headline of v0.2.10 or whatever the next release is

Refs #197