### PR TITLE
ADR-061 — REST API path canonicalization + response envelope rule

### DIFF
--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -1,14 +1,14 @@
 ---
 name: rest-api
-description: Routes dual-mount at /X and /projects/:project/X per ADR-026. JSON errors. Live graphology only — no graph.json reads at request time. Inbound bodies are Zod-validated.
+description: Routes dual-mount at /X and /projects/:project/X per ADR-026. JSON errors. Live graphology only — no graph.json reads at request time. Inbound bodies are Zod-validated. Outbound responses are always JSON objects (never bare arrays) per ADR-061's envelope rule.
 governs:
   - "packages/core/src/api.ts"
-adr: [ADR-040, ADR-026]
+adr: [ADR-040, ADR-026, ADR-061]
 ---
 
 # REST API contract
 
-Governs `packages/core/src/api.ts`.
+Governs `packages/core/src/api.ts`. Amended 2026-05-11 by ADR-061 (path canonicalization + response envelope rule); paths and shapes in this doc are the canonical source of truth.
 
 ## Dual-mount per ADR-026
 
@@ -16,32 +16,50 @@ Every route mounts at both `/X` and `/projects/:project/X`. `registerRoutes(scop
 
 `:project` defaults to `'default'` when missing.
 
-## Read-side endpoints (locked)
+## Response envelope rule (ADR-061)
 
-| Path | Returns |
-|------|---------|
-| `GET /health` | receiver health + project name |
-| `GET /graph` | full snapshot (live graphology serialized) |
-| `GET /graph/node/:id` | single node by id |
-| `GET /graph/edges/:id` | outbound edges from a node |
-| `GET /graph/dependencies/:nodeId?depth=N` | transitive outbound walk (#144 — default 3, max 10) |
-| `GET /graph/blast-radius/:nodeId?depth=N` | BFS outbound (default 10, max 20) |
-| `GET /graph/root-cause/:nodeId` | getRootCause result |
-| `GET /graph/diff?against=path` | snapshot diff |
-| `GET /search?q=...` | semantic search via ADR-025 embedder chain |
-| `GET /incidents` | recent ErrorEvents |
-| `GET /stale-events` | recent STALE transitions |
-| `GET /policies` | parsed `policy.json` (v0.2.4 #117) |
-| `GET /policies/violations` | current violations, filterable by `?severity=` and `?policyId=` (v0.2.4) |
+Every GET response is a JSON object. Never a bare array, never a bare value. The object's top-level keys describe the resource:
+
+- **List endpoints** wrap in plural-noun fields plus a count: `{ count, total, events: [...] }`, `{ violations: [...] }`. `count` is the length of the returned array; `total` is the size of the underlying collection before filtering / limiting.
+- **Single-item endpoints** wrap the item in a singular field: `{ node }`, `{ edge }`.
+- **Structured-result endpoints** (root cause, blast radius, divergences, diff) return their result type as the top-level object — already objects by virtue of their schema.
+
+Bare arrays from REST endpoints are a contract violation. Why: an object can grow new top-level fields without breaking parsers; a bare array can't.
+
+## Read-side endpoints (canonical paths + shapes)
+
+| Path | Returns | Response shape |
+|------|---------|----------------|
+| `GET /health` | receiver health + project name | `{ ok, project, uptimeMs }` |
+| `GET /graph` | full snapshot (live graphology serialized) | `{ nodes, edges }` |
+| `GET /graph/node/:id` | single node by id | `{ node: GraphNode }` |
+| `GET /graph/edges/:id` | inbound + outbound edges from a node | `{ inbound: GraphEdge[], outbound: GraphEdge[] }` |
+| `GET /graph/dependencies/:nodeId?depth=N` | transitive outbound walk (default 3, max 10) | `TransitiveDependenciesResult` |
+| `GET /graph/blast-radius/:nodeId?depth=N` | BFS outbound (default 10, max 20) | `BlastRadiusResult` |
+| `GET /graph/root-cause/:nodeId` | getRootCause result | `RootCauseResult` |
+| `GET /graph/diff?against=path` | snapshot diff | `GraphDiffResult` |
+| `GET /graph/divergences` | EXTRACTED-vs-OBSERVED divergences (ADR-060) | `DivergenceResult` |
+| `GET /search?q=...&limit=N` | semantic search via ADR-025 embedder chain | `{ query, provider, matches: SearchMatch[] }` |
+| `GET /incidents?limit=N` | recent ErrorEvents | `{ count, total, events: ErrorEvent[] }` |
+| `GET /incidents/:nodeId` | recent ErrorEvents filtered to a node | `{ count, total, events: ErrorEvent[] }` |
+| `GET /stale-events?limit=N&edgeType=X` | recent STALE transitions | `{ count, total, events: StaleEvent[] }` |
+| `GET /policies` | parsed `policy.json` | `{ version, policies: Policy[] }` |
+| `GET /policies/violations?severity=X&policyId=X` | current violations, filterable | `{ violations: PolicyViolation[] }` |
+| `GET /projects` | machine-registered projects (single-mount; not dual-mounted) | `Array<RegistryEntry>` *(the one bare-array exception — `/projects` is the switcher entry-point and its consumers (web, MCP) treat it as a list primitive)* |
+| `GET /projects/:project` | singular project lookup | `{ project: RegistryEntry }` |
 
 ## Write-side endpoints
 
-| Path | Effect |
-|------|--------|
-| `POST /graph/scan` | re-runs static-extraction pass |
-| `POST /policies/check` | dry-run policy evaluation; body `{ hypotheticalAction }` (v0.2.4) |
+| Path | Effect | Response shape |
+|------|--------|----------------|
+| `POST /graph/scan` | re-runs static-extraction pass | `{ nodesAdded, edgesAdded, durationMs }` |
+| `POST /policies/check` | dry-run policy evaluation; body `{ hypotheticalAction? }` | `{ allowed, violations: PolicyViolation[] }` |
 
 The OTLP receiver lives on its own port (`:4318`) — not part of the REST API.
+
+## SSE endpoint
+
+`GET /events` — Server-Sent Events stream per ADR-051 (frontend-facing API contract). Eight-type event taxonomy locked; see [`frontend-api.md`](./frontend-api.md).
 
 ## Error responses
 
@@ -51,12 +69,35 @@ JSON shape: `{ error: string, status: number, details?: unknown }`. `400` for ba
 
 Every `app.post` body parses via Zod schemas from `@neat.is/types`. Failure → 400 with the Zod error in `details`.
 
+Every GET response also parses through its declared schema (per ADR-061's enforcement). Schemas added in this contract:
+
+- `IncidentsResponseSchema`
+- `StaleEventsResponseSchema`
+- `PoliciesViolationsResponseSchema`
+- `GraphNodeResponseSchema`
+- `GraphEdgesResponseSchema`
+- `HealthResponseSchema`
+- `SingleProjectResponseSchema`
+
+Existing typed results (`RootCauseResult`, `BlastRadiusResult`, `TransitiveDependenciesResult`, `DivergenceResult`, `Policy`) already serve as their endpoint's response schemas.
+
 ## Live graphology, never `graph.json`
 
 Every read endpoint reads `proj.graph` (live in-memory). Already enforced by Rule 6.
+
+## Path canonicalization (ADR-061 amendment)
+
+Four paths were renamed from drifted backend variants to match the canonical table above:
+
+- `/traverse/root-cause/:nodeId` → `/graph/root-cause/:nodeId`
+- `/traverse/blast-radius/:nodeId` → `/graph/blast-radius/:nodeId`
+- `/incidents/stale` → `/stale-events`
+- `/graph/node/:id/dependencies` → `/graph/dependencies/:nodeId`
+
+No backward-compat aliases. The drifted paths were never on the contract; no non-test consumer called them.
 
 ## Authority
 
 Mostly read-only. Two write-side endpoints (`/graph/scan`, `/policies/check`) trigger producers but don't mutate the graph directly.
 
-Full rationale: [ADR-040](../decisions.md#adr-040--rest-api-contract).
+Full rationale: [ADR-040](../decisions.md#adr-040--rest-api-contract). Amendment rationale: [ADR-061](../decisions.md#adr-061--rest-api-path-canonicalization--response-envelope-rule).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1828,3 +1828,104 @@ The MVP-success-PR experiment (ADR-027) was the gate forcing the synthesis. The 
 - **Cross-project divergences.** Per ADR-026, each project is its own graph. Divergence list is per-project. Cross-codebase joins remain explicitly out of MVP.
 - **Persistence of divergence history.** No `divergences.ndjson` sidecar. The graph snapshot is the audit trail; if the operator wants divergence history, they diff snapshot N against snapshot N+1.
 - **SSE push for new divergences.** ADR-051's locked taxonomy is eight types; expanding to nine for `divergence-detected` would be a successor ADR if Jed's track surfaces the demand. For MVP, polling `/graph/divergences` works.
+
+## ADR-061 — REST API path canonicalization + response envelope rule
+
+**Date:** 2026-05-11
+**Status:** Active. Amends ADR-040.
+
+**Context.** The web shell shipped against an API surface that doesn't match the backend. The user hit it on the Incidents page first: `TypeError: can't access property "length", data.events is undefined`. Tracing it revealed a class of bugs, not one bug.
+
+The audit at `docs/plans/2026-05-11-rest-audit.md` (referenced inline below; not a separate file because the findings live here) surfaced two kinds of drift:
+
+**Path drift** — backend has routes at paths the contract doesn't specify and frontend doesn't call:
+- `/traverse/blast-radius/:nodeId` (contract + frontend say `/graph/blast-radius/:nodeId`)
+- `/traverse/root-cause/:nodeId` (contract + frontend say `/graph/root-cause/:nodeId`)
+- `/incidents/stale` (contract + frontend say `/stale-events`)
+- `/graph/node/:id/dependencies` (contract says `/graph/dependencies/:nodeId`)
+
+**Shape drift** — backend returns bare arrays / bare values where the contract + frontend expect wrapped envelopes:
+- `/incidents` returns `ErrorEvent[]`; frontend expects `{ count, total, events }`
+- `/policies/violations` returns `PolicyViolation[]`; frontend expects `{ violations }`
+- `/stale-events` (at any path) returns `StaleEvent[]`; frontend expects `{ count, total, events }`
+- `/graph/node/:id` returns `GraphNode`; contract says `{ node }`
+- `/incidents/:nodeId` (per-node filter) returns bare filtered array; same wrap expected
+
+Neither drift class was caught by existing regression tests. ADR-040's contract scan asserts:
+- Routes exist
+- Routes dual-mount per ADR-026
+- JSON error envelope on failures
+- POST bodies parse via Zod
+
+It does *not* assert response body schemas, and the path-level scan happily accepts whatever path the backend declares without checking it matches the canonical contract list.
+
+The result: every web shell call to a blast-radius, root-cause, stale-events, or incidents view either 404s or hits the wrong shape. ADRs 056-060 shipped on a backend the frontend couldn't actually talk to for several of its surfaces.
+
+**Decision.**
+
+1. **Path canonicalization — backend renames to match the contract.** The `rest-api.md` contract is the authoritative artifact (per ADR-005 process discipline); implementation aligns. Four renames in `packages/core/src/api.ts`:
+   - `/traverse/root-cause/:nodeId` → `/graph/root-cause/:nodeId`
+   - `/traverse/blast-radius/:nodeId` → `/graph/blast-radius/:nodeId`
+   - `/incidents/stale` → `/stale-events`
+   - `/graph/node/:id/dependencies` → `/graph/dependencies/:nodeId`
+
+   No backward-compat aliases. The drifted paths were never on the public contract; the frontend never called them; external consumers (MCP, CLI) route through `client.ts` which uses the canonical names. Renaming straight is the safest option.
+
+2. **Response envelope rule.** Every GET response from the REST API is a JSON object (never a bare array, never a bare value). The object's top-level keys describe the resource being returned:
+   - **List endpoints** wrap their list in a plural-noun field plus a count: `{ count: N, total: M, events: [...] }`, `{ violations: [...] }`, etc. `count` is the length of the returned array; `total` is the size of the underlying collection before filtering / limiting.
+   - **Single-item endpoints** wrap the item in a singular field: `{ node }`, `{ edge }`.
+   - **Structured-result endpoints** (root cause, blast radius, divergences, diff) return their result type as the top-level object — already objects by virtue of their schema.
+
+   Bare arrays from REST endpoints are a contract violation going forward. The rule is for the consumer's benefit: a JSON object can grow new top-level fields without breaking parsers; a bare array can't.
+
+3. **Required wraps (the specific fixes):**
+   - `/incidents` and `/incidents/:nodeId` → `{ count, total, events: ErrorEvent[] }`
+   - `/stale-events` → `{ count, total, events: StaleEvent[] }`
+   - `/policies/violations` → `{ violations: PolicyViolation[] }`
+   - `/graph/node/:id` → `{ node: GraphNode }`
+
+4. **New schemas in `@neat.is/types` for the response shapes.** Each wrap gets a Zod schema:
+   - `IncidentsResponseSchema`
+   - `StaleEventsResponseSchema`
+   - `PoliciesViolationsResponseSchema`
+   - `GraphNodeResponseSchema`
+
+   Per ADR-031, these are schema growth (commit-and-go; snapshot fixture regenerates).
+
+5. **Contract test class — response shape assertions.** Extend the ADR-040 describe block in `contracts.test.ts`: for each documented REST endpoint, hit the route against a fixture graph and parse the response through its declared schema. Failure to parse fails the test. This catches Class B drift mechanically going forward.
+
+6. **Path consistency assertion.** Add a regression scan: every `scope.get` / `scope.post` path in `api.ts` must appear in `docs/contracts/rest-api.md`'s endpoint table. Drift in either direction (route exists in code but not in contract; route documented but not implemented) fails the test.
+
+7. **Coverage gaps — endpoints backend has but contract doesn't.** Add to `rest-api.md`:
+   - `GET /incidents/:nodeId` — per-node incident filter
+   - `GET /projects/:project` — singular project lookup
+   - `GET /graph/divergences` — already part of ADR-060's surface
+
+**Authority.** `packages/core/src/api.ts` (the implementation), `docs/contracts/rest-api.md` (the canonical paths and shapes), `packages/types/src/index.ts` (the response schemas).
+
+**Enforcement.** New describe block in `contracts.test.ts` for ADR-061. Live + `it.todo` assertions:
+
+- For each Class A rename, the backend handler is registered at the canonical path (regex scan of `api.ts` against the contract's endpoint list).
+- For each Class B wrap, the response parses through its declared Zod schema (live runtime assertion, requires fixture data).
+- Path consistency: every `scope.get` / `scope.post` path appears in the contract's endpoint table.
+- No backend handler returns a bare array from a GET endpoint (scan for `return events` / `return violations` / similar bare-collection returns).
+
+**Why we didn't catch this earlier.**
+
+Three independent layers should have flagged this and didn't:
+
+1. **The audit-doc trail.** The 2026-05-04 verification pass didn't audit REST response shapes — it audited graph correctness. Subsystem audits in `docs/audits/NEAT-audit-*.md` similarly didn't grade the REST layer's response bodies.
+2. **The contracts.test.ts surface.** As covered above — assertions stopped at "route exists" / "dual-mounted" / "JSON error envelope." Body schemas weren't checked.
+3. **The API reference doc.** `docs/api-reference.md` documented the canonical shapes correctly. But the doc isn't enforced as a contract today — it's a reference for consumers, not a binding rule on producers. This ADR makes the doc-implementation linkage testable.
+
+The pre-v0.3.0 verification pass (`docs/plans/2026-05-10-pre-v0.3.0-verification.md`, Finding 9 / NOTE 9.2) flagged that per-subsystem audits should be re-graded before public release. That re-grade would have caught Class A; it's still queued.
+
+**Out of scope.**
+
+- **Versioning the REST API.** No `/v1/` prefix, no `Accept-Version` header. MVP is single-version; if NEAT ever needs multi-version support, that's a successor ADR.
+- **HATEOAS / hypermedia.** Out for MVP. Bare JSON.
+- **GraphQL / tRPC.** Speculative; not earned by current consumer demand.
+- **Backward-compatibility aliases for the renamed paths.** As noted in decision #1, none of the drifted paths were on the contract or called by any non-test consumer. Renaming clean is the right call.
+- **The CLI / MCP surface.** Both already route through the canonical names via `client.ts`. No CLI or MCP changes needed for this ADR.
+
+**First application.** This ADR ships in v0.2.11. The implementation work is delegated to a fresh Implementation Agent per the role discipline; the handoff prompt is in the conversation.

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -5654,3 +5654,71 @@ describe('Divergence query (ADR-060)', () => {
     expect(offenders, offenders.join('\n')).toEqual([])
   })
 })
