### PR TITLE
Add comms-voice contract — forward-looking framing at contract-edit time

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -40,6 +40,7 @@ This file is the index. Each rule has a short summary and a link to its full per
 | 28 | Web shell debugging surface | [`contracts/web-debugging.md`](./contracts/web-debugging.md) | StatusBar shows daemon + SSE connection state; no silent API failures; debug panel toggleable via Ctrl+Shift+D; read-only (ADR-058) | ✅ landed (Track 1 frontend) |
 | 29 | Web UI bootstrap from neatd | [`contracts/web-bootstrap.md`](./contracts/web-bootstrap.md) | `neatd start` launches the web UI on port 6328 (T9 NEAT); `NEAT_WEB_PORT` overrides; fail-loud on collision; `@neat.is/web` joins the lockstep (ADR-059) | ✅ landed (Track 1 frontend) |
 | 30 | Divergence query | [`contracts/divergence-query.md`](./contracts/divergence-query.md) | `get_divergences` as a first-class graph operation across REST + MCP + CLI; five divergence types; read-only; derived not persisted; OBSERVED-led weighting + graded EXTRACTED/OBSERVED confidence + precision floor at emit (ADR-060 + ADR-066) | ✅ landed (OBSERVED-led weighting amended v0.3.4) |
+| 31 | Comms voice | [`contracts/comms-voice.md`](./contracts/comms-voice.md) | Forward-looking framing in repo artifacts; never name drift or past-tense self-correction in commits, PRs, ADRs, contracts, README, runbooks, release notes. Plan files and conversation are exempt. Hook surfaces at edit time; PR/commit/release-note flows rely on session-start context (ADR-027 + ADR-053) | ✅ landed (Refs #262) |
 
 ### Future contracts — opened at the start of each milestone
 

--- a/docs/contracts/comms-voice.md
+++ b/docs/contracts/comms-voice.md
@@ -1,0 +1,82 @@
+---
+name: comms-voice
+description: Repo-visible artifacts use forward-looking framing only. Plan files and conversation can name drift; commits, PRs, ADRs, contracts, README, runbooks, and release notes cannot.
+governs:
+  - "docs/contracts/*.md"
+  - "docs/decisions.md"
+  - "README.md"
+  - "CLAUDE.md"
+  - "docs/runbook-publish.md"
+  - "docs/api-reference.md"
+  - "docs/architecture.md"
+adr: [ADR-027, ADR-053]
+---
+
+# Comms-voice contract
+
+Every repo-visible artifact NEAT publishes uses **forward-looking framing**. Plan files (`~/.claude/plans/`) and direct conversation with the maintainer can name drift, walk-backs, and past-tense self-correction accurately. Repo artifacts cannot.
+
+This contract is documentation that the PreToolUse hook surfaces at edit time. It is not enforced by code — the agent reads the rule when editing a governed file and applies discipline before writing.
+
+## What forward-looking framing means
+
+The structural change is identical either way; only the narrative wrapper differs. Past tense becomes a milestone, not an admission. When a change internally feels like correction, reframe as graduation or maturation of the existing design before writing the public text.
+
+If the only honest framing you can find is "we drifted, we're fixing it," that is a signal to revise the design intent itself in a new ADR or contract so the change reads as the natural next step rather than a fix.
+
+## Use (repo / public)
+
+- "OBSERVED has reached the maturity to lead the divergence query"
+- "Weighting `get_divergences` toward OBSERVED-led findings"
+- "ADR-066 — OBSERVED-led divergence query weighting"
+- "EXTRACTED continues to provide declared-intent enrichment; OBSERVED is now the primary signal source"
+- "NEAT graphs your runtime; declared intent enriches it"
+
+## Never use (repo / public)
+
+- "Drift" / "correcting drift" / "drifted from original intent"
+- "Symmetric framing was wrong"
+- "EXTRACTED was over-relied on"
+- "We're walking back ADR-XXX's framing"
+- Any past-tense self-correction language
+
+## Where the rule applies
+
+- **Commit messages** — every commit on every branch destined for `main`.
+- **PR bodies** — including the verification dry-run blocks pasted in.
+- **ADR text** — both new ADRs and amendments to existing ones in `docs/decisions.md`.
+- **Contract docs** — every per-topic file under `docs/contracts/`, plus the index `docs/contracts.md`.
+- **README** — repo root and any package READMEs published to npm.
+- **Runbooks** — `docs/runbook-publish.md` and any future operational docs.
+- **API / architecture docs** — `docs/api-reference.md`, `docs/architecture.md`, and anything similar that ships in the repo tree.
+- **Release notes** — GitHub release bodies, npm changelog entries.
+
+## Where the rule does not apply
+
+- **Plan files** under `~/.claude/plans/` (machine-local; not in the repo).
+- **Conversation** between agent and maintainer.
+- **Scratch notes** and `.local.md` files git-ignored from the repo.
+
+In those surfaces, drift framing is allowed and often clearer than the forward-looking equivalent. The discipline only applies once text reaches a path that ships.
+
+## Coverage boundary
+
+The PreToolUse hook surfaces this contract when an agent edits a file the `governs:` list matches. That covers contracts, ADRs, README, CLAUDE.md, runbooks, and the listed docs.
+
+It does **not** cover:
+
+- PR body text drafted via `gh pr create --body ...` (Bash, not Edit).
+- Release notes drafted via `gh release create --notes ...` (Bash, not Edit).
+- Commit messages drafted via `git commit -m ...` (Bash, not Edit).
+
+For those surfaces, the rule still binds — but the hook cannot enforce surfacing. The agent applies the discipline from session-start context (`CLAUDE.md` § Conventions and the comms-voice memory) instead of from edit-time hook output.
+
+## Why
+
+External reputation and narrative hygiene. NEAT is pre-Show-HN, pre-investor, pre-external-users. The repo is the public artifact; first impressions of "this product is being actively corrected" weaken positioning even when the corrections are honest engineering. Forward-looking framing is true (the next layer reasserts the original intent) without flagging implementation drift to readers who do not need that context.
+
+## References
+
+- Source rule: `~/.claude/plans/lazy-moseying-island.md`, the "Comms rule — strict, applies to all repo artifacts" section near the bottom.
+- Session-start memory: `~/.claude/projects/-Users-cem-Documents-GitHub-Untitled-Neat/memory/feedback_neat_repo_comms_voice.md`.
+- Adjacent ADRs: [ADR-027](../decisions.md#adr-027--mvp-success-is-closing-a-real-pr-on-an-unfamiliar-open-source-codebase) (thesis framing for the MVP) and [ADR-053](../decisions.md#adr-053--milestone-naming-rolls-forward-past-consumed-npm-slots) (forward-looking milestone naming convention).

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -6655,3 +6655,86 @@ describe('`neat watch` ignore globs + polling fallback (#233)', () => {
     expect(watchSrc).toMatch(/usePolling,/)
   })
 })
