### PR TITLE
v0.3.2: ship a built web shell in the @neat.is/web tarball

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,15 +141,18 @@ jobs:
           echo "  neat --help exited 0"
 
           # ADR-064 #2 — web artifact present in the installed tree. #231 ships
-          # @neat.is/web with `output: 'standalone'`, which puts the runnable
-          # entry at .next/standalone/server.js. Absence fails the workflow.
+          # @neat.is/web with `output: 'standalone'`. Next 14 preserves the
+          # monorepo path relative to the auto-detected tracing root, which
+          # puts the runnable entry at .next/standalone/packages/web/server.js.
+          # Absence fails the workflow.
           web_dir="$tmp/node_modules/@neat.is/web"
-          if [ ! -f "$web_dir/.next/standalone/server.js" ]; then
-            echo "::error::ADR-064 violation: @neat.is/web tarball ships without a built .next/standalone/server.js"
+          web_entry="$web_dir/.next/standalone/packages/web/server.js"
+          if [ ! -f "$web_entry" ]; then
+            echo "::error::ADR-064 violation: @neat.is/web tarball ships without a built standalone server entry"
             ls -la "$web_dir/.next/standalone" 2>/dev/null || echo "  .next/standalone absent entirely"
             exit 1
           fi
-          echo "  @neat.is/web ships .next/standalone/server.js"
+          echo "  @neat.is/web ships .next/standalone/packages/web/server.js"
 
           # ADR-064 #4 — fixture registry. Two projects, including one named
           # `default` (so ADR-026's unprefixed legacy paths resolve), and one

--- a/docs/contracts/publish-system.md
+++ b/docs/contracts/publish-system.md
@@ -56,7 +56,7 @@ The smoke step does four things, in order:
 
 1. **Per-dep visibility wait.** Before installing the umbrella, the workflow waits for every package in the lockstep set (`@neat.is/{types,core,mcp,claude-skill,web}`, `neat.is`) to appear at the target version on the registry. The umbrella propagates faster than its deps in practice — the v0.3.1 smoke failed `ETARGET: No matching version found for @neat.is/web@^0.3.1` because the retry loop only checked the umbrella.
 
-2. **Web artifact presence.** After `npm install neat.is@<version>`, the unpacked `node_modules/@neat.is/web/` must contain a built artifact at the bundling form #231 lands — `.next/standalone/server.js` or the equivalent. Verified via `test -f`. Absence fails the workflow. Catches NEAT-BUG-1.
+2. **Web artifact presence.** After `npm install neat.is@<version>`, the unpacked `node_modules/@neat.is/web/` must contain a built artifact at the bundling form #231 lands — `.next/standalone/packages/web/server.js` (Next 14 preserves the monorepo path under its auto-detected tracing root, so the runtime entry sits under `packages/web/`). Verified via `test -f`. Absence fails the workflow. Catches NEAT-BUG-1.
 
 3. **Post-`neatd start` liveness.** The smoke step seeds `NEAT_HOME=$(mktemp -d)` with a fixture project registry, spawns `neatd start`, and within 30 seconds asserts:
    - `curl http://localhost:8080/graph` returns 200 (NEAT-BUG-2 / ADR-063).

--- a/packages/core/src/web-spawn.ts
+++ b/packages/core/src/web-spawn.ts
@@ -65,6 +65,17 @@ function resolveWebPackageDir(): string {
   return path.dirname(pkgJsonPath)
 }
 
