### PR TITLE
ADR-059 — neatd start launches the web UI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,14 +48,14 @@ jobs:
           set -euo pipefail
           versions=$(node -e "
             const fs = require('fs')
-            const pkgs = ['types', 'core', 'mcp', 'claude-skill', 'neat.is']
+            const pkgs = ['types', 'core', 'mcp', 'claude-skill', 'web', 'neat.is']
             const vs = pkgs.map(p => JSON.parse(fs.readFileSync('packages/' + p + '/package.json', 'utf8')).version)
             console.log(vs.join(' '))
           ")
           unique=$(echo "$versions" | tr ' ' '\n' | sort -u | wc -l | tr -d ' ')
           echo "Versions: $versions"
           if [ "$unique" != "1" ]; then
-            echo "::error::Publishable packages have mismatched versions. All five must match."
+            echo "::error::Publishable packages have mismatched versions. All six must match."
             exit 1
           fi
 
@@ -96,6 +96,7 @@ jobs:
           publish_one "packages/core"
           publish_one "packages/mcp"
           publish_one "packages/claude-skill"
+          publish_one "packages/web"
           publish_one "packages/neat.is"
 
           echo

--- a/package-lock.json
+++ b/package-lock.json
@@ -10838,7 +10838,7 @@
     },
     "packages/claude-skill": {
       "name": "@neat.is/claude-skill",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "BUSL-1.1",
       "engines": {
         "node": ">=20"
@@ -10846,13 +10846,13 @@
     },
     "packages/core": {
       "name": "@neat.is/core",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "BUSL-1.1",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
         "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
-        "@neat.is/types": "^0.2.8",
+        "@neat.is/types": "^0.2.9",
         "chokidar": "^4.0.3",
         "fastify": "^5.0.0",
         "graphology": "^0.25.4",
@@ -10891,11 +10891,11 @@
     },
     "packages/mcp": {
       "name": "@neat.is/mcp",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "BUSL-1.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@neat.is/types": "^0.2.8",
+        "@neat.is/types": "^0.2.9",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -10913,12 +10913,13 @@
       }
     },
     "packages/neat.is": {
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "BUSL-1.1",
       "dependencies": {
-        "@neat.is/claude-skill": "^0.2.8",
-        "@neat.is/core": "^0.2.8",
-        "@neat.is/mcp": "^0.2.8"
+        "@neat.is/claude-skill": "^0.2.9",
+        "@neat.is/core": "^0.2.9",
+        "@neat.is/mcp": "^0.2.9",
+        "@neat.is/web": "^0.2.9"
       },
       "bin": {
         "neat": "bin/neat",
@@ -10931,7 +10932,7 @@
     },
     "packages/types": {
       "name": "@neat.is/types",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "BUSL-1.1",
       "dependencies": {
         "zod": "^3.23.8"
@@ -10947,9 +10948,10 @@
     },
     "packages/web": {
       "name": "@neat.is/web",
-      "version": "0.2.0",
+      "version": "0.2.9",
+      "license": "BUSL-1.1",
       "dependencies": {
-        "@neat.is/types": "*",
+        "@neat.is/types": "^0.2.9",
         "cytoscape": "^3.33.3",
         "next": "14.2.35",
         "react": "^18",
@@ -10964,6 +10966,9 @@
         "tailwindcss": "^3.4.1",
         "typescript": "^5",
         "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     }
   }

--- a/packages/core/src/neatd.ts
+++ b/packages/core/src/neatd.ts
@@ -10,12 +10,15 @@
  *
  * MVP runs in foreground only. Backgrounding is the supervisor's job
  * (launchd / systemd / nohup) — `neatd start` blocks until SIGINT/SIGTERM.
+ *
+ * v0.2.10: also brings up the web UI on port 6328 by default (ADR-059).
  */
 
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import { startDaemon } from './daemon.js'
 import { listProjects, registryPath } from './registry.js'
+import { spawnWebUI, DEFAULT_WEB_PORT, type WebHandle } from './web-spawn.js'
 
 function neatHome(): string {
   if (process.env.NEAT_HOME && process.env.NEAT_HOME.length > 0) {
@@ -39,10 +42,33 @@ function usage(): void {
   console.log('usage: neatd <start|stop|reload|status> [--foreground]')
 }
 
+function restPortFromEnv(): number {
+  const raw = process.env.PORT
+  return raw && raw.length > 0 ? Number.parseInt(raw, 10) : 8080
+}
+
 async function cmdStart(): Promise<void> {
   const handle = await startDaemon()
   console.log(`neatd: started, PID ${process.pid}, ${handle.slots.size} project(s)`)
   console.log(`neatd: registry at ${registryPath()}`)
+
+  // ADR-059 — bring up the web UI alongside the daemon. Failure here aborts
+  // start with the clear-error pattern from ADR-049 instead of silently
+  // running headless.
+  const skipWeb = process.env.NEAT_WEB_DISABLED === '1'
+  let web: WebHandle | null = null
+  if (!skipWeb) {
+    try {
+      web = await spawnWebUI(restPortFromEnv())
+    } catch (err) {
+      console.error((err as Error).message)
+      await handle.stop().catch(() => {})
+      process.exit(3)
+    }
+  } else {
+    console.log('neatd: web UI disabled (NEAT_WEB_DISABLED=1)')
+  }
+
   console.log('neatd: SIGHUP reloads, SIGTERM/SIGINT stops')
 
   let stopping = false
@@ -50,8 +76,7 @@ async function cmdStart(): Promise<void> {
     if (stopping) return
     stopping = true
     console.log(`neatd: ${signal} received, stopping…`)
-    void handle
-      .stop()
+    void Promise.allSettled([handle.stop(), web ? web.stop() : Promise.resolve()])
       .catch((err) => console.error(`neatd: shutdown error — ${(err as Error).message}`))
       .finally(() => process.exit(0))
   }
@@ -96,6 +121,10 @@ async function cmdStatus(): Promise<void> {
   const pid = await readPid()
   console.log(`pid:      ${pid ?? '(not running)'}`)
   console.log(`registry: ${registryPath()}`)
+  const webPort = process.env.NEAT_WEB_PORT
+    ? Number.parseInt(process.env.NEAT_WEB_PORT, 10)
+    : DEFAULT_WEB_PORT
+  console.log(`web ui:   http://localhost:${webPort}`)
   const projects = await listProjects().catch(() => [])
   if (projects.length === 0) {
     console.log('projects: (none)')

--- a/packages/core/src/web-spawn.ts
+++ b/packages/core/src/web-spawn.ts
@@ -1,0 +1,128 @@
+/**
+ * Web UI spawn helper (ADR-059).
+ *
+ * `neatd start` brings up the REST API + OTel receivers, then calls
+ * `spawnWebUI(restPort)` to launch the Next.js web shell as a child process.
+ * Lifecycle is parent-tied: SIGTERM/SIGINT on neatd cascades to the child
+ * via `stop()`.
+ *
+ * Default port `6328` (NEAT in T9). Override with `NEAT_WEB_PORT`.
+ * Hard-fails on collision so the operator never loses track of which URL to
+ * open.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process'
+import net from 'node:net'
+import path from 'node:path'
+
+export const DEFAULT_WEB_PORT = 6328
+
+export interface WebHandle {
+  child: ChildProcess
+  port: number
+  stop: () => Promise<void>
+}
+
+/**
+ * Best-effort port collision check before spawning. Binds, closes, returns.
+ * Race condition between the check and the actual `next start` is acceptable
+ * — Next.js will then fail loudly and the parent exits.
+ */
+async function assertPortFree(port: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const tester = net.createServer()
+    tester.once('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'EADDRINUSE') {
+        reject(
+          new Error(
+            `neatd: web UI port ${port} in use; set NEAT_WEB_PORT to override or stop the conflicting process`,
+          ),
+        )
+      } else {
+        reject(err)
+      }
+    })
+    tester.once('listening', () => {
+      tester.close(() => resolve())
+    })
+    tester.listen(port, '127.0.0.1')
+  })
+}
+
+/**
+ * Resolve the web package directory. In a global install
+ * (`npm install -g neat.is`) the package lives at
+ * `node_modules/@neat.is/web/`; in the monorepo it's
+ * `packages/web/`. `require.resolve` finds whichever one Node has on its
+ * search path.
+ */
+function resolveWebPackageDir(): string {
+  const req = (typeof require !== 'undefined'
+    ? require
+    : // ESM fallback — daemon CJS bundle has `require`, but typecheck wants this
+      (eval('require') as NodeRequire))
+  const pkgJsonPath = req.resolve('@neat.is/web/package.json')
+  return path.dirname(pkgJsonPath)
+}
+
+export async function spawnWebUI(restPort: number): Promise<WebHandle> {
+  const portRaw = process.env.NEAT_WEB_PORT
+  const port = portRaw && portRaw.length > 0 ? Number.parseInt(portRaw, 10) : DEFAULT_WEB_PORT
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+    throw new Error(`neatd: invalid NEAT_WEB_PORT="${portRaw}"`)
+  }
+
+  await assertPortFree(port)
+
+  const cwd = resolveWebPackageDir()
+  // ADR-059 #6 — child inherits NEAT_API_URL pointing at our REST server,
+  // unless the operator pre-configured it.
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    PORT: String(port),
+    NEAT_API_URL: process.env.NEAT_API_URL ?? `http://localhost:${restPort}`,
+  }
+
+  // `npm exec next start` works under both monorepo and global install.
+  // `detached: false` keeps the child in our process group so signals reach it.
+  const child = spawn('npm', ['exec', '--', 'next', 'start', '-p', String(port)], {
+    cwd,
+    env,
+    stdio: ['ignore', 'inherit', 'inherit'],
+    detached: false,
+  })
+
+  child.on('error', (err) => {
+    console.error(`neatd: web UI spawn error — ${err.message}`)
+  })
+
+  console.log(`neatd: web UI listening on http://localhost:${port}`)
+
+  let stopped = false
+  async function stop(): Promise<void> {
+    if (stopped || !child.pid) return
+    stopped = true
+    try {
+      child.kill('SIGTERM')
+    } catch {
+      /* already gone */
+    }
+    // Give the child up to 3s to exit gracefully, then SIGKILL.
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(() => {
+        try {
+          child.kill('SIGKILL')
+        } catch {
+          /* gone */
+        }
+        resolve()
+      }, 3000)
+      child.once('exit', () => {
+        clearTimeout(t)
+        resolve()
+      })
+    })
+  }
+
+  return { child, port, stop }
+}

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -4456,7 +4456,9 @@ describe('Publish system contract (ADR-052)', () => {
   // users. This block locks the failure shape so it can't recur.
 
   const REPO_ROOT = join(__dirname, '../../../..')
-  const PUBLISHABLE_PACKAGES = ['types', 'core', 'mcp', 'claude-skill', 'neat.is'] as const
+  // ADR-059 grew the lockstep from five to six packages — `@neat.is/web` is now
+  // shipped alongside the rest so `npm install -g neat.is` pulls in the UI.
+  const PUBLISHABLE_PACKAGES = ['types', 'core', 'mcp', 'claude-skill', 'web', 'neat.is'] as const
 
   function readPackageJson(pkgDirName: string): Record<string, unknown> {
     return JSON.parse(
@@ -4464,7 +4466,7 @@ describe('Publish system contract (ADR-052)', () => {
     ) as Record<string, unknown>
   }
 
-  it('all five publishable packages share the same version (ADR-052 #2 — lockstep)', () => {
+  it('all six publishable packages share the same version (ADR-052 #2 — lockstep)', () => {
     const versions = PUBLISHABLE_PACKAGES.map((p) => readPackageJson(p).version as string)
     const unique = [...new Set(versions)]
     expect(unique).toHaveLength(1)
@@ -4479,10 +4481,14 @@ describe('Publish system contract (ADR-052)', () => {
     const mcp = readPackageJson('mcp') as { dependencies: Record<string, string> }
     expect(mcp.dependencies['@neat.is/types']).toBe(`^${version}`)
 
+    const web = readPackageJson('web') as { dependencies: Record<string, string> }
+    expect(web.dependencies['@neat.is/types']).toBe(`^${version}`)
+
     const umbrella = readPackageJson('neat.is') as { dependencies: Record<string, string> }
     expect(umbrella.dependencies['@neat.is/core']).toBe(`^${version}`)
     expect(umbrella.dependencies['@neat.is/mcp']).toBe(`^${version}`)
     expect(umbrella.dependencies['@neat.is/claude-skill']).toBe(`^${version}`)
+    expect(umbrella.dependencies['@neat.is/web']).toBe(`^${version}`)
   })
 
   it('every publishable package declares engines.node: ">=20" (ADR-052 #8)', () => {
@@ -4684,36 +4690,86 @@ describe('Web shell debugging surface (ADR-058)', () => {
 // overrides. Fail loudly on collision. @neat.is/web joins the publish-system
 // lockstep — six packages instead of five going forward.
 describe('Web UI bootstrap from neatd (ADR-059)', () => {
-  it.todo(
-    'neatd.ts spawns a web UI child process during cmdStart (ADR-059 #1)',
-  )
-  it.todo(
-    'web UI port defaults to 6328 (NEAT in T9 keypad) (ADR-059 #2)',
-  )
-  it.todo(
-    'NEAT_WEB_PORT env var overrides the default port (ADR-059 #3)',
-  )
-  it.todo(
-    'port collision aborts neatd with a clear error and non-zero exit (ADR-059 #4)',
-  )
-  it.todo(
-    'spawned web UI inherits NEAT_API_URL=http://localhost:${restPort} (ADR-059 #6)',
-  )
-  it.todo(
-    'neatd stop / SIGTERM kills the spawned web UI process (no orphans) (ADR-059 #7)',
-  )
-  it.todo(
-    '@neat.is/web is no longer private:true and version-matches the lockstep (ADR-059 #8)',
-  )
-  it.todo(
-    'neat.is umbrella package.json includes @neat.is/web in dependencies (ADR-059 #8)',
-  )
-  it.todo(
-    '.github/workflows/publish.yml dependency order includes @neat.is/web before neat.is (ADR-059 #8)',
-  )
-  it.todo(
-    'scripts/publish.sh dependency order includes packages/web before packages/neat.is (ADR-059 #8)',
-  )
+  const REPO_ROOT = join(__dirname, '../../../..')
+  const NEATD = join(REPO_ROOT, 'packages/core/src/neatd.ts')
+  const WEB_SPAWN = join(REPO_ROOT, 'packages/core/src/web-spawn.ts')
+
+  function readSrc(p: string): string {
+    return readFileSync(p, 'utf8')
+  }
+  function readPkg(name: string): Record<string, unknown> {
+    return JSON.parse(readFileSync(join(REPO_ROOT, 'packages', name, 'package.json'), 'utf8'))
+  }
+
+  it('neatd.ts spawns a web UI child process during cmdStart (ADR-059 #1)', () => {
+    const src = readSrc(NEATD)
+    expect(src).toMatch(/spawnWebUI\(/)
+    const cmdStartIdx = src.indexOf('async function cmdStart')
+    const spawnIdx = src.indexOf('spawnWebUI(', cmdStartIdx)
+    expect(spawnIdx).toBeGreaterThan(cmdStartIdx)
+  })
+
+  it('web UI port defaults to 6328 (NEAT in T9 keypad) (ADR-059 #2)', () => {
+    expect(readSrc(WEB_SPAWN)).toMatch(/DEFAULT_WEB_PORT\s*=\s*6328/)
+  })
+
+  it('NEAT_WEB_PORT env var overrides the default port (ADR-059 #3)', () => {
+    const src = readSrc(WEB_SPAWN)
+    expect(src).toMatch(/process\.env\.NEAT_WEB_PORT/)
+    expect(src).toMatch(/NEAT_WEB_PORT[\s\S]*?DEFAULT_WEB_PORT/)
+  })
+
+  it('port collision aborts neatd with a clear error and non-zero exit (ADR-059 #4)', () => {
+    const spawn = readSrc(WEB_SPAWN)
+    expect(spawn).toMatch(/EADDRINUSE/)
+    expect(spawn).toMatch(/web UI port [^]*in use/)
+    const neatd = readSrc(NEATD)
+    expect(neatd).toMatch(/process\.exit\(3\)/)
+  })
+
+  it('spawned web UI inherits NEAT_API_URL=http://localhost:${restPort} (ADR-059 #6)', () => {
+    const src = readSrc(WEB_SPAWN)
+    expect(src).toMatch(/NEAT_API_URL/)
+    expect(src).toMatch(/http:\/\/localhost:\$\{restPort\}/)
+    expect(src).toMatch(/process\.env\.NEAT_API_URL\s*\?\?/)
+  })
+
+  it('neatd stop / SIGTERM kills the spawned web UI process (no orphans) (ADR-059 #7)', () => {
+    const neatd = readSrc(NEATD)
+    expect(neatd).toMatch(/web\s*\?\s*web\.stop\(\)/)
+    const spawn = readSrc(WEB_SPAWN)
+    expect(spawn).toMatch(/child\.kill\(['"]SIGTERM['"]\)/)
+    expect(spawn).toMatch(/SIGKILL/)
+  })
+
+  it('@neat.is/web is no longer private:true and version-matches the lockstep (ADR-059 #8)', () => {
+    const web = readPkg('web') as { private?: boolean; version: string; publishConfig?: Record<string, unknown> }
+    expect(web.private).not.toBe(true)
+    expect(web.publishConfig).toBeTruthy()
+    const types = readPkg('types') as { version: string }
+    expect(web.version).toBe(types.version)
+  })
+
+  it('neat.is umbrella package.json includes @neat.is/web in dependencies (ADR-059 #8)', () => {
+    const umbrella = readPkg('neat.is') as { dependencies: Record<string, string> }
+    expect(umbrella.dependencies['@neat.is/web']).toBeTruthy()
+  })
+
+  it('.github/workflows/publish.yml dependency order includes @neat.is/web before neat.is (ADR-059 #8)', () => {
+    const yml = readSrc(join(REPO_ROOT, '.github/workflows/publish.yml'))
+    const webIdx = yml.indexOf('publish_one "packages/web"')
+    const umbrellaIdx = yml.indexOf('publish_one "packages/neat.is"')
+    expect(webIdx).toBeGreaterThan(-1)
+    expect(umbrellaIdx).toBeGreaterThan(webIdx)
+  })
+
+  it('scripts/publish.sh dependency order includes packages/web before packages/neat.is (ADR-059 #8)', () => {
+    const sh = readSrc(join(REPO_ROOT, 'scripts/publish.sh'))
+    const webIdx = sh.indexOf('"packages/web"')
+    const umbrellaIdx = sh.indexOf('"packages/neat.is"')
+    expect(webIdx).toBeGreaterThan(-1)
+    expect(umbrellaIdx).toBeGreaterThan(webIdx)
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/neat.is/package.json
+++ b/packages/neat.is/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@neat.is/core": "^0.2.9",
     "@neat.is/mcp": "^0.2.9",
-    "@neat.is/claude-skill": "^0.2.9"
+    "@neat.is/claude-skill": "^0.2.9",
+    "@neat.is/web": "^0.2.9"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,8 +1,30 @@
 {
   "name": "@neat.is/web",
-  "version": "0.2.0",
-  "private": true,
+  "version": "0.2.9",
   "description": "NEAT web shell — minimal Next.js app fronting the core API",
+  "license": "BUSL-1.1",
+  "homepage": "https://neat.is",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NEAT-Technologies/Neat.git",
+    "directory": "packages/web"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "app",
+    "lib",
+    "public",
+    "next.config.js",
+    "tsconfig.json",
+    "postcss.config.js",
+    "tailwind.config.js",
+    "README.md"
+  ],
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -12,7 +34,7 @@
     "clean": "rm -rf .next .turbo"
   },
   "dependencies": {
-    "@neat.is/types": "*",
+    "@neat.is/types": "^0.2.9",
     "cytoscape": "^3.33.3",
     "next": "14.2.35",
     "react": "^18",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Local fallback for publishing the five NEAT packages to npm.
+# Local fallback for publishing the six NEAT packages to npm.
 #
 # Preferred path: tag push to GitHub triggers `.github/workflows/publish.yml`.
 # Use this script only when CI isn't an option (offline, hotfix, debugging).
@@ -27,6 +27,7 @@ PACKAGES=(
   "packages/core"
   "packages/mcp"
   "packages/claude-skill"
+  "packages/web"
   "packages/neat.is"
 )
 
@@ -77,7 +78,7 @@ UNIQUE_COUNT=$(printf '%s\n' "${VERSIONS[@]}" | sort -u | wc -l | tr -d ' ')
 if [ "$UNIQUE_COUNT" != "1" ]; then
   echo
   echo "ERROR: package versions are not in lockstep."
-  echo "All five packages must share the same version. Bump and try again."
+  echo "All six packages must share the same version. Bump and try again."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- `neatd start` now spawns the web UI as a child process on port 6328 (T9 NEAT — N=6 E=3 A=2 T=8). One command brings the daemon + REST + OTel + UI online for ADR-027's MVP-success-PR experiment instead of the previous "operator figures it out" shape.
- `NEAT_WEB_PORT` overrides the default; EADDRINUSE aborts with the clear-error pattern from ADR-049 (no silent fallback to a random port). SIGTERM/SIGINT cascade to the child.
- The child inherits `NEAT_API_URL=http://localhost:${restPort}` from the parent unless pre-set, so the proxy routes point back at the daemon that launched them.
- `@neat.is/web` joins the publish-system lockstep: five → six packages. Workflow + script + ADR-052 regression tests amended together. `private: true` flipped, `publishConfig` added, version snapped to 0.2.9, `@neat.is/web` added to the umbrella's dependencies so `npm install -g neat.is` pulls the UI alongside the CLI.
- Ten ADR-059 `it.todo`s flip to live; ADR-052 lockstep + dep-range tests grow a `web` entry. **180 → 190 live, 75 → 65 todo.**

Refs #197

## Test plan

- [ ] \`npx turbo build test lint\` green
- [ ] \`cd packages/core && npx vitest run test/audits/contracts.test.ts\` — 190 live, 65 todo
- [ ] Manual: \`neatd start\` boots and the web UI is reachable at \`http://localhost:6328\`
- [ ] Port collision: bind something to 6328, run \`neatd start\`, confirm clean abort with the expected error message and exit code 3
- [ ] Shutdown cascade: \`neatd stop\`, confirm no orphan \`next\` process (\`ps aux | grep next\`)
- [ ] \`NEAT_WEB_PORT=7000 neatd start\` — UI listens on 7000
- [ ] \`NEAT_WEB_DISABLED=1 neatd start\` — daemon boots without UI (escape hatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)