+
+// ──────────────────────────────────────────────────────────────────────────
+// Comms-voice contract (Refs #262)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// The contract framework is glob-based on the `governs:` frontmatter of each
+// per-topic contract under docs/contracts/. Adding comms-voice.md with a
+// cross-cutting glob list (contracts corpus + decisions log + README +
+// CLAUDE.md + key docs) makes the existing PreToolUse hook surface the
+// comms rule whenever any of those files is edited — zero change to
+// _hook.sh. These assertions lock the file's shape in place so future
+// edits can't silently weaken the coverage.
+describe('Comms-voice contract (Refs #262)', () => {
+  const CONTRACT_PATH = join(__dirname, '../../../../docs/contracts/comms-voice.md')
+
+  it('docs/contracts/comms-voice.md exists', () => {
+    expect(existsSync(CONTRACT_PATH)).toBe(true)
+  })
+
+  // Tiny frontmatter parser — the per-topic contracts use a fixed shape
+  // (name, description, governs list, adr list). The hook parses it with
+  // awk; mirroring its approach here avoids pulling yaml just to assert
+  // four fields. Anything sturdier than this would over-spec the format.
+  function parseFrontmatter(src: string): {
+    name?: string
+    description?: string
+    governs: string[]
+    adr: string[]
+  } {
+    const match = src.match(/^---\n([\s\S]*?)\n---/)
+    if (!match) return { governs: [], adr: [] }
+    const body = match[1]
+    const name = body.match(/^name:\s*(.+)$/m)?.[1]?.trim()
+    const description = body.match(/^description:\s*(.+)$/m)?.[1]?.trim()
+    const governsBlock = body.match(/^governs:\n((?:  - .+\n?)+)/m)?.[1] ?? ''
+    const governs = [...governsBlock.matchAll(/^  - "?([^"\n]+)"?$/gm)].map((m) => m[1].trim())
+    const adrMatch = body.match(/^adr:\s*\[([^\]]*)\]/m)?.[1] ?? ''
+    const adr = adrMatch
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+    return { name, description, governs, adr }
+  }
+
+  it('frontmatter has name, description, governs (array), adr (array)', () => {
+    const src = readFileSync(CONTRACT_PATH, 'utf8')
+    const fm = parseFrontmatter(src)
+    expect(fm.name).toBe('comms-voice')
+    expect(fm.description, 'description present').toBeTruthy()
+    expect(Array.isArray(fm.governs)).toBe(true)
+    expect(fm.governs.length).toBeGreaterThan(0)
+    expect(Array.isArray(fm.adr)).toBe(true)
+    expect(fm.adr.length).toBeGreaterThan(0)
+  })
+
+  it('governs list covers the contract corpus, ADR log, README, and CLAUDE.md', () => {
+    // These four are the floor: contracts, decisions, README, CLAUDE.md.
+    // The hook walks `docs/contracts/*.md` and matches against every glob
+    // in this list. Dropping any of these four would leave a class of
+    // repo-visible artifact uncovered by the comms rule.
+    const src = readFileSync(CONTRACT_PATH, 'utf8')
+    const fm = parseFrontmatter(src)
+    for (const required of ['docs/contracts/*.md', 'docs/decisions.md', 'README.md', 'CLAUDE.md']) {
+      expect(fm.governs, `comms-voice governs missing ${required}`).toContain(required)
+    }
+  })
+
+  it('body carries the forward-looking-framing rule', () => {
+    // Canary phrase. The body can be re-organised freely; this token has
+    // to land somewhere in the prose so the rule survives future edits.
+    const src = readFileSync(CONTRACT_PATH, 'utf8')
+    expect(src.toLowerCase()).toContain('forward-looking framing')
+  })
+
+  it('contracts.md index references the new contract', () => {
+    // Sanity check that the index row landed alongside the new file —
+    // a contract not in the index is invisible to a reader skimming the
+    // table.
+    const indexPath = join(__dirname, '../../../../docs/contracts.md')
+    const index = readFileSync(indexPath, 'utf8')
+    expect(index).toContain('contracts/comms-voice.md')
+  })
+})