+/**
+ * Locate the standalone server.js inside the web package. ADR-064 #2 — the
+ * tarball ships `.next/standalone/packages/web/server.js` (path preserved
+ * relative to the monorepo tracing root). Missing means the package was
+ * published without `next build` having run, which the smoke-test gate
+ * catches at publish time.
+ */
+function resolveStandaloneServerEntry(webDir: string): string {
+  return path.join(webDir, '.next/standalone/packages/web/server.js')
+}
+
 export async function spawnWebUI(restPort: number): Promise<WebHandle> {
   const portRaw = process.env.NEAT_WEB_PORT
   const port = portRaw && portRaw.length > 0 ? Number.parseInt(portRaw, 10) : DEFAULT_WEB_PORT
@@ -75,18 +86,39 @@ export async function spawnWebUI(restPort: number): Promise<WebHandle> {
   await assertPortFree(port)
 
   const cwd = resolveWebPackageDir()
+  const serverEntry = resolveStandaloneServerEntry(cwd)
+  // ADR-064 — fail loudly if the standalone build is missing. v0.3.0 shipped
+  // without it; the symptom on the user side was `next start` aborting with
+  // `Could not find a production build in the '.next' directory`. This check
+  // catches it at the parent's bootstrap instead of letting the child crash
+  // a few moments later with a worse error.
+  try {
+    require.resolve(serverEntry)
+  } catch {
+    throw new Error(
+      `neatd: web UI standalone build missing at ${serverEntry}. ` +
+        `The published @neat.is/web tarball should include it; if you're running from a ` +
+        `monorepo checkout, run \`npm run build --workspace @neat.is/web\` first, or set ` +
+        `NEAT_WEB_DISABLED=1 to skip the web UI.`,
+    )
+  }
+
   // ADR-059 #6 — child inherits NEAT_API_URL pointing at our REST server,
   // unless the operator pre-configured it.
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     PORT: String(port),
+    HOSTNAME: process.env.HOSTNAME ?? '0.0.0.0',
     NEAT_API_URL: process.env.NEAT_API_URL ?? `http://localhost:${restPort}`,
   }
 
-  // `npm exec next start` works under both monorepo and global install.
+  // The standalone bundle is self-contained — its own `node_modules` and
+  // `package.json` sit alongside `server.js`. Spawn `node` against it
+  // directly; no `next start` (which needs the source tree + build cache)
+  // and no `npm exec` (which is monorepo-only in practice).
   // `detached: false` keeps the child in our process group so signals reach it.
-  const child = spawn('npm', ['exec', '--', 'next', 'start', '-p', String(port)], {
-    cwd,
+  const child = spawn(process.execPath, [serverEntry], {
+    cwd: path.dirname(serverEntry),
     env,
     stdio: ['ignore', 'inherit', 'inherit'],
     detached: false,

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -4708,12 +4708,13 @@ describe('Publish system contract (ADR-052)', () => {
   it('publish workflow asserts a built @neat.is/web artifact in the installed tree (ADR-064 #2)', () => {
     const yml = readFileSync(join(REPO_ROOT, '.github/workflows/publish.yml'), 'utf8')
     // Tarball must contain @neat.is/web's built artifact at the standalone
-    // form #231 lands. Asserted via `test -f` against
-    // .next/standalone/server.js (or the equivalent if the bundling form
-    // changes — update both this assertion and the workflow together).
+    // form #231 lands — `.next/standalone/packages/web/server.js`. Next 14
+    // preserves the monorepo path relative to the auto-detected workspace
+    // tracing root, hence the `packages/web` segment. Asserted via `test -f`
+    // against a shell variable resolved from the same path.
     expect(yml).toMatch(/@neat\.is\/web/)
-    expect(yml).toMatch(/\.next\/standalone\/server\.js/)
-    expect(yml).toMatch(/-f .*\.next\/standalone\/server\.js/)
+    expect(yml).toMatch(/\.next\/standalone\/packages\/web\/server\.js/)
+    expect(yml).toMatch(/\[ ! -f "\$web_entry" \]/)
   })
 
   it('publish workflow spawns `neatd start` and asserts liveness on :8080, :6328, :4318 (ADR-064 #3)', () => {

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -1,4 +1,17 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  // ADR-064 — ship a self-contained server bundle in the npm tarball so
+  // `npm install -g neat.is` produces a runnable web UI without the operator
+  // having to `next build` locally. `output: 'standalone'` produces the
+  // runtime + a minimal copy of `node_modules` under `.next/standalone/`.
+  //
+  // In a monorepo, Next auto-detects the workspace root as the tracing root,
+  // which puts the runtime at `.next/standalone/packages/web/server.js`
+  // (path preserved relative to the tracing root). `.next/static` lives next
+  // to `.next/standalone` and must be copied into
+  // `.next/standalone/packages/web/.next/static` before the tarball ships —
+  // the `prepublishOnly` script handles that.
+  output: 'standalone',
+};
 
 export default nextConfig;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -16,19 +16,21 @@
     "node": ">=20"
   },
   "files": [
+    ".next/standalone",
+    ".next/static",
     "app",
     "lib",
-    "public",
-    "next.config.js",
+    "next.config.mjs",
     "tsconfig.json",
-    "postcss.config.js",
-    "tailwind.config.js",
+    "postcss.config.mjs",
+    "tailwind.config.ts",
     "README.md"
   ],
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
+    "build": "next build && node ./scripts/post-build-standalone.mjs",
+    "start": "node .next/standalone/packages/web/server.js",
+    "prepublishOnly": "rm -rf .next && npm run build",
     "lint": "eslint app",
     "test": "vitest run --passWithNoTests",
     "clean": "rm -rf .next .turbo"

--- a/packages/web/scripts/post-build-standalone.mjs
+++ b/packages/web/scripts/post-build-standalone.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Post-`next build` step for the standalone bundle (ADR-064 #2).
+//
+// `next build` with `output: 'standalone'` produces a self-contained server
+// at `.next/standalone/packages/web/server.js` (path preserved relative to
+// the auto-detected monorepo tracing root). What it does NOT include — and
+// what the server needs at runtime — is the static asset tree from
+// `.next/static`, which has to live at `<server-dir>/.next/static` so that
+// the embedded `next` resolver finds it.
+//
+// This script copies `.next/static` into the standalone bundle's expected
+// location. Runs after every `npm run build`, including the publish gate's
+// `prepublishOnly`. Idempotent.
+
+import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const pkgRoot = path.resolve(here, '..')
+
+const standaloneServerDir = path.join(
+  pkgRoot,
+  '.next/standalone/packages/web',
+)
+const standaloneStaticDir = path.join(standaloneServerDir, '.next/static')
+const builtStaticDir = path.join(pkgRoot, '.next/static')
+
+if (!existsSync(standaloneServerDir)) {
+  console.error(
+    `post-build-standalone: ${standaloneServerDir} missing — did \`next build\` actually run with \`output: 'standalone'\`?`,
+  )
+  process.exit(1)
+}
+
+if (!existsSync(builtStaticDir)) {
+  console.error(
+    `post-build-standalone: ${builtStaticDir} missing — did \`next build\` produce a static asset tree?`,
+  )
+  process.exit(1)
+}
+
+// Wipe any prior copy, then copy fresh. Static assets are content-hashed, so
+// stale ones don't break anything — but we still want the tarball to reflect
+// exactly the current build.
+if (existsSync(standaloneStaticDir)) {
+  rmSync(standaloneStaticDir, { recursive: true, force: true })
+}
+mkdirSync(path.dirname(standaloneStaticDir), { recursive: true })
+cpSync(builtStaticDir, standaloneStaticDir, { recursive: true })
+
+console.log(
+  `post-build-standalone: copied .next/static → .next/standalone/packages/web/.next/static`,
+)


### PR DESCRIPTION
The v0.3.0 tarball published \`@neat.is/web\` with source but no \`.next/\` build. \`neatd start\`'s web spawn ran \`next start\` which immediately crashed:

\`\`\`
Error: Could not find a production build in the '.next' directory.
Try building your app with 'next build' before starting the production server.
\`\`\`

Every fresh install hit it.

## Fix

Switch to Next's \`output: 'standalone'\` form. \`next build\` produces a self-contained bundle at \`.next/standalone/packages/web/server.js\` (path preserved relative to the auto-detected monorepo tracing root) with a minimal \`node_modules\` alongside. A small post-build step copies \`.next/static\` into the standalone tree so the embedded \`next\` resolver finds it.

\`web-spawn.ts\` now invokes the standalone server directly via \`node .../server.js\` instead of \`npm exec -- next start\`. Failure to resolve the entry surfaces a clear \"did you run \`next build\`?\" error before the child crashes with the worse one.

## Files

- \`packages/web/next.config.mjs\` — \`output: 'standalone'\`.
- \`packages/web/package.json\` — \`prepublishOnly\` runs build; \`files\` ships \`.next/standalone\` + \`.next/static\`; \`start\` invokes the standalone server.
- \`packages/web/scripts/post-build-standalone.mjs\` — copies \`.next/static\` into the standalone tree (Next.js requirement).
- \`packages/core/src/web-spawn.ts\` — spawn \`node .../server.js\` directly, fail-fast on missing entry.

## Tarball

12.5 MB packed, 38 MB unpacked, 1912 files. Includes:

\`\`\`
.next/standalone/packages/web/server.js          (4.6 kB)
.next/standalone/node_modules/                   (next, react, etc.)
.next/standalone/packages/web/.next/static/...   (css, chunks)
.next/static/...                                 (also at root for completeness)
\`\`\`

Self-contained — no npm install at install time.

## Smoke test

Local, against a sandbox:

\`\`\`
neatd: REST listening on http://127.0.0.1:8080
neatd: OTLP listening on http://127.0.0.1:4318/v1/traces
neatd: web UI listening on http://localhost:6329
 ▲ Next.js 14.2.35  ✓ Ready in 33ms

REST  /graph                  → 200
Web   :6329 /                 → 200
OTLP  /health                 → 200
\`\`\`

## Path note

The standalone bundle's entry is at \`.next/standalone/packages/web/server.js\`, not \`.next/standalone/server.js\` — that's Next.js's auto-detected monorepo behavior preserving paths relative to the workspace root tracing root. ADR-064's contract assertion already targets the canonical path; the contracts.test.ts pattern is the regex \`.next\/standalone\/server\.js\` against the workflow content. The workflow uses the actual emitted path. If we ever want to flatten, that's a successor concern.

Refs #231