### PR TITLE
v0.3.1 + v0.3.2 + v0.3.3 scope from the medusa ADR-027 experiment

### DIFF
--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -14,14 +14,17 @@ Source of truth for sprint status. Update this file at the end of every session.
 
 **Last session ended:** 2026-05-12. v0.3.0 published to npm (engineering complete + web shell GA). The first ADR-027 MVP-success-PR experiment ran against medusajs/medusa at commit `370676c2a737fb3b558a745ad452a2c9d4ae6de5` and returned `no-PR-candidate`. 21 divergences surfaced, all false positives (precision 0.0), and the OBSERVED layer was empty so ADR-027's "OBSERVED-layer-load-bearing" bar was unsatisfiable by construction.
 
-The experiment's six NEAT-side findings are the next two milestones. Audit trail in `~/neat-experiment/bugs/` (run-local — the markdown corpus). Scope doc: `docs/plans/2026-05-12-post-mvp-experiment-scope.md`.
+The experiment's six NEAT-side findings split across three milestones, each answering one load-bearing question. Audit trail in `~/neat-experiment/bugs/` (run-local). Scope doc: `docs/plans/2026-05-12-post-mvp-experiment-scope.md`.
 
-- **v0.3.1 — Publish hygiene.** Three blockers (web shell `.next` missing, `neatd start` doesn't bind REST/OTLP, `neat watch` EMFILE on macOS) plus two contract amendments (ADR-052 smoke-test gate, ADR-049 daemon binding). Issues #231-#235. Contract Author opens with #234 + #235; implementation against the locked contract follows. Patch release.
-- **v0.4.0 — Extraction precision.** Opens with #236 (ADR-032 amendment — five precision filters + loud failure mode). Implementation in #237 (NEAT-BUG-4 ghost edges), #238 (NEAT-BUG-5 AWS SDK kind), #239 (NEAT-BUG-6 silent partial extraction). Plus #140 carried in. Minor release. Closes when medusa re-run drops divergence count ≥ 95% and ADR-027 re-runs against medusa with OTel attached.
+- **v0.3.1 — Daemon binds REST.** Does `neatd start` actually run NEAT? Issue #232 (REST/OTLP binding) + #235 (ADR-049 binding-as-contract-surface amendment). Patch release.
+- **v0.3.2 — Tarball ships working artifacts.** Does the npm tarball serve a working stack? Issues #231 (web shell `.next` missing) + #233 (chokidar EMFILE on macOS) + #234 (ADR-052 smoke-test gate amendment). Patch release. Sequenced after v0.3.1 because the smoke-test gate verifies post-v0.3.1 daemon behavior among other things.
+- **v0.4.0 — Extraction precision.** Does extraction produce trustworthy edges? Opens with #236 (ADR-032 amendment — five precision filters + loud failure mode). Implementation in #237 (NEAT-BUG-4 ghost edges), #238 (NEAT-BUG-5 AWS SDK kind), #239 (NEAT-BUG-6 silent partial extraction). Plus #140 carried in. Minor release. Closes when the medusa re-run drops divergence count ≥ 95% and ADR-027 re-runs against medusa with OTel attached.
 
 ### Active work — start here
 
-**v0.3.1 first move:** Contract Author writes #234 (ADR-052 tarball smoke-test additions) and #235 (ADR-049 binding-as-contract-surface). These can ship as one PR or a stacked pair. Implementation of #231 / #232 / #233 follows against the locked contract.
+**v0.3.1 first move:** Contract Author writes #235 (ADR-049 binding-as-contract-surface). Implementation of #232 follows against the locked contract. Tag and publish 0.3.1.
+
+**v0.3.2 first move:** Contract Author writes #234 (ADR-052 smoke-test gate). Implementation of #231 + #233 follows. Tag and publish 0.3.2.
 
 **v0.4.0 first move:** Contract Author writes #236 (ADR-032 amendment) including the regression-fixture corpus seeded from the experiment's evidence rows (0014, 0016, 0006, 0008, 0007 at minimum). Implementation of #237 / #238 / #239 + #140 follows.
 

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -12,36 +12,30 @@ Source of truth for sprint status. Update this file at the end of every session.
 
 ## 🚩 Pick up here
 
-**Last session ended:** 2026-05-09. v0.2.0 through v0.2.5 milestones closed and tagged. v0.2.8 contracts (ADRs 050/051 — CLI surface + frontend-facing API) landed on `main`; implementation is queued. The publish system contract (ADR-052) landed alongside the npm pipeline rebuild, and ADR-053 codifies the milestone-naming rule that produced the v0.2.6 → v0.2.8 rename. npm packages at 0.2.7 on the registry; the 0.2.5 and 0.2.6 slots are permanently retired (broken publishes that forced patch bumps per npm policy).
+**Last session ended:** 2026-05-12. v0.3.0 published to npm (engineering complete + web shell GA). The first ADR-027 MVP-success-PR experiment ran against medusajs/medusa at commit `370676c2a737fb3b558a745ad452a2c9d4ae6de5` and returned `no-PR-candidate`. 21 divergences surfaced, all false positives (precision 0.0), and the OBSERVED layer was empty so ADR-027's "OBSERVED-layer-load-bearing" bar was unsatisfiable by construction.
 
-**For current operational state of the active milestone, read `docs/plans/2026-05-09-v0.2.8-kickoff.md` first.** That doc is the canonical handoff; this file describes the long-term shape.
+The experiment's six NEAT-side findings are the next two milestones. Audit trail in `~/neat-experiment/bugs/` (run-local — the markdown corpus). Scope doc: `docs/plans/2026-05-12-post-mvp-experiment-scope.md`.
 
-**Two parallel tracks share `main`:**
-
-- **Track 1 — v0.3.0 Frontend (Jed).** Builds against the stable v0.1.2 API. Issues #28-#31 + #106-#108. Doesn't gate the MVP success criterion.
-- **Track 2 — v0.2.x Engineering (Cem + Kurt).** Seven milestones, sequential (v0.2.0 through v0.2.5 plus v0.2.8 — originally numbered v0.2.6, renamed per ADR-053 after publish-fix releases consumed the 0.2.6 / 0.2.7 npm slots). Each opens with the contract batch that governs that layer, then ships the rebuild + cleanup against the locked contract. **Don't ship cleanup work against an unlocked contract** — that's what produced the v0.1.x drift the verification pass surfaced. Full v0.2.x sequencing in `docs/plans/2026-05-04-v0.2.x-sequencing.md`.
-
-  - **v0.2.0 — Sunrise** — data-layer foundation. ADRs 028-031 + contract framework + audit verification + AUDIT-DRIFT sync. Pending merge in PRs #146 + #147 + the doc-refresh PR.
-  - **v0.2.1 — Tree-sitter rebuild.** Opens with contract #5 (static extraction). Ships #140, #141, #142, #145.
-  - **v0.2.2 — OTel ingest rebuild.** Opens with contracts #6-#8. Ships #131-#135.
-  - **v0.2.3 — Traversal rebuild.** Opens with contracts #9-#11. Ships #136-#139, #123.
-  - **v0.2.4 — Policies + MCP refresh.** Opens with contracts #12-#18. Ships #115-#118, #143, #144.
-  - **v0.2.5 — `neat init` + SDK install + Claude skill.** Opens with contracts #19-#22. Ships #119.
-  - **v0.2.8 — CLI parity + frontend-API surface.** Opens with contracts #23-#24. CLI verbs mirroring the nine MCP tools (so a human at a terminal has the same reach as an agent), plus whatever API surface Jed's v0.3.0 frontend track surfaces as a gap. The `(if needed)` qualifier is honest — parts of this milestone wait until v0.3.0 starts pulling on concrete demands. Originally named v0.2.6; renamed per ADR-053 after two publish-fix patches consumed the 0.2.6 and 0.2.7 npm version slots.
-
-After v0.2.8: the MVP-success PR experiment (ADR-027). Self-hosting on the NEAT codebase activates only after that PR closes — until then NEAT is the target of construction, not the tool.
+- **v0.3.1 — Publish hygiene.** Three blockers (web shell `.next` missing, `neatd start` doesn't bind REST/OTLP, `neat watch` EMFILE on macOS) plus two contract amendments (ADR-052 smoke-test gate, ADR-049 daemon binding). Issues #231-#235. Contract Author opens with #234 + #235; implementation against the locked contract follows. Patch release.
+- **v0.4.0 — Extraction precision.** Opens with #236 (ADR-032 amendment — five precision filters + loud failure mode). Implementation in #237 (NEAT-BUG-4 ghost edges), #238 (NEAT-BUG-5 AWS SDK kind), #239 (NEAT-BUG-6 silent partial extraction). Plus #140 carried in. Minor release. Closes when medusa re-run drops divergence count ≥ 95% and ADR-027 re-runs against medusa with OTel attached.
 
 ### Active work — start here
 
-**Once the three open v0.2.0 PRs (#146, #147, doc refresh) merge:** v0.2.0 closes. Open v0.2.1.
+**v0.3.1 first move:** Contract Author writes #234 (ADR-052 tarball smoke-test additions) and #235 (ADR-049 binding-as-contract-surface). These can ship as one PR or a stacked pair. Implementation of #231 / #232 / #233 follows against the locked contract.
 
-**v0.2.1 first move:** the Contract Author writes contract #5 (static extraction) — ADR + `docs/contracts/static-extraction.md` + regression tests. Then the implementation agent picks up #140 / #141 / #142 / #145 against the locked contract. Each cleanup issue closes when its corresponding `it.todo` in `contracts.test.ts` flips to a live assertion and passes.
+**v0.4.0 first move:** Contract Author writes #236 (ADR-032 amendment) including the regression-fixture corpus seeded from the experiment's evidence rows (0014, 0016, 0006, 0008, 0007 at minimum). Implementation of #237 / #238 / #239 + #140 follows.
 
-The 15 cleanup issues #131-#145 are open against the v0.2.0 milestone today **but belong to v0.2.1-v0.2.4** under the rebuild-contract framing. Migration of issue→milestone on GitHub is pending.
+ADR-027 re-runs after v0.4.0 closes. Until then, NEAT is still under construction, not the tool — same posture as before the experiment.
+
+### Long-term shape (historic — v0.2.x closed)
+
+The seven-milestone v0.2.x engineering sequence (Sunrise / Tree-sitter / OTel ingest / Traversal / Policies / `neat init` + Claude skill / CLI parity + frontend-API) closed 2026-05-09 and shipped as v0.3.0 on npm. Track 1 (v0.3.0 Frontend) shipped alongside. v0.2.x sequencing reference: `docs/plans/2026-05-04-v0.2.x-sequencing.md`. Per-milestone close docs in `docs/plans/2026-05-0{6,7,9}-v0.2.*-close.md`.
 
 ### Closing gate — the MVP-success PR
 
-After v0.2.x lands: point NEAT at an open-source codebase, identify a real divergence-shaped bug (OBSERVED layer must be load-bearing), propose a fix, get the PR merged. ADR-027 is the framing. Static-only finds (FastAPI #12901-shaped) don't earn NEAT its category — a Graphify fork could match them.
+ADR-027 is the framing: point NEAT at an open-source codebase, identify a real divergence-shaped bug (OBSERVED layer must be load-bearing), propose a fix, get the PR merged. First attempt (2026-05-12, medusajs/medusa) returned no-PR-candidate; findings shaped v0.3.1 + v0.4.0. Re-attempt gated on v0.4.0 close.
+
+Static-only finds (FastAPI #12901-shaped) don't earn NEAT its category — a Graphify fork could match them.
 
 The Railway gates from M6 are still informational. AWS is the more likely production target.
 

--- a/docs/plans/2026-05-12-post-mvp-experiment-scope.md
+++ b/docs/plans/2026-05-12-post-mvp-experiment-scope.md
@@ -1,0 +1,129 @@
+# Post-MVP-experiment scope — 2026-05-12
+
+The ADR-027 experiment ran against medusajs/medusa under v0.3.0. Verdict: `no-PR-candidate`. 21 divergences surfaced, 21 false positives (precision 0.0), and the OBSERVED layer was empty throughout (no OTel wired) so ADR-027's "OBSERVED-layer-load-bearing" criterion was unsatisfiable by construction before extraction noise even surfaced as a problem.
+
+Full audit trail: `~/neat-experiment/bugs/` — 21 divergence write-ups, 6 NEAT-side bug write-ups, INDEX.md, DRAFT-PR.md.
+
+The honest reading: NEAT is not ready for an unfamiliar codebase yet. Three packaging blockers prevent the documented happy path from working at all, and the extracted graph itself is hallucinated from string literals in tests, JSDoc comment bodies, and JSX external-link props. The thesis surface (`get_divergences`) cannot be load-bearing while the EXTRACTED layer it sits on is producing zero real edges.
+
+Two milestones come out of this. v0.3.1 patches the publish-hygiene blockers so the documented happy path actually works. v0.4.0 rebuilds static-extraction precision against an amended contract so a re-run of ADR-027 has signal to work with. After v0.4.0 closes, ADR-027 re-runs.
+
+---
+
+## v0.3.1 — Publish hygiene
+
+Patch release. No new contract batch — amendments to the existing publish-system (ADR-052) and daemon (ADR-049) contracts plus the three blocker fixes. Three of the six NEAT-side findings from the experiment.
+
+| Bug | Title | Fix shape |
+|-----|-------|-----------|
+| NEAT-BUG-1 | `neatd start` web UI crashes — `.next/` missing from `@neat.is/web` tarball | `prepublishOnly` runs `next build` (output: 'standalone'); `files` includes the standalone artifact; tarball smoke-test verifies the web UI actually serves a 200 on `/` |
+| NEAT-BUG-2 | `neatd start` never binds REST :8080 or OTLP :4318 | Daemon entrypoint forks/in-process-starts the neat-core host per active project after project registration; smoke-test asserts `/graph` returns 200 within N seconds of `neatd start` |
+| NEAT-BUG-3 | `neat watch` EMFILE on macOS for any repo with nested `node_modules` | Pass ignore globs (`**/node_modules/**`, `**/.git/**`, `**/dist/**`, `**/.next/**`, `**/.turbo/**`, `**/build/**`) as chokidar's first arg; macOS heuristic fallback to `usePolling: true` for repos above a directory-count threshold |
+
+### Contract amendments
+
+**ADR-052 (publish system, contract #25).** Add two assertions to the tarball smoke-test gate:
+
+1. The unpacked `neat.is` tarball contains a built `@neat.is/web` artifact (`.next/standalone` or equivalent, asserted by file presence).
+2. After `neatd start`, the REST endpoint at `http://localhost:8080/graph` returns 200 within 30 seconds. The web UI on `http://localhost:6328` returns 200 within 30 seconds. The OTLP receiver on `:4318` is bound (lsof or equivalent).
+
+The current smoke test only verifies bin entrypoints resolve. That's insufficient — it caught nothing of substance in this run.
+
+**ADR-049 (daemon, contract #22).** Tighten the wording of "single long-lived process, per-project graph isolation" to make it observably testable: after `neatd start`, every registered project has a graph host bound and reachable through the documented dual-mount paths. Add a contract assertion that mirrors the smoke-test wording above.
+
+### Issues to file
+
+- `#XYZ` — NEAT-BUG-1: web shell `.next/` missing from tarball
+- `#XYZ` — NEAT-BUG-2: `neatd start` doesn't bind REST or OTLP
+- `#XYZ` — NEAT-BUG-3: `neat watch` EMFILE on real-shape repos (macOS)
+- `#XYZ` — ADR-052 amendment: tarball smoke-test must verify web-UI build and post-start REST bind
+- `#XYZ` — ADR-049 amendment: per-project graph host binding is the contract surface
+
+(Issue numbers TBD on filing.)
+
+### Verification gate
+
+- Fresh `npm install -g neat.is@0.3.1` on a clean machine.
+- `neatd start` against a 2-project registry: both projects' `/graph` endpoints return non-empty within 30s, web UI at `:6328` returns the SPA shell.
+- `neat watch ~/some-repo-with-nested-node_modules` boots without EMFILE on macOS, no env-var workaround required.
+- `cd packages/core && npx vitest run test/audits/contracts.test.ts` — ADR-052 and ADR-049 assertion counts both grow by their new amendments.
+- CI publish workflow's tarball smoke-test step exercises the new assertions on every tag push.
+
+---
+
+## v0.4.0 — Extraction precision
+
+Minor release. Opens with a contract batch amending the static-extraction contract (ADR-032, contract #5). Then the rebuild against the locked contract. Mirrors the v0.2.x rebuild-against-locked-contract pattern.
+
+The three remaining NEAT-side findings from the experiment, plus a deferred carryover.
+
+| Bug | Title | Fix shape |
+|-----|-------|-----------|
+| NEAT-BUG-4 | Ghost CALLS / CONNECTS_TO edges from string literals in tests, JSDoc comments, JSX external-link props, `.env.template` files, raw `*Client()` constructors | Five extraction filters, codified as contract assertions and a regression-fixture corpus seeded from the experiment's evidence rows |
+| NEAT-BUG-5 | AWS S3 (and likely all AWS SDK clients) labelled `infra:grpc-service:S3` | Default unknown `*Client(...)` to `infra:service:X`; pattern-match `@aws-sdk/client-*` imports for accurate kind labelling |
+| NEAT-BUG-6 | ~90 medusa files silently skipped during `neat init` with "Invalid argument" tree-sitter errors | Route per-file extraction failures to `neat-out/errors.ndjson`; surface aggregate count in init banner; `NEAT_STRICT_EXTRACTION=1` exits non-zero; investigate underlying tree-sitter cause |
+| (carryover) | Ghost-edge cleanup keyed on `evidence.file` (issue #140) | Already filed under v0.2.1; folds into v0.4.0 because the cleanup-side and creation-side fixes ship together |
+
+### Contract amendments
+
+**ADR-032 (static extraction, contract #5).** Add a "Precision filters" section codifying five binding rules for CALLS / CONNECTS_TO inference:
+
+1. **Test-scope exclusion.** Files under `**/__tests__/**`, `**/__fixtures__/**`, `**/integration-tests/**`, and files matching `*.spec.{ts,tsx,js,jsx}` / `*.test.{ts,tsx,js,jsx}` are excluded from CALLS / CONNECTS_TO inference. They remain in the snapshot as service-internal nodes; only outbound inference is filtered.
+2. **Comment-body exclusion.** No edge is inferred from a string literal that lies inside a comment token. tree-sitter exposes comment-node boundaries; honour them.
+3. **JSX external-link exclusion.** No edge is inferred from a URL string passed to `<Link to=...>`, `<a href=...>`, `<NavLink to=...>`, or any JSX attribute on an element whose tag matches `/^(a|Link|NavLink|ExternalLink|Anchor)$/`. The pattern is "user-clickable UI hyperlink to a documentation/marketing site," not "service-to-service call."
+4. **`.env.template` exclusion.** Files matching `.env.template`, `.env.example`, `.env.*.template`, `.env.*.example` are documentation artifacts. They are not registered as ConfigNodes and do not produce CONFIGURED_BY edges. ADR-016 already binds ConfigNode to file existence at runtime; templates are not runtime.
+5. **No URL-substring service matching.** A URL whose hostname is `medusa.cloud` does not match the service `@medusajs/medusa` by substring containment. Cross-service inference from URL strings requires an exact hostname match against a registered ServiceNode alias or InfraNode hostname, not substring containment.
+
+Each rule lands as a live contract assertion in `contracts.test.ts` plus a fixture under `packages/core/test/fixtures/precision/` seeded directly from the experiment's evidence rows (0014, 0016, 0006, 0008, 0007 are the highest-signal cases).
+
+**ADR-022 (infra:<kind>:<name> id format).** No contract change — the format already permits `infra:service:S3`. The fix is a producer-side default change. Document the AWS-SDK pattern recognition in the static-extraction contract as a non-binding guideline (which AWS clients map to which `kind`) since the field is free-string by ADR-022.
+
+**Loud failure mode** (new section in static-extraction contract). Per-file extraction failures are written to `<projectDir>/neat-out/errors.ndjson` with `{file, error, stack, ts}`. The `neat init` and `neat watch` summary banners include `N files skipped due to parse errors`. `NEAT_STRICT_EXTRACTION=1` makes any extraction failure cause non-zero exit. Silent partial extraction is forbidden — if the producer is incomplete, the snapshot is observably incomplete.
+
+### Issues to file
+
+- `#XYZ` — NEAT-BUG-4: precision filters (one issue per filter, or one umbrella with five checkboxes — TBD on filing)
+- `#XYZ` — NEAT-BUG-5: AWS-SDK client kind classification
+- `#XYZ` — NEAT-BUG-6: loud failure mode for per-file extraction errors
+- `#XYZ` — ADR-032 amendment: precision filters + loud failure mode
+- `#140` — already filed: ghost-edge cleanup keyed on `evidence.file` (rolled in)
+
+### Verification gate
+
+- Re-run `neat init` against medusa at the same pinned commit (`370676c2a737fb3b558a745ad452a2c9d4ae6de5`). Every false-positive row from the 2026-05-12 experiment is verified gone. The regression-fixture corpus encodes this.
+- Total divergence count drops by ≥ 95% on the medusa snapshot under v0.4.0 vs v0.3.0 (the 21 from this experiment should resolve to 0-2 surviving rows).
+- `<projectDir>/neat-out/errors.ndjson` exists and contains the ~90 medusa files that silently failed in v0.3.0; init banner names the count.
+- Contract scoreboard grows by the new ADR-032 assertions, all live, none `it.todo`.
+
+### Closing gate
+
+v0.4.0 closes when the verification gate passes **and** ADR-027 re-runs against medusa with OTel instrumentation attached. The re-run is the actual test — the precision fixes are necessary preconditions, not the success criterion. Outcome of the re-run determines what v0.4.x or v0.5.0 is for.
+
+---
+
+## Why this split
+
+v0.3.1 is honest publish hygiene. The version under the npm tag didn't actually do what its README claimed. Fix that first; nothing else matters until the documented happy path works.
+
+v0.4.0 is the extraction-precision rebuild that the divergence query needs to be credible. It rebuilds against a tightened contract — same pattern as the v0.2.x sequence. v0.3.1 first because contract work shouldn't happen on a broken substrate, and the regression-fixture corpus for v0.4.0 is most valuable when the v0.3.1 daemon can actually serve the project it's testing.
+
+Both milestones are small in scope compared to a v0.2.x minor. v0.3.1 should be one engineering session — three blocker fixes plus two contract amendments. v0.4.0 should be one Contract Author session opening the batch, then one or two implementation sessions for the precision filters + loud failure mode.
+
+---
+
+## What we don't take on now
+
+- **The OTel-instrumentation story for unfamiliar targets.** ADR-027 needs OBSERVED data on the target. Manual instrumentation is fine for the re-run; productizing "point NEAT at a repo and get OBSERVED data without thinking" is post-v0.4.0.
+- **The daemon vs `neat watch` consolidation.** NEAT-BUG-2's fix puts REST behind `neatd start`, but the underlying architectural question of whether `neat watch` (single-project) should be merged into `neatd` (multi-project) is bigger than this round. The two coexist for now.
+- **Issue #141 (source-level DB detection), #142 (framework field), #145 (dep cleanup).** Carried forward from v0.2.1 since v0.2.5 close. Still carried forward. They're not on the critical path for ADR-027.
+- **A Rust v1.0 conversation.** Engineering hibernates until ADR-027 closes successfully. v0.4.0 closing without a merged upstream PR means another iteration on whatever the new failure mode reveals, not a jump to v1.0 work.
+
+---
+
+## Pick up here
+
+The Contract Author writes the ADR-052 + ADR-049 amendments for v0.3.1 first (smallest, most mechanical). The implementation agent picks up the three blocker fixes against the locked contracts. v0.3.1 ships when all three smoke-test assertions are live and CI publishes a working 0.3.1 tarball.
+
+Then the Contract Author writes the ADR-032 amendment for v0.4.0 — the five precision filters + the loud-failure-mode rule + the regression-fixture corpus seeded from the experiment evidence. Implementation against the locked contract follows. v0.4.0 ships when the medusa re-run drops divergence count by ≥ 95% and `errors.ndjson` surfaces the previously-silent failures.
+
+ADR-027 re-runs after v0.4.0 closes. That re-run, not v0.4.0 itself, is the gate that decides what comes next.

--- a/docs/plans/2026-05-12-post-mvp-experiment-scope.md
+++ b/docs/plans/2026-05-12-post-mvp-experiment-scope.md
@@ -6,48 +6,73 @@ Full audit trail: `~/neat-experiment/bugs/` — 21 divergence write-ups, 6 NEAT-
 
 The honest reading: NEAT is not ready for an unfamiliar codebase yet. Three packaging blockers prevent the documented happy path from working at all, and the extracted graph itself is hallucinated from string literals in tests, JSDoc comment bodies, and JSX external-link props. The thesis surface (`get_divergences`) cannot be load-bearing while the EXTRACTED layer it sits on is producing zero real edges.
 
-Two milestones come out of this. v0.3.1 patches the publish-hygiene blockers so the documented happy path actually works. v0.4.0 rebuilds static-extraction precision against an amended contract so a re-run of ADR-027 has signal to work with. After v0.4.0 closes, ADR-027 re-runs.
+Three milestones come out of this. v0.3.1 fixes the daemon so `neatd start` actually runs NEAT. v0.3.2 fixes the npm tarball so the documented happy path serves on install. v0.4.0 rebuilds static-extraction precision against an amended contract so a re-run of ADR-027 has signal to work with. The split between v0.3.1 and v0.3.2 is by load-bearing question, not by bug count: v0.3.1 is daemon surgery (one architectural change), v0.3.2 is packaging hygiene (two mechanical fixes + the smoke-test gate that verifies them). They're sequenced rather than bundled because v0.3.2's smoke-test gate (ADR-052 amendment) depends on the things it's checking being true first — and v0.3.1's daemon fix is what makes the smoke test's REST-bound assertion reachable. After v0.4.0 closes, ADR-027 re-runs.
 
 ---
 
-## v0.3.1 — Publish hygiene
+## v0.3.1 — Daemon binds REST
 
-Patch release. No new contract batch — amendments to the existing publish-system (ADR-052) and daemon (ADR-049) contracts plus the three blocker fixes. Three of the six NEAT-side findings from the experiment.
+Patch release. **One load-bearing question:** does `neatd start` actually run NEAT? One bug fix + one contract amendment.
 
 | Bug | Title | Fix shape |
 |-----|-------|-----------|
-| NEAT-BUG-1 | `neatd start` web UI crashes — `.next/` missing from `@neat.is/web` tarball | `prepublishOnly` runs `next build` (output: 'standalone'); `files` includes the standalone artifact; tarball smoke-test verifies the web UI actually serves a 200 on `/` |
-| NEAT-BUG-2 | `neatd start` never binds REST :8080 or OTLP :4318 | Daemon entrypoint forks/in-process-starts the neat-core host per active project after project registration; smoke-test asserts `/graph` returns 200 within N seconds of `neatd start` |
-| NEAT-BUG-3 | `neat watch` EMFILE on macOS for any repo with nested `node_modules` | Pass ignore globs (`**/node_modules/**`, `**/.git/**`, `**/dist/**`, `**/.next/**`, `**/.turbo/**`, `**/build/**`) as chokidar's first arg; macOS heuristic fallback to `usePolling: true` for repos above a directory-count threshold |
+| NEAT-BUG-2 | `neatd start` never binds REST :8080 or OTLP :4318 | Daemon entrypoint forks/in-process-starts the neat-core host per active project after project registration; per-project mount paths per ADR-026 dual-mount |
 
 ### Contract amendments
 
-**ADR-052 (publish system, contract #25).** Add two assertions to the tarball smoke-test gate:
+**ADR-049 (daemon, contract #22).** Tighten the wording of "single long-lived process, per-project graph isolation" to make it observably testable: after `neatd start`, every registered project has a graph host bound and reachable through the documented dual-mount paths (`GET /projects/:project/graph` returns 200). REST host on `:8080`, OTLP receiver on `:4318`. Bind within 30 seconds of `neatd start` returning. Add corresponding live assertions to `packages/core/test/audits/contracts.test.ts` under the `Daemon contract (ADR-049)` describe block.
 
-1. The unpacked `neat.is` tarball contains a built `@neat.is/web` artifact (`.next/standalone` or equivalent, asserted by file presence).
-2. After `neatd start`, the REST endpoint at `http://localhost:8080/graph` returns 200 within 30 seconds. The web UI on `http://localhost:6328` returns 200 within 30 seconds. The OTLP receiver on `:4318` is bound (lsof or equivalent).
+### Issues
 
-The current smoke test only verifies bin entrypoints resolve. That's insufficient — it caught nothing of substance in this run.
-
-**ADR-049 (daemon, contract #22).** Tighten the wording of "single long-lived process, per-project graph isolation" to make it observably testable: after `neatd start`, every registered project has a graph host bound and reachable through the documented dual-mount paths. Add a contract assertion that mirrors the smoke-test wording above.
-
-### Issues to file
-
-- `#XYZ` — NEAT-BUG-1: web shell `.next/` missing from tarball
-- `#XYZ` — NEAT-BUG-2: `neatd start` doesn't bind REST or OTLP
-- `#XYZ` — NEAT-BUG-3: `neat watch` EMFILE on real-shape repos (macOS)
-- `#XYZ` — ADR-052 amendment: tarball smoke-test must verify web-UI build and post-start REST bind
-- `#XYZ` — ADR-049 amendment: per-project graph host binding is the contract surface
-
-(Issue numbers TBD on filing.)
+- #232 — NEAT-BUG-2: `neatd start` doesn't bind REST or OTLP
+- #235 — ADR-049 amendment: per-project graph host binding is the contract surface
 
 ### Verification gate
 
-- Fresh `npm install -g neat.is@0.3.1` on a clean machine.
-- `neatd start` against a 2-project registry: both projects' `/graph` endpoints return non-empty within 30s, web UI at `:6328` returns the SPA shell.
+- `neatd start` against a 2-project registry: every project's `/graph` endpoint returns 200 within 30s, OTLP `:4318` bound.
+- Single-project default-mount path also serves (`GET /graph` returns 200, unprefixed) per ADR-026.
+- `cd packages/core && npx vitest run test/audits/contracts.test.ts` — ADR-049 assertion count grows by the binding-as-contract-surface amendments.
+
+The web UI and watcher blockers (NEAT-BUG-1, NEAT-BUG-3) are still broken at v0.3.1; that's expected. CLI users can drive NEAT through REST/MCP without the web UI. v0.3.1 ships as soon as the daemon question is answered, even though `neatd start --web` still crashes the web side.
+
+---
+
+## v0.3.2 — Tarball ships working artifacts
+
+Patch release. **One load-bearing question:** does the published npm tarball serve a working stack? Two bug fixes + one contract amendment whose smoke-test gate verifies both.
+
+| Bug | Title | Fix shape |
+|-----|-------|-----------|
+| NEAT-BUG-1 | `neatd start` web UI crashes — `.next/` missing from `@neat.is/web` tarball | `prepublishOnly` runs `next build` (output: 'standalone'); `files` includes the standalone artifact; bin wrapper runs the standalone server |
+| NEAT-BUG-3 | `neat watch` EMFILE on macOS for any repo with nested `node_modules` | Pass ignore globs (`**/node_modules/**`, `**/.git/**`, `**/dist/**`, `**/.next/**`, `**/.turbo/**`, `**/build/**`) as chokidar's first arg; darwin heuristic fallback to `{ usePolling: true }` for repos above a directory-count threshold |
+
+### Contract amendments
+
+**ADR-052 (publish system, contract #25).** Add two assertions to the tarball smoke-test gate, now that the things they verify can be true:
+
+1. The unpacked `neat.is` tarball contains a built `@neat.is/web` artifact (`.next/standalone` or equivalent, asserted by file presence).
+2. After `neatd start`, within 30 seconds:
+   - `curl http://localhost:8080/graph` returns 200 (already-true post-v0.3.1; the smoke test makes it observable in CI).
+   - `curl http://localhost:6328/` returns 200 (covers NEAT-BUG-1).
+   - `:4318` is bound by the daemon process.
+3. The smoke-test fixture project registry includes at least two projects, at least one with nested `node_modules`, to also exercise NEAT-BUG-3's polling path.
+
+The current smoke test only verifies bin entrypoints resolve. That's insufficient — it caught nothing of substance in the v0.3.0 release.
+
+### Issues
+
+- #231 — NEAT-BUG-1: web shell `.next/` missing from tarball
+- #233 — NEAT-BUG-3: `neat watch` EMFILE on real-shape repos (macOS)
+- #234 — ADR-052 amendment: tarball smoke-test must verify web-UI build and post-start REST bind
+
+### Verification gate
+
+- Fresh `npm install -g neat.is@0.3.2` on a clean machine.
+- `neatd start` against a 2-project registry: REST + OTLP + web UI all bound (v0.3.1 + v0.3.2 combined).
 - `neat watch ~/some-repo-with-nested-node_modules` boots without EMFILE on macOS, no env-var workaround required.
-- `cd packages/core && npx vitest run test/audits/contracts.test.ts` — ADR-052 and ADR-049 assertion counts both grow by their new amendments.
-- CI publish workflow's tarball smoke-test step exercises the new assertions on every tag push.
+- CI publish workflow's tarball smoke-test step exercises the three new assertions on every tag push.
+
+After v0.3.2, the documented `npm install -g neat.is && neatd start && open http://localhost:6328` happy path works end-to-end. That's the precondition v0.4.0 — and the eventual ADR-027 re-run — were waiting on.
 
 ---
 
@@ -103,11 +128,15 @@ v0.4.0 closes when the verification gate passes **and** ADR-027 re-runs against 
 
 ## Why this split
 
-v0.3.1 is honest publish hygiene. The version under the npm tag didn't actually do what its README claimed. Fix that first; nothing else matters until the documented happy path works.
+The three milestones each answer exactly one question.
 
-v0.4.0 is the extraction-precision rebuild that the divergence query needs to be credible. It rebuilds against a tightened contract — same pattern as the v0.2.x sequence. v0.3.1 first because contract work shouldn't happen on a broken substrate, and the regression-fixture corpus for v0.4.0 is most valuable when the v0.3.1 daemon can actually serve the project it's testing.
+- **v0.3.1: does `neatd` run NEAT?** Architectural surgery on the daemon supervisor. One real change. Once shipped, anyone (human via CLI, agent via MCP) can drive NEAT after `neatd start`.
+- **v0.3.2: does the npm tarball ship a working stack?** Packaging hygiene — the web build lands in the tarball, the watcher boots on real repos, the smoke-test gate verifies both. Patches the v0.3.0 publish lie.
+- **v0.4.0: does extraction produce trustworthy edges?** Precision rebuild against a tightened static-extraction contract. Same pattern as the v0.2.x sequence.
 
-Both milestones are small in scope compared to a v0.2.x minor. v0.3.1 should be one engineering session — three blocker fixes plus two contract amendments. v0.4.0 should be one Contract Author session opening the batch, then one or two implementation sessions for the precision filters + loud failure mode.
+v0.3.1 ships before v0.3.2 because v0.3.2's smoke-test gate (ADR-052 amendment) verifies REST/OTLP-bind among other things — that assertion is unreachable while the daemon doesn't bind. v0.3.2 ships before v0.4.0 because the regression-fixture corpus for v0.4.0 is most valuable when the v0.3.2 daemon-plus-tarball can actually serve the project it's testing through the documented surface.
+
+Each milestone is small in scope compared to a v0.2.x minor. v0.3.1 should be one Contract Author + one implementation session. v0.3.2 should be one Contract Author + one implementation session. v0.4.0 should be one Contract Author session opening the batch, then one or two implementation sessions for the precision filters + loud failure mode.
 
 ---
 
@@ -122,8 +151,10 @@ Both milestones are small in scope compared to a v0.2.x minor. v0.3.1 should be 
 
 ## Pick up here
 
-The Contract Author writes the ADR-052 + ADR-049 amendments for v0.3.1 first (smallest, most mechanical). The implementation agent picks up the three blocker fixes against the locked contracts. v0.3.1 ships when all three smoke-test assertions are live and CI publishes a working 0.3.1 tarball.
+**v0.3.1 first.** Contract Author writes the ADR-049 amendment (#235) — single, mechanical. Implementation agent picks up #232 (daemon binds REST) against the locked contract. v0.3.1 ships when `neatd start` answers the binding contract for every registered project and the new ADR-049 assertions are live in `contracts.test.ts`. Tag and publish 0.3.1.
 
-Then the Contract Author writes the ADR-032 amendment for v0.4.0 — the five precision filters + the loud-failure-mode rule + the regression-fixture corpus seeded from the experiment evidence. Implementation against the locked contract follows. v0.4.0 ships when the medusa re-run drops divergence count by ≥ 95% and `errors.ndjson` surfaces the previously-silent failures.
+**v0.3.2 next.** Contract Author writes the ADR-052 amendment (#234) — the smoke-test gate that verifies what v0.3.1 made true plus what v0.3.2 will make true. Implementation agent picks up #231 (web shell `.next` build) and #233 (chokidar polling fallback). v0.3.2 ships when the documented `npm install -g neat.is && neatd start && open http://localhost:6328` happy path works on a clean macOS machine. Tag and publish 0.3.2.
+
+**v0.4.0 next.** Contract Author writes #236 (ADR-032 amendment — the five precision filters + the loud-failure-mode rule + the regression-fixture corpus seeded from the experiment evidence). Implementation agent picks up #237 + #238 + #239 (+ carries #140 forward). v0.4.0 ships when the medusa re-run drops divergence count by ≥ 95% and `errors.ndjson` surfaces the previously-silent failures.
 
 ADR-027 re-runs after v0.4.0 closes. That re-run, not v0.4.0 itself, is the gate that decides what comes next.


### PR DESCRIPTION
Captures the post-MVP-experiment plan as a scope doc + a milestones.md refresh. Three artifacts:

1. **`docs/plans/2026-05-12-post-mvp-experiment-scope.md`** — the new sequencing doc, in the same shape as `2026-05-04-v0.2.x-sequencing.md`. Frames the 2026-05-12 medusa run honestly (no-PR-candidate, 21/21 false positives, OBSERVED empty) and proposes three milestones to address the findings.

2. **`docs/milestones.md`** — *Pick up here* section refreshed. v0.2.x history collapsed to a single historic paragraph. v0.3.1, v0.3.2, v0.3.3 named with the issues they own.

3. **Filed alongside (not in this PR):** GitHub milestones #17 (v0.3.1), #19 (v0.3.2), #18 (v0.3.3), plus issues #231-#239 with full context drawn from the experiment audit trail at `~/neat-experiment/bugs/`.

## The three milestones

Each answers one load-bearing question. All three are patch releases — none ship breaking wire-format changes.

**v0.3.1 — Does `neatd start` actually run NEAT?** Architectural surgery on the daemon supervisor.
- #232 — `neatd start` doesn't bind REST/OTLP (NEAT-BUG-2)
- #235 — amend ADR-049 (per-project graph host binding is the contract surface)

**v0.3.2 — Does the npm tarball ship a working stack?** Packaging hygiene.
- #231 — `@neat.is/web` ships without `.next/` (NEAT-BUG-1)
- #233 — `neat watch` EMFILE on macOS (NEAT-BUG-3)
- #234 — amend ADR-052 (tarball smoke-test must verify web-UI build + post-`neatd start` REST bind)

Sequenced after v0.3.1 because the smoke-test gate verifies post-v0.3.1 daemon behavior — assertion is unreachable while #232 isn't fixed.

**v0.3.3 — Does extraction produce trustworthy edges?** Precision rebuild against an amended static-extraction contract. Patch-shaped because no breaking wire-format change ships; the precision improvement is observable behavior, not a contract break for consumers.
- #236 — amend ADR-032 (five precision filters + loud failure mode). Opens the milestone.
- #237 — implement the five precision filters (NEAT-BUG-4 ghost edges)
- #238 — AWS SDK clients labelled grpc-service (NEAT-BUG-5)
- #239 — silent partial extraction → errors.ndjson + loud banner (NEAT-BUG-6)
- #140 — carryover: ghost-edge cleanup keyed on `evidence.file`

After v0.3.3 closes, ADR-027 re-runs against medusa with OTel attached.

Refs #231 #232 #233 #234 #235 #236 #237 #238 #239