### PR TITLE
ADR-057 #2a — SSR-safe web shell project resolution (Contract Author)

### DIFF
--- a/docs/contracts/web-multi-project.md
+++ b/docs/contracts/web-multi-project.md
@@ -37,6 +37,20 @@ In order, first non-empty wins:
 3. First entry from `GET /projects` if registry is non-empty
 4. `'default'` fallback (only allowed value of `'default'` in branching logic)
 
+### 2a. SSR-safe execution of the resolution chain (ADR-057 amendment)
+
+`AppShell.tsx`'s `useState<string>('default')` is the contract surface. Both server and client render `'default'` as the initial state so server-rendered HTML and first-client-render HTML are byte-identical at the project-name text node.
+
+The four-step resolution chain in rule #2 runs entirely in a `useEffect` after mount — never during the synchronous render path. **Forbidden patterns:**
+
+- `useState(() => /* reads window.*, localStorage.*, document.*, navigator.* */)` lazy initializers
+- `useRef(/* reads any browser API */)` initial values
+- Any synchronous read of browser-only globals during a component's render path
+
+These break Next.js hydration because the server has no DOM. The 2026-05-11 hydration bug (`Text content did not match. Server: "default" Client: "Neat"`) was caused by exactly this pattern; this rule mechanically prevents recurrence.
+
+Same rule applies to every component under `packages/web/app/components/**` and every route under `packages/web/app/**/page.tsx`, not just `AppShell.tsx`.
+
 ### 3. Project change triggers data refresh
 
 When `project` changes — switcher click, URL update, deep link — every component that depends on it re-fetches via `useEffect(..., [project])`. No stale data from the previous project carries over. GraphCanvas, Inspector, StatusBar, Incidents page — all of them.
@@ -83,5 +97,7 @@ Allowed locations for project-name string literals:
 - Every API proxy route under `packages/web/app/api/` forwards `project` query/path to the backend.
 - No hardcoded project names (`medusa`, `neat`, `demo`, etc.) in branching logic under `packages/web/app/components/` or `packages/web/lib/` (excluding fixtures.ts).
 - Multi-project re-fetch test: render AppShell with `project=A`, change to `B`, assert all data-fetching hooks re-ran. Requires Vitest + React Testing Library — new tooling for the web track. Flag in PR.
