### PR TITLE
v0.3.4 contract: ADR-066 — OBSERVED-led divergence query weighting

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -11,7 +11,7 @@ This file is the index. Each rule has a short summary and a link to its full per
 | # | Contract | File | Governs | Status |
 |---|----------|------|---------|--------|
 | 1 | Node identity | [`contracts/identity.md`](./contracts/identity.md) | Node ids constructed via `@neat.is/types/identity` helpers, never literals (ADR-028) | ✅ landed |
-| 2 | Edge identity + provenance | [`contracts/provenance.md`](./contracts/provenance.md) | Edge id wire format per provenance, `PROV_RANK` ordering, coexistence, confidence semantics (ADR-029) | ✅ landed |
+| 2 | Edge identity + provenance | [`contracts/provenance.md`](./contracts/provenance.md) | Edge id wire format per provenance, `PROV_RANK` ordering, coexistence, graded confidence per tier (ADR-029 + ADR-066) | ✅ landed (graded confidence amended v0.3.4) |
 | 3 | Node + edge lifecycle | [`contracts/lifecycle.md`](./contracts/lifecycle.md) | Creation, transition, retirement. Mutation authority locked to `ingest.ts` and `extract/*` (ADR-030) | ✅ landed |
 | 4 | Schema growth vs shape | [`contracts/schema.md`](./contracts/schema.md) | Growth = commit-and-go (snapshot diff). Shape change = ADR + `persist.ts` migration (ADR-031) | ✅ landed |
 | 5 | Static extraction | [`contracts/static-extraction.md`](./contracts/static-extraction.md) | Producer interface, evidence on every EXTRACTED edge, ghost-edge cleanup keyed on `evidence.file`, language dispatch, idempotency, five precision filters (test-scope / comment-body / JSX-link / .env.template / no-substring-matching), loud failure mode via errors.ndjson + banner + NEAT_STRICT_EXTRACTION (ADR-032 + ADR-065) | ✅ landed (v0.2.1 opens; precision + loud-failure amended v0.3.3) |
@@ -39,7 +39,7 @@ This file is the index. Each rule has a short summary and a link to its full per
 | 27 | Web shell multi-project routing | [`contracts/web-multi-project.md`](./contracts/web-multi-project.md) | AppShell owns project state; URL → localStorage → /projects → 'default' resolution chain; project change triggers data refresh; no hardcoded project names; AppShell mounts client-only via `dynamic({ ssr: false })` (ADR-057 + ADR-062) | ✅ landed (Track 1 frontend) |
 | 28 | Web shell debugging surface | [`contracts/web-debugging.md`](./contracts/web-debugging.md) | StatusBar shows daemon + SSE connection state; no silent API failures; debug panel toggleable via Ctrl+Shift+D; read-only (ADR-058) | ✅ landed (Track 1 frontend) |
 | 29 | Web UI bootstrap from neatd | [`contracts/web-bootstrap.md`](./contracts/web-bootstrap.md) | `neatd start` launches the web UI on port 6328 (T9 NEAT); `NEAT_WEB_PORT` overrides; fail-loud on collision; `@neat.is/web` joins the lockstep (ADR-059) | ✅ landed (Track 1 frontend) |
-| 30 | Divergence query | [`contracts/divergence-query.md`](./contracts/divergence-query.md) | `get_divergences` as a first-class graph operation across REST + MCP + CLI; five divergence types; read-only; derived not persisted; amends ADR-039 + ADR-050 allowlists from nine to ten (ADR-060) | ✅ landed (the thesis surface; we waited until the end) |
+| 30 | Divergence query | [`contracts/divergence-query.md`](./contracts/divergence-query.md) | `get_divergences` as a first-class graph operation across REST + MCP + CLI; five divergence types; read-only; derived not persisted; OBSERVED-led weighting + graded EXTRACTED/OBSERVED confidence + precision floor at emit (ADR-060 + ADR-066) | ✅ landed (OBSERVED-led weighting amended v0.3.4) |
 
 ### Future contracts — opened at the start of each milestone
 

