### PR TITLE
v0.3.3: loud failure mode for static extraction

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -5,6 +5,10 @@ import { promises as fs } from 'node:fs'
 import type { GraphEdge, GraphNode, ServiceNode } from '@neat.is/types'
 import { DEFAULT_PROJECT, getGraph, resetGraph } from './graph.js'
 import { extractFromDirectory } from './extract.js'
+import {
+  formatExtractionBanner,
+  isStrictExtractionEnabled,
+} from './extract/errors.js'
 import { discoverServices } from './extract/services.js'
 import type { DiscoveredService } from './extract/shared.js'
 import { saveGraphToDisk } from './persist.js'
@@ -391,7 +395,15 @@ export async function runInit(opts: InitOptions): Promise<InitResult> {
   const graphKey = opts.projectExplicit ? opts.project : DEFAULT_PROJECT
   resetGraph(graphKey)
   const graph = getGraph(graphKey)
-  const result = await extractFromDirectory(graph, opts.scanPath)
+  // ADR-065 — per-file extraction failures land alongside the snapshot in
+  // <projectDir>/neat-out/errors.ndjson. Same file as OTel error events
+  // (ADR-033) with a `source: 'extract'` discriminator.
+  const projectPaths = pathsForProject(
+    graphKey,
+    path.join(opts.scanPath, 'neat-out'),
+  )
+  const errorsPath = path.join(path.dirname(opts.outPath), path.basename(projectPaths.errorsPath))
+  const result = await extractFromDirectory(graph, opts.scanPath, { errorsPath })
   await saveGraphToDisk(graph, opts.outPath)
   written.push(opts.outPath)
 
@@ -445,6 +457,13 @@ export async function runInit(opts: InitOptions): Promise<InitResult> {
   console.log(`added: ${result.nodesAdded} nodes, ${result.edgesAdded} edges`)
   console.log(`total:  ${graph.order} nodes, ${graph.size} edges`)
   console.log(summarise(nodes, edges))
+  // ADR-065 — loud failure mode banner. Unconditional; 0 is a positive
+  // signal. When errors > 0, also surface the sidecar path so the operator
+  // can read per-file detail.
+  console.log(formatExtractionBanner(result.extractionErrors))
+  if (result.extractionErrors > 0) {
+    console.log(`errors:   ${errorsPath}`)
+  }
 
   const incompatibilities = findIncompatibilities(nodes)
   if (incompatibilities.length > 0) {
@@ -455,6 +474,13 @@ export async function runInit(opts: InitOptions): Promise<InitResult> {
         console.log(`  ${svc.name}: ${formatIncompat(inc)}`)
       }
     }
+  }
+
+  // ADR-065 — NEAT_STRICT_EXTRACTION=1 makes any per-file failure exit
+  // non-zero. Default is forgiving (banner only). Exit code 4 keeps
+  // misuse (2) and daemon-down (3) distinguishable per the CLI contract.
+  if (result.extractionErrors > 0 && isStrictExtractionEnabled()) {
+    return { exitCode: 4, writtenFiles: written }
   }
 
   return { exitCode: 0, writtenFiles: written }

--- a/packages/core/src/extract/aliases.ts
+++ b/packages/core/src/extract/aliases.ts
@@ -4,6 +4,7 @@ import { parseAllDocuments } from 'yaml'
 import type { ServiceNode } from '@neat.is/types'
 import { NodeType } from '@neat.is/types'
 import type { NeatGraph } from '../graph.js'
+import { recordExtractionError } from './errors.js'
 import {
   CONFIG_FILE_EXTENSIONS,
   IGNORED_DIRS,
@@ -99,8 +100,10 @@ async function collectComposeAliases(
   try {
     compose = await readYaml<ComposeFile>(composePath)
   } catch (err) {
-    console.warn(
-      `[neat] aliases compose skipped ${path.relative(scanPath, composePath)}: ${(err as Error).message}`,
+    recordExtractionError(
+      'aliases compose',
+      path.relative(scanPath, composePath),
+      err,
     )
     return
   }
@@ -158,9 +161,7 @@ async function collectDockerfileAliases(
     try {
       content = await fs.readFile(dockerfilePath, 'utf8')
     } catch (err) {
-      console.warn(
-        `[neat] aliases dockerfile skipped ${dockerfilePath}: ${(err as Error).message}`,
-      )
+      recordExtractionError('aliases dockerfile', dockerfilePath, err)
       continue
     }
     const aliases = parseDockerfileLabels(content)

--- a/packages/core/src/extract/calls/http.ts
+++ b/packages/core/src/extract/calls/http.ts
@@ -11,6 +11,7 @@ import {
   urlMatchesHost,
   type DiscoveredService,
 } from '../shared.js'
+import { recordExtractionError } from '../errors.js'
 import { loadSourceFiles, lineOf, snippet } from './shared.js'
 
 // JS uses `string_fragment` for the textual interior of a template/string;
@@ -135,9 +136,7 @@ export async function addHttpCallEdges(
       try {
         targets = callsFromSource(file.content, parser, knownHosts)
       } catch (err) {
-        console.warn(
-          `[neat] http call extraction skipped ${file.path}: ${(err as Error).message}`,
-        )
+        recordExtractionError('http call extraction', file.path, err)
         continue
       }
       for (const t of targets) {

--- a/packages/core/src/extract/errors.ts
+++ b/packages/core/src/extract/errors.ts
@@ -1,0 +1,104 @@
+// ADR-065 — loud failure mode for static extraction.
+//
+// Per-file extraction failures used to land as a single `console.warn` line
+// with no aggregate count and no on-disk record. The 2026-05-12 medusa
+// experiment ran `neat init` against ~90 files that all silently failed
+// extraction with "Invalid argument"; the snapshot shipped with those files
+// missing, the user had no signal it had happened, and the divergence query
+// couldn't surface gaps it didn't know it had.
+//
+// This module is the failure-mode plumbing: a process-local sink that every
+// producer appends to when a per-file parse fails, with helpers to drain the
+// sink to `<projectDir>/neat-out/errors.ndjson` and to surface the aggregate
+// count in init / watch banners.
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+
+export interface ExtractionError {
+  // Producer name (e.g. "http", "services", "infra docker-compose"). Stable
+  // human-readable identifier for logs and contract assertions.
+  producer: string
+  // Absolute or relative path of the file that failed. Stored verbatim from
+  // the call site; no normalisation here.
+  file: string
+  // The error's `.message`. Stringified if the throw value wasn't an Error.
+  error: string
+  // Optional stack trace (captured at the call site). Useful for diagnosing
+  // tree-sitter "Invalid argument" cases where the message alone is generic.
+  stack?: string
+  // ISO timestamp of when the error was recorded.
+  ts: string
+  // Discriminator for `errors.ndjson` consumers — separates extract failures
+  // from OTel error events that share the same file (ADR-033).
+  source: 'extract'
+}
+
+const sink: ExtractionError[] = []
+
+// Record a per-file extraction failure. Preserves the visible warn line so
+// existing scripts/CI consumers still see a per-file message; appends to the
+// process-local sink so the aggregate count + sidecar write can fire later.
+export function recordExtractionError(
+  producer: string,
+  file: string,
+  err: unknown,
+): void {
+  const e = err instanceof Error ? err : new Error(String(err))
+  sink.push({
+    producer,
+    file,
+    error: e.message,
+    stack: e.stack,
+    ts: new Date().toISOString(),
+    source: 'extract',
+  })
+  // Visible warn preserved (pre-ADR-065 callers logged this). Banners
+  // aggregate, but per-file context still useful for tail -f sessions.
+  console.warn(`[neat] ${producer} skipped ${file}: ${e.message}`)
+}
+
+// Drain all queued errors. Idempotent — subsequent calls return an empty
+// array until new errors land. Callers (extractFromDirectory) drain at start
+// to clear stale state from prior runs, then drain again at end to collect
+// the pass's failures.
+export function drainExtractionErrors(): ExtractionError[] {
+  return sink.splice(0, sink.length)
+}
+
+// Read-only count of currently-queued errors. Used by callers that want the
+// count without consuming the sink (the banner case — we want the count for
+// display and the entries for `errors.ndjson`).
+export function pendingExtractionErrors(): number {
+  return sink.length
+}
+
+// Append the drained entries to `<projectDir>/neat-out/errors.ndjson`. The
+// file is shared with OTel error events (per ADR-033); the `source: 'extract'`
+// discriminator separates them for consumers. Creates the directory if
+// missing. Append-only — never rewritten.
+export async function writeExtractionErrors(
+  errors: ExtractionError[],
+  errorsPath: string,
+): Promise<void> {
+  if (errors.length === 0) return
+  await fs.mkdir(path.dirname(errorsPath), { recursive: true })
+  const lines = errors.map((e) => JSON.stringify(e)).join('\n') + '\n'
+  await fs.appendFile(errorsPath, lines, 'utf8')
+}
+
+// ADR-065 — `NEAT_STRICT_EXTRACTION=1` makes any per-file extraction failure
+// cause the calling command to exit non-zero. Default is forgiving (banner
+// only). The check is at the caller (cli.ts / server.ts / watch.ts) so the
+// extraction phase itself stays library-shaped.
+export function isStrictExtractionEnabled(): boolean {
+  const raw = process.env.NEAT_STRICT_EXTRACTION
+  return raw === '1' || raw === 'true'
+}
+
+// Format the unconditional summary banner. Zero errors is a positive signal
+// ("0 files skipped") so callers print this even on clean runs.
+export function formatExtractionBanner(count: number): string {
+  if (count === 1) return `[neat] 1 file skipped due to parse errors`
+  return `[neat] ${count} files skipped due to parse errors`
+}

--- a/packages/core/src/extract/index.ts
+++ b/packages/core/src/extract/index.ts
@@ -21,11 +21,22 @@ import { addDatabasesAndCompat } from './databases/index.js'
 import { addConfigNodes } from './configs.js'
 import { addCallEdges } from './calls/index.js'
 import { addInfra } from './infra/index.js'
+import {
+  drainExtractionErrors,
+  writeExtractionErrors,
+  type ExtractionError,
+} from './errors.js'
 
 export interface ExtractResult {
   nodesAdded: number
   edgesAdded: number
   frontiersPromoted: number
+  // ADR-065 — per-file extraction failures collected during the pass.
+  // `extractionErrors` is the count; `errorEntries` is the drained list,
+  // available for callers that want to surface per-file context. Both are
+  // present on every pass (zero is observable as a positive signal).
+  extractionErrors: number
+  errorEntries: ExtractionError[]
 }
 
 export interface ExtractOptions {
@@ -36,6 +47,12 @@ export interface ExtractOptions {
   // Project tag for the extraction-complete event (ADR-051). Defaults to
   // DEFAULT_PROJECT when omitted.
   project?: string
+  // ADR-065 — when set, drained extraction errors are appended to this
+  // path as ndjson with `source: 'extract'`. Daemons / `neat init` /
+  // `neat watch` wire this to `<projectDir>/neat-out/errors.ndjson`. When
+  // omitted, errors are still drained and returned in the result, just
+  // not persisted.
+  errorsPath?: string
 }
 
 export async function extractFromDirectory(
@@ -44,6 +61,11 @@ export async function extractFromDirectory(
   opts: ExtractOptions = {},
 ): Promise<ExtractResult> {
   await ensureCompatLoaded()
+  // Clear any stale entries from a prior pass (the producer-side sink is
+  // process-local). Per ADR-065, every pass collects its own errors; we drain
+  // again at the end to capture this pass's failures.
+  drainExtractionErrors()
+
   const services = await discoverServices(scanPath)
 
   const phase1Nodes = addServiceNodes(graph, services)
@@ -59,6 +81,20 @@ export async function extractFromDirectory(
   // upgrades that just landed).
   if (opts.onPolicyTrigger) await opts.onPolicyTrigger(graph)
 
+  // ADR-065 — drain the per-file extraction errors collected during the pass.
+  // If a sidecar path was supplied, append the entries; otherwise return them
+  // for the caller to surface.
+  const errorEntries = drainExtractionErrors()
+  if (opts.errorsPath && errorEntries.length > 0) {
+    try {
+      await writeExtractionErrors(errorEntries, opts.errorsPath)
+    } catch (err) {
+      console.warn(
+        `[neat] failed to write extraction errors to ${opts.errorsPath}: ${(err as Error).message}`,
+      )
+    }
+  }
+
   const result: ExtractResult = {
     nodesAdded:
       phase1Nodes +
@@ -69,6 +105,8 @@ export async function extractFromDirectory(
     edgesAdded:
       phase2.edgesAdded + phase3.edgesAdded + phase4.edgesAdded + phase5.edgesAdded,
     frontiersPromoted,
+    extractionErrors: errorEntries.length,
+    errorEntries,
   }
 
   // extraction-complete (ADR-051). fileCount is the number of services

--- a/packages/core/src/extract/infra/docker-compose.ts
+++ b/packages/core/src/extract/infra/docker-compose.ts
@@ -3,6 +3,7 @@ import type { GraphEdge } from '@neat.is/types'
 import { EdgeType, Provenance } from '@neat.is/types'
 import type { NeatGraph } from '../../graph.js'
 import { exists, makeEdgeId, readYaml, type DiscoveredService } from '../shared.js'
+import { recordExtractionError } from '../errors.js'
 import { classifyImage, makeInfraNode } from './shared.js'
 
 interface ComposeService {
@@ -59,8 +60,10 @@ export async function addComposeInfra(
   try {
     compose = await readYaml<ComposeFile>(composePath)
   } catch (err) {
-    console.warn(
-      `[neat] infra docker-compose skipped ${path.relative(scanPath, composePath)}: ${(err as Error).message}`,
+    recordExtractionError(
+      'infra docker-compose',
+      path.relative(scanPath, composePath),
+      err,
     )
     return { nodesAdded, edgesAdded }
   }

--- a/packages/core/src/extract/infra/dockerfile.ts
+++ b/packages/core/src/extract/infra/dockerfile.ts
@@ -4,6 +4,7 @@ import type { GraphEdge } from '@neat.is/types'
 import { EdgeType, Provenance } from '@neat.is/types'
 import type { NeatGraph } from '../../graph.js'
 import { exists, makeEdgeId, type DiscoveredService } from '../shared.js'
+import { recordExtractionError } from '../errors.js'
 import { makeInfraNode } from './shared.js'
 
 // Pull the first non-`scratch` `FROM` line out of a Dockerfile, ignoring
@@ -43,8 +44,10 @@ export async function addDockerfileRuntimes(
     try {
       content = await fs.readFile(dockerfilePath, 'utf8')
     } catch (err) {
-      console.warn(
-        `[neat] infra dockerfile skipped ${path.relative(scanPath, dockerfilePath)}: ${(err as Error).message}`,
+      recordExtractionError(
+        'infra dockerfile',
+        path.relative(scanPath, dockerfilePath),
+        err,
       )
       continue
     }

--- a/packages/core/src/extract/services.ts
+++ b/packages/core/src/extract/services.ts
@@ -14,6 +14,7 @@ import {
 } from './shared.js'
 import { discoverPythonService, pythonToPackage } from './python.js'
 import { computeServiceOwner, loadCodeowners } from './owners.js'
+import { recordExtractionError } from './errors.js'
 
 const DEFAULT_SCAN_DEPTH = 5
 
@@ -126,9 +127,7 @@ async function discoverNodeService(
   try {
     pkg = await readJson<PackageJson>(pkgPath)
   } catch (err) {
-    console.warn(
-      `[neat] services skipped ${path.relative(scanPath, pkgPath)}: ${(err as Error).message}`,
-    )
+    recordExtractionError('services', path.relative(scanPath, pkgPath), err)
     return null
   }
   if (!pkg.name) return null
@@ -182,8 +181,10 @@ export async function discoverServices(scanPath: string): Promise<DiscoveredServ
     try {
       rootPkg = await readJson<RootPackageJson>(rootPkgPath)
     } catch (err) {
-      console.warn(
-        `[neat] services workspaces skipped ${path.relative(scanPath, rootPkgPath)}: ${(err as Error).message}`,
+      recordExtractionError(
+        'services workspaces',
+        path.relative(scanPath, rootPkgPath),
+        err,
       )
     }
   }

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -919,15 +919,73 @@ describe('ServiceNode.owner extraction (ADR-054)', () => {
     }
   })
 
-  it.todo(
-    'ADR-065 — errors.ndjson lines have shape { file, error, stack, ts, source: "extract" } (#239)',
-  )
-  it.todo(
-    'ADR-065 — neat init banner contains "N files skipped due to parse errors" unconditionally (#239)',
-  )
-  it.todo(
-    'ADR-065 — NEAT_STRICT_EXTRACTION=1 makes neat init exit non-zero on any per-file extraction failure (#239)',
-  )
+  it('ADR-065 — errors.ndjson lines have shape { file, error, stack, ts, source: "extract" }', async () => {
+    const { recordExtractionError, drainExtractionErrors, writeExtractionErrors } =
+      await import('../../src/extract/errors.js')
+    const os2 = await import('node:os')
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const tmp = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'adr-065-errors-'))
+    const errorsPath = path2.join(tmp, 'errors.ndjson')
+    const prevWarn = console.warn
+    console.warn = () => {}
+    try {
+      drainExtractionErrors() // clear any prior state
+      // recordExtractionError captures the shape; writeExtractionErrors
+      // serialises it as ndjson with `source: 'extract'`.
+      recordExtractionError('test-producer', '/repo/foo.ts', new Error('boom'))
+      const entries = drainExtractionErrors()
+      await writeExtractionErrors(entries, errorsPath)
+      const raw = await fs2.readFile(errorsPath, 'utf8')
+      const lines = raw.trim().split('\n')
+      expect(lines).toHaveLength(1)
+      const parsed = JSON.parse(lines[0]!) as Record<string, unknown>
+      expect(parsed.file).toBe('/repo/foo.ts')
+      expect(parsed.error).toBe('boom')
+      expect(typeof parsed.stack).toBe('string')
+      expect(typeof parsed.ts).toBe('string')
+      expect(parsed.source).toBe('extract')
+      expect(parsed.producer).toBe('test-producer')
+    } finally {
+      console.warn = prevWarn
+      await fs2.rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('ADR-065 — extraction banner reports a skipped-count phrase unconditionally', async () => {
+    const { formatExtractionBanner } = await import('../../src/extract/errors.js')
+    // Zero is observable as a positive signal — no special-casing.
+    expect(formatExtractionBanner(0)).toBe('[neat] 0 files skipped due to parse errors')
+    expect(formatExtractionBanner(1)).toBe('[neat] 1 file skipped due to parse errors')
+    expect(formatExtractionBanner(92)).toBe('[neat] 92 files skipped due to parse errors')
+    // The CLI summary in cli.ts always logs this — source-grep to make sure
+    // the line stays in place across refactors.
+    const cliSrc = readFileSync(join(CORE_SRC, 'cli.ts'), 'utf8')
+    expect(cliSrc).toMatch(/formatExtractionBanner\(\s*result\.extractionErrors\s*\)/)
+  })
+
+  it('ADR-065 — isStrictExtractionEnabled flips on NEAT_STRICT_EXTRACTION and the CLI exits non-zero on any failure', async () => {
+    const { isStrictExtractionEnabled } = await import('../../src/extract/errors.js')
+    const prev = process.env.NEAT_STRICT_EXTRACTION
+    try {
+      delete process.env.NEAT_STRICT_EXTRACTION
+      expect(isStrictExtractionEnabled()).toBe(false)
+      process.env.NEAT_STRICT_EXTRACTION = '0'
+      expect(isStrictExtractionEnabled()).toBe(false)
+      process.env.NEAT_STRICT_EXTRACTION = '1'
+      expect(isStrictExtractionEnabled()).toBe(true)
+      process.env.NEAT_STRICT_EXTRACTION = 'true'
+      expect(isStrictExtractionEnabled()).toBe(true)
+    } finally {
+      if (prev === undefined) delete process.env.NEAT_STRICT_EXTRACTION
+      else process.env.NEAT_STRICT_EXTRACTION = prev
+    }
+    // The CLI uses isStrictExtractionEnabled() to gate a non-zero exit when
+    // the extract pass reported any per-file failures.
+    const cliSrc = readFileSync(join(CORE_SRC, 'cli.ts'), 'utf8')
+    expect(cliSrc).toMatch(/isStrictExtractionEnabled\(\)/)
+    expect(cliSrc).toMatch(/result\.extractionErrors\s*>\s*0\s*&&\s*isStrictExtractionEnabled/)
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
The v0.3.0 medusa run silently skipped ~90 source files with a generic \`Invalid argument\` from tree-sitter; \`neat init\` exited 0 with no aggregate count and no on-disk record. The thesis surface (\`get_divergences\`) can't be load-bearing while extraction is silently incomplete.

## New module

\`extract/errors.ts\` is the failure-mode plumbing:

- \`ExtractionError\` shape (\`{ producer, file, error, stack, ts, source: 'extract' }\`)
- Process-local sink + \`recordExtractionError(producer, file, err)\` helper that appends and preserves the visible per-file warn line
- \`drainExtractionErrors()\` / \`writeExtractionErrors(entries, path)\`
- \`isStrictExtractionEnabled()\` / \`formatExtractionBanner(count)\`

## Producer changes

Seven \`console.warn(...)\` skip lines swap to \`recordExtractionError(...)\`:

- \`services.ts\` (×2 — per-package, workspaces root)
- \`aliases.ts\` (×2 — compose, dockerfile)
- \`infra/dockerfile.ts\`, \`infra/docker-compose.ts\`
- \`calls/http.ts\`

## Pipeline + CLI

- \`extract/index.ts\` drains the sink at start (clears stale state), runs phases, drains again at end, and appends to \`errorsPath\` when supplied. \`ExtractResult\` gains \`extractionErrors: number\` + \`errorEntries\` so callers can banner / strict-check.
- \`cli.ts\` (\`runInit\`) computes the project's \`errorsPath\` via \`pathsForProject\`, passes it through to \`extractFromDirectory\`, prints the banner unconditionally (\`0\` is a positive signal), and returns exit 4 when \`NEAT_STRICT_EXTRACTION=1\` and \`extractionErrors > 0\`.

## Test scoreboard

Three ADR-065 \`it.todo\`s flip live:

- ✓ \`errors.ndjson\` lines have shape \`{ file, error, stack, ts, source: 'extract' }\`
- ✓ \`formatExtractionBanner\` reports the count unconditionally; \`cli.ts\` logs it
- ✓ \`isStrictExtractionEnabled()\` honours the env var; \`cli.ts\` gates the non-zero exit

\`Static-extraction contract\`: 8 / 8 ADR-065 asserts live, 0 todo.

## End-to-end smoke

Against the NEAT core package itself (still has 1 known tree-sitter "Invalid argument" file):

\`\`\`
=== neat init: summary ===
snapshot: /.../neat-core/neat-out/graph.json
added: 1 nodes, 12 edges
total:  6 nodes, 15 edges
[neat] 1 file skipped due to parse errors
errors:   /.../neat-core/neat-out/errors.neat-core.ndjson
\`\`\`

\`errors.ndjson\` contains the real underlying tree-sitter Parser.parse stack at the call site, not the generic N-API "Invalid argument" alone. With \`NEAT_STRICT_EXTRACTION=1\` the run exits 4 instead of 0.

Refs #239