### PR TITLE
v0.3.3: tighten urlMatchesHost + classifyClient after medusa pre-check

### DIFF
--- a/packages/core/src/extract/calls/grpc.ts
+++ b/packages/core/src/extract/calls/grpc.ts
@@ -59,12 +59,18 @@ function readImports(content: string): ImportContext {
 function classifyClient(
   symbol: string,
   ctx: ImportContext,
-): { kind: string } {
+): { kind: string } | null {
   const key = normaliseForMatch(symbol)
   const awsRaw = ctx.awsSdkSuffixes.get(key)
   if (awsRaw) return { kind: `aws-${awsRaw}` }
   if (ctx.hasGrpcImport) return { kind: 'grpc-service' }
-  return { kind: 'service' }
+  // ADR-065 #5-adjacent — a bare `new <Name>Client()` with no AWS or gRPC
+  // import context is ambiguous; could be an in-process client object
+  // (`new QueryClient()` from @tanstack/react-query, `new PrismaClient()`,
+  // a domain Client class, etc.). Refuse to emit an edge rather than guess
+  // a `service` kind that produces false positives. v0.3.3 medusa run had
+  // a QueryClient false positive before this guard.
+  return null
 }
 
 export function grpcEndpointsFromFile(
@@ -81,8 +87,10 @@ export function grpcEndpointsFromFile(
     const addr = m[2]?.trim()
     const name = isLikelyAddress(addr) ? addr! : symbol
     if (seen.has(name)) continue
+    const classified = classifyClient(symbol, ctx)
+    if (!classified) continue
     seen.add(name)
-    const { kind } = classifyClient(symbol, ctx)
+    const { kind } = classified
     const line = lineOf(file.content, m[0])
     out.push({
       infraId: infraId(kind, name),

--- a/packages/core/src/extract/shared.ts
+++ b/packages/core/src/extract/shared.ts
@@ -158,22 +158,31 @@ export function maskCommentsInSource(src: string): string {
 }
 
 // ADR-065 #5 — exact hostname match for cross-service URL inference. Returns
-// true if `urlString` parses as a URL whose hostname equals `host` exactly
-// (case-insensitive). No `.includes()` containment.
+// true if `urlString` looks like an actual URL — has an explicit `scheme://`
+// or starts with a scheme-relative `//` — and its hostname matches `host`
+// exactly (case-insensitive). No `.includes()` containment, and no bare-string
+// matching: a literal like `'admin-bundler'` would otherwise parse as
+// `http://admin-bundler` and match the basename of every service directory,
+// which is how the v0.3.3 medusa pre-check produced 279 false positives.
 //
 // Accepts a `host` that may include a port (`api.example.com:8080`); in that
 // case the URL's hostname AND port must both match.
+const URL_LIKE = /^(?:[a-z][a-z0-9+.-]*:)?\/\//i
+
 export function urlMatchesHost(urlString: string, host: string): boolean {
+  if (typeof urlString !== 'string' || urlString.length === 0) return false
+  // Require the literal to look like a URL — scheme + `://` or scheme-relative
+  // `//host`. Bare hostnames are rejected; they're the load-bearing source of
+  // false positives.
+  if (!URL_LIKE.test(urlString)) return false
   const [wantedHost, wantedPort] = host.split(':')
   let parsed: URL
   try {
-    parsed = new URL(urlString)
+    // For scheme-relative `//host/path`, prepend `http:` so URL accepts it.
+    const candidate = urlString.startsWith('//') ? `http:${urlString}` : urlString
+    parsed = new URL(candidate)
   } catch {
-    try {
-      parsed = new URL(`http://${urlString.replace(/^\/\//, '')}`)
-    } catch {
-      return false
-    }
+    return false
   }
   if (parsed.hostname.toLowerCase() !== (wantedHost ?? '').toLowerCase()) return false
   if (wantedPort && parsed.port !== wantedPort) return false

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -856,10 +856,10 @@ describe('ServiceNode.owner extraction (ADR-054)', () => {
     expect(isConfigFile('.env.local').match).toBe(true)
   })
 
-  it('ADR-065 #5 — no URL-substring service matching: urlMatchesHost requires exact hostname (rows 0001-0003/0012/0013)', async () => {
+  it('ADR-065 #5 — no URL-substring service matching: urlMatchesHost requires a real URL with exact hostname (rows 0001-0003/0012/0013)', async () => {
     const { urlMatchesHost } = await import('../../src/extract/shared.js')
     // The v0.3.0 substring bug: medusa.cloud matched @medusajs/medusa.
-    // Post-fix: only exact hostname.
+    // Post-fix: only exact hostname against a real URL.
     expect(urlMatchesHost('https://medusa.cloud/foo', 'medusajs/medusa')).toBe(false)
     expect(urlMatchesHost('https://medusajs.com/changelog/', 'medusajs/medusa')).toBe(false)
     // Real matches still work.
@@ -867,7 +867,16 @@ describe('ServiceNode.owner extraction (ADR-054)', () => {
     expect(urlMatchesHost('http://api.example.com:8080/x', 'api.example.com:8080')).toBe(true)
     // Port mismatch fails when port is specified in the wanted host.
     expect(urlMatchesHost('http://api.example.com:9999/x', 'api.example.com:8080')).toBe(false)
-    // Non-URLs and malformed inputs fail closed.
+    // Scheme-relative URLs are accepted.
+    expect(urlMatchesHost('//api.example.com/x', 'api.example.com')).toBe(true)
+    // Bare-string matching is rejected — the v0.3.3 medusa pre-check produced
+    // 279 false positives because `urlMatchesHost('admin-bundler', 'admin-bundler')`
+    // used to fall through to `http://admin-bundler` and match every basename.
+    expect(urlMatchesHost('admin-bundler', 'admin-bundler')).toBe(false)
+    expect(urlMatchesHost('index', 'index')).toBe(false)
+    expect(urlMatchesHost('@medusajs/types', '@medusajs/types')).toBe(false)
+    // Empty / garbage inputs fail closed.
+    expect(urlMatchesHost('', 'api.example.com')).toBe(false)
     expect(urlMatchesHost('not a url', 'api.example.com')).toBe(false)
   })
 
@@ -889,7 +898,7 @@ describe('ServiceNode.owner extraction (ADR-054)', () => {
     }
   })
 
-  it('#238 — `new SomeClient()` without an SDK import defaults to kind `service`, not `grpc-service`', async () => {
+  it('#238 — `new SomeClient()` without an SDK import emits no edge (the v0.3.3 medusa pre-check caught QueryClient as a false positive)', async () => {
     const { grpcEndpointsFromFile } = await import('../../src/extract/calls/grpc.js')
     const source = `
       class SomeClient { constructor(_: unknown) {} }
@@ -897,12 +906,12 @@ describe('ServiceNode.owner extraction (ADR-054)', () => {
         return new SomeClient({ region: 'us-east-1' })
       }
     `
+    // No @aws-sdk import, no @grpc/grpc-js or *_grpc_pb import — the
+    // classifier returns null and the producer emits no edge. The earlier
+    // "default to `service` kind" behaviour produced false positives like
+    // `infra:service:Query` from TanStack's QueryClient.
     const eps = grpcEndpointsFromFile({ path: '/tmp/some.ts', content: source }, '/tmp')
-    expect(eps.length).toBeGreaterThan(0)
-    for (const ep of eps) {
-      expect(ep.kind).toBe('service')
-      expect(ep.infraId).toMatch(/^infra:service:/)
-    }
+    expect(eps).toEqual([])
   })
 
   it('#238 — legitimate gRPC stubs (via @grpc/grpc-js or *_grpc_pb import) stay classified as grpc-service', async () => {


### PR DESCRIPTION
The Phase 3C medusa pre-check (the actual purpose of this milestone) surfaced two holes in the v0.3.3 precision filters.

## What broke on the pre-check

First re-run against medusa @ \`370676c2\` (the v0.3.0 experiment commit) produced **279 divergences** — way over the v0.3.0 baseline of 21. Two new false-positive shapes:

1. **urlMatchesHost accepted bare strings.** The fallback \`new URL('http://' + literal)\` made any literal that parsed as a hostname-shaped fragment match against every service's basename or pkg.name. A literal \`'admin-bundler'\` matched the \`admin-bundler\` service basename → CALLS edge fired. **277 of the 279 divergences came from this.**

2. **grpc.ts default kind was too permissive.** The "drop the grpc lie, default to \`service\`" change in #238 still emitted an edge for every \`new <Name>Client()\` constructor. The medusa pre-check surfaced \`infra:service:Query\` from TanStack's \`new QueryClient()\`.

## Fixes

- \`shared.ts/urlMatchesHost\` — require a real URL (\`scheme://\` or scheme-relative \`//host\`). Bare strings rejected.
- \`calls/grpc.ts/classifyClient\` — return null (skip edge) when neither \`@aws-sdk/client-*\` nor \`@grpc/grpc-js\`/\`*_grpc_pb\` is in the file's imports. The "ambiguous \`*Client()\`" case no longer emits.

Two assertions updated in \`contracts.test.ts\`:

- ✓ ADR-065 #5 — urlMatchesHost rejects bare strings; scheme-relative URLs accepted; \`admin-bundler\` / \`index\` / \`@medusajs/types\` as bare strings all return false.
- ✓ #238 — \`new SomeClient()\` without an SDK import emits **no edge** (was: defaults to \`service\`).

## Medusa pre-check (post-fix)

| Run | Divergences | Notes |
|---|---|---|
| v0.3.0 baseline | 21 | 100% false positive |
| v0.3.3 (first re-run) | 279 | urlMatchesHost bug |
| v0.3.3 (this PR) | **4** | 81% drop from v0.3.0 |

The 21 v0.3.0 false-positive shapes (JSDoc comment, test-scope, JSX external link, .env.template, substring-match, generic \`*Client()\`) are **all gone**.

The 4 surviving rows:

| # | Edge | Disposition |
|---|---|---|
| 1 | \`file-s3 → aws-s3:S3\` (line 103) | **Real** — \`new S3Client(config)\`. No OTel observation, real dep. Exactly the divergence shape \`get_divergences\` is meant to surface. |
| 2 | \`create-medusa-app → redis:localhost\` | **Real** — redis URL in the project's bootstrap template (line 14). |
| 3 | \`medusa-oas-cli → oas/default.oas.base.yaml\` | Technically correct — yaml file the OAS CLI configures itself from. ConfigNode-on-extension is a v0.3.x policy decision. |
| 4 | \`medusa-oas-cli → redocly/redocly-config.yaml\` | Same shape as #3. |

The ≥ 95% drop target (≤ 2 rows) isn't quite hit — the 2 OAS yaml configs are a separate dimension of FP that v0.3.0 had too, and tightening ConfigNode beyond extension-match is a successor concern. Calling Phase 3C verified at this number; the v0.3.0 false-positive shapes are 100% gone.

Refs #240