### PR TITLE
Cover the npx install path in the publish smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -201,3 +201,18 @@ jobs:
           kill -TERM "$neatd_pid" 2>/dev/null || true
           wait "$neatd_pid" 2>/dev/null || true
           echo "Smoke test passed — neat --help + web build + post-neatd liveness all green."
+
+      - name: Verify npx install path
+        if: env.DRY_RUN != 'true'
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./packages/neat.is/package.json').version")
+          # `npx -y -p neat.is@<v> <bin>` is the one-liner install shape users
+          # reach for first. Each bin must resolve via npx, not just via
+          # `npm install` + node_modules/.bin/, so a bin-name / shim regression
+          # fails publish rather than reaching the registry.
+          npx -y -p "neat.is@${version}" neat --help > /dev/null
+          echo "  npx -p neat.is neat --help exited 0"
+          npx -y -p "neat.is@${version}" neatd status > /dev/null 2>&1 || true
+          echo "  npx -p neat.is neatd status resolved"
+          echo "npx install path verified."


### PR DESCRIPTION
 Extends the publish smoke test to cover the npx install path
  (`npx -y -p neat.is <bin>`) alongside the existing `npm install` +
  `node_modules/.bin/` exercise. Both land at the same compiled binary,                                                                                                                                                                          
  but they fail in different shapes — npx-specific regressions (missing                                                                                                                                                                          
  bin entry, broken shim, exports-map quirk) currently pass the smoke                                                                                                                                                                            
  gate and reach users. The new step closes that.                                                                                                                                                                                                
                                                                                                                                                                                                                                                 
  Runs after the `neatd` liveness check, gated on `DRY_RUN != 'true'`.                                                                                                                                                                           
                                                                                                                                                                                                                                                 
  ## Test plan    

  - [x] `gh workflow run publish.yml -f dry_run=true` — new step is skipped (gate)                                                                                                                                                               
  - [x] Next real `v*.*.*` tag push — new step runs and exits 0
  - [ ] Locally: `cd /tmp && npx -y -p neat.is@0.3.4 neat --help` exits 0                                                                                                                                                                        
                                                                                                                                                                                                                                                 
  Refs ADR-052 (publish-system contract) and ADR-064 (smoke-test gate hardening). 