### PR TITLE
v0.3.5: preserve span attributes + read errorMessage from exception.message

### DIFF
--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -436,21 +436,46 @@ async function appendErrorEvent(ctx: IngestContext, ev: ErrorEvent): Promise<voi
 // originating service because graph state isn't available at this point —
 // the queued handleSpan path may reach a more precise target later, but the
 // durable record is what the receiver writes here.
+//
+// errorMessage prefers the exception event's `exception.message` (OTel
+// semconv), falls back to the span name, then the literal 'unknown error'.
+// `span.status.message` is intentionally not in the chain — OTel
+// auto-instrumentation often pollutes that field with the HTTP method for
+// HTTP server errors, which is misleading at the incident surface.
+// Span attributes pass through verbatim so consumers can read source
+// attribution (`code.filepath`, `code.lineno`, `code.function`) and other
+// SDK-emitted context without ingest enumerating every key it cares about.
+// Coerce span attributes to a JSON-safe shape — bigint values from the
+// parsed span (long ids, high-cardinality counters) become strings so the
+// passthrough record can be serialised to the ErrorEvent shape and round-
+// tripped through ErrorEventSchema. All other types pass through verbatim.
+function sanitizeAttributes(
+  attrs: ParsedSpan['attributes'],
+): Record<string, string | number | boolean | null | string[] | number[] | boolean[]> {
+  const out: Record<string, string | number | boolean | null | string[] | number[] | boolean[]> = {}
+  for (const [k, v] of Object.entries(attrs)) {
+    if (typeof v === 'bigint') out[k] = v.toString()
+    else out[k] = v as string | number | boolean | null | string[] | number[] | boolean[]
+  }
+  return out
+}
+
 export function buildErrorEventForReceiver(span: ParsedSpan): ErrorEvent | null {
   if (span.statusCode !== 2) return null
   const ts = span.startTimeIso ?? new Date().toISOString()
+  const attrs = sanitizeAttributes(span.attributes)
   return {
     id: `${span.traceId}:${span.spanId}`,
     timestamp: ts,
     service: span.service,
     traceId: span.traceId,
     spanId: span.spanId,
-    errorMessage:
-      span.exception?.message ?? span.errorMessage ?? span.name ?? 'unknown error',
+    errorMessage: span.exception?.message ?? span.name ?? 'unknown error',
     ...(span.exception?.type ? { exceptionType: span.exception.type } : {}),
     ...(span.exception?.stacktrace
       ? { exceptionStacktrace: span.exception.stacktrace }
       : {}),
+    ...(Object.keys(attrs).length > 0 ? { attributes: attrs } : {}),
     affectedNode: serviceId(span.service),
   }
 }
