### PR TITLE
v0.3.4: OBSERVED confidence grading by signal block

### DIFF
--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -15,6 +15,7 @@ import {
   EdgeType,
   NodeType,
   Provenance,
+  confidenceForObservedSignal,
   databaseId,
   extractedEdgeId,
   frontierEdgeId,
@@ -355,36 +356,41 @@ function upsertObservedEdge(
     const existing = graph.getEdgeAttributes(id) as GraphEdge
     const newSpanCount = (existing.signal?.spanCount ?? existing.callCount ?? 0) + 1
     const newErrorCount = (existing.signal?.errorCount ?? 0) + (isError ? 1 : 0)
+    const newSignal = {
+      spanCount: newSpanCount,
+      errorCount: newErrorCount,
+      lastObservedAgeMs: 0,
+    }
+    // ADR-066 §2 — confidence grades from the signal block. PROV_RANK stays;
+    // the grade reflects volume + recency + error ratio within the OBSERVED
+    // tier.
     const updated: GraphEdge = {
       ...existing,
       provenance: Provenance.OBSERVED,
       lastObserved: ts,
       callCount: newSpanCount,
-      signal: {
-        spanCount: newSpanCount,
-        errorCount: newErrorCount,
-        lastObservedAgeMs: 0,
-      },
-      confidence: 1.0,
+      signal: newSignal,
+      confidence: confidenceForObservedSignal(newSignal),
     }
     graph.replaceEdgeAttributes(id, updated)
     return { edge: updated, created: false }
   }
 
+  const signal = {
+    spanCount: 1,
+    errorCount: isError ? 1 : 0,
+    lastObservedAgeMs: 0,
+  }
   const edge: GraphEdge = {
     id,
     source,
     target,
     type,
     provenance: Provenance.OBSERVED,
-    confidence: 1.0,
+    confidence: confidenceForObservedSignal(signal),
     lastObserved: ts,
     callCount: 1,
-    signal: {
-      spanCount: 1,
-      errorCount: isError ? 1 : 0,
-      lastObservedAgeMs: 0,
-    },
+    signal,
   }
   graph.addEdgeWithKey(id, source, target, edge)
   return { edge, created: true }

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -387,7 +387,7 @@ describe('Lifecycle contract — mutation authority (ADR-030)', () => {
 })
 
 describe('Lifecycle contract — STALE → OBSERVED resurrection (ADR-030)', () => {
-  it('a span on a STALE edge flips provenance back to OBSERVED with confidence 1.0', async () => {
+  it('a span on a STALE edge flips provenance back to OBSERVED with a fresh graded confidence', async () => {
     const { observedEdgeId } = await import('@neat.is/types')
     const { handleSpan } = await import('../../src/ingest.js')
     const { mkdtempSync } = await import('node:fs')
@@ -443,7 +443,11 @@ describe('Lifecycle contract — STALE → OBSERVED resurrection (ADR-030)', () 
 
     const after = g.getEdgeAttributes(id) as GraphEdge
     expect(after.provenance).toBe(Provenance.OBSERVED)
-    expect(after.confidence).toBe(1.0)
+    // ADR-066 — confidence grades from the signal block. The resurrection
+    // restores OBSERVED provenance; the grade reflects how much fresh signal
+    // came in. Bounded above STALE's 0.3 floor and below the strong tier's
+    // 1.0 ceiling.
+    expect(after.confidence).toBeGreaterThan(0.3)
     expect(after.callCount).toBeGreaterThanOrEqual(6)
   })
 })
@@ -6229,9 +6233,53 @@ describe('OBSERVED-led divergence weighting + graded confidence (ADR-066)', () =
     expect(degraded).toBeLessThan(clean)
   })
 
-  it.todo(
-    'OBSERVED never emits flat confidence: 1.0 unless the signal block warrants it — flips live with #258',
-  )
+  it('OBSERVED grades at ingest by signal block — a single-span edge does not emit flat 1.0 (ADR-066 §2)', async () => {
+    const { MultiDirectedGraph } = await import('graphology')
+    const { handleSpan, resetParentSpanCache } = await import('../../src/ingest.js')
+    const pathMod = await import('node:path')
+    const os = await import('node:os')
+    const fs = await import('node:fs/promises')
+    resetParentSpanCache()
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:caller', {
+      id: 'service:caller',
+      type: NodeType.ServiceNode,
+      name: 'caller',
+      language: 'javascript',
+    })
+    g.addNode('service:callee', {
+      id: 'service:callee',
+      type: NodeType.ServiceNode,
+      name: 'callee',
+      language: 'javascript',
+    })
+    const tmp = await fs.mkdtemp(pathMod.join(os.tmpdir(), 'neat-066-observed-'))
+    await handleSpan(
+      {
+        graph: g,
+        errorsPath: pathMod.join(tmp, 'errors.ndjson'),
+        writeErrorEventInline: false,
+      },
+      {
+        traceId: 't1',
+        spanId: 's1',
+        service: 'caller',
+        name: 'GET /work',
+        kind: 3,
+        startTimeUnixNano: '0',
+        endTimeUnixNano: '0',
+        durationNanos: 0n,
+        startTimeIso: new Date().toISOString(),
+        statusCode: 0,
+        attributes: { 'server.address': 'callee', 'http.method': 'GET' },
+      },
+    )
+    const id = `${EdgeType.CALLS}:OBSERVED:service:caller->service:callee`
+    expect(g.hasEdge(id)).toBe(true)
+    const e = g.getEdgeAttributes(id) as GraphEdge
+    expect(e.confidence).toBeDefined()
+    expect(e.confidence as number).toBeLessThan(1.0)
+  })
 
   it('precision floor: a fixture with above- and below-threshold EXTRACTED candidates produces only above-threshold edges in the graph (ADR-066 §3)', async () => {
     // Demo graph contains a hostname-shape CALLS edge (0.2, below default

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -142,7 +142,11 @@ describe('handleSpan', () => {
     const edge = ctx.graph.getEdgeAttributes(id) as GraphEdge
     expect(edge.provenance).toBe(Provenance.OBSERVED)
     expect(edge.callCount).toBe(1)
-    expect(edge.confidence).toBe(1)
+    // ADR-066 — confidence grades from the signal block. A single span lands
+    // in the weak tier (< 1.0); 1.0 is reserved for the strong tier
+    // (spanCount >= 100 + recent).
+    expect(edge.confidence).toBeGreaterThan(0)
+    expect(edge.confidence).toBeLessThan(1)
     expect(edge.lastObserved).toBeTruthy()
   })
 


### PR DESCRIPTION
Implements ADR-066 §2 against the locked contract. Pairs with the EXTRACTED grading PR (#261, merged) and the upcoming divergence-reweighting PR (#259).

## What lands

`upsertObservedEdge` in `packages/core/src/ingest.ts` now writes `confidence` by calling `confidenceForObservedSignal` at the same point it writes the `signal` block. PROV_RANK stays — OBSERVED still outranks INFERRED and EXTRACTED for traversal preference. The grading sits within the OBSERVED tier:

| Signal | Grade |
|---|---|
| `spanCount >= 100` + `lastObservedAgeMs < 1h` | `0.95–1.0` |
| `spanCount 10–99` + recent | `0.7–0.9` |
| `spanCount < 10` + recent | `0.4–0.6` |
| `errorCount / spanCount > 0` | subtracts up to `0.2` |

The grading helper (`confidenceForObservedSignal` in `@neat.is/types/confidence.ts`) shipped with #261 — this PR consumes it.

## Test updates

Two existing assertions reframe to express the grading semantics:

- `test/ingest.test.ts` — the OBSERVED single-span CALLS test now asserts `confidence` in `(0, 1)` instead of flat `1.0`.
- `test/audits/contracts.test.ts` — the STALE → OBSERVED resurrection contract asserts `confidence > 0.3` (above STALE's floor) instead of `1.0`.

## Contract assertion flipped live

The ADR-066 `it.todo` for "OBSERVED grades at ingest by signal block — a single-span edge does not emit flat 1.0" becomes a live assertion. Six remaining `it.todo` entries cover the divergence-reweighting + envelope work and stay parked for #259.

## Verification

- `cd packages/core && npx vitest run` — 22 files / 540 passed / 10 todo (was 11 passed / 8 todo for ADR-066)
- `npx turbo build test lint` — 14/14 clean

Refs #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)