+- **SSR-safe: no `useState(...)` lazy initializer in `packages/web/app/components/**` or `packages/web/app/**/page.tsx` calls `window.*` / `localStorage.*` / `document.*` / `navigator.*` (ADR-057 #2a).**
+- **SSR-safe: no `useRef(...)` initial value in those files reads the same browser APIs (ADR-057 #2a).**
 
 Full rationale: [ADR-057](../decisions.md#adr-057--web-shell-multi-project-routing).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1636,6 +1636,25 @@ This is the runtime corollary of ADR-026 (multi-project dual-mount). The backend
 - No hardcoded project names (`medusa`, `neat`, `demo`, etc.) in branching logic under `packages/web/app/components/` or `packages/web/lib/`.
 - Multi-project re-fetch test: render AppShell with project=A, change to B, assert all data-fetching hooks re-ran (uses Vitest + React Testing Library — a new-tooling addition for the web track).
 
+**Amendment (2026-05-11) — rule 2a, SSR-safe resolution chain.**
+
+A live web-shell session against the medusa project surfaced a hydration error: `Text content did not match. Server: "default" Client: "Neat"`. Root cause was `AppShell.tsx` running rule 2's resolution chain *synchronously inside a `useState` lazy initializer and a `useRef` initial value*. SSR has no `window` → returned `'default'`; client first render had `localStorage` → returned the stored project. The two renders disagreed at the project-name text node; React 18 threw error 425 / 418 and the GraphCanvas's `useEffect` failed to mount cleanly against the recovery render — net effect: no graph visible.
+
+This was a contract violation of rule #7 (*"`'default'` is allowed only as the explicit fallback in `AppShell.tsx`'s state initializer"*) but the original ADR's rule #2 didn't make the SSR-safe execution explicit. This amendment closes that gap.
+
+2a. **Resolution chain runs client-only.** SSR initial state is always `'default'` on both server and client to make server-rendered HTML byte-identical to first-client-render HTML at the project-name text node. The four-step resolution chain in rule #2 runs entirely in `useEffect` after mount — never during the synchronous render path, never in a `useState` lazy initializer, never in a `useRef` initial value. This is the SSR-safe execution of rule #2's logical order and the explicit reading of rule #7's `'default'`-as-initial-state requirement.
+
+The same SSR-safety rule applies to every component under `packages/web/app/components/` and every route under `packages/web/app/**/page.tsx` — lazy initializers / ref initial values reading `window.*` / `localStorage.*` / `document.*` / `navigator.*` are forbidden across the surface, not just in `AppShell.tsx`.
+
+**Enforcement additions for the amendment.** Two new live regression scans in the ADR-057 describe block:
+
+- No `useState(...)` lazy initializer in `packages/web/app/components/**` (or `packages/web/app/**/page.tsx`) calls `window.*` / `localStorage.*` / `document.*` / `navigator.*`.
+- No `useRef(...)` initial value in those files calls the same browser APIs.
+
+Both fail closed — match → fail, no match → pass. They flip to live the moment the AppShell patch lands.
+
+**First application.** The implementation fix lands alongside this amendment (handoff prompt in conversation). Affected files: `AppShell.tsx` (primary patch), `incidents/page.tsx` (defense-in-depth guard), `GraphCanvas.tsx` (null-check on `cy.getElementById(id).remove()` — separate small defensive improvement on a file already being touched).
+
 ## ADR-058 — Web shell debugging surface
 
 **Date:** 2026-05-10

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -4873,6 +4873,19 @@ describe('Web shell multi-project routing (ADR-057)', () => {
     }
     expect(offenders, offenders.join('\n')).toEqual([])
   })
+
+  // ADR-057 amendment rule 2a — SSR-safe execution of the resolution chain.
+  // No useState lazy initializer or useRef initial value in web components
+  // / pages may call browser-only globals during the render path. The
+  // 2026-05-11 hydration bug ("Text content did not match. Server: 'default'
+  // Client: 'Neat'") came from exactly this pattern. Implementation flips
+  // these from todo to live once the AppShell fix lands.
+  it.todo(
+    'no useState(...) lazy initializer in packages/web/app/components/** or packages/web/app/**/page.tsx reads window.* / localStorage.* / document.* / navigator.* (ADR-057 #2a — SSR safety)',
+  )
+  it.todo(
+    'no useRef(...) initial value in packages/web/app/components/** or packages/web/app/**/page.tsx reads window.* / localStorage.* / document.* / navigator.* (ADR-057 #2a — SSR safety)',
+  )
 })
 
 // ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The user hit a Next.js hydration error opening the web shell against medusa:

```
Text content did not match. Server: "default" Client: "Neat"
```

The graph didn't render. Root cause: `AppShell.tsx` ran rule 2's resolution chain in a `useState` lazy initializer + `useRef` initial value, reading `window.location.search` and `window.localStorage` synchronously. SSR has no `window` → `'default'`. Client first render reads localStorage → `'Neat'`. React 18 hydration aborted, recovery left GraphCanvas's `useEffect` torn down.

Technically a contract violation of ADR-057 rule #7 (`'default'`-as-initial-state), but rule #2 didn't make the SSR-safe execution explicit. This PR closes the gap.

**Contract Author scope only.** Implementation lands separately via a fresh Implementation Agent — handoff prompt below.

## What's in this PR

- **`docs/decisions.md`** — ADR-057 amendment block (rule 2a) appended after the original Enforcement section, with full rationale
- **`docs/contracts/web-multi-project.md`** — new "2a. SSR-safe execution of the resolution chain" section + two new enforcement bullets
- **`packages/core/test/audits/contracts.test.ts`** — two new `it.todo` regression scans in the ADR-057 describe block (live after the AppShell patch lands)

Test count: **279 live + 6 todo** (was 279 + 4; +2 SSR-safety todos).

## What's NOT in this PR

Per role discipline (Contract Author writes; Implementation Agent ships):

- The `AppShell.tsx` refactor (defer reads to `useEffect`) — Implementation Agent
- The `incidents/page.tsx` defensive `typeof window` guard — Implementation Agent
- The `GraphCanvas.tsx` null-check on `cy.getElementById(id).remove()` — Implementation Agent
- Flipping the two new `it.todo`s to live — Implementation Agent as the AppShell patch lands

## Verification

- [x] `npx turbo build` clean
- [x] `vitest run test/audits/contracts.test.ts` — 279 pass / 6 todo / 0 fail
- [ ] Post-merge: Implementation Agent ships the AppShell patch + flips the 2 SSR-safety todos to live. Test count flips to 281 pass / 4 todo (the v0.2.1 carryovers remain).
- [ ] Post-implementation: hard-reload http://localhost:6328 against a registered project — no React hydration error 425/418/423, GraphCanvas renders against medusa's 88-node graph.

Refs #197