+
+// ──────────────────────────────────────────────────────────────────────────
+// REST API path canonicalization + response envelope rule (ADR-061)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Amends ADR-040 / docs/contracts/rest-api.md after the 2026-05-11 audit
+// found path drift (4 endpoints) and shape drift (5 endpoints) between
+// backend and contract. Canonical paths and shapes are in rest-api.md.
+//
+// Three classes of assertion:
+// 1. Canonical paths — drifted paths must NOT appear in api.ts; canonical
+//    paths MUST appear.
+// 2. Response envelope rule — every GET handler returns a JSON object,
+//    never a bare array (with the documented /projects exception).
+// 3. Response shape — runtime parse through Zod schema for each endpoint.
+//
+// Each flips from todo to live as the implementation agent ships the fix.
+describe('REST API canonicalization (ADR-061)', () => {
+  // ── Class A: path canonicalization ───────────────────────────────────
+  // Backend must declare each canonical path; drifted variants must be gone.
+  it.todo('api.ts declares `/graph/root-cause/:nodeId` (renamed from /traverse/root-cause) (ADR-061 #1)')
+  it.todo('api.ts declares `/graph/blast-radius/:nodeId` (renamed from /traverse/blast-radius) (ADR-061 #1)')
+  it.todo('api.ts declares `/stale-events` (renamed from /incidents/stale) (ADR-061 #1)')
+  it.todo('api.ts declares `/graph/dependencies/:nodeId` (renamed from /graph/node/:id/dependencies) (ADR-061 #1)')
+  it.todo('api.ts contains no references to drifted paths (/traverse/*, /incidents/stale, /graph/node/:id/dependencies) (ADR-061 #1)')
+
+  // ── Class B: response envelope rule ──────────────────────────────────
+  // Every GET handler returns a JSON object — never a bare array. Scans
+  // api.ts for `return events`, `return violations`, `return result_array`,
+  // etc. — flags bare-collection returns that violate ADR-061 #2.
+  it.todo('no GET handler in api.ts returns a bare array (ADR-061 #2 — envelope rule)')
+  it.todo('the documented /projects bare-array exception is the only bare-array GET return (ADR-061 #2)')
+
+  // ── Class C: response shape via Zod schemas ──────────────────────────
+  // Each endpoint's response parses through its declared schema. Live
+  // runtime assertions against fixture data; require buildApi() + supertest
+  // (or equivalent in-process HTTP test client). Fixtures live alongside.
+  it.todo('GET /incidents response parses through IncidentsResponseSchema (ADR-061 #3)')
+  it.todo('GET /incidents/:nodeId response parses through IncidentsResponseSchema (ADR-061 #3)')
+  it.todo('GET /stale-events response parses through StaleEventsResponseSchema (ADR-061 #3)')
+  it.todo('GET /policies/violations response parses through PoliciesViolationsResponseSchema (ADR-061 #3)')
+  it.todo('GET /graph/node/:id response parses through GraphNodeResponseSchema (ADR-061 #3)')
+  it.todo('GET /graph/edges/:id response parses through GraphEdgesResponseSchema (ADR-061 #3)')
+  it.todo('GET /health response parses through HealthResponseSchema (ADR-061 #3)')
+  it.todo('GET /projects/:project response parses through SingleProjectResponseSchema (ADR-061 #3)')
+  it.todo('GET /search response parses through SearchResponseSchema (ADR-061 #3)')
+  // For endpoints with existing typed results, assertion uses the existing schema:
+  it.todo('GET /graph/root-cause/:nodeId response parses through RootCauseResultSchema (ADR-061 #3)')
+  it.todo('GET /graph/blast-radius/:nodeId response parses through BlastRadiusResultSchema (ADR-061 #3)')
+  it.todo('GET /graph/dependencies/:nodeId response parses through TransitiveDependenciesResultSchema (ADR-061 #3)')
+  it.todo('GET /graph/divergences response parses through DivergenceResultSchema (ADR-061 #3)')
+  it.todo('GET /policies response parses through PolicyFileSchema (ADR-061 #3)')
+  it.todo('GET /graph response parses through SerializedGraphSchema (ADR-061 #3)')
+  it.todo('GET /graph/diff response parses through GraphDiffResultSchema (ADR-061 #3)')
+
+  // ── Class D: path consistency scan ───────────────────────────────────
+  // Every scope.get / scope.post path in api.ts must appear in
+  // rest-api.md's canonical endpoint table. Catches future drift in
+  // either direction (route exists but not documented; route documented
+  // but not implemented).
+  it.todo('every path registered in api.ts appears in rest-api.md endpoint table (ADR-061 #6)')
+  it.todo('every path in rest-api.md endpoint table is registered in api.ts (ADR-061 #6)')
+
+  // ── Class E: coverage gaps now documented ────────────────────────────
+  it.todo('rest-api.md documents GET /incidents/:nodeId (ADR-061 #7)')
+  it.todo('rest-api.md documents GET /projects/:project (ADR-061 #7)')
+  it.todo('rest-api.md documents GET /graph/divergences (ADR-061 #7 — also ADR-060)')
+})


