### PR TITLE
v0.3.3: precision filters for static extraction

### DIFF
--- a/packages/core/src/extract/calls/http.ts
+++ b/packages/core/src/extract/calls/http.ts
@@ -5,7 +5,12 @@ import Python from 'tree-sitter-python'
 import type { GraphEdge } from '@neat.is/types'
 import { EdgeType, Provenance } from '@neat.is/types'
 import type { NeatGraph } from '../../graph.js'
-import { makeEdgeId, type DiscoveredService } from '../shared.js'
+import {
+  isTestPath,
+  makeEdgeId,
+  urlMatchesHost,
+  type DiscoveredService,
+} from '../shared.js'
 import { loadSourceFiles, lineOf, snippet } from './shared.js'
 
 // JS uses `string_fragment` for the textual interior of a template/string;
@@ -13,8 +18,49 @@ import { loadSourceFiles, lineOf, snippet } from './shared.js'
 // raw textual content (no quotes), so we accept both.
 const STRING_LITERAL_NODE_TYPES = new Set(['string_fragment', 'string_content'])
 
-function collectStringLiterals(node: Parser.SyntaxNode, out: string[]): void {
-  if (STRING_LITERAL_NODE_TYPES.has(node.type)) out.push(node.text)
+// ADR-065 #3 — JSX external-link exclusion. Tags whose URL-attr strings are
+// user-clickable hyperlinks, not service-to-service calls.
+const JSX_EXTERNAL_LINK_TAGS = new Set(['a', 'Link', 'NavLink', 'ExternalLink', 'Anchor'])
+
+// Walk upward from a string-literal node to detect whether it sits inside a
+// JSX attribute on an external-link element. Returns true if the literal
+// should be filtered.
+function isInsideJsxExternalLink(node: Parser.SyntaxNode): boolean {
+  let cursor: Parser.SyntaxNode | null = node.parent
+  // Step out of the string wrapper if needed (parent is `string` /
+  // `template_string`).
+  while (cursor) {
+    if (cursor.type === 'jsx_attribute') {
+      // The element that owns this attribute. jsx_attribute lives inside
+      // jsx_opening_element / jsx_self_closing_element.
+      let owner: Parser.SyntaxNode | null = cursor.parent
+      while (owner && owner.type !== 'jsx_opening_element' && owner.type !== 'jsx_self_closing_element') {
+        owner = owner.parent
+      }
+      if (!owner) return false
+      // First named child of an opening/self-closing element is the tag name
+      // (`identifier` or `member_expression`).
+      const tagNode = owner.namedChild(0)
+      const tagName = tagNode?.text ?? ''
+      // For `<Foo.Bar>` we just want the rightmost ident; pick after the
+      // last dot.
+      const right = tagName.includes('.') ? tagName.split('.').pop()! : tagName
+      return JSX_EXTERNAL_LINK_TAGS.has(right)
+    }
+    cursor = cursor.parent
+  }
+  return false
+}
+
+// Collect (literal text, ast-node) pairs so the JSX-context check has the
+// node available. Comment tokens have no string_fragment / string_content
+// children in tree-sitter — JSDoc text lives inside `comment` nodes — so
+// comment-body exclusion comes for free with this AST walk (ADR-065 #2).
+function collectStringLiterals(
+  node: Parser.SyntaxNode,
+  out: { text: string; node: Parser.SyntaxNode }[],
+): void {
+  if (STRING_LITERAL_NODE_TYPES.has(node.type)) out.push({ text: node.text, node })
   for (let i = 0; i < node.namedChildCount; i++) {
     const child = node.namedChild(i)
     if (child) collectStringLiterals(child, out)
@@ -27,12 +73,18 @@ export function callsFromSource(
   knownHosts: Set<string>,
 ): Set<string> {
   const tree = parser.parse(source)
-  const literals: string[] = []
+  const literals: { text: string; node: Parser.SyntaxNode }[] = []
   collectStringLiterals(tree.rootNode, literals)
   const targets = new Set<string>()
   for (const lit of literals) {
+    // ADR-065 #3 — JSX external-link exclusion. URL strings on <a>, <Link>,
+    // <NavLink>, <ExternalLink>, <Anchor> are user-clickable hyperlinks, not
+    // service calls.
+    if (isInsideJsxExternalLink(lit.node)) continue
     for (const host of knownHosts) {
-      if (lit.includes(`//${host}`) || lit.includes(`//${host}:`)) {
+      // ADR-065 #5 — exact hostname match (not substring containment).
+      // `medusa.cloud` no longer matches `@medusajs/medusa`.
+      if (urlMatchesHost(lit.text, host)) {
         targets.add(host)
       }
     }
@@ -76,6 +128,8 @@ export async function addHttpCallEdges(
     const files = await loadSourceFiles(service.dir)
     const seenTargets = new Map<string, { file: string; host: string }>()
     for (const file of files) {
+      // ADR-065 #1 — test-scope exclusion.
+      if (isTestPath(file.path)) continue
       const parser = path.extname(file.path) === '.py' ? pyParser : jsParser
       let targets: Set<string>
       try {

--- a/packages/core/src/extract/calls/index.ts
+++ b/packages/core/src/extract/calls/index.ts
@@ -1,7 +1,12 @@
 import type { GraphEdge, InfraNode } from '@neat.is/types'
 import { EdgeType, NodeType, Provenance } from '@neat.is/types'
 import type { NeatGraph } from '../../graph.js'
-import { makeEdgeId, type DiscoveredService } from '../shared.js'
+import {
+  isTestPath,
+  makeEdgeId,
+  maskCommentsInSource,
+  type DiscoveredService,
+} from '../shared.js'
 import { addHttpCallEdges } from './http.js'
 import { loadSourceFiles, type ExternalEndpoint } from './shared.js'
 import { kafkaEndpointsFromFile } from './kafka.js'
@@ -36,10 +41,21 @@ async function addExternalEndpointEdges(
     const files = await loadSourceFiles(service.dir)
     const endpoints: ExternalEndpoint[] = []
     for (const file of files) {
-      endpoints.push(...kafkaEndpointsFromFile(file, service.dir))
-      endpoints.push(...redisEndpointsFromFile(file, service.dir))
-      endpoints.push(...awsEndpointsFromFile(file, service.dir))
-      endpoints.push(...grpcEndpointsFromFile(file, service.dir))
+      // ADR-065 #1 — test-scope exclusion. Tests stay registered as
+      // service-internal (via the file walk earlier); only outbound
+      // endpoint inference from them is filtered.
+      if (isTestPath(file.path)) continue
+      // ADR-065 #2 — comment-body exclusion. The regex-based extractors
+      // (redis / kafka / aws / grpc) scan raw file.content; URLs inside
+      // JSDoc / line / block comments leaked through to the graph in the
+      // v0.3.0 medusa run. Mask comments while preserving line/column for
+      // evidence line-mapping.
+      const masked = maskCommentsInSource(file.content)
+      const maskedFile = { path: file.path, content: masked }
+      endpoints.push(...kafkaEndpointsFromFile(maskedFile, service.dir))
+      endpoints.push(...redisEndpointsFromFile(maskedFile, service.dir))
+      endpoints.push(...awsEndpointsFromFile(maskedFile, service.dir))
+      endpoints.push(...grpcEndpointsFromFile(maskedFile, service.dir))
     }
     if (endpoints.length === 0) continue
 

--- a/packages/core/src/extract/shared.ts
+++ b/packages/core/src/extract/shared.ts
@@ -33,8 +33,151 @@ export function isConfigFile(name: string): { match: boolean; fileType: string }
   if (CONFIG_FILE_EXTENSIONS.has(ext)) return { match: true, fileType: ext.slice(1) }
   // .env, .env.local, .env.production. Bare filename or any dotted-suffix
   // variant; folder names get filtered upstream by walking files only.
-  if (name === '.env' || name.startsWith('.env.')) return { match: true, fileType: 'env' }
+  // ADR-065 #4 filters .env.template / .env.example / .env.sample (and the
+  // dotted-suffix variants) at the producer level — those are documentation,
+  // not runtime config.
+  if (name === '.env' || name.startsWith('.env.')) {
+    if (isEnvTemplateFile(name)) return { match: false, fileType: '' }
+    return { match: true, fileType: 'env' }
+  }
   return { match: false, fileType: '' }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// ADR-065 precision-filter helpers. Pre-emit gates inside the producer pass.
+// Filtered candidates are never written to the graph (idempotency intact).
+// ─────────────────────────────────────────────────────────────────────────
+
+// ADR-065 #1 — test-scope exclusion. Returns true when the file path matches
+// any test-scope pattern. Path is normalised to forward slashes before
+// matching so callers can pass either form.
+//
+// Patterns:
+//   - any segment named __tests__, __fixtures__, or integration-tests
+//   - basename matches *.spec.{ts,tsx,js,jsx,mjs,cjs,py}
+//   - basename matches *.test.{ts,tsx,js,jsx,mjs,cjs,py}
+export function isTestPath(filePath: string): boolean {
+  const normalised = filePath.replace(/\\/g, '/')
+  const segments = normalised.split('/')
+  for (const seg of segments) {
+    if (seg === '__tests__' || seg === '__fixtures__' || seg === 'integration-tests') {
+      return true
+    }
+  }
+  const base = segments[segments.length - 1] ?? ''
+  return /\.(spec|test)\.(?:tsx?|jsx?|mjs|cjs|py)$/i.test(base)
+}
+
+// ADR-065 #4 — `.env.template` exclusion. Matches:
+//   .env.template / .env.example / .env.sample
+//   .env.*.template / .env.*.example / .env.*.sample
+// These are docs/onboarding artifacts, not runtime config. ConfigNodes are
+// bound to runtime existence (ADR-016); templates fail that test.
+export function isEnvTemplateFile(name: string): boolean {
+  if (
+    name === '.env.template' ||
+    name === '.env.example' ||
+    name === '.env.sample'
+  ) {
+    return true
+  }
+  // `.env.*.template` / `.env.*.example` / `.env.*.sample`
+  return /^\.env\.[^.]+\.(?:template|example|sample)$/i.test(name)
+}
+
+// ADR-065 #2 — comment-body exclusion. Replaces every JS/TS comment span in
+// the source with an equal-length run of spaces, preserving line/column for
+// downstream line-mapping. Strings that contain `//` sequences (URLs) are
+// preserved by tracking the string context as we scan.
+//
+// Not a full parser — good enough for the medusa-shape failures. The HTTP
+// extractor's AST walk already gets comment-awareness for free; this helper
+// is for the regex-based extractors (redis, kafka, aws, grpc).
+export function maskCommentsInSource(src: string): string {
+  const len = src.length
+  const out: string[] = new Array(len)
+  let i = 0
+  // String context: ' " ` (template) — open-quote char, 0 when not in a string.
+  let inString: string | 0 = 0
+  let escaped = false
+  while (i < len) {
+    const c = src[i]!
+    if (inString !== 0) {
+      out[i] = c
+      if (escaped) {
+        escaped = false
+      } else if (c === '\\') {
+        escaped = true
+      } else if (c === inString) {
+        inString = 0
+      }
+      i++
+      continue
+    }
+    if (c === '/' && i + 1 < len) {
+      const next = src[i + 1]!
+      if (next === '/') {
+        out[i] = ' '
+        out[i + 1] = ' '
+        let j = i + 2
+        while (j < len && src[j] !== '\n') {
+          out[j] = ' '
+          j++
+        }
+        i = j
+        continue
+      }
+      if (next === '*') {
+        out[i] = ' '
+        out[i + 1] = ' '
+        let j = i + 2
+        while (j < len) {
+          if (src[j] === '\n') {
+            out[j] = '\n'
+            j++
+            continue
+          }
+          if (src[j] === '*' && j + 1 < len && src[j + 1] === '/') {
+            out[j] = ' '
+            out[j + 1] = ' '
+            j += 2
+            break
+          }
+          out[j] = ' '
+          j++
+        }
+        i = j
+        continue
+      }
+    }
+    out[i] = c
+    if (c === "'" || c === '"' || c === '`') inString = c
+    i++
+  }
+  return out.join('')
+}
+
+// ADR-065 #5 — exact hostname match for cross-service URL inference. Returns
+// true if `urlString` parses as a URL whose hostname equals `host` exactly
+// (case-insensitive). No `.includes()` containment.
+//
+// Accepts a `host` that may include a port (`api.example.com:8080`); in that
+// case the URL's hostname AND port must both match.
+export function urlMatchesHost(urlString: string, host: string): boolean {
+  const [wantedHost, wantedPort] = host.split(':')
+  let parsed: URL
+  try {
+    parsed = new URL(urlString)
+  } catch {
+    try {
+      parsed = new URL(`http://${urlString.replace(/^\/\//, '')}`)
+    } catch {
+      return false
+    }
+  }
+  if (parsed.hostname.toLowerCase() !== (wantedHost ?? '').toLowerCase()) return false
+  if (wantedPort && parsed.port !== wantedPort) return false
+  return true
 }
 
 // Strip semver range prefixes (^, ~, >=, etc.) and bare "v" so the extracted

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -784,21 +784,92 @@ describe('ServiceNode.owner extraction (ADR-054)', () => {
   // live in the corresponding Phase 3B implementation PR.
   // ────────────────────────────────────────────────────────────────────────
 
-  it.todo(
-    'ADR-065 #1 — test-scope exclusion: __tests__/test-scope-postgres.spec.ts produces no EXTRACTED edges (#237)',
-  )
-  it.todo(
-    'ADR-065 #2 — comment-body exclusion: comment-body-jsdoc.ts produces no edge from JSDoc @example URL (#237)',
-  )
-  it.todo(
-    'ADR-065 #3 — JSX external-link exclusion: jsx-external-link.tsx produces no CALLS edge (#237)',
-  )
-  it.todo(
-    'ADR-065 #4 — .env.template exclusion: env-template/.env.template registers no ConfigNode (#237)',
-  )
-  it.todo(
-    'ADR-065 #5 — no URL-substring service matching: hostname must match an alias exactly (#237)',
-  )
+  it('ADR-065 #1 — test-scope exclusion: isTestPath matches the documented patterns', async () => {
+    const { isTestPath } = await import('../../src/extract/shared.js')
+    expect(isTestPath('packages/foo/__tests__/bar.spec.ts')).toBe(true)
+    expect(isTestPath('packages/foo/__fixtures__/bar.ts')).toBe(true)
+    expect(isTestPath('packages/foo/integration-tests/bar.ts')).toBe(true)
+    expect(isTestPath('packages/foo/bar.spec.ts')).toBe(true)
+    expect(isTestPath('packages/foo/bar.test.ts')).toBe(true)
+    expect(isTestPath('packages/foo/bar.test.tsx')).toBe(true)
+    expect(isTestPath('packages/foo/bar.test.py')).toBe(true)
+    expect(isTestPath('packages/foo/bar.ts')).toBe(false)
+    expect(isTestPath('packages/foo/specifications.ts')).toBe(false)
+    // The seed fixture from experiment row 0016 is correctly identified.
+    const fixture = join(
+      __dirname,
+      '../fixtures/precision/__tests__/test-scope-postgres.spec.ts',
+    )
+    expect(isTestPath(fixture)).toBe(true)
+  })
+
+  it('ADR-065 #2 — comment-body exclusion: maskCommentsInSource strips URLs in comments (row 0014)', async () => {
+    const { maskCommentsInSource } = await import('../../src/extract/shared.js')
+    const fixture = readFileSync(
+      join(__dirname, '../fixtures/precision/comment-body-jsdoc.ts'),
+      'utf8',
+    )
+    const masked = maskCommentsInSource(fixture)
+    // The JSDoc @example URL the v0.3.0 extractor pulled an edge from is gone
+    // from the masked content. Strings in code still survive.
+    expect(masked).not.toContain('http://localhost:9000')
+    expect(masked).not.toContain('@example')
+    // Identifier from the interface declaration is preserved.
+    expect(masked).toContain('backendUrl')
+  })
+
+  it('ADR-065 #3 — JSX external-link exclusion: <Link to="..."> URL produces no CALLS edge (row 0006)', async () => {
+    const { callsFromSource } = await import('../../src/extract/calls/http.js')
+    const ParserMod = (await import('tree-sitter')).default as unknown as new () => {
+      setLanguage(lang: unknown): void
+      parse(src: string): { rootNode: unknown }
+    }
+    const JavaScript = (await import('tree-sitter-javascript')).default
+    const parser = new ParserMod() as unknown as import('tree-sitter')
+    parser.setLanguage(JavaScript)
+    const src = readFileSync(
+      join(__dirname, '../fixtures/precision/jsx-external-link.tsx'),
+      'utf8',
+    )
+    // Configure knownHosts so without the JSX filter, the substring matcher
+    // would have produced a candidate match against `medusajs.com`.
+    const targets = callsFromSource(src, parser, new Set(['medusajs.com']))
+    expect([...targets]).toEqual([])
+  })
+
+  it('ADR-065 #4 — .env.template exclusion: isEnvTemplateFile + isConfigFile both filter (rows 0008/0015)', async () => {
+    const { isEnvTemplateFile, isConfigFile } = await import('../../src/extract/shared.js')
+    // Direct predicate.
+    expect(isEnvTemplateFile('.env.template')).toBe(true)
+    expect(isEnvTemplateFile('.env.example')).toBe(true)
+    expect(isEnvTemplateFile('.env.sample')).toBe(true)
+    expect(isEnvTemplateFile('.env.production.template')).toBe(true)
+    expect(isEnvTemplateFile('.env.production.example')).toBe(true)
+    // Real env files keep matching.
+    expect(isEnvTemplateFile('.env')).toBe(false)
+    expect(isEnvTemplateFile('.env.local')).toBe(false)
+    expect(isEnvTemplateFile('.env.production')).toBe(false)
+    // isConfigFile delegates — templates are not config.
+    expect(isConfigFile('.env.template').match).toBe(false)
+    expect(isConfigFile('.env.production.template').match).toBe(false)
+    expect(isConfigFile('.env').match).toBe(true)
+    expect(isConfigFile('.env.local').match).toBe(true)
+  })
+
+  it('ADR-065 #5 — no URL-substring service matching: urlMatchesHost requires exact hostname (rows 0001-0003/0012/0013)', async () => {
+    const { urlMatchesHost } = await import('../../src/extract/shared.js')
+    // The v0.3.0 substring bug: medusa.cloud matched @medusajs/medusa.
+    // Post-fix: only exact hostname.
+    expect(urlMatchesHost('https://medusa.cloud/foo', 'medusajs/medusa')).toBe(false)
+    expect(urlMatchesHost('https://medusajs.com/changelog/', 'medusajs/medusa')).toBe(false)
+    // Real matches still work.
+    expect(urlMatchesHost('http://api.example.com:8080/x', 'api.example.com')).toBe(true)
+    expect(urlMatchesHost('http://api.example.com:8080/x', 'api.example.com:8080')).toBe(true)
+    // Port mismatch fails when port is specified in the wanted host.
+    expect(urlMatchesHost('http://api.example.com:9999/x', 'api.example.com:8080')).toBe(false)
+    // Non-URLs and malformed inputs fail closed.
+    expect(urlMatchesHost('not a url', 'api.example.com')).toBe(false)
+  })
   it.todo(
     'ADR-065 — errors.ndjson lines have shape { file, error, stack, ts, source: "extract" } (#239)',
   )


### PR DESCRIPTION
The 2026-05-12 medusa experiment produced 20 EXTRACTED edges in the divergence report; **every single one was a false positive**. Five filter shapes cover the failures. Implements ADR-065 #1–#5 against the locked contract from #247.

## Filters

| # | Filter | Where | Caught by fixture |
|---|---|---|---|
| 1 | Test-scope exclusion | \`shared.ts\` → \`isTestPath\`, applied in \`calls/index.ts\` + \`calls/http.ts\` | \`__tests__/test-scope-postgres.spec.ts\` |
| 2 | Comment-body exclusion | \`shared.ts\` → \`maskCommentsInSource\` applied in \`calls/index.ts\`; AST walk in \`http.ts\` is comment-aware natively | \`comment-body-jsdoc.ts\` |
| 3 | JSX external-link exclusion | \`http.ts\` → \`isInsideJsxExternalLink\` walks ancestors to \`jsx_attribute\` → \`jsx_opening_element\` / \`jsx_self_closing_element\` | \`jsx-external-link.tsx\` |
| 4 | \`.env.template\` exclusion | \`shared.ts\` → \`isEnvTemplateFile\` wired through \`isConfigFile\` | \`env-template/.env.template\` |
| 5 | No URL-substring matching | \`shared.ts\` → \`urlMatchesHost\` replaces \`lit.includes('//host')\` in \`http.ts\` | (assertion-level) |

All five are pre-emit gates — filtered candidates are never written, idempotency intact.

## Contract scoreboard

Five \`it.todo\`s under \`Static-extraction contract (ADR-032)\` flip live:

- ✓ #1 — \`isTestPath\` matches documented patterns
- ✓ #2 — \`maskCommentsInSource\` strips row-0014 JSDoc URL
- ✓ #3 — \`callsFromSource\` against \`jsx-external-link.tsx\` returns no targets
- ✓ #4 — \`isEnvTemplateFile\` + \`isConfigFile\` both filter templates
- ✓ #5 — \`urlMatchesHost\` requires exact hostname (medusa.cloud ≠ medusajs/medusa)

Three loud-failure-mode todos remain queued for #239.

## Verification

- \`calls.test.ts\` (4 tests) and \`extract.test.ts\` (9 tests) pass unchanged — the filters don't false-positive against valid runtime URL evidence.
- Full turbo green from cold cache.

Refs #237