### PR DESCRIPTION
Refs #262.

Adds `docs/contracts/comms-voice.md` with a cross-cutting `governs:` list targeting the contract corpus, ADR log, README, CLAUDE.md, runbooks, and key documentation. The existing PreToolUse hook picks it up — zero changes to `_hook.sh`. Plus a `contracts.md` index row at #31 and five new assertions in `packages/core/test/audits/contracts.test.ts`.

The hook surfaces the rule at edit time for any file the `governs:` list matches. PR bodies, commit messages, and release notes go through Bash / `gh`, not Edit — so the hook can't surface this contract for those flows. The contract is honest about that coverage boundary; those surfaces rely on session-start context (`CLAUDE.md` § Conventions + the comms-voice memory) instead.

## Verification

`npx turbo build test lint` — 14/14 tasks pass. Contracts test reports 321 passed (5 new comms-voice assertions live).

Hook dry-runs:

```
=== Step 3 (docs/decisions.md) — comms-voice surfaces ===
The following NEAT contracts govern this file. Read them before editing — they are binding.

----

---
name: comms-voice
description: Repo-visible artifacts use forward-looking framing only. Plan files and conversation can name drift; commits, PRs, ADRs, contracts, README, runbooks, and release notes cannot.
governs:
  - "docs/contracts/*.md"
  - "docs/decisions.md"
  - "README.md"
  - "CLAUDE.md"
  - "docs/runbook-publish.md"
  - "docs/api-reference.md"
  - "docs/architecture.md"
adr: [ADR-027, ADR-053]
---

=== Step 4 (docs/contracts/divergence-query.md) — comms-voice surfaces ===
(Same comms-voice frontmatter block. divergence-query.md's own governs list
doesn't include `docs/contracts/*.md`, so only comms-voice surfaces when
editing the contract file itself — which is the new desired behavior.)

=== Step 5 (packages/core/src/extract/services.ts) — names only ===
name: identity
name: provenance
name: static-extraction

(comms-voice does NOT appear — services.ts isn't in the comms-voice governs list.)
```

Three file touches:

- `docs/contracts/comms-voice.md` (new)
- `docs/contracts.md` (index row #31)
- `packages/core/test/audits/contracts.test.ts` (Comms-voice contract describe block, 5 assertions)