@@ -575,18 +600,19 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
     // for the optional opt-in path below — daemon-less callers (CLI tests,
     // ad-hoc scripts) that skip the receiver hook still get a write here.
     if (ctx.writeErrorEventInline !== false) {
+      const attrs = sanitizeAttributes(span.attributes)
       const ev: ErrorEvent = {
         id: `${span.traceId}:${span.spanId}`,
         timestamp: ts,
         service: span.service,
         traceId: span.traceId,
         spanId: span.spanId,
-        errorMessage:
-          span.exception?.message ?? span.errorMessage ?? span.name ?? 'unknown error',
+        errorMessage: span.exception?.message ?? span.name ?? 'unknown error',
         ...(span.exception?.type ? { exceptionType: span.exception.type } : {}),
         ...(span.exception?.stacktrace
           ? { exceptionStacktrace: span.exception.stacktrace }
           : {}),
+        ...(Object.keys(attrs).length > 0 ? { attributes: attrs } : {}),
         affectedNode,
       }
       await appendErrorEvent(ctx, ev)

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -903,6 +903,29 @@
   "ErrorEventSchema": {
     "_object": {
       "affectedNode": "_string",
+      "attributes": {
+        "_optional": {
+          "_record": {
+            "_union": [
+              "_string",
+              "_number",
+              "_boolean",
+              {
+                "_other": "ZodNull"
+              },
+              {
+                "_array": "_string"
+              },
+              {
+                "_array": "_number"
+              },
+              {
+                "_array": "_boolean"
+              }
+            ]
+          }
+        }
+      },
       "errorMessage": "_string",
       "errorType": {
         "_optional": "_string"

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -164,6 +164,51 @@ describe('handleSpan', () => {
     expect(edge.signal?.lastObservedAgeMs).toBe(0)
   })
 
+  it('OBSERVED confidence grades higher with more spans (ADR-066 #2)', async () => {
+    // 100 spans lands in the strong tier (~0.95+); 3 spans lands in the
+    // weak tier (~0.4-0.5). The grading helper in @neat.is/types/confidence
+    // is the single source of truth — this fixture proves the wiring.
+    const lowCtx = ctx
+    for (let i = 0; i < 3; i++) {
+      await handleSpan(lowCtx, clientHttpSpan({ spanId: `low-${i}` }))
+    }
+    const lowId = `${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`
+    const lowConfidence = (lowCtx.graph.getEdgeAttributes(lowId) as GraphEdge).confidence!
+
+    // Reset the same graph state by clearing the edge and replaying.
+    lowCtx.graph.dropEdge(lowId)
+    for (let i = 0; i < 100; i++) {
+      await handleSpan(lowCtx, clientHttpSpan({ spanId: `high-${i}` }))
+    }
+    const highConfidence = (lowCtx.graph.getEdgeAttributes(lowId) as GraphEdge).confidence!
+
+    expect(highConfidence).toBeGreaterThan(lowConfidence)
+    expect(highConfidence).toBeGreaterThanOrEqual(0.95)
+  })
+
+  it('OBSERVED confidence drops when error ratio climbs (ADR-066 #2)', async () => {
+    // 5 clean spans vs 5 spans with 2 errors. Clean grades higher.
+    for (let i = 0; i < 5; i++) {
+      await handleSpan(ctx, clientHttpSpan({ spanId: `clean-${i}` }))
+    }
+    const id = `${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`
+    const cleanConfidence = (ctx.graph.getEdgeAttributes(id) as GraphEdge).confidence!
+
+    ctx.graph.dropEdge(id)
+    for (let i = 0; i < 5; i++) {
+      const isError = i < 2
+      await handleSpan(
+        ctx,
+        clientHttpSpan({
+          spanId: `err-${i}`,
+          ...(isError ? { statusCode: 2, exception: { message: 'boom' } } : {}),
+        }),
+      )
+    }
+    const erroringConfidence = (ctx.graph.getEdgeAttributes(id) as GraphEdge).confidence!
+    expect(erroringConfidence).toBeLessThan(cleanConfidence)
+  })
+
   it('increments callCount on repeat observations without duplicating the edge', async () => {
     await handleSpan(ctx, clientHttpSpan())
     await handleSpan(ctx, clientHttpSpan({ spanId: 'span-a2' }))
@@ -275,7 +320,13 @@ describe('handleSpan', () => {
   it('writes an ErrorEvent line to the ndjson file when status.code === 2', async () => {
     await handleSpan(
       ctx,
-      dbSpan({ statusCode: 2, errorMessage: 'SASL: SCRAM-SERVER-FIRST-MESSAGE' }),
+      dbSpan({
+        statusCode: 2,
+        // ADR-068 follow-up — errorMessage reads exception.message per OTel
+        // semconv; the polluted status.message fallback is gone, so the
+        // exception event has to carry the actual error string.
+        exception: { message: 'SASL: SCRAM-SERVER-FIRST-MESSAGE' },
+      }),
     )
     const events = await readErrorEvents(ctx.errorsPath)
     expect(events).toHaveLength(1)
@@ -286,6 +337,65 @@ describe('handleSpan', () => {
       affectedNode: 'database:payments-db',
       errorMessage: expect.stringContaining('SCRAM'),
     } as ErrorEvent)
+  })
+
+  it('preserves span attributes on the ErrorEvent (ADR-068 follow-up)', async () => {
+    await handleSpan(
+      ctx,
+      dbSpan({
+        statusCode: 2,
+        exception: { message: 'boom' },
+        attributes: {
+          'db.system': 'postgresql',
+          'db.name': 'neatdemo',
+          'server.address': 'payments-db',
+          'code.filepath': 'src/payment.ts',
+          'code.lineno': 84,
+          'code.function': 'processPayment',
+        },
+      }),
+    )
+    const events = await readErrorEvents(ctx.errorsPath)
+    expect(events).toHaveLength(1)
+    const ev = events[0]!
+    expect(ev.attributes).toBeDefined()
+    expect(ev.attributes!['code.filepath']).toBe('src/payment.ts')
+    expect(ev.attributes!['code.lineno']).toBe(84)
+    expect(ev.attributes!['code.function']).toBe('processPayment')
+  })
+
+  it('errorMessage prefers exception.message over span.name; ignores status.message (ADR-068 follow-up)', async () => {
+    // Mirror the NEAT-BUG-11 reproduction: OTel auto-instrumentation can
+    // surface the HTTP method in status.message for HTTP server errors.
+    // The receiver must read exception.message, not span.errorMessage.
+    await handleSpan(
+      ctx,
+      dbSpan({
+        statusCode: 2,
+        errorMessage: 'GET', // polluted status.message
+        name: 'POST /payments',
+        exception: { message: 'synthetic failure (counter=3)' },
+      }),
+    )
+    const events = await readErrorEvents(ctx.errorsPath)
+    expect(events).toHaveLength(1)
+    expect(events[0]!.errorMessage).toBe('synthetic failure (counter=3)')
+  })
+
+  it('errorMessage falls back to span.name when no exception event is recorded (ADR-068 follow-up)', async () => {
+    // No exception event — falls through to span.name. status.message
+    // (the auto-instrumentation pollution from NEAT-BUG-11) is not used.
+    await handleSpan(
+      ctx,
+      dbSpan({
+        statusCode: 2,
+        errorMessage: 'GET', // polluted status.message
+        name: 'pg.query',
+      }),
+    )
+    const events = await readErrorEvents(ctx.errorsPath)
+    expect(events).toHaveLength(1)
+    expect(events[0]!.errorMessage).toBe('pg.query')
   })
 
   it('does not log an ErrorEvent for a successful span', async () => {

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -1,5 +1,17 @@
 import { z } from 'zod'
 
+// Passthrough of OTel span attributes. Records source-attribution
+// (`code.filepath`, `code.lineno`, `code.function`), HTTP context
+// (`http.method`, `http.target`, `http.status_code`), DB context
+// (`db.system`, `db.statement`), and any other span attribute the SDK
+// emitted. Consumers (incident UI, MCP getRootCause) filter what they
+// surface. Schema growth per ADR-031 — optional, additive only.
+export const SpanAttributesSchema = z.record(
+  z.string(),
+  z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(z.string()), z.array(z.number()), z.array(z.boolean())]),
+)
+export type SpanAttributes = z.infer<typeof SpanAttributesSchema>
+
 export const ErrorEventSchema = z.object({
   id: z.string(),
   timestamp: z.string().datetime(),
@@ -14,6 +26,10 @@ export const ErrorEventSchema = z.object({
   // growth — added without a shape change because both fields are optional.
   exceptionType: z.string().optional(),
   exceptionStacktrace: z.string().optional(),
+  // Span attributes passthrough (ADR-068 follow-up). Surfaces `code.*`
+  // semconv attributes for source attribution, plus the rest of the
+  // attribute set for downstream filtering.
+  attributes: SpanAttributesSchema.optional(),
   affectedNode: z.string(),
 })
 export type ErrorEvent = z.infer<typeof ErrorEventSchema>


### PR DESCRIPTION
## Summary

- Span attributes pass through verbatim onto the \`ErrorEvent\` record so source attribution (\`code.filepath\`, \`code.lineno\`, \`code.function\`), HTTP context, DB context, and any other SDK-emitted attribute reach the incident surface.
- \`errorMessage\` reads the OTel exception-event's \`exception.message\` per semconv, then falls back to \`span.name\`, then 'unknown error'. \`span.status.message\` is no longer in the chain — auto-instrumentation pollution (HTTP method showing up there) is what NEAT-BUG-11 reproduced.
- \`SpanAttributesSchema\` lives in \`@neat.is/types/events\`. Bigints on the parsed span are coerced to strings at the boundary so the passthrough round-trips through \`ErrorEventSchema\`.
- Phase 2B (signal block grading) lands alongside as two new fixtures in \`ingest.test.ts\`: spanCount-100 vs spanCount-3 grading, error-rate penalty.

Stacks on #273.

## Test plan

- [x] \`npx turbo build test lint\` clean (562 tests + 4 todo across all packages)
- [x] New \`ingest.test.ts\` fixtures cover attribute passthrough, exception.message precedence, status.message dropped, signal-block grading
- [x] Schema snapshot regenerated for the new \`attributes\` field on \`ErrorEventSchema\`
- [ ] Re-run A1 smoke battery against hello-smoke after merge (#271)

Refs #269 #270