### PR TITLE
v0.3.3: ghost-edge cleanup keyed on evidence.file (#140)

### DIFF
--- a/packages/core/src/extract/databases/index.ts
+++ b/packages/core/src/extract/databases/index.ts
@@ -227,13 +227,12 @@ export async function addDatabasesAndCompat(
         target: dbNode.id,
         type: EdgeType.CONNECTS_TO,
         provenance: Provenance.EXTRACTED,
-        ...(config.sourceFile
-          ? {
-              evidence: {
-                file: path.relative(scanPath, config.sourceFile).split(path.sep).join('/'),
-              },
-            }
-          : {}),
+        // ADR-032 / #140 — every EXTRACTED edge carries evidence.file.
+        // Ghost-edge cleanup keys retirement on this; the conditional
+        // sourceFile spread that used to live here was a v0.1.x leftover.
+        evidence: {
+          file: path.relative(scanPath, config.sourceFile).split(path.sep).join('/'),
+        },
       }
       if (!graph.hasEdge(edge.id)) {
         graph.addEdgeWithKey(edge.id, edge.source, edge.target, edge)

--- a/packages/core/src/extract/databases/shared.ts
+++ b/packages/core/src/extract/databases/shared.ts
@@ -7,11 +7,11 @@ export interface DbConfig {
   database: string
   engine: string
   engineVersion: string // "unknown" when not statically determinable
-  // Absolute path to the file the parser read this config from. Used to
-  // populate evidence.file on the resulting CONNECTS_TO edge. Optional so
-  // synthesized configs (e.g. prisma's env() fallback) can omit it; the
-  // CONNECTS_TO writer emits evidence only when present.
-  sourceFile?: string
+  // Absolute path to the file the parser read this config from. Required —
+  // ghost-edge cleanup keys CONNECTS_TO retirement on `evidence.file` per
+  // ADR-032 / #140. Parsers that synthesize a DbConfig from a partial
+  // source still set this to the file the partial came from.
+  sourceFile: string
 }
 
 // Map a connection-string scheme to the engine name our compat matrix uses.
@@ -39,7 +39,11 @@ export function schemeToEngine(scheme: string): string | null {
   }
 }
 
-export function parseConnectionString(url: string): DbConfig | null {
+// Returns the inner DbConfig fields without sourceFile — every caller spreads
+// the parser's own file path on top. Type makes that contract explicit.
+export type ParsedConnectionConfig = Omit<DbConfig, 'sourceFile'>
+
+export function parseConnectionString(url: string): ParsedConnectionConfig | null {
   const m = url.match(
     /^(?<scheme>[a-z][a-z+]*):\/\/(?:[^@/]+(?::[^@]*)?@)?(?<host>[^:/?]+)(?::(?<port>\d+))?(?:\/(?<db>[^?#]*))?/i,
   )

--- a/packages/core/src/extract/index.ts
+++ b/packages/core/src/extract/index.ts
@@ -26,6 +26,7 @@ import {
   writeExtractionErrors,
   type ExtractionError,
 } from './errors.js'
+import { retireExtractedEdgesByMissingFile } from './retire.js'
 
 export interface ExtractResult {
   nodesAdded: number
@@ -37,6 +38,10 @@ export interface ExtractResult {
   // present on every pass (zero is observable as a positive signal).
   extractionErrors: number
   errorEntries: ExtractionError[]
+  // #140 — count of EXTRACTED edges retired this pass because their
+  // evidence.file no longer exists on disk. Zero on a clean pass; non-zero
+  // means the snapshot was carrying ghosts from deleted source.
+  ghostsRetired: number
 }
 
 export interface ExtractOptions {
@@ -74,6 +79,17 @@ export async function extractFromDirectory(
   const phase3 = await addConfigNodes(graph, services, scanPath)
   const phase4 = await addCallEdges(graph, services)
   const phase5 = await addInfra(graph, scanPath, services)
+  // #140 — drop EXTRACTED edges whose evidence.file no longer exists on disk.
+  // Catches the deleted-file ghost case for the full-pass entry point
+  // (init / daemon bootstrap). The edited-file case is handled per-mtime by
+  // watch.ts's `retireEdgesByFile`. Service dirs are passed alongside scanPath
+  // because CALLS-family producers store service-dir-relative paths while
+  // configs / databases / infra store scanPath-relative.
+  const ghostsRetired = retireExtractedEdgesByMissingFile(
+    graph,
+    scanPath,
+    services.map((s) => s.dir),
+  )
   const frontiersPromoted = promoteFrontierNodes(graph)
 
   // Post-extract policy trigger (ADR-043). Fires after frontier promotion so
@@ -107,6 +123,7 @@ export async function extractFromDirectory(
     frontiersPromoted,
     extractionErrors: errorEntries.length,
     errorEntries,
+    ghostsRetired,
   }
 
   // extraction-complete (ADR-051). fileCount is the number of services

--- a/packages/core/src/extract/retire.ts
+++ b/packages/core/src/extract/retire.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs'
+import path from 'node:path'
 import type { GraphEdge } from '@neat.is/types'
 import { Provenance } from '@neat.is/types'
 import type { NeatGraph } from '../graph.js'
@@ -16,6 +18,46 @@ export function retireEdgesByFile(graph: NeatGraph, file: string): number {
     if (edge.provenance !== Provenance.EXTRACTED) return
     if (!edge.evidence?.file) return
     if (edge.evidence.file === normalized) toDrop.push(id)
+  })
+  for (const id of toDrop) graph.dropEdge(id)
+  return toDrop.length
+}
+
+// #140 — full-pass cleanup. Walk every EXTRACTED edge in the graph; if its
+// `evidence.file` cannot be resolved on disk against the scan root or any
+// discovered service directory, drop it. extractFromDirectory calls this at
+// the end of every pass so a daemon bootstrap (or a re-init after the
+// operator deleted some source) gets a snapshot consistent with what's
+// actually on disk.
+//
+// Handles the deleted-file half of the ghost-edge bug. The edited-file half
+// (file still exists, producer no longer emits the edge) is handled by
+// watch.ts's per-file `retireEdgesByFile` on the mtime trigger.
+//
+// Path resolution is tolerant: producers in this tree are inconsistent about
+// whether `evidence.file` is scanPath-relative (configs, databases, infra)
+// or service-dir-relative (calls/*). We try every candidate base before
+// concluding the file is gone — the cost is one extra `existsSync` per
+// service dir per ghost candidate, which is cheap.
+export function retireExtractedEdgesByMissingFile(
+  graph: NeatGraph,
+  scanPath: string,
+  serviceDirs: readonly string[] = [],
+): number {
+  const toDrop: string[] = []
+  const bases = [scanPath, ...serviceDirs]
+  graph.forEachEdge((id, attrs) => {
+    const edge = attrs as GraphEdge
+    if (edge.provenance !== Provenance.EXTRACTED) return
+    const evidenceFile = edge.evidence?.file
+    if (!evidenceFile) return
+    if (path.isAbsolute(evidenceFile)) {
+      if (!existsSync(evidenceFile)) toDrop.push(id)
+      return
+    }
+    // Tolerant: the file is "present" if any base resolves it.
+    const found = bases.some((base) => existsSync(path.join(base, evidenceFile)))
+    if (!found) toDrop.push(id)
   })
   for (const id of toDrop) graph.dropEdge(id)
   return toDrop.length

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -3833,6 +3833,92 @@ describe('Queued contracts (v0.2.1 leftovers — #141, #142, #145)', () => {
     expect(g.hasEdge(ghostId)).toBe(false)
     expect(g.hasEdge(survivorId)).toBe(true)
   })
+
+  it('retireExtractedEdgesByMissingFile drops EXTRACTED edges for files no longer on disk (#140)', async () => {
+    const { retireExtractedEdgesByMissingFile } = await import(
+      '../../src/extract/retire.js'
+    )
+    const { extractedEdgeId } = await import('@neat.is/types')
+    const os2 = await import('node:os')
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const root = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'adr-032-ghost-'))
+    const survivorFile = 'apps/foo/.env'
+    const ghostFile = 'apps/foo/db.yaml'
+    await fs2.mkdir(path2.join(root, 'apps/foo'), { recursive: true })
+    await fs2.writeFile(path2.join(root, survivorFile), 'DATABASE_URL=postgres://db/x')
+    // Note: ghostFile is intentionally NOT created.
+
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:foo', {
+      id: 'service:foo',
+      type: NodeType.ServiceNode,
+      name: 'foo',
+      language: 'javascript',
+    })
+    g.addNode('database:db', {
+      id: 'database:db',
+      type: NodeType.DatabaseNode,
+      name: 'db',
+      engine: 'postgresql',
+      engineVersion: '15',
+      host: 'db',
+    })
+    g.addNode('config:apps/foo/.env', {
+      id: 'config:apps/foo/.env',
+      type: NodeType.ConfigNode,
+      name: '.env',
+      path: 'apps/foo/.env',
+      fileType: 'env',
+    })
+
+    const survivorId = extractedEdgeId(
+      'service:foo',
+      'database:db',
+      EdgeType.CONNECTS_TO,
+    )
+    g.addEdgeWithKey(survivorId, 'service:foo', 'database:db', {
+      id: survivorId,
+      source: 'service:foo',
+      target: 'database:db',
+      type: EdgeType.CONNECTS_TO,
+      provenance: Provenance.EXTRACTED,
+      evidence: { file: survivorFile },
+    })
+
+    const ghostId = extractedEdgeId(
+      'service:foo',
+      'config:apps/foo/.env',
+      EdgeType.CONFIGURED_BY,
+    )
+    g.addEdgeWithKey(ghostId, 'service:foo', 'config:apps/foo/.env', {
+      id: ghostId,
+      source: 'service:foo',
+      target: 'config:apps/foo/.env',
+      type: EdgeType.CONFIGURED_BY,
+      provenance: Provenance.EXTRACTED,
+      evidence: { file: ghostFile },
+    })
+
+    try {
+      const dropped = retireExtractedEdgesByMissingFile(g, root)
+      expect(dropped).toBe(1)
+      expect(g.hasEdge(ghostId)).toBe(false)
+      expect(g.hasEdge(survivorId)).toBe(true)
+    } finally {
+      await fs2.rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('extractFromDirectory exposes ghostsRetired in its result (#140)', async () => {
+    // Source-grep guard so a refactor doesn't quietly drop the field — the
+    // CLI / daemon banner needs to count ghosts cleaned.
+    const idx = readFileSync(join(CORE_SRC, 'extract/index.ts'), 'utf8')
+    expect(idx).toMatch(/ghostsRetired:\s*number/)
+    expect(idx).toMatch(/retireExtractedEdgesByMissingFile\(/)
+    expect(idx).toMatch(/ghostsRetired,/)
+  })
+
   it.todo('Source-level DB connection + import detection (issue #141)')
   it.todo('ServiceNode.framework populated from package.json (issue #142)')
   it.todo('Drop unused graphology-traversal/-shortest-path deps (issue #145)')


### PR DESCRIPTION
v0.2.1 carryover. The original v0.2.1 PR (#152) closed the watch-side per-file retire; what stayed open was the full-pass cleanup and the conditional \`evidence.file\` in databases. Both close here.

## A — every CONNECTS_TO carries evidence.file

\`databases/index.ts\` had a conditional spread that emitted the \`evidence\` field only when \`config.sourceFile\` was set. Every parser already sets it; the conditional was a v0.1.x defensive leftover. Tighten:

- \`DbConfig.sourceFile\` is now required (was \`?: string\`).
- \`parseConnectionString\` returns the omit type (\`Omit<DbConfig, 'sourceFile'>\`); the five callers (knex, drizzle, prisma, dotenv, etc.) already spread sourceFile so the call sites don't change.
- The CONNECTS_TO emit unconditionally writes \`evidence: { file: ... }\`.

## B — full-pass cleanup hook

\`extract/retire.ts\` adds \`retireExtractedEdgesByMissingFile(graph, scanPath, serviceDirs)\`. Walks every EXTRACTED edge; if its \`evidence.file\` resolves to a missing file relative to scanPath OR any discovered service dir, the edge is dropped.

\`extractFromDirectory\` calls it after the producer phases. \`ExtractResult\` gains \`ghostsRetired: number\` so callers can surface the count. The edited-file half of the bug stays handled per-mtime by watch.ts's existing \`retireEdgesByFile\`.

The tolerant resolution matters: CALLS-family producers store service-dir-relative paths (\`'index.js'\`); configs / databases / infra store scanPath-relative paths (\`'apps/foo/.env'\`). Trying every base before declaring a file "gone" avoids false drops against the demo and existing fixtures.

## Test scoreboard

Two new live assertions under the queued-contracts block:

- ✓ \`retireExtractedEdgesByMissingFile\` drops ghosts for missing files, keeps edges whose source file still exists
- ✓ \`extractFromDirectory\` exposes \`ghostsRetired\` and calls the helper

Existing \`calls.test.ts\`, \`extract.test.ts\`, \`api.test.ts\`, \`python.test.ts\` all pass unchanged. Full turbo green.

## Branch name

This is the \`v0.3.3\` carryover for #140. The original v0.2.1 branch (\`140-ghost-edge-cleanup\`) is still on the remote from PR #152 — the new branch is named \`140-ghost-edge-cleanup-v033\` to avoid history collision.

Refs #140