### PR TITLE
Mount /incidents client-only (ADR-062 §4 amendment)

### DIFF
--- a/docs/contracts/web-multi-project.md
+++ b/docs/contracts/web-multi-project.md
@@ -8,6 +8,9 @@ governs:
   - "packages/web/app/components/Inspector.tsx"
   - "packages/web/app/components/StatusBar.tsx"
   - "packages/web/app/components/Rail.tsx"
+  - "packages/web/app/page.tsx"
+  - "packages/web/app/incidents/page.tsx"
+  - "packages/web/app/incidents/IncidentsClient.tsx"
   - "packages/web/lib/proxy.ts"
   - "packages/web/lib/fixtures.ts"
   - "packages/web/app/api/**"
@@ -39,9 +42,14 @@ In order, first non-empty wins:
 
 Steps 1-2 run synchronously inside the `useState` lazy initializer; step 3 is async and runs from a `useEffect` after mount only when steps 1-2 produced no value. AppShell is rendered client-only (see rule 2a below), so the synchronous reads are safe — no server-side execution to disagree with.
 
-### 2a. AppShell renders client-only (ADR-062, supersedes the 2026-05-11 SSR-safety amendment)
+### 2a. Client-only render boundaries (ADR-062 + 2026-05-11 amendment, supersedes the SSR-safety amendment to ADR-057)
 
-`packages/web/app/page.tsx` mounts AppShell via `next/dynamic` with `{ ssr: false }`. The Next.js server emits the static HTML shell (head, fonts, CSS link, empty `<body>`); the entire AppShell tree builds on the client.
+Two page entrypoints mount client-only via `next/dynamic` with `{ ssr: false }`:
+
+- `packages/web/app/page.tsx` mounts AppShell client-only (ADR-062 §1).
+- `packages/web/app/incidents/page.tsx` mounts `IncidentsClient` client-only (ADR-062 §4 amendment, 2026-05-11).
+
+In both cases the Next.js server emits the static HTML shell (head, fonts, CSS link, empty `<body>` placeholder); the React subtree builds on the client.
 
 Required shape:
 