--- a/docs/contracts/divergence-query.md
+++ b/docs/contracts/divergence-query.md
@@ -8,7 +8,7 @@ governs:
   - "packages/core/src/cli.ts"
   - "packages/core/src/cli-client.ts"
   - "packages/mcp/src/index.ts"
-adr: [ADR-060, ADR-029, ADR-039, ADR-050, ADR-027]
+adr: [ADR-060, ADR-066, ADR-029, ADR-039, ADR-050, ADR-027, ADR-061]
 ---
 
 # Divergence query contract
@@ -32,8 +32,8 @@ Computed against the live graph at request time. No persistence; pure derivation
 
 | Type | Detection | Confidence |
 |---|---|---|
-| `missing-observed` | EXTRACTED edge exists; no OBSERVED edge for the same `(source, target, edgeType)` triple | `1.0` if any traffic observed on source else `0.5` |
-| `missing-extracted` | OBSERVED edge exists; no EXTRACTED edge for the same triple | cascaded from OBSERVED edge confidence |
+| `missing-observed` | EXTRACTED edge exists; no OBSERVED edge for the same `(source, target, edgeType)` triple | weighted by the EXTRACTED edge's graded confidence (ADR-066) |
+| `missing-extracted` | OBSERVED edge exists; no EXTRACTED edge for the same triple | cascaded from the OBSERVED edge's graded confidence (ADR-066) |
 | `version-mismatch` | ServiceNode has declared dependency version; OBSERVED edge to a DatabaseNode (or similar) with incompatible engineVersion per compat.json | `1.0` (compat rule definitive) |
 | `host-mismatch` | EXTRACTED CONFIGURED_BY edge points at a config declaring host X; OBSERVED CONNECTS_TO target's host is Y | cascaded from CONNECTS_TO confidence |
 | `compat-violation` | Any compat.json rule fires against an OBSERVED edge (broader than version mismatch) | rule-determined |
@@ -103,9 +103,17 @@ No `divergences.ndjson` sidecar. Each query computes fresh against the live grap
 
 `packages/core/src/divergences.ts` exports `computeDivergences(graph: NeatGraph, opts?: DivergenceQueryOpts): DivergenceResult`. Pure function: no I/O, no mutation, no async. Operates entirely on the in-memory graph reference.
 
-### 5. Sorted by confidence
+### 5. Sorted by confidence; OBSERVED-led ties
 