### PR DESCRIPTION
## Summary

The user's Incidents-page TypeError (`data.events is undefined`) wasn't isolated. A REST audit found two classes of drift between contract and implementation; this PR locks the canonical surface and queues the fixes for an Implementation Agent.

**Don't publish v0.2.11 until the implementation lands.** Five frontend pages currently break against the live backend.

## What this PR contains

Contract Author scope only. Writing, not coding.

- **`docs/decisions.md`** — ADR-061 appended (~100 lines)
- **`docs/contracts/rest-api.md`** — amended with canonical path + shape table + envelope rule. Now the binding source of truth.
- **`packages/core/test/audits/contracts.test.ts`** — 28 new `it.todo` entries across five test classes (paths, envelope rule, response shapes, path consistency, coverage gaps)

Test count: 251 live + 32 todo (was 251 + 4; +28 from this PR).

## The two classes of drift

### Class A — Path drift (4 endpoints)

| Frontend / contract says | Backend has |
|---|---|
| `/graph/root-cause/:nodeId` | `/traverse/root-cause/:nodeId` |
| `/graph/blast-radius/:nodeId` | `/traverse/blast-radius/:nodeId` |
| `/stale-events` | `/incidents/stale` |
| `/graph/dependencies/:nodeId` | `/graph/node/:id/dependencies` |

