### PR TITLE
Guard GraphCanvas SSE remove handlers against missing elements

### DIFF
--- a/packages/web/app/components/GraphCanvas.tsx
+++ b/packages/web/app/components/GraphCanvas.tsx
@@ -486,12 +486,14 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
       })
       sse.addEventListener('node-removed', (e) => {
         const { id } = JSON.parse(e.data) as { id: string }
-        cy.getElementById(id).remove()
+        const el = cy.getElementById(id)
+        if (el && el.length) el.remove()
         pushGraphUpdate()
       })
       sse.addEventListener('edge-removed', (e) => {
         const { id } = JSON.parse(e.data) as { id: string }
-        cy.getElementById(id).remove()
+        const el = cy.getElementById(id)
+        if (el && el.length) el.remove()
         pushGraphUpdate()
       })
       sse.addEventListener('error', () => {


### PR DESCRIPTION
## Summary

The `node-removed` and `edge-removed` SSE listeners in `GraphCanvas` called `cy.getElementById(id).remove()` directly. Cytoscape returns an empty collection on miss and `.remove()` is a silent no-op there, so this isn't a bug fix — but the guard makes the no-op visible to the next reader.

Was part of closed PR #226; didn't carry over to #227. Landing it on its own.

Refs #227

## Test plan

- [x] \`npx turbo build test lint\` clean