### PR TITLE
v0.3.3: import-aware kind classification for *Client() constructors

### DIFF
--- a/packages/core/src/extract/calls/grpc.ts
+++ b/packages/core/src/extract/calls/grpc.ts
@@ -2,20 +2,69 @@ import path from 'node:path'
 import { infraId } from '@neat.is/types'
 import { lineOf, snippet, type ExternalEndpoint, type SourceFile } from './shared.js'
 
-// gRPC client construction in JS/TS:
+// Client-construction in JS/TS:
 //
 //   const client = new orders_proto.OrderService(...)
 //   const client = new OrdersClient('orders.internal:50051', ...)
+//   const client = new S3Client({ region: 'us-east-1' })
 //
-// We catch `new <Name>Client(...)` and `new <namespace>.<Name>Service(...)`
-// patterns and use the symbol name as the inferred service id. The address
-// argument, when statically resolvable, becomes the host hint on the
-// resulting CALLS edge — but resolution is best-effort.
+// The same `new <Name>Client(...)` shape is used by gRPC client stubs, AWS
+// SDK v3 service clients, and a long tail of other SDKs. v0.3.0 mapped every
+// `*Client(...)` to `infra:grpc-service:*`, which was true for the demo and
+// false for every AWS service medusa imported.
+//
+// Per ADR-065 / #238, classification is import-aware:
+//   1. file imports `@aws-sdk/client-<suffix>` and `<Name>` lowercases to the
+//      same alphanumeric tail (`S3Client` ↔ `client-s3`,
+//      `CognitoIdentityProviderClient` ↔ `client-cognito-identity-provider`)
+//      → kind `aws-<suffix>` (e.g. `infra:aws-s3:S3`).
+//   2. file imports `@grpc/grpc-js` or any `*_grpc_pb` generated stub
+//      → kind `grpc-service` (the legitimate gRPC path; demo unchanged).
+//   3. otherwise → kind `service` (the safe default — accurate but
+//      uninformative, the v0.3.0 grpc lie is removed).
 const GRPC_CLIENT_RE = /new\s+([A-Z][A-Za-z0-9_]*)Client\s*\(\s*['"`]?([^,'"`)]+)?/g
+const AWS_SDK_IMPORT_RE =
+  /(?:from\s+['"`]|require\(\s*['"`])@aws-sdk\/client-([a-z0-9-]+)['"`]/g
+const GRPC_IMPORT_RE =
+  /(?:from\s+['"`]|require\(\s*['"`])@grpc\/grpc-js['"`]|_grpc_pb['"`]/
 
 function isLikelyAddress(value: string | undefined): boolean {
   if (!value) return false
   return /:\d{2,5}$/.test(value) || value.includes('.')
+}
+
+function normaliseForMatch(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+interface ImportContext {
+  awsSdkSuffixes: Map<string, string>  // normalised → raw suffix (e.g. 's3' → 's3')
+  hasGrpcImport: boolean
+}
+
+function readImports(content: string): ImportContext {
+  const awsSdkSuffixes = new Map<string, string>()
+  AWS_SDK_IMPORT_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = AWS_SDK_IMPORT_RE.exec(content)) !== null) {
+    const raw = m[1]!
+    awsSdkSuffixes.set(normaliseForMatch(raw), raw)
+  }
+  return {
+    awsSdkSuffixes,
+    hasGrpcImport: GRPC_IMPORT_RE.test(content),
+  }
+}
+
+function classifyClient(
+  symbol: string,
+  ctx: ImportContext,
+): { kind: string } {
+  const key = normaliseForMatch(symbol)
+  const awsRaw = ctx.awsSdkSuffixes.get(key)
+  if (awsRaw) return { kind: `aws-${awsRaw}` }
+  if (ctx.hasGrpcImport) return { kind: 'grpc-service' }
+  return { kind: 'service' }
 }
 
 export function grpcEndpointsFromFile(
@@ -24,6 +73,7 @@ export function grpcEndpointsFromFile(
 ): ExternalEndpoint[] {
   const out: ExternalEndpoint[] = []
   const seen = new Set<string>()
+  const ctx = readImports(file.content)
   GRPC_CLIENT_RE.lastIndex = 0
   let m: RegExpExecArray | null
   while ((m = GRPC_CLIENT_RE.exec(file.content)) !== null) {
@@ -32,11 +82,12 @@ export function grpcEndpointsFromFile(
     const name = isLikelyAddress(addr) ? addr! : symbol
     if (seen.has(name)) continue
     seen.add(name)
+    const { kind } = classifyClient(symbol, ctx)
     const line = lineOf(file.content, m[0])
     out.push({
-      infraId: infraId('grpc-service', name),
+      infraId: infraId(kind, name),
       name,
-      kind: 'grpc-service',
+      kind,
       edgeType: 'CALLS',
       evidence: {
         file: path.relative(serviceDir, file.path),

--- a/packages/core/src/extract/calls/index.ts
+++ b/packages/core/src/extract/calls/index.ts
@@ -30,6 +30,14 @@ function edgeTypeFromEndpoint(ep: ExternalEndpoint): (typeof EdgeType)[keyof typ
   }
 }
 
+function isAwsKind(kind: string): boolean {
+  return (
+    kind.startsWith('aws-') ||
+    kind.startsWith('s3') ||
+    kind.startsWith('dynamodb')
+  )
+}
+
 async function addExternalEndpointEdges(
   graph: NeatGraph,
   services: DiscoveredService[],
@@ -66,7 +74,10 @@ async function addExternalEndpointEdges(
           id: ep.infraId,
           type: NodeType.InfraNode,
           name: ep.name,
-          provider: ep.kind.startsWith('s3') || ep.kind.startsWith('dynamodb') ? 'aws' : 'self',
+          // #238 — `aws-*` covers AWS-SDK client kinds (aws-s3, aws-dynamodb,
+          // aws-cognito-identity-provider, …); `s3-` / `dynamodb-` cover the
+          // bucket / table kinds from aws.ts.
+          provider: isAwsKind(ep.kind) ? 'aws' : 'self',
           kind: ep.kind,
         }
         graph.addNode(node.id, node)

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -870,6 +870,55 @@ describe('ServiceNode.owner extraction (ADR-054)', () => {
     // Non-URLs and malformed inputs fail closed.
     expect(urlMatchesHost('not a url', 'api.example.com')).toBe(false)
   })
+
+  it('#238 — `new S3Client()` with @aws-sdk/client-s3 import → kind aws-s3 (row 0007)', async () => {
+    const { grpcEndpointsFromFile } = await import('../../src/extract/calls/grpc.js')
+    const fixturePath = join(
+      __dirname,
+      '../fixtures/precision/aws-client-raw.ts',
+    )
+    const content = readFileSync(fixturePath, 'utf8')
+    const eps = grpcEndpointsFromFile({ path: fixturePath, content }, __dirname)
+    expect(eps.length).toBeGreaterThan(0)
+    // Every endpoint emitted from this file must be aws-s3, never the
+    // v0.3.0 `grpc-service` lie.
+    for (const ep of eps) {
+      expect(ep.kind).toBe('aws-s3')
+      expect(ep.infraId).toMatch(/^infra:aws-s3:/)
+      expect(ep.infraId).not.toMatch(/grpc-service/)
+    }
+  })
+
+  it('#238 — `new SomeClient()` without an SDK import defaults to kind `service`, not `grpc-service`', async () => {
+    const { grpcEndpointsFromFile } = await import('../../src/extract/calls/grpc.js')
+    const source = `
+      class SomeClient { constructor(_: unknown) {} }
+      export function build(): SomeClient {
+        return new SomeClient({ region: 'us-east-1' })
+      }
+    `
+    const eps = grpcEndpointsFromFile({ path: '/tmp/some.ts', content: source }, '/tmp')
+    expect(eps.length).toBeGreaterThan(0)
+    for (const ep of eps) {
+      expect(ep.kind).toBe('service')
+      expect(ep.infraId).toMatch(/^infra:service:/)
+    }
+  })
+
+  it('#238 — legitimate gRPC stubs (via @grpc/grpc-js or *_grpc_pb import) stay classified as grpc-service', async () => {
+    const { grpcEndpointsFromFile } = await import('../../src/extract/calls/grpc.js')
+    const source = `
+      const grpc = require('@grpc/grpc-js')
+      const { OrdersClient } = require('./generated/orders_grpc_pb')
+      const client = new OrdersClient('orders.internal:50051', grpc.credentials.createInsecure())
+    `
+    const eps = grpcEndpointsFromFile({ path: '/tmp/g.js', content: source }, '/tmp')
+    expect(eps.length).toBeGreaterThan(0)
+    for (const ep of eps) {
+      expect(ep.kind).toBe('grpc-service')
+    }
+  })
+
   it.todo(
     'ADR-065 — errors.ndjson lines have shape { file, error, stack, ts, source: "extract" } (#239)',
   )


### PR DESCRIPTION
The v0.3.0 extractor mapped every \`new <Name>Client(...)\` to \`infra:grpc-service:*\` — true for the demo, false for every AWS SDK client medusa imports. NEAT-BUG-5: \`new S3Client(config)\` in \`@medusajs/file-s3\` produced \`infra:grpc-service:S3\`. S3 is REST/HTTP, not gRPC.

## Classification

\`grpc.ts\` now reads imports in the same file:

1. **AWS SDK** — \`@aws-sdk/client-<suffix>\` import + matching \`<Name>Client\` symbol → kind \`aws-<suffix>\` (e.g. \`S3Client\` ↔ \`client-s3\` → \`aws-s3\`). Symbol/suffix matching lowercases both and strips non-alphanumerics, so \`CognitoIdentityProviderClient\` ↔ \`client-cognito-identity-provider\` works.
2. **Legitimate gRPC** — \`@grpc/grpc-js\` import OR any \`*_grpc_pb\` generated stub import → kind \`grpc-service\`. The demo's gRPC path stays unchanged.
3. **Default** — kind \`service\`. The grpc lie is dropped; we don't invent a protocol we can't prove from source.

\`calls/index.ts\` gets an \`isAwsKind\` helper so the \`provider: 'aws'\` tagging covers the new \`aws-*\` kinds alongside the existing \`s3-bucket\` / \`dynamodb-table\` shapes from \`aws.ts\`.

## Verification

Three new live assertions in \`contracts.test.ts\`:

- ✓ \`@aws-sdk/client-s3\` + \`new S3Client()\` → kind \`aws-s3\` (asserted against fixture \`aws-client-raw.ts\`, row 0007 of the medusa experiment)
- ✓ bare \`new SomeClient()\` with no SDK import → kind \`service\` (not \`grpc-service\`)
- ✓ \`@grpc/grpc-js\` or \`*_grpc_pb\` import → kind stays \`grpc-service\`

\`calls.test.ts\` (4 tests) passes unchanged — the demo's grpc-service fixture imports \`./generated/orders_grpc_pb\` and stays classified correctly. Full turbo green.

Refs #238