### PR TITLE
v0.3.1: neatd start binds REST :8080 and OTLP :4318

### DIFF
--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -28,10 +28,14 @@
 
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import type { FastifyInstance } from 'fastify'
 import { DEFAULT_PROJECT, getGraph, resetGraph, type NeatGraph } from './graph.js'
 import { extractFromDirectory } from './extract.js'
 import { loadGraphFromDisk, startPersistLoop } from './persist.js'
-import { pathsForProject } from './projects.js'
+import { Projects, pathsForProject, type ProjectPaths } from './projects.js'
+import { buildApi } from './api.js'
+import { buildOtelReceiver } from './otel.js'
+import { handleSpan, makeErrorSpanWriter } from './ingest.js'
 import {
   listProjects,
   registryPath,
@@ -45,12 +49,23 @@ export interface DaemonOptions {
   // Defaults to `~/.neat/`. Honors NEAT_HOME the same way registry.ts does.
   // Tests override via NEAT_HOME and don't pass this directly.
   neatHome?: string
+  // ADR-063 — bind targets. Defaults to PORT (8080) / OTEL_PORT (4318) env
+  // vars, matching server.ts. Tests pass 0 to get ephemeral ports.
+  restPort?: number
+  otlpPort?: number
+  // ADR-063 — bind host. Defaults to HOST env (0.0.0.0).
+  host?: string
+  // ADR-063 — opt out of binding entirely (e.g. integration tests that
+  // exercise daemon slots without needing the listeners). Production
+  // `neatd start` never sets this.
+  bindListeners?: boolean
 }
 
 export interface ProjectSlot {
   entry: RegistryEntry
   graph: NeatGraph
   outPath: string
+  paths: ProjectPaths
   stopPersist: () => void
   status: 'active' | 'broken'
   errorReason?: string
@@ -68,6 +83,11 @@ export interface DaemonHandle {
   stop: () => Promise<void>
   // Path to the PID file the daemon owns. Useful for test assertions.
   pidPath: string
+  // ADR-063 — addresses where consumers reach the daemon. Empty string when
+  // bindListeners is false. REST is the Fastify app's listening address;
+  // OTLP is the receiver's.
+  restAddress: string
+  otlpAddress: string
 }
 
 function neatHomeFor(opts: DaemonOptions): string {
@@ -103,6 +123,8 @@ export function routeSpanToProject(
 }
 
 async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
+  const paths = pathsForProject(entry.name, path.join(entry.path, 'neat-out'))
+
   // Path missing on disk → mark broken and surface the reason. Daemon
   // continues with the rest of the registry.
   try {
@@ -118,6 +140,7 @@ async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
       // output; nothing routes to it because it's not 'active'.
       graph: getGraph(`__broken__:${entry.name}`),
       outPath: '',
+      paths,
       stopPersist: () => {},
       status: 'broken',
       errorReason: (err as Error).message,
@@ -129,10 +152,7 @@ async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
   // bootstrap (ADR-030 — mutation authority).
   resetGraph(entry.name)
   const graph = getGraph(entry.name)
-  const outPath = pathsForProject(
-    entry.name,
-    path.join(entry.path, 'neat-out'),
-  ).snapshotPath
+  const outPath = paths.snapshotPath
 
   await loadGraphFromDisk(graph, outPath)
   await extractFromDirectory(graph, entry.path)
@@ -143,9 +163,37 @@ async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
     entry,
     graph,
     outPath,
+    paths,
     stopPersist,
     status: 'active',
   }
+}
+
+function resolveRestPort(opts: DaemonOptions): number {
+  if (typeof opts.restPort === 'number') return opts.restPort
+  const env = process.env.PORT
+  if (env && env.length > 0) {
+    const n = Number.parseInt(env, 10)
+    if (Number.isFinite(n)) return n
+  }
+  return 8080
+}
+
+function resolveOtlpPort(opts: DaemonOptions): number {
+  if (typeof opts.otlpPort === 'number') return opts.otlpPort
+  const env = process.env.OTEL_PORT
+  if (env && env.length > 0) {
+    const n = Number.parseInt(env, 10)
+    if (Number.isFinite(n)) return n
+  }
+  return 4318
+}
+
+function resolveHost(opts: DaemonOptions): string {
+  if (opts.host && opts.host.length > 0) return opts.host
+  const env = process.env.HOST
+  if (env && env.length > 0) return env
+  return '0.0.0.0'
 }
 
 export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandle> {
@@ -165,6 +213,18 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
   await writeAtomically(pidPath, `${process.pid}\n`)
 
   const slots = new Map<string, ProjectSlot>()
+  // Projects registry mirrors slots for the REST listener (ADR-063). buildApi
+  // reads from this; we keep it in sync as slots come and go.
+  const registry = new Projects()
+
+  function upsertRegistryFromSlot(slot: ProjectSlot): void {
+    if (slot.status !== 'active') return
+    registry.set(slot.entry.name, {
+      scanPath: slot.entry.path,
+      paths: slot.paths,
+      graph: slot.graph,
+    })
+  }
 
   async function loadAll(): Promise<void> {
     const projects = await listProjects()
@@ -175,6 +235,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
       try {
         const slot = await bootstrapProject(entry)
         slots.set(entry.name, slot)
+        upsertRegistryFromSlot(slot)
         if (slot.status === 'broken') {
           console.warn(`neatd: project "${entry.name}" broken — ${slot.errorReason}`)
         } else {
@@ -202,6 +263,91 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
 
   await loadAll()
 
+  // ADR-063 — bind the REST host and the OTLP HTTP receiver. One listener
+  // each, multi-tenant by project name in the URL (REST) and by service.name
+  // dispatch (OTLP). Failure on either listen aborts startDaemon with a
+  // surfacing error rather than letting the supervisor sit half-up.
+  const bind = opts.bindListeners !== false
+  let restApp: FastifyInstance | null = null
+  let otlpApp:
+    | (FastifyInstance & { flushPending: () => Promise<void> })
+    | null = null
+  let restAddress = ''
+  let otlpAddress = ''
+
+  if (bind) {
+    const host = resolveHost(opts)
+    const restPort = resolveRestPort(opts)
+    const otlpPort = resolveOtlpPort(opts)
+
+    try {
+      restApp = await buildApi({ projects: registry })
+      restAddress = await restApp.listen({ port: restPort, host })
+      console.log(`neatd: REST listening on ${restAddress}`)
+    } catch (err) {
+      // Roll back anything we started so far before surfacing the error.
+      for (const slot of slots.values()) {
+        try {
+          slot.stopPersist()
+        } catch {
+          // best-effort
+        }
+      }
+      if (restApp) await restApp.close().catch(() => {})
+      await fs.unlink(pidPath).catch(() => {})
+      throw new Error(
+        `neatd: failed to bind REST on port ${restPort} — ${(err as Error).message}`,
+      )
+    }
+
+    try {
+      otlpApp = await buildOtelReceiver({
+        onSpan: async (span) => {
+          // ADR-049 OTel routing — dispatch by service.name across active
+          // registry entries. Unknown services route to DEFAULT_PROJECT so
+          // the FrontierNode auto-creation flow keeps working (ADR-033).
+          const liveEntries = await listProjects().catch(() => [])
+          const target = routeSpanToProject(span.service, liveEntries)
+          const slot = slots.get(target) ?? slots.get(DEFAULT_PROJECT)
+          if (!slot || slot.status !== 'active') return
+          await handleSpan(
+            {
+              graph: slot.graph,
+              errorsPath: slot.paths.errorsPath,
+              project: slot.entry.name,
+              // Receiver already wrote the error event synchronously below.
+              writeErrorEventInline: false,
+            },
+            span,
+          )
+        },
+        onErrorSpanSync: async (span) => {
+          const liveEntries = await listProjects().catch(() => [])
+          const target = routeSpanToProject(span.service, liveEntries)
+          const slot = slots.get(target) ?? slots.get(DEFAULT_PROJECT)
+          if (!slot || slot.status !== 'active') return
+          await makeErrorSpanWriter(slot.paths.errorsPath)(span)
+        },
+      })
+      otlpAddress = await otlpApp.listen({ port: otlpPort, host })
+      console.log(`neatd: OTLP listening on ${otlpAddress}/v1/traces`)
+    } catch (err) {
+      for (const slot of slots.values()) {
+        try {
+          slot.stopPersist()
+        } catch {
+          // best-effort
+        }
+      }
+      if (restApp) await restApp.close().catch(() => {})
+      if (otlpApp) await otlpApp.close().catch(() => {})
+      await fs.unlink(pidPath).catch(() => {})
+      throw new Error(
+        `neatd: failed to bind OTLP on port ${otlpPort} — ${(err as Error).message}`,
+      )
+    }
+  }
+
   let reloading: Promise<void> | null = null
   const reload = async (): Promise<void> => {
     if (reloading) return reloading
@@ -228,6 +374,8 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
     if (stopped) return
     stopped = true
     process.off('SIGHUP', sighupHandler)
+    if (otlpApp) await otlpApp.close().catch(() => {})
+    if (restApp) await restApp.close().catch(() => {})
     for (const slot of slots.values()) {
       try {
         slot.stopPersist()
@@ -238,5 +386,5 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
     await fs.unlink(pidPath).catch(() => {})
   }
 
-  return { slots, reload, stop, pidPath }
+  return { slots, reload, stop, pidPath, restAddress, otlpAddress }
 }

--- a/packages/core/src/neatd.ts
+++ b/packages/core/src/neatd.ts
@@ -51,6 +51,10 @@ async function cmdStart(): Promise<void> {
   const handle = await startDaemon()
   console.log(`neatd: started, PID ${process.pid}, ${handle.slots.size} project(s)`)
   console.log(`neatd: registry at ${registryPath()}`)
+  // ADR-063 — surface the bound addresses so the operator can sanity-check
+  // the documented happy path without grepping startup logs.
+  if (handle.restAddress) console.log(`neatd: REST  → ${handle.restAddress}`)
+  if (handle.otlpAddress) console.log(`neatd: OTLP  → ${handle.otlpAddress}`)
 
   // ADR-059 — bring up the web UI alongside the daemon. Failure here aborts
   // start with the clear-error pattern from ADR-049 instead of silently

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -3152,7 +3152,16 @@ describe('Daemon contract (ADR-049)', () => {
     const addedPaths = new Map<string, string>()
     const cleanups: Array<() => Promise<void>> = []
     const prevHome = process.env.NEAT_HOME
+    const prevPort = process.env.PORT
+    const prevOtelPort = process.env.OTEL_PORT
+    const prevHost = process.env.HOST
     process.env.NEAT_HOME = home
+    // ADR-063 — daemon binds REST :8080 and OTLP :4318 by default. Force
+    // ephemeral ports under test so the suite is robust against ports being
+    // occupied on dev boxes and against multiple workers fighting for 8080.
+    process.env.PORT = '0'
+    process.env.OTEL_PORT = '0'
+    process.env.HOST = '127.0.0.1'
 
     const { addProject, setStatus } = await import('../../src/registry.js')
     for (const p of opts.projects ?? []) {
@@ -3180,6 +3189,12 @@ describe('Daemon contract (ADR-049)', () => {
       cleanup: async () => {
         if (prevHome === undefined) delete process.env.NEAT_HOME
         else process.env.NEAT_HOME = prevHome
+        if (prevPort === undefined) delete process.env.PORT
+        else process.env.PORT = prevPort
+        if (prevOtelPort === undefined) delete process.env.OTEL_PORT
+        else process.env.OTEL_PORT = prevOtelPort
+        if (prevHost === undefined) delete process.env.HOST
+        else process.env.HOST = prevHost
         for (const c of cleanups) await c().catch(() => {})
         await fs2.rm(home, { recursive: true, force: true })
       },
@@ -3372,18 +3387,97 @@ describe('Daemon contract (ADR-049)', () => {
     }
   })
 
-  // ADR-063 — binding observability. The three assertions below ship as
-  // `it.todo` in the contract amendment PR (#235) and flip live in the
-  // implementation PR (#232). v0.3.1 closes when all three are live.
-  it.todo(
-    'ADR-063 — REST :8080 bound within 30s of startDaemon resolving (every registered project answers GET /graph)',
-  )
-  it.todo(
-    'ADR-063 — OTLP HTTP receiver :4318 bound within 30s of startDaemon resolving',
-  )
-  it.todo(
-    'ADR-063 — every registered project answers GET /projects/:project/graph with 200',
-  )
+  // ADR-063 — binding observability. The daemon binds REST :8080 and the
+  // OTLP HTTP receiver :4318 after slot bootstrap; the contract surface is
+  // "an outside caller can reach the daemon," not "the supervisor is up."
+  // Tests run on ephemeral ports — see setupDaemonSandbox.
+  it('ADR-063 — REST listener bound within 30s; default project answers GET /graph 200', async () => {
+    const { home, cleanup } = await setupDaemonSandbox({
+      projects: [{ name: 'default' }],
+    })
+    const prevWarn = console.warn
+    const prevLog = console.log
+    console.warn = () => {}
+    console.log = () => {}
+    try {
+      const t0 = Date.now()
+      const { startDaemon } = await import('../../src/daemon.js')
+      const handle = await startDaemon()
+      try {
+        expect(handle.restAddress).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/)
+        const res = await fetch(`${handle.restAddress}/graph`)
+        expect(res.status).toBe(200)
+        const elapsedMs = Date.now() - t0
+        expect(elapsedMs).toBeLessThan(30_000)
+      } finally {
+        await handle.stop()
+      }
+      void home
+    } finally {
+      console.warn = prevWarn
+      console.log = prevLog
+      await cleanup()
+    }
+  })
+
+  it('ADR-063 — OTLP HTTP receiver bound within 30s of startDaemon resolving', async () => {
+    const { home, cleanup } = await setupDaemonSandbox({
+      projects: [{ name: 'default' }],
+    })
+    const prevWarn = console.warn
+    const prevLog = console.log
+    console.warn = () => {}
+    console.log = () => {}
+    try {
+      const t0 = Date.now()
+      const { startDaemon } = await import('../../src/daemon.js')
+      const handle = await startDaemon()
+      try {
+        expect(handle.otlpAddress).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/)
+        // /health is the cheap liveness probe wired in buildOtelReceiver.
+        // The contract is that the socket is bound, not that /v1/traces
+        // accepts an empty GET.
+        const res = await fetch(`${handle.otlpAddress}/health`)
+        expect(res.status).toBe(200)
+        const elapsedMs = Date.now() - t0
+        expect(elapsedMs).toBeLessThan(30_000)
+      } finally {
+        await handle.stop()
+      }
+      void home
+    } finally {
+      console.warn = prevWarn
+      console.log = prevLog
+      await cleanup()
+    }
+  })
+
+  it('ADR-063 — every registered project answers GET /projects/:project/graph with 200', async () => {
+    const { home, cleanup } = await setupDaemonSandbox({
+      projects: [{ name: 'default' }, { name: 'second' }, { name: 'third' }],
+    })
+    const prevWarn = console.warn
+    const prevLog = console.log
+    console.warn = () => {}
+    console.log = () => {}
+    try {
+      const { startDaemon } = await import('../../src/daemon.js')
+      const handle = await startDaemon()
+      try {
+        for (const name of ['default', 'second', 'third']) {
+          const res = await fetch(`${handle.restAddress}/projects/${name}/graph`)
+          expect(res.status, `project ${name} should answer 200`).toBe(200)
+        }
+      } finally {
+        await handle.stop()
+      }
+      void home
+    } finally {
+      console.warn = prevWarn
+      console.log = prevLog
+      await cleanup()
+    }
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Implements ADR-063 (merged in #242). The v0.3.0 daemon bootstrapped per-project graphs and ran extraction, but nothing listened — every `neat <verb>` consumer landed on `fetch failed`. This PR makes the binding part of what `neatd start` returning success actually means.

After registry load and per-project bootstrap, `startDaemon` now stands up:

- One Fastify app for the REST API, single listener on `:8080`, multi-tenant via ADR-026 dual-mount paths (`/X` for default, `/projects/:project/X` for everyone).
- One Fastify app for the OTLP HTTP receiver on `:4318`. Span dispatch routes by `service.name` through `routeSpanToProject` to the right slot's graph and errors path.

Failure on either listen rolls back the slots' persist loops, closes whichever app started, removes the PID file, and surfaces the error. The supervisor doesn't sit half-up.

`PORT` and `OTEL_PORT` env vars override the defaults symmetrically with `server.ts`. Tests pass 0 for ephemeral ports — the daemon sandbox sets both so the suite is robust against ports being occupied on dev boxes.

## Contract scoreboard

The three ADR-063 assertions flip from `it.todo` to live:

- REST listener bound within 30s; `GET /graph` returns 200
- OTLP receiver bound within 30s; `GET /health` returns 200
- every registered project answers `GET /projects/:project/graph` 200

`Daemon contract (ADR-049)` now 9 passed, 0 todo (was 6 + 3 todo).

## Smoke test

End-to-end against a 2-project sandbox on macOS:

```
neatd: project "default" active
neatd: project "second" active
neatd: REST listening on http://127.0.0.1:<port>
neatd: OTLP listening on http://127.0.0.1:<port>/v1/traces
GET /graph                       → 200
GET /projects/second/graph       → 200
GET OTLP /health                 → 200
```

## Not in scope

- `Projects` registry doesn't drop entries on SIGHUP-removed projects. Latent before this PR (no consumer read it), surfaced here. Filed as a follow-up — out of scope for v0.3.1's binding fix.
- Web UI bootstrap order in `neatd.ts` is unchanged (REST/OTLP bind first, web spawn second, same as before).

Refs #232