@@ -53,15 +61,24 @@ const AppShell = dynamic(() => import('./components/AppShell').then((m) => m.App
 })
 ```
 
+```tsx
+// packages/web/app/incidents/page.tsx
+import dynamic from 'next/dynamic'
+const IncidentsClient = dynamic(
+  () => import('./IncidentsClient').then((m) => m.IncidentsClient),
+  { ssr: false },
+)
+```
+
 Consequences:
 
-- AppShell may read `window.*` / `localStorage.*` / `document.*` / `navigator.*` synchronously during its render path. The lazy-initializer pattern for rule 2 is the contract surface, not a workaround.
+- Both subtrees may read `window.*` / `localStorage.*` / `document.*` / `navigator.*` synchronously during their render path. The lazy-initializer pattern for rule 2 is the contract surface, not a workaround.
 - There is no server-side first render to keep byte-identical. The earlier ADR-057 "rule 2a — SSR-safe execution" amendment is superseded; its body is retained in `decisions.md` for historical context only.
-- Other routes (`/incidents`, `/api/**`) keep server-side rendering — only the AppShell subtree is client-only.
+- Layout, `/api/**` route handlers, and any future page that doesn't need synchronous browser-API reads keep server-side rendering. SSR-off is opt-in per route, named explicitly here.
 
 Forbidden:
 
-- Removing `{ ssr: false }` from the `dynamic(...)` call without a superseding ADR. The two costs the SSR-safe amendment imposed (the `'default'`-flash and the double-fetch on every `useEffect([project])` consumer) re-appear immediately if AppShell starts SSR-ing again.
+- Removing `{ ssr: false }` from either `dynamic(...)` call without a superseding ADR. The two costs the SSR-safe amendment imposed (the `'default'`-flash and the double-fetch on every `useEffect([project])` consumer) re-appear immediately if either subtree starts SSR-ing again.
 
 ### 3. Project change triggers data refresh
 
@@ -109,6 +126,6 @@ Allowed locations for project-name string literals:
 - Every API proxy route under `packages/web/app/api/` forwards `project` query/path to the backend.
 - No hardcoded project names (`medusa`, `neat`, `demo`, etc.) in branching logic under `packages/web/app/components/` or `packages/web/lib/` (excluding fixtures.ts).
 - Multi-project re-fetch test: render AppShell with `project=A`, change to `B`, assert all data-fetching hooks re-ran. Requires Vitest + React Testing Library — new tooling for the web track. Flag in PR.
-- **Client-only boundary: `app/page.tsx` imports `dynamic` from `next/dynamic` and mounts AppShell with `{ ssr: false }` (ADR-062).**
+- **Client-only boundaries: both `app/page.tsx` and `app/incidents/page.tsx` import `dynamic` from `next/dynamic` and mount their respective subtree with `{ ssr: false }` (ADR-062 + 2026-05-11 amendment).**
 
 Full rationale: [ADR-057](../decisions.md#adr-057--web-shell-multi-project-routing), [ADR-062](../decisions.md#adr-062--web-shell-renders-client-only-ssr-disabled-at-the-appshell-boundary).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1996,3 +1996,9 @@ Both costs come from the same source: we're paying an SSR tax for a benefit we d
 The two SSR-safety scans (no `useState` lazy initializer / `useRef` initial value reads browser globals in web components) are removed — they were guarding a constraint that no longer applies.
 
 **Why a new ADR and not a third amendment to ADR-057.** Amendments are appropriate for tightening or clarifying an existing rule; ADR-062 removes a rule and adds a structurally different one (client-only render boundary vs SSR-safe execution discipline). Treating it as supersession leaves the trail readable for future sessions.
+
+**Amendment (2026-05-11) — §4 extended to /incidents.**
+
+The /incidents page had the same double-fetch shape AppShell did before ADR-062: `useState<string>('default')`, a `useEffect` that resolves the project from URL/localStorage, and a `useEffect([project])` that re-fires once the resolved value lands. Same root cause as the AppShell case — the SSR initial state has to be `'default'` to keep hydration byte-identical, which mandates the deferred resolution — and the same fix shape applies.
+
+§4 ("Other routes keep SSR") is amended: `/incidents/page.tsx` also mounts client-only via `dynamic({ ssr: false })`. Layout, `/api/**` routes, and any future routes default to SSR; an additional route opts out only by being added here. This keeps the minimum-blast-radius principle intact — every SSR-off opt-out is named explicitly, not opted into by default.

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -4879,11 +4879,17 @@ describe('Web shell multi-project routing (ADR-057)', () => {
   // byte-identical-initial-state constraint no longer binds, so guarding
   // useState lazy initializers and useRef initial values against browser-API
   // reads is moot. What we guard instead is the client-only boundary itself.
-  it('app/page.tsx mounts AppShell via next/dynamic with { ssr: false } (ADR-062)', () => {
-    const page = readSrc(join(WEB, 'app/page.tsx'))
-    expect(page).toMatch(/from\s+['"]next\/dynamic['"]/)
-    expect(page).toMatch(/\bdynamic\s*\(/)
-    expect(page).toMatch(/ssr\s*:\s*false/)
+  //
+  // 2026-05-11 amendment extends §4 to /incidents/page.tsx — same shape,
+  // same fix. The scan loops over every known client-only mount.
+  it('client-only page mounts use dynamic({ ssr: false }) (ADR-062 §4)', () => {
+    const paths = [join(WEB, 'app/page.tsx'), join(WEB, 'app/incidents/page.tsx')]
+    for (const p of paths) {
+      const src = readSrc(p)
+      expect(src, p).toMatch(/from\s+['"]next\/dynamic['"]/)
+      expect(src, p).toMatch(/\bdynamic\s*\(/)
+      expect(src, p).toMatch(/ssr\s*:\s*false/)
+    }
   })
 })
 

--- a/packages/web/app/incidents/IncidentsClient.tsx
+++ b/packages/web/app/incidents/IncidentsClient.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+
+interface Incident {
+  nodeId: string
+  timestamp: string
+  type: string
+  message: string
+  stacktrace?: string
+}
+
+interface IncidentsResponse {
+  count: number
+  total: number
+  events: Incident[]
+}
+
+function formatTs(iso: string): string {
+  try {
+    const d = new Date(iso)
+    return d.toLocaleDateString() + ' ' + d.toTimeString().slice(0, 8)
+  } catch {
+    return iso
+  }
+}
+
+export function IncidentsClient() {
+  const [data, setData] = useState<IncidentsResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [openRow, setOpenRow] = useState<string | null>(null)
+
+  // ADR-057 #2 — read project from URL (deep-linkable) or localStorage,
+  // matching AppShell's resolution chain. The lazy initializer reads
+  // window.* synchronously; safe because the page mounts client-only via
+  // dynamic({ ssr: false }) per ADR-062 §4 (2026-05-11 amendment). The
+  // typeof window guard stays as belt-and-suspenders — if someone later
+  // removes the dynamic wrapper, this degrades to a flicker, not a crash.
+  const [project] = useState<string>(() => {
+    if (typeof window === 'undefined') return 'default'
+    const fromUrl = new URLSearchParams(window.location.search).get('project')
+    if (fromUrl) return fromUrl
+    try {
+      const stored = window.localStorage.getItem('neat:lastProject')
+      if (stored) return stored
+    } catch { /* noop */ }
+    return 'default'
+  })
+
+  // ADR-057 #3 — re-fetch when project changes.
+  useEffect(() => {
+    setLoading(true)
+    fetch(`/api/incidents?limit=100&project=${encodeURIComponent(project)}`)
+      .then((r) => r.json())
+      .then((d: IncidentsResponse) => {
+        setData(d)
+        setLoading(false)
+      })
+      .catch((e: Error) => {
+        setError(e.message)
+        setLoading(false)
+      })
+  }, [project])
+
+  return (
+    <div style={{ background: 'var(--ink-0)', minHeight: '100vh' }}>
+      <header className="topbar">
+        <div className="brand" title="NEAT">N</div>
+        <div className="crumbs">
+          <Link href="/" className="incidents-nav-link">graph view</Link>
+          <span className="sep">/</span>
+          <span className="here">incidents</span>
+        </div>
+      </header>
+
+      <div className="incidents-page" style={{ marginTop: 44 }}>
+        <h1>Incidents</h1>
+        <div className="subtitle">
+          {data ? `${data.total} total events — showing ${data.events.length}` : 'loading…'}
+        </div>
+
+        {loading && (
+          <div className="incidents-empty">loading…</div>
+        )}
+
+        {error && (
+          <div className="incidents-empty" style={{ color: '#e87a7a' }}>
+            failed to load: {error}
+          </div>
+        )}
+
+        {!loading && !error && data && data.events.length === 0 && (
+          <div className="incidents-empty">no incidents recorded</div>
+        )}
+
+        {!loading && !error && data && data.events.length > 0 && (
+          <table className="incidents-table">
+            <thead>
+              <tr>
+                <th>Node</th>
+                <th>Time</th>
+                <th>Type</th>
+                <th>Message</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.events.map((evt, i) => {
+                const rowKey = `${i}-${evt.nodeId}`
+                const isOpen = openRow === rowKey
+                return (
+                  <>
+                    <tr
+                      key={rowKey}
+                      style={{ cursor: evt.stacktrace ? 'pointer' : undefined }}
+                      onClick={() => evt.stacktrace && setOpenRow(isOpen ? null : rowKey)}
+                      title={evt.stacktrace ? (isOpen ? 'Collapse stacktrace' : 'Expand stacktrace') : undefined}
+                    >
+                      <td className="td-node">
+                        <Link href={`/?node=${encodeURIComponent(evt.nodeId)}&project=${encodeURIComponent(project)}`} className="incidents-node-link">
+                          {evt.nodeId}
+                        </Link>
+                      </td>
+                      <td className="td-time">{formatTs(evt.timestamp)}</td>
+                      <td className="td-type">{evt.type}</td>
+                      <td className="td-msg">
+                        {evt.message}
+                        {evt.stacktrace && (
+                          <span className="stack-toggle">{isOpen ? ' ▲' : ' ▼'}</span>
+                        )}
+                      </td>
+                    </tr>
+                    {isOpen && evt.stacktrace && (
+                      <tr key={`${rowKey}-stack`}>
+                        <td colSpan={4} className="td-stacktrace">
+                          <pre className="stacktrace-pre">{evt.stacktrace}</pre>
+                        </td>
+                      </tr>
+                    )}
+                  </>
+                )
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/web/app/incidents/page.tsx
+++ b/packages/web/app/incidents/page.tsx
@@ -1,145 +1,16 @@
-'use client'
+import dynamic from 'next/dynamic'
 
-import { useEffect, useState } from 'react'
-import Link from 'next/link'
+// ADR-062 §4 (2026-05-11 amendment) — /incidents renders client-only.
+// Same shape as app/page.tsx: the IncidentsClient subtree reads the URL
+// and localStorage synchronously inside its useState lazy initializer,
+// which would diverge from the SSR pass; removing the SSR pass keeps the
+// resolution chain honest and avoids the double-fetch the deferred shape
+// produced on every page load.
+const IncidentsClient = dynamic(
+  () => import('./IncidentsClient').then((m) => m.IncidentsClient),
+  { ssr: false },
+)
 
-interface Incident {
-  nodeId: string
-  timestamp: string
-  type: string
-  message: string
-  stacktrace?: string
-}
-
-interface IncidentsResponse {
-  count: number
-  total: number
-  events: Incident[]
-}
-
-function formatTs(iso: string): string {
-  try {
-    const d = new Date(iso)
-    return d.toLocaleDateString() + ' ' + d.toTimeString().slice(0, 8)
-  } catch {
-    return iso
-  }
-}
-
-export default function IncidentsPage() {
-  const [data, setData] = useState<IncidentsResponse | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [openRow, setOpenRow] = useState<string | null>(null)
-
-  // ADR-057 #2 — page reads project from URL (deep-linkable) or localStorage,
-  // matching AppShell's resolution chain so the incidents view stays in sync
-  // with whichever project the operator last selected on the graph view.
-  const [project, setProject] = useState<string>('default')
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    const fromUrl = new URLSearchParams(window.location.search).get('project')
-    let stored: string | null = null
-    try { stored = window.localStorage.getItem('neat:lastProject') } catch { /* noop */ }
-    setProject(fromUrl || stored || 'default')
-  }, [])
-
-  // ADR-057 #3 — re-fetch when project changes.
-  useEffect(() => {
-    setLoading(true)
-    fetch(`/api/incidents?limit=100&project=${encodeURIComponent(project)}`)
-      .then((r) => r.json())
-      .then((d: IncidentsResponse) => {
-        setData(d)
-        setLoading(false)
-      })
-      .catch((e: Error) => {
-        setError(e.message)
-        setLoading(false)
-      })
-  }, [project])
-
-  return (
-    <div style={{ background: 'var(--ink-0)', minHeight: '100vh' }}>
-      <header className="topbar">
-        <div className="brand" title="NEAT">N</div>
-        <div className="crumbs">
-          <Link href="/" className="incidents-nav-link">graph view</Link>
-          <span className="sep">/</span>
-          <span className="here">incidents</span>
-        </div>
-      </header>
-
-      <div className="incidents-page" style={{ marginTop: 44 }}>
-        <h1>Incidents</h1>
-        <div className="subtitle">
-          {data ? `${data.total} total events — showing ${data.events.length}` : 'loading…'}
-        </div>
-
-        {loading && (
-          <div className="incidents-empty">loading…</div>
-        )}
-
-        {error && (
-          <div className="incidents-empty" style={{ color: '#e87a7a' }}>
-            failed to load: {error}
-          </div>
-        )}
-
-        {!loading && !error && data && data.events.length === 0 && (
-          <div className="incidents-empty">no incidents recorded</div>
-        )}
-
-        {!loading && !error && data && data.events.length > 0 && (
-          <table className="incidents-table">
-            <thead>
-              <tr>
-                <th>Node</th>
-                <th>Time</th>
-                <th>Type</th>
-                <th>Message</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.events.map((evt, i) => {
-                const rowKey = `${i}-${evt.nodeId}`
-                const isOpen = openRow === rowKey
-                return (
-                  <>
-                    <tr
-                      key={rowKey}
-                      style={{ cursor: evt.stacktrace ? 'pointer' : undefined }}
-                      onClick={() => evt.stacktrace && setOpenRow(isOpen ? null : rowKey)}
-                      title={evt.stacktrace ? (isOpen ? 'Collapse stacktrace' : 'Expand stacktrace') : undefined}
-                    >
-                      <td className="td-node">
-                        <Link href={`/?node=${encodeURIComponent(evt.nodeId)}&project=${encodeURIComponent(project)}`} className="incidents-node-link">
-                          {evt.nodeId}
-                        </Link>
-                      </td>
-                      <td className="td-time">{formatTs(evt.timestamp)}</td>
-                      <td className="td-type">{evt.type}</td>
-                      <td className="td-msg">
-                        {evt.message}
-                        {evt.stacktrace && (
-                          <span className="stack-toggle">{isOpen ? ' ▲' : ' ▼'}</span>
-                        )}
-                      </td>
-                    </tr>
-                    {isOpen && evt.stacktrace && (
-                      <tr key={`${rowKey}-stack`}>
-                        <td colSpan={4} className="td-stacktrace">
-                          <pre className="stacktrace-pre">{evt.stacktrace}</pre>
-                        </td>
-                      </tr>
-                    )}
-                  </>
-                )
-              })}
-            </tbody>
-          </table>
-        )}
-      </div>
-    </div>
-  )
+export default function IncidentsPage(): JSX.Element {
+  return <IncidentsClient />
 }


### PR DESCRIPTION
## Summary

`/incidents/page.tsx` had the same double-fetch shape AppShell did before ADR-062: a `'default'` initial state, a `useEffect` that resolved the project from URL/localStorage, and a `useEffect([project])` that re-fired once the resolved value landed. Same root cause (SSR initial state has to be `'default'` to keep hydration byte-identical), same fix shape.

This PR amends ADR-062 §4 to name `/incidents/page.tsx` as a second client-only mount, restructures the page (body moves into `IncidentsClient.tsx`, `page.tsx` becomes a thin `dynamic({ ssr: false })` boundary), and generalises the contract assertion over both client-only mounts.

The 2026-05-11 amendment to ADR-062 is the load-bearing review surface — please flag if the boundary semantics feel off. Layout, `/api/**`, and any future route still default to SSR; SSR-off is opt-in per route, named explicitly in the ADR.

Refs #227

## Commits

1. ADR-062 §4 amendment + contract markdown update
2. Restructure /incidents into IncidentsClient + thin page.tsx
3. Generalize the contract assertion over both client-only mounts

## Test plan

- [x] \`npx turbo build test lint\` clean
- [x] Contract count 498 live / 4 todo (replacement, no count change)
- [ ] Manual smoke against medusa: \`curl http://localhost:6328/incidents\` shows BAILOUT_TO_CLIENT_SIDE_RENDERING in the body where IncidentsClient would have landed; no 'default'-flash, single fetch per project change

cc Contract Author for the §4 amendment block specifically.