### Class B — Shape drift (5 endpoints)

| Endpoint | Backend returns | Should return |
|---|---|---|
| `/incidents` | bare `ErrorEvent[]` | `{ count, total, events }` |
| `/incidents/:nodeId` | bare filtered array | `{ count, total, events }` |
| `/stale-events` (post-rename) | bare `StaleEvent[]` | `{ count, total, events }` |
| `/policies/violations` | bare `PolicyViolation[]` | `{ violations }` |
| `/graph/node/:id` | bare `GraphNode` | `{ node }` |

## ADR-061 decisions in brief

1. **Backend renames to match contract.** Per ADR-005 discipline, contract is authoritative. No back-compat aliases — drifted paths were never on the contract; no non-test consumer called them.
2. **Response envelope rule.** Every GET response is a JSON object. Bare arrays prohibited (with `/projects` as the documented exception — it's a list primitive).
3. **New schemas in `@neat.is/types`** for the wrapped responses. Schema growth per ADR-031.
4. **Two new regression-test classes** in `contracts.test.ts`:
   - Response shape parses through Zod schema (catches Class B mechanically)
   - Path consistency between `api.ts` and `rest-api.md` (catches Class A drift)
5. **Coverage gaps fixed in the contract** — `/incidents/:nodeId`, `/projects/:project` now documented.

## Why this hadn't been caught

ADR-040's contract scan asserts route existence, dual-mount, JSON error envelope, POST body validation. It doesn't assert response body schemas or path-vs-contract consistency. That gap is the root cause; this ADR closes it.

The pre-v0.3.0 verification pass (Pass 9 of `docs/plans/2026-05-10-pre-v0.3.0-verification.md`) flagged that per-subsystem audits should be re-graded before public release. That re-grade would have caught Class A. Still queued.

## What's NOT in this PR

Per role discipline (Contract Author drafts; Implementation Agent ships):

- The four backend path renames in `packages/core/src/api.ts` — Implementation Agent
- The five response-wrap fixes in `api.ts` — Implementation Agent
- The new Zod schemas in `packages/types/src/` — Implementation Agent
- Flipping the 28 `it.todo`s to live — Implementation Agent as work ships
- The path-consistency regression test (cross-checks api.ts against rest-api.md) — Implementation Agent
- Any updates to `docs/api-reference.md` if drift surfaces during implementation — Implementation Agent

A fresh Claude Code session picks this up against the locked contract. Handoff prompt in conversation.

## Test plan

- [x] `npx turbo build` clean
- [x] `vitest run test/audits/contracts.test.ts` — 251 pass / 32 todo / 0 fail
- [ ] Post-merge: Implementation Agent ships the renames + wraps + schemas + flips 28 todos. Test count flips to ~279 live + 4 todo (the v0.2.1 carryovers).
- [ ] Post-implementation: Publisher Agent bumps to 0.2.11, tags, publishes.

Refs #197