-Default order is `confidence` descending. Consumer can re-sort. No type-specific severity weights in the contract.
+Default order is `confidence` descending. When confidence ties, `missing-extracted` orders ahead of `missing-observed` so the OBSERVED-led finding leads at the same confidence (ADR-066 §4). Consumer can re-sort.
+
+### 5a. Weighting (ADR-066)
+
+The five divergence types are not symmetric peers. `missing-extracted` is the headline finding type — OBSERVED found an edge that static analysis missed, and that gap is exactly what NEAT's thesis surface exists to surface. `missing-observed` is weighted by the EXTRACTED edge's graded confidence; sub-floor heuristic candidates never enter the graph in the first place (per the static-extraction contract's precision floor), so what surfaces is backed by structural or verified-call-site evidence. `version-mismatch`, `host-mismatch`, and `compat-violation` retain their existing weighting because both sides are specific about a versioned or hostname-identified entity.
+
+### 5b. Envelope (ADR-061)
+
+`/graph/divergences` is a structured-result endpoint per ADR-061 §2 b — it returns the documented `DivergenceResultSchema` shape (`{ divergences, totalAffected, computedAt }`) on snapshot-load, zero-result, and live-state paths at both mount points (default + project-scoped). No `null`, no bare values. The contract scan asserts the shape end-to-end.
 
 ### 6. Allowlist amendments are explicit
 
@@ -123,7 +131,17 @@ The frontend surfaces for this query are real and several — `/divergences` pag
 - **MCP surface:** `packages/mcp/src/index.ts` — register tenth tool, route via REST client
 - **CLI surface:** `packages/core/src/cli.ts` + `packages/core/src/cli-client.ts` — register tenth verb, plumb through
 
-## Enforcement
+## Enforcement (ADR-066 additions)
+
+New live assertions in the `Divergence query (ADR-060)` describe block of `contracts.test.ts`:
+
+- `missing-extracted` orders ahead of `missing-observed` at the same confidence grade.
+- `missing-observed` rows whose EXTRACTED edge graded below the precision floor never enter the graph, and therefore never appear in `computeDivergences` output.
+- `/graph/divergences` returns `DivergenceResultSchema` on snapshot-load (graph reconstructed from `graph.json`), zero-result (no divergences detected), and live-state paths — at both mount points.
+
+Initial entries are `it.todo` in the contract PR; they flip live in the v0.3.4 implementation PRs.
+
+## Enforcement (ADR-060 baseline)
 
 `it.todo` block in `contracts.test.ts` for ADR-060:
 

--- a/docs/contracts/provenance.md
+++ b/docs/contracts/provenance.md
@@ -9,7 +9,7 @@ governs:
   - "packages/types/src/identity.ts"
   - "packages/types/src/edges.ts"
   - "packages/types/src/constants.ts"
-adr: [ADR-029, ADR-024, ADR-027]
+adr: [ADR-029, ADR-024, ADR-027, ADR-066]
 ---
 
 # Provenance contract
@@ -80,19 +80,21 @@ Frozen object. Consumers import it; nobody re-defines it locally. Traversal uses
 
 FRONTIER ranks 0 alongside STALE for the case where it ends up in a comparison set, but [contracts.md Rule 3](../contracts.md#3-frontier-edges-are-not-traversed) says traversal must skip FRONTIER edges entirely — so this rank is rarely consulted for FRONTIER in practice.
 
-## Confidence semantics per provenance
+## Confidence semantics per provenance (ADR-066)
 
-- **OBSERVED** — `confidence: 1.0` always. Direct measurement; the value is a max-trust marker, not a derived score.
-- **INFERRED** — `confidence ≤ 0.7`, default `0.6` (`INFERRED_CONFIDENCE` in `ingest.ts`). Set at creation by the trace stitcher; never exceeds 0.7.
-- **EXTRACTED** — confidence is **not stored**. EXTRACTED edges either exist (the static analyzer found them) or they don't. They don't decay on a clock; their confidence is implicit.
+PROV_RANK still locks tier ordering — OBSERVED outranks INFERRED outranks EXTRACTED outranks STALE | FRONTIER. The grading below sits *within* each tier so the divergence query (ADR-060 / ADR-066) can reweight against honest values, not flat coarse ones.
+
+- **OBSERVED** — graded by the `signal` block at ingest. `spanCount >= 100` plus `lastObservedAgeMs < 1h` grades `0.95–1.0`; `spanCount 10–99` recent grades `0.7–0.9`; `spanCount < 10` recent grades `0.4–0.6` (a single span could be a misconfig). `errorCount / spanCount > 0` subtracts up to `0.2` for degraded edges. The grading helper lives in `@neat.is/types/confidence.ts`; `upsertObservedEdge` calls it at the same point it writes `signal`.
+- **INFERRED** — `confidence ≤ 0.7`, default `0.6` (`INFERRED_CONFIDENCE` in `ingest.ts`). Set at creation by the trace stitcher; never exceeds `0.7`.
+- **EXTRACTED** — graded at emit time per extractor. Structural file facts (imports, package.json deps, Dockerfile `RUNS_ON`, ConfigNode existence per ADR-016) and verified call sites (framework-aware recognizer matched) grade `0.85`. String-shaped candidates with structural support grade `0.5`. String-shaped candidates without structural support grade `0.2` and are dropped at emit by the precision floor (`NEAT_EXTRACTED_PRECISION_FLOOR`, default `0.7`) before they reach the graph. The grading helper in `@neat.is/types/confidence.ts` is the single source of truth; per-extractor code imports it rather than hand-rolling values.
 - **STALE** — confidence drops to `≤ 0.3` on transition; original `lastObserved` preserved.
 - **FRONTIER** — confidence not stored as a numeric field. FRONTIER is excluded from traversal so its confidence is never compared.
 
 ## Required fields per provenance
 
-- **OBSERVED:** `lastObserved` (ISO8601), `callCount`, `confidence: 1.0`.
+- **OBSERVED:** `lastObserved` (ISO8601), `callCount`, `signal: { spanCount, errorCount, lastObservedAgeMs }`, graded `confidence` in `[0, 1]` per the OBSERVED grading function.
 - **INFERRED:** `confidence` (0.0–0.7).
-- **EXTRACTED:** `evidence: { file, line?, snippet? }` for CALLS-family edges; broader evidence shapes for other edge types are pending the v0.2.1 tree-sitter rebuild (issue #140).
+- **EXTRACTED:** `evidence: { file, line?, snippet? }` for CALLS-family edges; broader evidence shapes for other edge types are pending the v0.2.1 tree-sitter rebuild (issue #140). Graded `confidence` in `[0, 1]` per the EXTRACTED grading function — flat-`0.5` emissions are a contract violation (ADR-066).
 - **STALE:** `lastObserved` preserved from the OBSERVED state, `confidence ≤ 0.3`.
 - **FRONTIER:** `lastObserved` (ISO8601 of the span that revealed the unresolved peer).
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2188,3 +2188,97 @@ The assertions land as `it.todo` in this PR (Phase 3A — contract only) and fli
 - **Tree-sitter upgrade or grammar swap to fix the "Invalid argument" cause.** The loud failure mode surfaces the failures; the underlying parser fix lives in the implementation PR (#239) and may end up as an upstream issue against `tree-sitter-typescript` if the cause is in the grammar.
 
 Full rationale and the v0.3.0 failure-mode evidence: `~/neat-experiment/bugs/NEAT-BUG-4-ghost-edges-from-strings.md`, `~/neat-experiment/bugs/NEAT-BUG-6-http-extraction-invalid-argument.md`, `~/neat-experiment/bugs/INDEX.md`.
+
+## ADR-066 — OBSERVED-led divergence query weighting + graded confidence
+
+**Date:** 2026-05-15
+**Status:** Active. Amends ADR-029 (provenance confidence semantics), ADR-060 (divergence query weighting). Extends ADR-065's precision filters with a confidence-based emit floor on top of the same producer surface.
+
+**Context.** The thesis surface (`get_divergences`, ADR-060) treats all five divergence types as symmetric peers, and it operates on edges that all carry the same coarse confidence — flat `0.5` on every EXTRACTED edge, flat `1.0` on every OBSERVED edge. The original provenance ranking — `OBSERVED > EXTRACTED > INFERRED > STALE` — treats EXTRACTED as a high-trust direct signal when its claims are structurally derived (file existence, package.json deps, AST imports, Dockerfile facts). A single coarse `0.5` for every EXTRACTED edge conflates structural emissions with heuristic ones (URL-string pattern matches), and a single `1.0` for every OBSERVED edge treats a single span as evidence equivalent to a thousand recent ones. Grading confidence within each provenance tier restores honest signal so the divergence query can lead with findings that warrant action.
+
+The ADR formalises three pieces:
+
+1. EXTRACTED is graded at emit time per extractor.
+2. OBSERVED is graded by signal block.
+3. The divergence query consumes the graded values and surfaces OBSERVED-led findings first.
+
+PROV_RANK stays as it is. The grading lives within tiers, not across them.
+
+**Decision.**
+
+### 1. EXTRACTED confidence is graded at emit time
+
+Every producer under `packages/core/src/extract/` emits a `confidence` value reflecting how the edge was derived. The grading helper lives in `@neat.is/types/confidence.ts` so producers and tests share one source of truth.
+
+| Source of the EXTRACTED edge | Confidence |
+|---|---|
+| Structural file fact (import, package.json dep, Dockerfile `RUNS_ON`, ConfigNode existence per ADR-016) | `0.85` |
+| Verified call site (framework-aware recognizer matched the call expression) | `0.85` |
+| String-shaped candidate with structural support (URL near a known call expression) | `0.5` |
+| String-shaped candidate without structural support (substring or hostname-shape alone) | `0.2` |
+
+ADR-065's five precision filters still gate emission upstream of this scale; what passes the filters is then graded here.
+
+### 2. OBSERVED confidence is graded by signal block
+
+`upsertObservedEdge` in `packages/core/src/ingest.ts` writes confidence at the same point it writes the `signal` block (`spanCount`, `errorCount`, `lastObservedAgeMs`). The grading shape:
+
+- `spanCount >= 100` and `lastObservedAgeMs < 1h` → `0.95–1.0` (strong)
+- `spanCount 10–99` and `lastObservedAgeMs < 1h` → `0.7–0.9` (good)
+- `spanCount < 10` and `lastObservedAgeMs < 1h` → `0.4–0.6` (weak — a single span could be a misconfig)
+- `errorCount / spanCount > 0` subtracts up to `0.2` (degraded edge)
+
+The exact piecewise function lives in the confidence helper; the ADR sets the buckets and the direction (more volume + more recent = higher confidence; more errors = lower). PROV_RANK is preserved — OBSERVED still outranks INFERRED + EXTRACTED for traversal preference. The grading sits within the OBSERVED tier.
+
+### 3. Precision floor on EXTRACTED at emit time
+
+EXTRACTED edges with `confidence` below `NEAT_EXTRACTED_PRECISION_FLOOR` (default `0.7`) are computed but never added to the graph. The check sits at the single producer chokepoint that hands edges to the graph — sub-threshold candidates increment a counter that surfaces on the extraction banner (`[neat] M extracted edges dropped below precision floor`). Optional logging to `<projectDir>/neat-out/rejected.ndjson` activates when `NEAT_EXTRACTED_REJECTED_LOG=1`; the default keeps the rejected sidecar quiet.
+
+Today's URL/hostname-shape matchers produce mostly `0.2` candidates — the floor means almost nothing crosses into the graph for cross-service EXTRACTED until framework-aware recognizers land in a later milestone. Intra-codebase structural edges keep flowing because they grade above the floor. That is the intended outcome; 10 trustworthy edges beats 20 edges with 10 lies in them.
+
+`NEAT_EXTRACTED_PRECISION_FLOOR=0.0` flips off the floor for diagnostics — useful when reproducing a missing edge.
+
+### 4. Divergence query reweighting
+
+`computeDivergences` (`packages/core/src/divergences.ts`) reweights against the graded values:
+
+- **`missing-extracted`** (OBSERVED found something EXTRACTED missed) is the headline finding type. Its confidence cascades from the underlying OBSERVED edge's graded confidence. When OBSERVED is graded high, the divergence surfaces high.
+- **`missing-observed`** (EXTRACTED claims an edge OBSERVED never confirmed) is weighted by the EXTRACTED edge's confidence grade. Substring-match-only EXTRACTED candidates never enter the graph in the first place (rule 3 above), so the only `missing-observed` rows that surface are backed by structural or verified-call-site facts.
+- **`version-mismatch` / `host-mismatch` / `compat-violation`** retain symmetric weighting — both sides are specific about a versioned or hostname-identified entity, and definitive compat rules fire at `1.0`.
+
+Default sort order remains `confidence` descending (ADR-060 §5). Within the same confidence, `missing-extracted` ties break ahead of `missing-observed` so the OBSERVED-led finding leads when grades are otherwise equal. Callers can re-sort.
+
+The existing `?minConfidence` query parameter is unchanged. The reweighting does not introduce a hidden default floor; consumers that want one apply it via the existing parameter.
+
+### 5. Edge schema
+
+`EdgeSchema.confidence` in `packages/types/src/edges.ts` stays at `z.number().min(0).max(1).optional()` for snapshot back-compat (older snapshots may carry edges without a `confidence` field; persist.ts loads them on the documented growth path per ADR-031). Producers going forward write `confidence` on every EXTRACTED and OBSERVED edge; the contract test enforces presence.
+
+### 6. Response envelope
+
+ADR-061's envelope rule applies to `/graph/divergences` as a structured-result endpoint (ADR-061 §2 b). The documented shape — `{ divergences, totalAffected, computedAt }` — is the only valid response on snapshot-load, zero-result, and live-state. No `null`, no bare values. The contract scan extends to assert this shape for the divergence endpoint at both mount points (default + project-scoped).
+
+**Authority.**
+
+- Schema + grading helpers: `packages/types/src/confidence.ts` (new), `packages/types/src/edges.ts`.
+- EXTRACTED grading at emit: `packages/core/src/extract/services.ts`, `packages/core/src/extract/configs.ts`, `packages/core/src/extract/infra/*.ts`, `packages/core/src/extract/calls/*.ts`.
+- Precision floor: `packages/core/src/ingest.ts` (or the producer-side emit helper feeding it; the chokepoint is wherever EXTRACTED edges land in the graph).
+- OBSERVED grading: `packages/core/src/ingest.ts` (`upsertObservedEdge`).
+- Reweighting: `packages/core/src/divergences.ts`.
+
+**Enforcement.** New describe block in `packages/core/test/audits/contracts.test.ts` for ADR-066. Initial `it.todo` entries flip live as the v0.3.4 implementation lands:
+
+- EXTRACTED edges in the live graph carry confidence per the grading helper; the flat-`0.5` emission pattern is forbidden (regex scan of `packages/core/src/extract/` for `confidence: 0.5` literals).
+- OBSERVED edges grade by signal block — an edge with `spanCount: 5` grades below an otherwise-identical edge with `spanCount: 500`; an edge with `errorCount: 4, spanCount: 5` grades below `errorCount: 0, spanCount: 5`.
+- The precision floor drops sub-threshold EXTRACTED candidates at emit; a fixture with both above- and below-threshold candidate edges produces only above-threshold edges in the graph.
+- `computeDivergences` returns rows with `missing-extracted` leading `missing-observed` when both types are present at comparable confidence.
+- `/graph/divergences` returns the `DivergenceResultSchema` shape on snapshot-load, zero-result, and live-state paths at both mount points — never `null`, never a bare value.
+
+**Out of scope.**
+
+- **Framework-aware call-site recognition.** Today's grading treats every cross-service URL-string match as a `0.2` candidate; the precision floor means most cross-service EXTRACTED disappears until per-framework recognizers land in a later milestone. That is the intended outcome.
+- **PROV_RANK ordering.** ADR-066 grades within tiers; the rank stays `OBSERVED > INFERRED > EXTRACTED > STALE | FRONTIER`.
+- **Persisted divergence history.** ADR-060 §2 stands — derived, not persisted. ADR-066 changes how confidence is graded; it does not add a sidecar.
+- **Confidence-grade enum in `@neat.is/types`.** Free-float `[0, 1]` confidence is enough for the divergence query to reweight against. Whether the grading buckets earn a typed enum is a later question once the v0.3.4 medusa re-run produces signal.
+
+**First application.** v0.3.4.

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -6158,6 +6158,93 @@ describe('Divergence query (ADR-060)', () => {
 })
 
 // ──────────────────────────────────────────────────────────────────────────
+// OBSERVED-led divergence query weighting + graded confidence (ADR-066)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Amends ADR-029 (provenance confidence semantics), ADR-060 (divergence query
+// weighting). EXTRACTED grades at emit time per extractor; OBSERVED grades by
+// the signal block; a precision floor drops sub-threshold EXTRACTED candidates
+// before they enter the graph; the divergence query reweights so
+// `missing-extracted` (OBSERVED-led) is the headline finding type.
+//
+// Initial entries are `it.todo` and flip to live as the v0.3.4 implementation
+// PRs land (#257 EXTRACTED grading, #258 OBSERVED grading, #259 reweighting +
+// NEAT-BUG-8 envelope).
+describe('OBSERVED-led divergence weighting + graded confidence (ADR-066)', () => {
+  it.todo(
+    '`@neat.is/types/confidence.ts` exports a single grading helper for EXTRACTED and OBSERVED tiers (ADR-066 §1 + §2)',
+  )
+
+  it.todo(
+    'EXTRACTED grades structural file facts at ~0.85: package.json deps, AST imports, Dockerfile RUNS_ON, ConfigNode existence (ADR-066 §1)',
+  )
+
+  it.todo(
+    'EXTRACTED grades verified call sites at ~0.85 when a framework-aware recognizer matched (ADR-066 §1)',
+  )
+
+  it.todo(
+    'EXTRACTED grades string-shaped candidates with structural support at ~0.5 (ADR-066 §1)',
+  )
+
+  it.todo(
+    'EXTRACTED grades string-shaped candidates without structural support at ~0.2 (ADR-066 §1) — these fall below the precision floor by default',
+  )
+
+  it.todo(
+    'no `confidence: 0.5` literal remains in packages/core/src/extract/ (the flat-coarse emission pattern is a contract violation under ADR-066)',
+  )
+
+  it.todo(
+    'OBSERVED grades by signal block: spanCount: 500 + recent grades strictly above spanCount: 5 + recent on otherwise-identical edges (ADR-066 §2)',
+  )
+
+  it.todo(
+    'OBSERVED grades by signal block: errorCount: 4 / spanCount: 5 grades strictly below errorCount: 0 / spanCount: 5 (ADR-066 §2)',
+  )
+
+  it.todo(
+    'OBSERVED never emits flat confidence: 1.0 unless the signal block warrants it (spanCount >= 100 + lastObservedAgeMs < 1h) (ADR-066 §2)',
+  )
+
+  it.todo(
+    'precision floor: a fixture with above- and below-threshold EXTRACTED candidates produces only above-threshold edges in the graph (ADR-066 §3)',
+  )
+
+  it.todo(
+    'precision floor: NEAT_EXTRACTED_PRECISION_FLOOR overrides the default 0.7 threshold (ADR-066 §3)',
+  )
+
+  it.todo(
+    'precision floor: NEAT_EXTRACTED_PRECISION_FLOOR=0.0 keeps every candidate (diagnostic mode) (ADR-066 §3)',
+  )
+
+  it.todo(
+    'computeDivergences orders `missing-extracted` ahead of `missing-observed` when both surface at equal confidence (ADR-066 §4)',
+  )
+
+  it.todo(
+    '`missing-observed` rows backed by sub-floor EXTRACTED candidates never surface — the underlying edge was never added to the graph (ADR-066 §4)',
+  )
+
+  it.todo(
+    'GET /graph/divergences returns DivergenceResultSchema on a freshly-loaded snapshot (NEAT-BUG-8 — ADR-066 §6)',
+  )
+
+  it.todo(
+    'GET /graph/divergences returns DivergenceResultSchema on a graph with no detectable divergences (zero-result; never null, never a bare value) (NEAT-BUG-8 — ADR-066 §6)',
+  )
+
+  it.todo(
+    'GET /projects/:project/graph/divergences returns DivergenceResultSchema on snapshot-load + zero-result paths (dual-mount per ADR-026 — ADR-066 §6)',
+  )
+
+  it.todo(
+    'every documented GET endpoint returns a JSON object matching its declared schema on snapshot-load + zero-result paths (ADR-066 §6 — broader ADR-061 envelope assertion)',
+  )
+})
+
+// ──────────────────────────────────────────────────────────────────────────
 // REST API path canonicalization + response envelope rule (ADR-061)
 // ──────────────────────────────────────────────────────────────────────────
 //

--- a/packages/types/src/edges.ts
+++ b/packages/types/src/edges.ts
@@ -42,6 +42,12 @@ export const EdgeSignalSchema = z.object({
 })
 export type EdgeSignal = z.infer<typeof EdgeSignalSchema>
 
+// `confidence` is in [0, 1] and graded per provenance tier (ADR-066). Producers
+// write it on every EXTRACTED and OBSERVED edge via the helpers in
+// confidence.ts; flat coarse values (the old `0.5` / `1.0` shape) are a
+// contract violation. The field stays `.optional()` for snapshot back-compat —
+// older snapshots may carry edges without confidence and persist.ts loads them
+// on the documented growth path (ADR-031).
 export const GraphEdgeSchema = z.object({
   id: z.string(),
   source: z.string(),


### PR DESCRIPTION
Opens the v0.3.4 milestone. OBSERVED has reached the maturity to lead the divergence query.

## What this contract locks

**EXTRACTED is graded at emit time per extractor.** Structural file facts (imports, package.json deps, Dockerfile RUNS_ON, ConfigNode existence per ADR-016) and verified call sites grade `0.85`. String-shaped candidates with structural support grade `0.5`. String-shaped candidates without grade `0.2`.

**OBSERVED is graded by signal block.** `spanCount >= 100` + recent → `0.95–1.0`; `spanCount 10–99` recent → `0.7–0.9`; `spanCount < 10` recent → `0.4–0.6`. `errorCount / spanCount > 0` subtracts up to `0.2`. The grading sits within the OBSERVED tier; PROV_RANK is preserved.

**Precision floor on EXTRACTED at emit time.** `NEAT_EXTRACTED_PRECISION_FLOOR` defaults to `0.7`. Sub-threshold candidates are computed but never added to the graph; a banner counter surfaces the drop count.

**Divergence query reweighting.** `missing-extracted` becomes the headline finding type — OBSERVED-led. `missing-observed` is weighted by the EXTRACTED edge's graded confidence. `version-mismatch` / `host-mismatch` / `compat-violation` retain their existing weighting.

**Envelope conformance.** `/graph/divergences` returns `DivergenceResultSchema` on snapshot-load, zero-result, and live-state paths at both mount points (ADR-061 §2 b extended via the contract scan).

## Files

- `docs/decisions.md` — ADR-066 appended
- `docs/contracts/divergence-query.md` — weighting + envelope amendments
- `docs/contracts/provenance.md` — graded confidence per tier
- `docs/contracts.md` — index updated for ADR-066 references on contracts #2 and #30
- `packages/types/src/edges.ts` — confidence semantics clarified in-line
- `packages/core/test/audits/contracts.test.ts` — 18 `it.todo` assertions under a new ADR-066 describe block; flip live as the implementation PRs land

## Verification

- `npx turbo build lint` — clean
- `npx vitest run test/audits/contracts.test.ts` — 305 passed / 22 todo (was 305 passed / 4 todo; +18 from ADR-066)

## Coordination

Implementation issues open against the locked contract:

- #257 — EXTRACTED grading + precision floor at emit
- #258 — OBSERVED grading by signal block
- #259 — divergence query reweighting, paired with NEAT-BUG-8 (#255) on the same code path

Refs #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)