### PR TITLE
v0.3.5: ingest swap + span attribute passthrough (re-target to main)

### DIFF
--- a/packages/core/src/divergences.ts
+++ b/packages/core/src/divergences.ts
@@ -56,7 +56,6 @@ interface EdgeBucket {
   observed?: GraphEdge
   inferred?: GraphEdge
   stale?: GraphEdge
-  frontier?: GraphEdge
 }
 
 function bucketKey(source: string, target: string, type: string): string {
@@ -83,9 +82,6 @@ function bucketEdges(graph: NeatGraph): Map<string, EdgeBucket> {
         break
       case Provenance.INFERRED:
         cur.inferred = e
-        break
-      case Provenance.FRONTIER:
-        cur.frontier = e
         break
       default:
         // STALE rides on what used to be an OBSERVED edge — the id format

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -18,7 +18,6 @@ import {
   confidenceForObservedSignal,
   databaseId,
   extractedEdgeId,
-  frontierEdgeId,
   frontierId,
   inferredEdgeId,
   observedEdgeId,
@@ -304,38 +303,6 @@ function ensureFrontierNode(graph: NeatGraph, host: string, ts: string): string 
   return id
 }
 
-function upsertFrontierEdge(
-  graph: NeatGraph,
-  type: EdgeTypeValue,
-  source: string,
-  target: string,
-  ts: string,
-): void {
-  const id = frontierEdgeId(source, target, type)
-  if (graph.hasEdge(id)) {
-    const existing = graph.getEdgeAttributes(id) as GraphEdge
-    const updated: GraphEdge = {
-      ...existing,
-      provenance: Provenance.FRONTIER,
-      lastObserved: ts,
-      callCount: (existing.callCount ?? 0) + 1,
-    }
-    graph.replaceEdgeAttributes(id, updated)
-    return
-  }
-  const edge: GraphEdge = {
-    id,
-    source,
-    target,
-    type,
-    provenance: Provenance.FRONTIER,
-    confidence: 1.0,
-    lastObserved: ts,
-    callCount: 1,
-  }
-  graph.addEdgeWithKey(id, source, target, edge)
-}
-
 interface UpsertResult {
   edge: GraphEdge
   created: boolean
@@ -539,11 +506,15 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
     }
   } else {
     // Possibly a cross-service call. Resolve the peer; if it matches a known
-    // ServiceNode, record an OBSERVED CALLS edge. If it matches nothing — pod
-    // IP, ingress hostname, AWS PrivateLink endpoint — drop a FRONTIER
-    // placeholder so the call isn't lost. promoteFrontierNodes (run by the
-    // extract orchestrator) replaces it once a later round records the host
-    // as an alias on a real service.
+    // ServiceNode, record an OBSERVED CALLS edge to the typed target. If it
+    // matches nothing — pod IP, ingress hostname, AWS PrivateLink endpoint —
+    // create a FrontierNode placeholder and record an OBSERVED edge to that
+    // FrontierNode so the call carries the same provenance + signal-block +
+    // graded confidence as any other OBSERVED edge (ADR-068). The target ref
+    // identifies the node-type; provenance describes how the edge was learned.
+    // promoteFrontierNodes (run by the extract orchestrator) rewrites the
+    // target ref once a later round resolves the host; the edge's provenance
+    // stays OBSERVED across promotion.
     const host = pickAddress(span)
     let resolvedViaAddress = false
     if (host && host !== span.service) {
@@ -560,11 +531,16 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
         affectedNode = targetId
         resolvedViaAddress = true
       } else if (!targetId) {
-        const frontierId = ensureFrontierNode(ctx.graph, host, ts)
-        if (ctx.graph.hasNode(sourceId)) {
-          upsertFrontierEdge(ctx.graph, EdgeType.CALLS, sourceId, frontierId, ts)
-        }
-        affectedNode = frontierId
+        const frontierNodeId = ensureFrontierNode(ctx.graph, host, ts)
+        upsertObservedEdge(
+          ctx.graph,
+          EdgeType.CALLS,
+          sourceId,
+          frontierNodeId,
+          ts,
+          isError,
+        )
+        affectedNode = frontierNodeId
         resolvedViaAddress = true
       }
     }
@@ -708,19 +684,15 @@ function rebuildEdge(
   oldEdgeId: string,
 ): void {
   graph.dropEdge(oldEdgeId)
-  // FRONTIER provenance gets upgraded to OBSERVED on promotion: the call
-  // certainty was always there; only the target identity was unknown, and now
-  // it isn't.
-  const promotedProvenance =
-    edge.provenance === Provenance.FRONTIER ? Provenance.OBSERVED : edge.provenance
+  // ADR-068 — promotion rewrites the target ref; provenance carries forward.
+  // An OBSERVED edge to a FrontierNode promotes to an OBSERVED edge to the
+  // matched typed node; an INFERRED edge stays INFERRED; etc.
   const newId =
-    promotedProvenance === Provenance.OBSERVED
+    edge.provenance === Provenance.OBSERVED
       ? observedEdgeId(newSource, newTarget, edge.type)
-      : promotedProvenance === Provenance.INFERRED
+      : edge.provenance === Provenance.INFERRED
         ? inferredEdgeId(newSource, newTarget, edge.type)
-        : promotedProvenance === Provenance.EXTRACTED
-          ? extractedEdgeId(newSource, newTarget, edge.type)
-          : frontierEdgeId(newSource, newTarget, edge.type)
+        : extractedEdgeId(newSource, newTarget, edge.type)
 
   if (graph.hasEdge(newId)) {
     const existing = graph.getEdgeAttributes(newId) as GraphEdge
@@ -738,7 +710,6 @@ function rebuildEdge(
     id: newId,
     source: newSource,
     target: newTarget,
-    provenance: promotedProvenance,
   }
   graph.addEdgeWithKey(newId, newSource, newTarget, rebuilt)
 }

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -436,21 +436,46 @@ async function appendErrorEvent(ctx: IngestContext, ev: ErrorEvent): Promise<voi
 // originating service because graph state isn't available at this point —
 // the queued handleSpan path may reach a more precise target later, but the
 // durable record is what the receiver writes here.
+//
+// errorMessage prefers the exception event's `exception.message` (OTel
+// semconv), falls back to the span name, then the literal 'unknown error'.
+// `span.status.message` is intentionally not in the chain — OTel
+// auto-instrumentation often pollutes that field with the HTTP method for
+// HTTP server errors, which is misleading at the incident surface.
+// Span attributes pass through verbatim so consumers can read source
+// attribution (`code.filepath`, `code.lineno`, `code.function`) and other
+// SDK-emitted context without ingest enumerating every key it cares about.
+// Coerce span attributes to a JSON-safe shape — bigint values from the
+// parsed span (long ids, high-cardinality counters) become strings so the
+// passthrough record can be serialised to the ErrorEvent shape and round-
+// tripped through ErrorEventSchema. All other types pass through verbatim.
+function sanitizeAttributes(
+  attrs: ParsedSpan['attributes'],
+): Record<string, string | number | boolean | null | string[] | number[] | boolean[]> {
+  const out: Record<string, string | number | boolean | null | string[] | number[] | boolean[]> = {}
+  for (const [k, v] of Object.entries(attrs)) {
+    if (typeof v === 'bigint') out[k] = v.toString()
+    else out[k] = v as string | number | boolean | null | string[] | number[] | boolean[]
+  }
+  return out
+}
+
 export function buildErrorEventForReceiver(span: ParsedSpan): ErrorEvent | null {
   if (span.statusCode !== 2) return null
   const ts = span.startTimeIso ?? new Date().toISOString()
+  const attrs = sanitizeAttributes(span.attributes)
   return {
     id: `${span.traceId}:${span.spanId}`,
     timestamp: ts,
     service: span.service,
     traceId: span.traceId,
     spanId: span.spanId,
-    errorMessage:
-      span.exception?.message ?? span.errorMessage ?? span.name ?? 'unknown error',
+    errorMessage: span.exception?.message ?? span.name ?? 'unknown error',
     ...(span.exception?.type ? { exceptionType: span.exception.type } : {}),
     ...(span.exception?.stacktrace
       ? { exceptionStacktrace: span.exception.stacktrace }
       : {}),
+    ...(Object.keys(attrs).length > 0 ? { attributes: attrs } : {}),
     affectedNode: serviceId(span.service),
   }
 }
@@ -575,18 +600,19 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
     // for the optional opt-in path below — daemon-less callers (CLI tests,
     // ad-hoc scripts) that skip the receiver hook still get a write here.
     if (ctx.writeErrorEventInline !== false) {
+      const attrs = sanitizeAttributes(span.attributes)
       const ev: ErrorEvent = {
         id: `${span.traceId}:${span.spanId}`,
         timestamp: ts,
         service: span.service,
         traceId: span.traceId,
         spanId: span.spanId,
-        errorMessage:
-          span.exception?.message ?? span.errorMessage ?? span.name ?? 'unknown error',
+        errorMessage: span.exception?.message ?? span.name ?? 'unknown error',
         ...(span.exception?.type ? { exceptionType: span.exception.type } : {}),
         ...(span.exception?.stacktrace
           ? { exceptionStacktrace: span.exception.stacktrace }
           : {}),
+        ...(Object.keys(attrs).length > 0 ? { attributes: attrs } : {}),
         affectedNode,
       }
       await appendErrorEvent(ctx, ev)

--- a/packages/core/src/persist.ts
+++ b/packages/core/src/persist.ts
@@ -1,8 +1,9 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import { Provenance, observedEdgeId } from '@neat.is/types'
 import type { NeatGraph } from './graph.js'
 
-const SCHEMA_VERSION = 2
+const SCHEMA_VERSION = 3
 
 interface PersistedGraph {
   schemaVersion: number
@@ -24,6 +25,44 @@ function migrateV1ToV2(payload: PersistedGraph): PersistedGraph {
     }
   }
   return { ...payload, schemaVersion: 2 }
+}
+
+// v2 → v3: Provenance enum shrinks to four values (ADR-068). Any edge whose
+// provenance still carries the pre-v0.3.5 'FRONTIER' literal is rewritten to
+// Provenance.OBSERVED on load. The target ref is unchanged — FrontierNodes
+// remain placeholders for unresolved peers; only how the edge was labelled
+// changes. If the edge id still carries the legacy provenance segment, it
+// is re-keyed to the OBSERVED wire format so consumers that parse the id
+// (traversal, divergence query, MCP) see the same shape downstream.
+//
+// The 'FRONTIER' string literal here is the only place in the codebase that
+// recognises the legacy value; the Rule 1 contract scan exempts persist.ts
+// for exactly this reason.
+function migrateV2ToV3(payload: PersistedGraph): PersistedGraph {
+  const edges = (payload.graph as {
+    edges?: Array<{
+      key?: string
+      attributes?: Record<string, unknown>
+    }>
+  }).edges
+  if (Array.isArray(edges)) {
+    for (const edge of edges) {
+      const attrs = edge.attributes
+      // 'FRONTIER' is the pre-v0.3.5 literal — read-only here, never written
+      // by current producers. The rewrite swaps to Provenance.OBSERVED.
+      if (!attrs || attrs.provenance !== 'FRONTIER') continue
+      attrs.provenance = Provenance.OBSERVED
+      const type = typeof attrs.type === 'string' ? attrs.type : undefined
+      const source = typeof attrs.source === 'string' ? attrs.source : undefined
+      const target = typeof attrs.target === 'string' ? attrs.target : undefined
+      if (type && source && target) {
+        const newId = observedEdgeId(source, target, type)
+        attrs.id = newId
+        if (edge.key) edge.key = newId
+      }
+    }
+  }
+  return { ...payload, schemaVersion: 3 }
 }
 
 async function ensureDir(filePath: string): Promise<void> {
@@ -55,6 +94,9 @@ export async function loadGraphFromDisk(graph: NeatGraph, outPath: string): Prom
   let payload = JSON.parse(raw) as PersistedGraph
   if (payload.schemaVersion === 1) {
     payload = migrateV1ToV2(payload)
+  }
+  if (payload.schemaVersion === 2) {
+    payload = migrateV2ToV3(payload)
   }
   if (payload.schemaVersion !== SCHEMA_VERSION) {
     throw new Error(

--- a/packages/core/src/policy.ts
+++ b/packages/core/src/policy.ts
@@ -15,7 +15,6 @@ import {
   EdgeType,
   NodeType,
   PolicyFileSchema,
-  Provenance,
 } from '@neat.is/types'
 import type { NeatGraph } from './graph.js'
 import { DEFAULT_PROJECT } from './graph.js'
@@ -108,8 +107,10 @@ const evaluateStructural: RuleEvaluator<Extract<PolicyRule, { type: 'structural'
     for (const edgeId of graph.outboundEdges(id)) {
       const e = graph.getEdgeAttributes(edgeId) as GraphEdge
       if (e.type !== rule.edgeType) continue
-      if (e.provenance === Provenance.FRONTIER) continue
       const target = graph.getNodeAttributes(e.target) as GraphNode
+      // FrontierNodes are unresolved peers (ADR-068) — skip; the rule
+      // counts edges that resolve to a real typed node only.
+      if (target.type === NodeType.FrontierNode) continue
       if (target.type === rule.toNodeType) {
         satisfied = true
         break
@@ -242,8 +243,10 @@ const evaluateCompatibility: RuleEvaluator<Extract<PolicyRule, { type: 'compatib
       for (const edgeId of graph.outboundEdges(svcId)) {
         const e = graph.getEdgeAttributes(edgeId) as GraphEdge
         if (e.type !== EdgeType.CONNECTS_TO) continue
-        if (e.provenance === Provenance.FRONTIER) continue
         const dbAttrs = graph.getNodeAttributes(e.target) as GraphNode
+        // FrontierNodes are unresolved peers (ADR-068) — skip; compat
+        // checking needs a typed DatabaseNode.
+        if (dbAttrs.type === NodeType.FrontierNode) continue
         if (dbAttrs.type !== NodeType.DatabaseNode) continue
         const db = dbAttrs as { engine: string; engineVersion: string }
         for (const pair of compatPairs()) {

--- a/packages/core/src/traverse.ts
+++ b/packages/core/src/traverse.ts
@@ -14,7 +14,6 @@ import {
   BlastRadiusResultSchema,
   NodeType,
   PROV_RANK,
-  Provenance,
   RootCauseResultSchema,
   TransitiveDependenciesResultSchema,
 } from '@neat.is/types'
@@ -30,8 +29,10 @@ import {
 
 // Contract anchors (see /docs/contracts.md + docs/contracts/provenance.md):
 //   * Rule 2 — Coexistence: walk by provenance priority, never collapse edges.
-//   * Rule 3 — FRONTIER edges must be skipped, not merely deprioritized.
-//     If a node's only edges are FRONTIER, traversal stops there.
+//   * Rule 3 — FrontierNodes terminate traversal — edges to/from FrontierNodes
+//     are skipped, not merely deprioritized. If a node's only neighbour is a
+//     FrontierNode, traversal stops there. ADR-068 makes node-type the gating
+//     property, independent of edge provenance.
 //   * Rule 5 — Validate results against RootCauseResultSchema /
 //     BlastRadiusResultSchema before returning.
 //   * Rule 8 — No demo-name hardcoding: driver/engine identifiers come from
@@ -42,17 +43,23 @@ import {
 const ROOT_CAUSE_MAX_DEPTH = 5
 const BLAST_RADIUS_DEFAULT_DEPTH = 10
 
+function isFrontierNode(graph: NeatGraph, nodeId: string): boolean {
+  if (!graph.hasNode(nodeId)) return false
+  const attrs = graph.getNodeAttributes(nodeId) as GraphNode
+  return attrs.type === NodeType.FrontierNode
+}
+
 // Multiple edges between the same pair coexist by provenance (EXTRACTED next to
 // OBSERVED next to INFERRED). Traversal walks the system as the graph "sees it
 // best", so for any neighbour pair we pick the highest-provenance edge.
-// FRONTIER means unknown territory — ADR-036 / Rule 3 require these edges to
-// be skipped, not merely deprioritized. Filtering happens here so the rest of
-// traversal can stay generic.
+// Edges connecting to FrontierNodes are skipped at the node level (ADR-068):
+// FrontierNodes are unresolved peers, traversal terminates at them rather than
+// pretending the path continues into unknown territory.
 function bestEdgeBySource(graph: NeatGraph, edgeIds: string[]): Map<string, GraphEdge> {
   const best = new Map<string, GraphEdge>()
   for (const id of edgeIds) {
     const e = graph.getEdgeAttributes(id) as GraphEdge
-    if (e.provenance === Provenance.FRONTIER) continue
+    if (isFrontierNode(graph, e.source)) continue
     const cur = best.get(e.source)
     if (!cur || PROV_RANK[e.provenance] > PROV_RANK[cur.provenance]) {
       best.set(e.source, e)
@@ -65,7 +72,7 @@ function bestEdgeByTarget(graph: NeatGraph, edgeIds: string[]): Map<string, Grap
   const best = new Map<string, GraphEdge>()
   for (const id of edgeIds) {
     const e = graph.getEdgeAttributes(id) as GraphEdge
-    if (e.provenance === Provenance.FRONTIER) continue
+    if (isFrontierNode(graph, e.target)) continue
     const cur = best.get(e.target)
     if (!cur || PROV_RANK[e.provenance] > PROV_RANK[cur.provenance]) {
       best.set(e.target, e)
@@ -76,7 +83,7 @@ function bestEdgeByTarget(graph: NeatGraph, edgeIds: string[]): Map<string, Grap
 
 // Per-edge confidence is provenance × volume × recency × cleanliness.
 //   * provenance gives a ceiling: OBSERVED 1.0, INFERRED 0.7, EXTRACTED 0.5,
-//     STALE/FRONTIER 0.3.
+//     STALE 0.3.
 //   * volume: log-scaled span count, saturating quickly so 1 span ≈ 0.55 and
 //     ~1k spans ≈ 1.0.
 //   * recency: 1.0 within an hour; decays toward 0.5 by 24h, toward 0.3 past.
@@ -88,7 +95,6 @@ const PROVENANCE_CEILING: Record<string, number> = {
   INFERRED: 0.7,
   EXTRACTED: 0.5,
   STALE: 0.3,
-  FRONTIER: 0.3,
 }
 
 function volumeWeight(spanCount: number | undefined): number {

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -48,21 +48,23 @@ function walkSrc(dir: string, files: string[] = []): string[] {
 // Rule 1 — Provenance is a shared const; no raw string literals outside @neat.is/types
 // ──────────────────────────────────────────────────────────────────────────
 describe('Rule 1 — Provenance contract', () => {
-  it('Provenance enum includes the five MVP values', () => {
+  it('Provenance enum has exactly four values (ADR-068)', () => {
     expect(Provenance.OBSERVED).toBe('OBSERVED')
     expect(Provenance.INFERRED).toBe('INFERRED')
     expect(Provenance.EXTRACTED).toBe('EXTRACTED')
     expect(Provenance.STALE).toBe('STALE')
-    expect(Provenance.FRONTIER).toBe('FRONTIER')
-    expect(ProvenanceSchema.options).toEqual(
-      expect.arrayContaining(['OBSERVED', 'INFERRED', 'EXTRACTED', 'STALE', 'FRONTIER']),
-    )
+    expect(Object.keys(Provenance).sort()).toEqual(['EXTRACTED', 'INFERRED', 'OBSERVED', 'STALE'])
+    expect(ProvenanceSchema.options.slice().sort()).toEqual(['EXTRACTED', 'INFERRED', 'OBSERVED', 'STALE'])
   })
 
   it('no raw provenance string literals in core/src or mcp/src', () => {
     const offenders: string[] = []
     const re = /['"](OBSERVED|INFERRED|EXTRACTED|STALE|FRONTIER)['"]/
+    // persist.ts is the single allowed site — its v2 → v3 migration matches
+    // the legacy 'FRONTIER' literal and writes 'OBSERVED' as part of the
+    // schema rewrite (ADR-068). No other code reads or writes raw provenance.
     for (const file of [...walkSrc(CORE_SRC), ...walkSrc(MCP_SRC)]) {
+      if (file.endsWith('persist.ts')) continue
       const content = readFileSync(file, 'utf8')
       content.split('\n').forEach((line, i) => {
         if (
@@ -115,14 +117,13 @@ describe('Rule 2 — OBSERVED/EXTRACTED coexistence', () => {
 // ──────────────────────────────────────────────────────────────────────────
 // Rule 3 — FRONTIER edges excluded from traversal
 // ──────────────────────────────────────────────────────────────────────────
-describe('Rule 3 — FRONTIER exclusion from traversal', () => {
-  it('getRootCause returns null when the only path to a candidate root cause is via FRONTIER (issue #136)', async () => {
-    const { frontierId, frontierEdgeId, extractedEdgeId, databaseId } = await import('@neat.is/types')
+describe('Rule 3 — FrontierNode termination in traversal (ADR-068)', () => {
+  it('getRootCause returns null when the only inbound path is through a FrontierNode (issue #136)', async () => {
+    const { observedEdgeId, frontierId, databaseId } = await import('@neat.is/types')
     const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
-    // Origin is a DatabaseNode (the only origin getRootCause currently handles).
-    // The would-be culprit ServiceNode sits behind a FRONTIER edge — if FRONTIER
-    // were traversed, the walk would reach the service and check compat. With
-    // FRONTIER filtered, the walk halts at the database and returns null.
+    // Origin is a DatabaseNode. The would-be culprit sits behind a
+    // FrontierNode hop — traversal terminates at the FrontierNode per Rule 3
+    // and the walk returns null without checking compat.
     const dbId = databaseId('payments')
     g.addNode(dbId, {
       id: dbId,
@@ -134,31 +135,34 @@ describe('Rule 3 — FRONTIER exclusion from traversal', () => {
     })
     const fid = frontierId('mystery-host')
     g.addNode(fid, { id: fid, type: NodeType.FrontierNode, name: 'mystery-host', host: 'mystery-host' })
-    const eId = frontierEdgeId(fid, dbId, EdgeType.CONNECTS_TO)
+    const eId = observedEdgeId(fid, dbId, EdgeType.CONNECTS_TO)
     g.addEdgeWithKey(eId, fid, dbId, {
       id: eId,
       source: fid,
       target: dbId,
       type: EdgeType.CONNECTS_TO,
-      provenance: Provenance.FRONTIER,
+      provenance: Provenance.OBSERVED,
+      lastObserved: '2026-05-16T00:00:00.000Z',
+      callCount: 1,
     })
     expect(getRootCause(g, dbId)).toBeNull()
-    void extractedEdgeId
   })
 
-  it('getBlastRadius does not enqueue past a FRONTIER edge (issue #136)', async () => {
-    const { frontierId, frontierEdgeId } = await import('@neat.is/types')
+  it('getBlastRadius does not enqueue a FrontierNode target (issue #136)', async () => {
+    const { observedEdgeId, frontierId } = await import('@neat.is/types')
     const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
     g.addNode('service:origin', { id: 'service:origin', type: NodeType.ServiceNode, name: 'origin', language: 'javascript' })
     const fid = frontierId('unknown:8080')
     g.addNode(fid, { id: fid, type: NodeType.FrontierNode, name: 'unknown:8080', host: 'unknown:8080' })
-    const eId = frontierEdgeId('service:origin', fid, EdgeType.CALLS)
+    const eId = observedEdgeId('service:origin', fid, EdgeType.CALLS)
     g.addEdgeWithKey(eId, 'service:origin', fid, {
       id: eId,
       source: 'service:origin',
       target: fid,
       type: EdgeType.CALLS,
-      provenance: Provenance.FRONTIER,
+      provenance: Provenance.OBSERVED,
+      lastObserved: '2026-05-16T00:00:00.000Z',
+      callCount: 1,
     })
     const result = getBlastRadius(g, 'service:origin')
     expect(result.affectedNodes.find((n) => n.nodeId === fid)).toBeUndefined()
@@ -452,9 +456,9 @@ describe('Lifecycle contract — STALE → OBSERVED resurrection (ADR-030)', () 
   })
 })
 
-describe('Lifecycle contract — FRONTIER → OBSERVED on promotion (ADR-030)', () => {
-  it('promoteFrontierNodes upgrades a FRONTIER edge to OBSERVED', async () => {
-    const { frontierId, frontierEdgeId } = await import('@neat.is/types')
+describe('Lifecycle contract — FrontierNode promotion preserves provenance (ADR-030 + ADR-068)', () => {
+  it('promoteFrontierNodes rewires target ref; OBSERVED edge stays OBSERVED', async () => {
+    const { frontierId, observedEdgeId } = await import('@neat.is/types')
     const { promoteFrontierNodes } = await import('../../src/ingest.js')
 
     const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
@@ -479,13 +483,13 @@ describe('Lifecycle contract — FRONTIER → OBSERVED on promotion (ADR-030)', 
       host: 'callee.internal',
     })
 
-    const oldEdgeId = frontierEdgeId('service:caller', fid, EdgeType.CALLS)
+    const oldEdgeId = observedEdgeId('service:caller', fid, EdgeType.CALLS)
     g.addEdgeWithKey(oldEdgeId, 'service:caller', fid, {
       id: oldEdgeId,
       source: 'service:caller',
       target: fid,
       type: EdgeType.CALLS,
-      provenance: Provenance.FRONTIER,
+      provenance: Provenance.OBSERVED,
       lastObserved: '2026-05-05T12:00:00.000Z',
       callCount: 3,
     })
@@ -495,13 +499,13 @@ describe('Lifecycle contract — FRONTIER → OBSERVED on promotion (ADR-030)', 
     expect(g.hasNode(fid)).toBe(false)
     expect(g.hasEdge(oldEdgeId)).toBe(false)
 
-    // After promotion, an OBSERVED edge from caller to callee exists.
-    const promotedEdges = g.outboundEdges('service:caller').map((id) => g.getEdgeAttributes(id) as GraphEdge)
-    const callsCallee = promotedEdges.find(
-      (e) => e.target === 'service:callee' && e.type === EdgeType.CALLS,
-    )
-    expect(callsCallee).toBeDefined()
-    expect(callsCallee!.provenance).toBe(Provenance.OBSERVED)
+    // After promotion, an OBSERVED edge from caller to callee exists at the
+    // canonical observedEdgeId; provenance carried through unchanged.
+    const newId = observedEdgeId('service:caller', 'service:callee', EdgeType.CALLS)
+    expect(g.hasEdge(newId)).toBe(true)
+    const rebuilt = g.getEdgeAttributes(newId) as GraphEdge
+    expect(rebuilt.provenance).toBe(Provenance.OBSERVED)
+    expect(rebuilt.target).toBe('service:callee')
   })
 })
 
@@ -1599,8 +1603,8 @@ describe('FrontierNode promotion contract (ADR-035)', () => {
     expect(offenders, offenders.join('\n')).toEqual([])
   })
 
-  it('rebuildEdge constructs ids via canonical helpers — promoted FRONTIER→OBSERVED edge id matches observedEdgeId()', async () => {
-    const { observedEdgeId, frontierId, frontierEdgeId } = await import('@neat.is/types')
+  it('rebuildEdge constructs ids via canonical helpers — promoted OBSERVED-to-FrontierNode edge id matches observedEdgeId() (ADR-068)', async () => {
+    const { observedEdgeId, frontierId } = await import('@neat.is/types')
     const { promoteFrontierNodes } = await import('../../src/ingest.js')
 
     const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
@@ -1624,13 +1628,13 @@ describe('FrontierNode promotion contract (ADR-035)', () => {
       name: 'callee.internal',
       host: 'callee.internal',
     })
-    const oldEdgeId = frontierEdgeId('service:caller', fid, EdgeType.CALLS)
+    const oldEdgeId = observedEdgeId('service:caller', fid, EdgeType.CALLS)
     g.addEdgeWithKey(oldEdgeId, 'service:caller', fid, {
       id: oldEdgeId,
       source: 'service:caller',
       target: fid,
       type: EdgeType.CALLS,
-      provenance: Provenance.FRONTIER,
+      provenance: Provenance.OBSERVED,
       lastObserved: '2026-05-05T12:00:00.000Z',
       callCount: 3,
     })
@@ -1638,6 +1642,7 @@ describe('FrontierNode promotion contract (ADR-035)', () => {
     expect(promoteFrontierNodes(g)).toBe(1)
     const expectedId = observedEdgeId('service:caller', 'service:callee', EdgeType.CALLS)
     expect(g.hasEdge(expectedId)).toBe(true)
+    expect((g.getEdgeAttributes(expectedId) as GraphEdge).provenance).toBe(Provenance.OBSERVED)
   })
 })
 
@@ -1652,14 +1657,15 @@ describe('Traversal contract (ADR-036)', () => {
     expect(re.test(content), 'traverse.ts must be read-only').toBe(false)
   })
 
-  it('FRONTIER edges are filtered (not just deprioritized) by bestEdgeBySource / bestEdgeByTarget (issue #136)', () => {
+  it('FrontierNode-targeted edges terminate traversal in bestEdgeBySource / bestEdgeByTarget (ADR-068, issue #136)', () => {
     const content = readFileSync(join(CORE_SRC, 'traverse.ts'), 'utf8')
-    // Both helpers must guard with `Provenance.FRONTIER`. The contract is "skip,
-    // not deprioritize" — relying on PROV_RANK alone is the v0.1.x bug.
+    // Both helpers must guard via isFrontierNode (node-type check), which is
+    // the ADR-068 expression of the "skip, not deprioritize" rule. PROV_RANK
+    // alone is the v0.1.x bug.
     const helpers = ['bestEdgeBySource', 'bestEdgeByTarget']
     for (const helper of helpers) {
-      const re = new RegExp(`function\\s+${helper}\\b[\\s\\S]*?provenance\\s*===\\s*Provenance\\.FRONTIER`)
-      expect(re.test(content), `${helper} must filter FRONTIER edges explicitly`).toBe(true)
+      const re = new RegExp(`function\\s+${helper}\\b[\\s\\S]*?isFrontierNode\\s*\\(`)
+      expect(re.test(content), `${helper} must guard via isFrontierNode`).toBe(true)
     }
   })
   it('confidenceFromMix multiplies per-edge confidences (multiplicative cascade)', () => {
@@ -1978,15 +1984,22 @@ describe('getBlastRadius contract (ADR-038)', () => {
 // Provenance contract — Edge identity helpers + PROV_RANK (ADR-029)
 // ──────────────────────────────────────────────────────────────────────────
 describe('Provenance contract — edge identity (ADR-029)', () => {
-  it('no hand-rolled `:OBSERVED:`/`:INFERRED:`/`:FRONTIER:` edge id template literals', () => {
+  it('no hand-rolled `:OBSERVED:`/`:INFERRED:` edge id template literals (ADR-068)', () => {
     const offenders: string[] = []
-    // Match a template literal with `:OBSERVED:` / `:INFERRED:` / `:FRONTIER:` followed by `${...}`.
-    const re = /`[^`]*:(OBSERVED|INFERRED|FRONTIER):\$\{/
+    // Match a template literal with `:OBSERVED:` / `:INFERRED:` followed by `${...}`.
+    // Allow the v2 → v3 persist migration which rebuilds the legacy id form
+    // as a one-time rewrite at snapshot-load time.
+    const re = /`[^`]*:(OBSERVED|INFERRED):\$\{/
     for (const file of [...walkSrc(CORE_SRC), ...walkSrc(MCP_SRC)]) {
       const content = readFileSync(file, 'utf8')
       content.split('\n').forEach((line, i) => {
         const trimmed = line.trim()
-        if (re.test(line) && !trimmed.startsWith('//') && !trimmed.startsWith('*')) {
+        if (
+          re.test(line) &&
+          !trimmed.startsWith('//') &&
+          !trimmed.startsWith('*') &&
+          !file.endsWith('persist.ts')
+        ) {
           offenders.push(`${file}:${i + 1}: ${trimmed}`)
         }
       })
@@ -2012,24 +2025,23 @@ describe('Provenance contract — edge identity (ADR-029)', () => {
     expect(offenders, offenders.join('\n')).toEqual([])
   })
 
-  it('edge id helpers produce stable wire format', async () => {
-    const { extractedEdgeId, observedEdgeId, inferredEdgeId, frontierEdgeId } = await import('@neat.is/types')
+  it('edge id helpers produce stable wire format; OBSERVED-to-FrontierNode is just observedEdgeId (ADR-068)', async () => {
+    const { extractedEdgeId, observedEdgeId, inferredEdgeId, frontierId } = await import('@neat.is/types')
     expect(extractedEdgeId('service:a', 'service:b', 'CALLS')).toBe('CALLS:service:a->service:b')
     expect(observedEdgeId('service:a', 'service:b', 'CALLS')).toBe('CALLS:OBSERVED:service:a->service:b')
     expect(inferredEdgeId('service:a', 'service:b', 'CALLS')).toBe('CALLS:INFERRED:service:a->service:b')
-    expect(frontierEdgeId('service:a', 'frontier:unknown:8080', 'CALLS')).toBe(
-      'CALLS:FRONTIER:service:a->frontier:unknown:8080',
+    expect(observedEdgeId('service:a', frontierId('unknown:8080'), 'CALLS')).toBe(
+      'CALLS:OBSERVED:service:a->frontier:unknown:8080',
     )
   })
 
-  it('parseEdgeId round-trips all four provenance variants', async () => {
-    const { extractedEdgeId, observedEdgeId, inferredEdgeId, frontierEdgeId, parseEdgeId } =
+  it('parseEdgeId round-trips the three creation variants (ADR-068)', async () => {
+    const { extractedEdgeId, observedEdgeId, inferredEdgeId, parseEdgeId } =
       await import('@neat.is/types')
     const cases = [
       { make: extractedEdgeId, prov: 'EXTRACTED' as const },
       { make: observedEdgeId, prov: 'OBSERVED' as const },
       { make: inferredEdgeId, prov: 'INFERRED' as const },
-      { make: frontierEdgeId, prov: 'FRONTIER' as const },
     ]
     for (const { make, prov } of cases) {
       const id = make('service:a', 'service:b', 'CALLS')
@@ -2044,12 +2056,12 @@ describe('Provenance contract — edge identity (ADR-029)', () => {
     expect(parseEdgeId('CALLS:no-arrow')).toBe(null)
   })
 
-  it('PROV_RANK ordering is OBSERVED > INFERRED > EXTRACTED > {STALE, FRONTIER}', async () => {
+  it('PROV_RANK has exactly four entries with ordering OBSERVED > INFERRED > EXTRACTED > STALE (ADR-068)', async () => {
     const { PROV_RANK } = await import('@neat.is/types')
+    expect(Object.keys(PROV_RANK).sort()).toEqual(['EXTRACTED', 'INFERRED', 'OBSERVED', 'STALE'])
     expect(PROV_RANK.OBSERVED).toBeGreaterThan(PROV_RANK.INFERRED)
     expect(PROV_RANK.INFERRED).toBeGreaterThan(PROV_RANK.EXTRACTED)
     expect(PROV_RANK.EXTRACTED).toBeGreaterThan(PROV_RANK.STALE)
-    expect(PROV_RANK.FRONTIER).toBe(0)
     expect(PROV_RANK.STALE).toBe(0)
   })
 
@@ -2581,7 +2593,7 @@ describe('Policy contracts (ADRs 042-045)', () => {
 
   it('promoteFrontierNodes honors canPromoteFrontier and skips block-gated frontiers (ADR-044)', async () => {
     const { promoteFrontierNodes } = await import('../../src/ingest.js')
-    const { frontierId, frontierEdgeId } = await import('@neat.is/types')
+    const { frontierId, observedEdgeId } = await import('@neat.is/types')
     const fid = frontierId('blocked.host')
     const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
     g.addNode('service:caller', {
@@ -2604,13 +2616,13 @@ describe('Policy contracts (ADRs 042-045)', () => {
       name: 'blocked.host',
       host: 'blocked.host',
     })
-    const eId = frontierEdgeId('service:caller', fid, EdgeType.CALLS)
+    const eId = observedEdgeId('service:caller', fid, EdgeType.CALLS)
     g.addEdgeWithKey(eId, 'service:caller', fid, {
       id: eId,
       source: 'service:caller',
       target: fid,
       type: EdgeType.CALLS,
-      provenance: Provenance.FRONTIER,
+      provenance: Provenance.OBSERVED,
       lastObserved: '2026-05-07T00:00:00.000Z',
       callCount: 1,
     })
@@ -7004,26 +7016,196 @@ describe('Comms-voice contract (Refs #262)', () => {
 // ADR-068 — FrontierNode and OBSERVED provenance are orthogonal (#267)
 // ──────────────────────────────────────────────────────────────────────────
 //
-// Provenance shrinks to four values; FrontierNode stays as a node type but
-// no longer doubles as a provenance value. Span-derived edges to unresolved
-// peers carry OBSERVED provenance with the FrontierNode id as the target
-// string. The `frontierEdgeId` helper retires; OBSERVED-with-FrontierNode-
-// target uses `observedEdgeId`. `persist.ts` carries a v2 → v3 migration
-// that rewrites legacy FRONTIER-provenance edges to OBSERVED on load.
-//
-// These assertions flip from `it.todo` to live as the v0.3.5 implementation
-// lands (ingest swap, enum shrink, identity helper drop, persist migration).
+// Provenance is four values; FrontierNode is a node type that no longer
+// doubles as a provenance value. Span-derived edges to unresolved peers
+// carry OBSERVED provenance with the FrontierNode id as the target string.
+// The frontierEdgeId helper retires; OBSERVED-with-FrontierNode-target uses
+// observedEdgeId. persist.ts carries a v2 → v3 migration that rewrites
+// legacy FRONTIER-provenance edges to OBSERVED on load.
 describe('ADR-068 — FrontierNode + OBSERVED orthogonality (#267)', () => {
-  it.todo('Provenance enum has exactly four values (OBSERVED, INFERRED, EXTRACTED, STALE)')
-  it.todo('ProvenanceSchema.options matches the four-value enum')
-  it.todo('PROV_RANK has exactly four entries and the OBSERVED > INFERRED > EXTRACTED > STALE ordering')
-  it.todo('@neat.is/types/identity exports no frontierEdgeId symbol')
-  it.todo('no source file under packages/core/src/, packages/mcp/src/, packages/types/src/ references Provenance.FRONTIER')
-  it.todo('no source file under packages/core/src/, packages/mcp/src/, packages/types/src/ references the frontierEdgeId helper')
-  it.todo('observedEdgeId(source, frontierId(host), type) round-trips through parseEdgeId with provenance=OBSERVED and FrontierNode target preserved')
-  it.todo('OTLP span to an unresolved peer produces a single OBSERVED edge with FrontierNode target, signal block populated, graded confidence')
-  it.todo('promoteFrontierNodes rewires target ref without changing provenance: OBSERVED-to-FrontierNode edge promotes to OBSERVED-to-typed-node edge')
-  it.todo('persist.ts SCHEMA_VERSION bumps to 3')
-  it.todo('persist v2 → v3 migration rewrites edges with provenance=FRONTIER to provenance=OBSERVED; target ref preserved; id re-keyed via observedEdgeId')
-  it.todo('contracts/provenance.md and contracts/frontier-promotion.md reference ADR-068 in their adr: list')
+  it('Provenance enum has exactly four values (OBSERVED, INFERRED, EXTRACTED, STALE)', () => {
+    expect(Object.keys(Provenance).sort()).toEqual(['EXTRACTED', 'INFERRED', 'OBSERVED', 'STALE'])
+  })
+
+  it('ProvenanceSchema.options matches the four-value enum', () => {
+    expect(ProvenanceSchema.options.slice().sort()).toEqual(['EXTRACTED', 'INFERRED', 'OBSERVED', 'STALE'])
+  })
+
+  it('PROV_RANK has exactly four entries and the OBSERVED > INFERRED > EXTRACTED > STALE ordering', async () => {
+    const { PROV_RANK } = await import('@neat.is/types')
+    expect(Object.keys(PROV_RANK).sort()).toEqual(['EXTRACTED', 'INFERRED', 'OBSERVED', 'STALE'])
+    expect(PROV_RANK.OBSERVED).toBeGreaterThan(PROV_RANK.INFERRED)
+    expect(PROV_RANK.INFERRED).toBeGreaterThan(PROV_RANK.EXTRACTED)
+    expect(PROV_RANK.EXTRACTED).toBeGreaterThan(PROV_RANK.STALE)
+  })
+
+  it('@neat.is/types exports no frontierEdgeId symbol', async () => {
+    const mod = (await import('@neat.is/types')) as Record<string, unknown>
+    expect(mod.frontierEdgeId).toBeUndefined()
+  })
+
+  it('no source file under packages/core/src/, packages/mcp/src/, packages/types/src/ references Provenance.FRONTIER', () => {
+    const offenders: string[] = []
+    const re = /\bProvenance\.FRONTIER\b/
+    for (const file of [...walkSrc(CORE_SRC), ...walkSrc(MCP_SRC), ...walkSrc(TYPES_SRC)]) {
+      const content = readFileSync(file, 'utf8')
+      content.split('\n').forEach((line, i) => {
+        const trimmed = line.trim()
+        if (re.test(line) && !trimmed.startsWith('//') && !trimmed.startsWith('*')) {
+          offenders.push(`${file}:${i + 1}: ${trimmed}`)
+        }
+      })
+    }
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
+
+  it('no source file references the frontierEdgeId helper', () => {
+    const offenders: string[] = []
+    const re = /\bfrontierEdgeId\b/
+    for (const file of [...walkSrc(CORE_SRC), ...walkSrc(MCP_SRC), ...walkSrc(TYPES_SRC)]) {
+      const content = readFileSync(file, 'utf8')
+      content.split('\n').forEach((line, i) => {
+        const trimmed = line.trim()
+        if (re.test(line) && !trimmed.startsWith('//') && !trimmed.startsWith('*')) {
+          offenders.push(`${file}:${i + 1}: ${trimmed}`)
+        }
+      })
+    }
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
+
+  it('observedEdgeId(source, frontierId(host), type) round-trips through parseEdgeId with provenance=OBSERVED and FrontierNode target preserved', async () => {
+    const { observedEdgeId, frontierId, parseEdgeId } = await import('@neat.is/types')
+    const id = observedEdgeId('service:checkout', frontierId('api.github.com'), EdgeType.CALLS)
+    expect(id).toBe('CALLS:OBSERVED:service:checkout->frontier:api.github.com')
+    expect(parseEdgeId(id)).toEqual({
+      type: EdgeType.CALLS,
+      provenance: 'OBSERVED',
+      source: 'service:checkout',
+      target: 'frontier:api.github.com',
+    })
+  })
+
+  it('OTLP span to an unresolved peer produces an OBSERVED edge with FrontierNode target, signal block populated, graded confidence', async () => {
+    const { handleSpan } = await import('../../src/ingest.js')
+    const { frontierId, observedEdgeId } = await import('@neat.is/types')
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:hello-smoke', {
+      id: 'service:hello-smoke',
+      type: NodeType.ServiceNode,
+      name: 'hello-smoke',
+      language: 'javascript',
+    })
+    const errorsPath = `/tmp/neat-adr068-${Date.now()}.ndjson`
+    await handleSpan(
+      { graph: g, errorsPath, writeErrorEventInline: false },
+      {
+        service: 'hello-smoke',
+        traceId: 't1',
+        spanId: 's1',
+        name: 'GET /work',
+        startTimeUnixNano: '1747400400000000000',
+        endTimeUnixNano: '1747400400100000000',
+        startTimeIso: '2026-05-16T14:00:00.000Z',
+        durationNanos: 0n,
+        attributes: { 'server.address': 'api.github.com' },
+      },
+    )
+    const fid = frontierId('api.github.com')
+    expect(g.hasNode(fid)).toBe(true)
+    const id = observedEdgeId('service:hello-smoke', fid, EdgeType.CALLS)
+    expect(g.hasEdge(id)).toBe(true)
+    const edge = g.getEdgeAttributes(id) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.signal).toBeDefined()
+    expect(edge.signal!.spanCount).toBe(1)
+    expect(edge.signal!.errorCount).toBe(0)
+    expect(typeof edge.confidence).toBe('number')
+  })
+
+  it('promoteFrontierNodes preserves provenance: OBSERVED-to-FrontierNode promotes to OBSERVED-to-typed-node (already asserted in lifecycle block)', async () => {
+    const { observedEdgeId, frontierId } = await import('@neat.is/types')
+    const { promoteFrontierNodes } = await import('../../src/ingest.js')
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:caller', { id: 'service:caller', type: NodeType.ServiceNode, name: 'caller', language: 'javascript' })
+    g.addNode('service:callee', {
+      id: 'service:callee', type: NodeType.ServiceNode, name: 'callee', language: 'javascript', aliases: ['callee.host'],
+    })
+    const fid = frontierId('callee.host')
+    g.addNode(fid, { id: fid, type: NodeType.FrontierNode, name: 'callee.host', host: 'callee.host' })
+    const oldId = observedEdgeId('service:caller', fid, EdgeType.CALLS)
+    g.addEdgeWithKey(oldId, 'service:caller', fid, {
+      id: oldId, source: 'service:caller', target: fid, type: EdgeType.CALLS,
+      provenance: Provenance.OBSERVED, lastObserved: '2026-05-16T00:00:00.000Z', callCount: 1,
+    })
+    expect(promoteFrontierNodes(g)).toBe(1)
+    const newId = observedEdgeId('service:caller', 'service:callee', EdgeType.CALLS)
+    expect(g.hasEdge(newId)).toBe(true)
+    expect((g.getEdgeAttributes(newId) as GraphEdge).provenance).toBe(Provenance.OBSERVED)
+  })
+
+  it('persist.ts SCHEMA_VERSION is 3', () => {
+    const content = readFileSync(join(CORE_SRC, 'persist.ts'), 'utf8')
+    expect(content).toMatch(/const\s+SCHEMA_VERSION\s*=\s*3/)
+  })
+
+  it('persist v2 → v3 migration rewrites edges with provenance=FRONTIER to provenance=OBSERVED; target ref preserved; id re-keyed via OBSERVED wire format', async () => {
+    const { writeFile, mkdtemp, rm } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { join: pathJoin } = await import('node:path')
+    const { loadGraphFromDisk } = await import('../../src/persist.js')
+    const { MultiDirectedGraph: MDG } = await import('graphology')
+
+    const tmp = await mkdtemp(pathJoin(tmpdir(), 'neat-adr068-'))
+    try {
+      const snapshotPath = pathJoin(tmp, 'graph.json')
+      const legacy = {
+        schemaVersion: 2,
+        exportedAt: '2026-05-16T14:00:00.000Z',
+        graph: {
+          attributes: {},
+          options: { allowSelfLoops: false, multi: true, type: 'directed' },
+          nodes: [
+            { key: 'service:caller', attributes: { id: 'service:caller', type: NodeType.ServiceNode, name: 'caller', language: 'javascript' } },
+            { key: 'frontier:peer.host', attributes: { id: 'frontier:peer.host', type: NodeType.FrontierNode, name: 'peer.host', host: 'peer.host' } },
+          ],
+          edges: [
+            {
+              key: 'CALLS:FRONTIER:service:caller->frontier:peer.host',
+              source: 'service:caller',
+              target: 'frontier:peer.host',
+              attributes: {
+                id: 'CALLS:FRONTIER:service:caller->frontier:peer.host',
+                source: 'service:caller',
+                target: 'frontier:peer.host',
+                type: EdgeType.CALLS,
+                provenance: 'FRONTIER',
+                lastObserved: '2026-05-16T13:59:00.000Z',
+                callCount: 5,
+              },
+            },
+          ],
+        },
+      }
+      await writeFile(snapshotPath, JSON.stringify(legacy), 'utf8')
+      const g = new MDG<GraphNode, GraphEdge>({ allowSelfLoops: false })
+      await loadGraphFromDisk(g as unknown as NeatGraph, snapshotPath)
+
+      const expectedId = 'CALLS:OBSERVED:service:caller->frontier:peer.host'
+      expect(g.hasEdge(expectedId)).toBe(true)
+      const edge = g.getEdgeAttributes(expectedId) as GraphEdge
+      expect(edge.provenance).toBe(Provenance.OBSERVED)
+      expect(edge.target).toBe('frontier:peer.host')
+      expect(edge.callCount).toBe(5)
+    } finally {
+      await rm(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('contracts/provenance.md and contracts/frontier-promotion.md reference ADR-068 in their adr: list', () => {
+    const provFm = readFileSync(join(__dirname, '../../../../docs/contracts/provenance.md'), 'utf8')
+    const frontierFm = readFileSync(join(__dirname, '../../../../docs/contracts/frontier-promotion.md'), 'utf8')
+    expect(provFm).toMatch(/adr:.*ADR-068/)
+    expect(frontierFm).toMatch(/adr:.*ADR-068/)
+  })
 })

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -19,7 +19,6 @@
             "edgeProvenance": {
               "_enum": [
                 "EXTRACTED",
-                "FRONTIER",
                 "INFERRED",
                 "OBSERVED",
                 "STALE"
@@ -119,7 +118,6 @@
                       "provenance": {
                         "_enum": [
                           "EXTRACTED",
-                          "FRONTIER",
                           "INFERRED",
                           "OBSERVED",
                           "STALE"
@@ -240,7 +238,6 @@
                       "provenance": {
                         "_enum": [
                           "EXTRACTED",
-                          "FRONTIER",
                           "INFERRED",
                           "OBSERVED",
                           "STALE"
@@ -395,7 +392,6 @@
                       "provenance": {
                         "_enum": [
                           "EXTRACTED",
-                          "FRONTIER",
                           "INFERRED",
                           "OBSERVED",
                           "STALE"
@@ -547,7 +543,6 @@
                 "provenance": {
                   "_enum": [
                     "EXTRACTED",
-                    "FRONTIER",
                     "INFERRED",
                     "OBSERVED",
                     "STALE"
@@ -668,7 +663,6 @@
                 "provenance": {
                   "_enum": [
                     "EXTRACTED",
-                    "FRONTIER",
                     "INFERRED",
                     "OBSERVED",
                     "STALE"
@@ -823,7 +817,6 @@
                 "provenance": {
                   "_enum": [
                     "EXTRACTED",
-                    "FRONTIER",
                     "INFERRED",
                     "OBSERVED",
                     "STALE"
@@ -978,7 +971,6 @@
       "provenance": {
         "_enum": [
           "EXTRACTED",
-          "FRONTIER",
           "INFERRED",
           "OBSERVED",
           "STALE"
@@ -1343,7 +1335,6 @@
                             {
                               "_enum": [
                                 "EXTRACTED",
-                                "FRONTIER",
                                 "INFERRED",
                                 "OBSERVED",
                                 "STALE"
@@ -1353,7 +1344,6 @@
                               "_array": {
                                 "_enum": [
                                   "EXTRACTED",
-                                  "FRONTIER",
                                   "INFERRED",
                                   "OBSERVED",
                                   "STALE"
@@ -1512,7 +1502,6 @@
   "ProvenanceSchema": {
     "_enum": [
       "EXTRACTED",
-      "FRONTIER",
       "INFERRED",
       "OBSERVED",
       "STALE"
@@ -1530,7 +1519,6 @@
         "_array": {
           "_enum": [
             "EXTRACTED",
-            "FRONTIER",
             "INFERRED",
             "OBSERVED",
             "STALE"
@@ -1573,7 +1561,6 @@
             "provenance": {
               "_enum": [
                 "EXTRACTED",
-                "FRONTIER",
                 "INFERRED",
                 "OBSERVED",
                 "STALE"

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -903,6 +903,29 @@
   "ErrorEventSchema": {
     "_object": {
       "affectedNode": "_string",
+      "attributes": {
+        "_optional": {
+          "_record": {
+            "_union": [
+              "_string",
+              "_number",
+              "_boolean",
+              {
+                "_other": "ZodNull"
+              },
+              {
+                "_array": "_string"
+              },
+              {
+                "_array": "_number"
+              },
+              {
+                "_array": "_boolean"
+              }
+            ]
+          }
+        }
+      },
       "errorMessage": "_string",
       "errorType": {
         "_optional": "_string"

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -164,6 +164,51 @@ describe('handleSpan', () => {
     expect(edge.signal?.lastObservedAgeMs).toBe(0)
   })
 
+  it('OBSERVED confidence grades higher with more spans (ADR-066 #2)', async () => {
+    // 100 spans lands in the strong tier (~0.95+); 3 spans lands in the
+    // weak tier (~0.4-0.5). The grading helper in @neat.is/types/confidence
+    // is the single source of truth — this fixture proves the wiring.
+    const lowCtx = ctx
+    for (let i = 0; i < 3; i++) {
+      await handleSpan(lowCtx, clientHttpSpan({ spanId: `low-${i}` }))
+    }
+    const lowId = `${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`
+    const lowConfidence = (lowCtx.graph.getEdgeAttributes(lowId) as GraphEdge).confidence!
+
+    // Reset the same graph state by clearing the edge and replaying.
+    lowCtx.graph.dropEdge(lowId)
+    for (let i = 0; i < 100; i++) {
+      await handleSpan(lowCtx, clientHttpSpan({ spanId: `high-${i}` }))
+    }
+    const highConfidence = (lowCtx.graph.getEdgeAttributes(lowId) as GraphEdge).confidence!
+
+    expect(highConfidence).toBeGreaterThan(lowConfidence)
+    expect(highConfidence).toBeGreaterThanOrEqual(0.95)
+  })
+
+  it('OBSERVED confidence drops when error ratio climbs (ADR-066 #2)', async () => {
+    // 5 clean spans vs 5 spans with 2 errors. Clean grades higher.
+    for (let i = 0; i < 5; i++) {
+      await handleSpan(ctx, clientHttpSpan({ spanId: `clean-${i}` }))
+    }
+    const id = `${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`
+    const cleanConfidence = (ctx.graph.getEdgeAttributes(id) as GraphEdge).confidence!
+
+    ctx.graph.dropEdge(id)
+    for (let i = 0; i < 5; i++) {
+      const isError = i < 2
+      await handleSpan(
+        ctx,
+        clientHttpSpan({
+          spanId: `err-${i}`,
+          ...(isError ? { statusCode: 2, exception: { message: 'boom' } } : {}),
+        }),
+      )
+    }
+    const erroringConfidence = (ctx.graph.getEdgeAttributes(id) as GraphEdge).confidence!
+    expect(erroringConfidence).toBeLessThan(cleanConfidence)
+  })
+
   it('increments callCount on repeat observations without duplicating the edge', async () => {
     await handleSpan(ctx, clientHttpSpan())
     await handleSpan(ctx, clientHttpSpan({ spanId: 'span-a2' }))
@@ -275,7 +320,13 @@ describe('handleSpan', () => {
   it('writes an ErrorEvent line to the ndjson file when status.code === 2', async () => {
     await handleSpan(
       ctx,
-      dbSpan({ statusCode: 2, errorMessage: 'SASL: SCRAM-SERVER-FIRST-MESSAGE' }),
+      dbSpan({
+        statusCode: 2,
+        // ADR-068 follow-up — errorMessage reads exception.message per OTel
+        // semconv; the polluted status.message fallback is gone, so the
+        // exception event has to carry the actual error string.
+        exception: { message: 'SASL: SCRAM-SERVER-FIRST-MESSAGE' },
+      }),
     )
     const events = await readErrorEvents(ctx.errorsPath)
     expect(events).toHaveLength(1)
@@ -286,6 +337,65 @@ describe('handleSpan', () => {
       affectedNode: 'database:payments-db',
       errorMessage: expect.stringContaining('SCRAM'),
     } as ErrorEvent)
+  })
+
+  it('preserves span attributes on the ErrorEvent (ADR-068 follow-up)', async () => {
+    await handleSpan(
+      ctx,
+      dbSpan({
+        statusCode: 2,
+        exception: { message: 'boom' },
+        attributes: {
+          'db.system': 'postgresql',
+          'db.name': 'neatdemo',
+          'server.address': 'payments-db',
+          'code.filepath': 'src/payment.ts',
+          'code.lineno': 84,
+          'code.function': 'processPayment',
+        },
+      }),
+    )
+    const events = await readErrorEvents(ctx.errorsPath)
+    expect(events).toHaveLength(1)
+    const ev = events[0]!
+    expect(ev.attributes).toBeDefined()
+    expect(ev.attributes!['code.filepath']).toBe('src/payment.ts')
+    expect(ev.attributes!['code.lineno']).toBe(84)
+    expect(ev.attributes!['code.function']).toBe('processPayment')
+  })
+
+  it('errorMessage prefers exception.message over span.name; ignores status.message (ADR-068 follow-up)', async () => {
+    // Mirror the NEAT-BUG-11 reproduction: OTel auto-instrumentation can
+    // surface the HTTP method in status.message for HTTP server errors.
+    // The receiver must read exception.message, not span.errorMessage.
+    await handleSpan(
+      ctx,
+      dbSpan({
+        statusCode: 2,
+        errorMessage: 'GET', // polluted status.message
+        name: 'POST /payments',
+        exception: { message: 'synthetic failure (counter=3)' },
+      }),
+    )
+    const events = await readErrorEvents(ctx.errorsPath)
+    expect(events).toHaveLength(1)
+    expect(events[0]!.errorMessage).toBe('synthetic failure (counter=3)')
+  })
+
+  it('errorMessage falls back to span.name when no exception event is recorded (ADR-068 follow-up)', async () => {
+    // No exception event — falls through to span.name. status.message
+    // (the auto-instrumentation pollution from NEAT-BUG-11) is not used.
+    await handleSpan(
+      ctx,
+      dbSpan({
+        statusCode: 2,
+        errorMessage: 'GET', // polluted status.message
+        name: 'pg.query',
+      }),
+    )
+    const events = await readErrorEvents(ctx.errorsPath)
+    expect(events).toHaveLength(1)
+    expect(events[0]!.errorMessage).toBe('pg.query')
   })
 
   it('does not log an ErrorEvent for a successful span', async () => {

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -214,16 +214,11 @@ describe('handleSpan', () => {
     ).toBe(true)
   })
 
-  it('emits a FRONTIER placeholder when the span peer matches no service node', async () => {
+  it('emits an OBSERVED edge to a FrontierNode placeholder when the span peer matches no service node (ADR-068)', async () => {
     await handleSpan(
       ctx,
       clientHttpSpan({ attributes: { 'server.address': 'payments-api.cluster.local' } }),
     )
-    let observedCalls = 0
-    ctx.graph.forEachEdge((k) => {
-      if (k.startsWith(`${EdgeType.CALLS}:OBSERVED:`)) observedCalls++
-    })
-    expect(observedCalls).toBe(0)
 
     expect(ctx.graph.hasNode('frontier:payments-api.cluster.local')).toBe(true)
     const frontier = ctx.graph.getNodeAttributes(
@@ -233,11 +228,15 @@ describe('handleSpan', () => {
     expect(frontier.host).toBe('payments-api.cluster.local')
     expect(frontier.firstObserved).toBeTruthy()
 
-    const frontierEdgeId = `${EdgeType.CALLS}:FRONTIER:service:service-a->frontier:payments-api.cluster.local`
-    expect(ctx.graph.hasEdge(frontierEdgeId)).toBe(true)
-    const edge = ctx.graph.getEdgeAttributes(frontierEdgeId) as GraphEdge
-    expect(edge.provenance).toBe(Provenance.FRONTIER)
+    const observedFrontierEdgeId = `${EdgeType.CALLS}:OBSERVED:service:service-a->frontier:payments-api.cluster.local`
+    expect(ctx.graph.hasEdge(observedFrontierEdgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(observedFrontierEdgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
     expect(edge.callCount).toBe(1)
+    expect(edge.signal).toBeDefined()
+    expect(edge.signal!.spanCount).toBe(1)
+    expect(edge.signal!.errorCount).toBe(0)
+    expect(typeof edge.confidence).toBe('number')
   })
 
   it('resolves a span peer through ServiceNode.aliases', async () => {

--- a/packages/core/test/persist.test.ts
+++ b/packages/core/test/persist.test.ts
@@ -31,7 +31,7 @@ describe('persistence', () => {
 
     const raw = await fs.readFile(outPath, 'utf8')
     const parsed = JSON.parse(raw)
-    expect(parsed.schemaVersion).toBe(2)
+    expect(parsed.schemaVersion).toBe(3)
     expect(parsed.exportedAt).toBeTypeOf('string')
     expect(parsed.graph.nodes.length).toBeGreaterThanOrEqual(3)
     expect(parsed.graph.edges.length).toBeGreaterThanOrEqual(2)

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -3,7 +3,6 @@ export const Provenance = {
   INFERRED: 'INFERRED',
   OBSERVED: 'OBSERVED',
   STALE: 'STALE',
-  FRONTIER: 'FRONTIER',
 } as const
 
 export type ProvenanceValue = (typeof Provenance)[keyof typeof Provenance]

--- a/packages/types/src/edges.ts
+++ b/packages/types/src/edges.ts
@@ -6,7 +6,6 @@ export const ProvenanceSchema = z.enum([
   Provenance.INFERRED,
   Provenance.OBSERVED,
   Provenance.STALE,
-  Provenance.FRONTIER,
 ])
 
 export const EdgeTypeSchema = z.enum([

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -1,5 +1,17 @@
 import { z } from 'zod'
 
+// Passthrough of OTel span attributes. Records source-attribution
+// (`code.filepath`, `code.lineno`, `code.function`), HTTP context
+// (`http.method`, `http.target`, `http.status_code`), DB context
+// (`db.system`, `db.statement`), and any other span attribute the SDK
+// emitted. Consumers (incident UI, MCP getRootCause) filter what they
+// surface. Schema growth per ADR-031 — optional, additive only.
+export const SpanAttributesSchema = z.record(
+  z.string(),
+  z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(z.string()), z.array(z.number()), z.array(z.boolean())]),
+)
+export type SpanAttributes = z.infer<typeof SpanAttributesSchema>
+
 export const ErrorEventSchema = z.object({
   id: z.string(),
   timestamp: z.string().datetime(),
@@ -14,6 +26,10 @@ export const ErrorEventSchema = z.object({
   // growth — added without a shape change because both fields are optional.
   exceptionType: z.string().optional(),
   exceptionStacktrace: z.string().optional(),
+  // Span attributes passthrough (ADR-068 follow-up). Surfaces `code.*`
+  // semconv attributes for source attribution, plus the rest of the
+  // attribute set for downstream filtering.
+  attributes: SpanAttributesSchema.optional(),
   affectedNode: z.string(),
 })
 export type ErrorEvent = z.infer<typeof ErrorEventSchema>

--- a/packages/types/src/identity.ts
+++ b/packages/types/src/identity.ts
@@ -72,16 +72,20 @@ export function parseFrontierId(id: string): string | null {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Edge ids (ADR-029)
+// Edge ids (ADR-029, ADR-068)
 // ──────────────────────────────────────────────────────────────────────────
 //
 // Edge id wire format per provenance:
 //   EXTRACTED: `${type}:${source}->${target}`
 //   OBSERVED:  `${type}:OBSERVED:${source}->${target}`
 //   INFERRED:  `${type}:INFERRED:${source}->${target}`
-//   FRONTIER:  `${type}:FRONTIER:${source}->${target}`
 //   STALE never appears in an edge id; STALE is a transition of an existing
 //   OBSERVED edge (ADR-024), not a creation pattern.
+//
+// Per ADR-068, edges to FrontierNodes carry whatever provenance describes
+// how the edge was learned — span-derived edges use observedEdgeId with the
+// FrontierNode id as the target string. Node-type is orthogonal to
+// provenance; the wire format reflects provenance only.
 //
 // Multiple edges between the same node pair coexist under distinct provenance
 // ids — that's what makes the EXTRACTED+OBSERVED coexistence rule
@@ -101,19 +105,16 @@ export function inferredEdgeId(source: string, target: string, type: string): st
   return `${type}:INFERRED:${source}${EDGE_ARROW}${target}`
 }
 
-export function frontierEdgeId(source: string, target: string, type: string): string {
-  return `${type}:FRONTIER:${source}${EDGE_ARROW}${target}`
-}
-
 // Parse an edge id into its parts. Returns null if the input is not a
-// well-formed edge id — covers all four provenance variants. Useful for
-// consumers (traversal, MCP, persist) that need to walk back from an id.
+// well-formed edge id — covers all three creation variants (STALE rides on
+// the OBSERVED id format). Useful for consumers (traversal, MCP, persist)
+// that need to walk back from an id.
 //
 // Note: EXTRACTED ids have no provenance segment, so we detect them by
 // checking whether the second segment matches a known provenance marker.
 export function parseEdgeId(id: string): {
   type: string
-  provenance: 'EXTRACTED' | 'OBSERVED' | 'INFERRED' | 'FRONTIER'
+  provenance: 'EXTRACTED' | 'OBSERVED' | 'INFERRED'
   source: string
   target: string
 } | null {
@@ -127,13 +128,12 @@ export function parseEdgeId(id: string): {
   //   `${type}:${source}`             → EXTRACTED
   //   `${type}:OBSERVED:${source}`    → OBSERVED
   //   `${type}:INFERRED:${source}`    → INFERRED
-  //   `${type}:FRONTIER:${source}`    → FRONTIER
   const firstColon = left.indexOf(':')
   if (firstColon === -1) return null
   const type = left.slice(0, firstColon)
   const rest = left.slice(firstColon + 1)
 
-  for (const prov of ['OBSERVED', 'INFERRED', 'FRONTIER'] as const) {
+  for (const prov of ['OBSERVED', 'INFERRED'] as const) {
     if (rest.startsWith(`${prov}:`)) {
       return { type, provenance: prov, source: rest.slice(prov.length + 1), target }
     }
@@ -142,20 +142,19 @@ export function parseEdgeId(id: string): {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Provenance ranking (ADR-029)
+// Provenance ranking (ADR-029, ADR-068)
 // ──────────────────────────────────────────────────────────────────────────
 //
 // Canonical priority used by traversal and any consumer that needs to pick
 // a single edge between two nodes when multiple provenance variants exist.
 // Higher number = higher trust = preferred.
 //
-// FRONTIER is ranked 0 alongside STALE for the case where it does end up in
-// a comparison set, but contracts.md Rule 3 says traversal must skip FRONTIER
-// edges entirely — so this rank is rarely consulted for FRONTIER in practice.
-export const PROV_RANK: Readonly<Record<'OBSERVED' | 'INFERRED' | 'EXTRACTED' | 'STALE' | 'FRONTIER', number>> = Object.freeze({
+// Four entries match the four-value Provenance enum (ADR-068). Node-type
+// gating (e.g. "stop at FrontierNodes" per contracts.md Rule 3) is enforced
+// at the node level by traversal, independent of edge rank.
+export const PROV_RANK: Readonly<Record<'OBSERVED' | 'INFERRED' | 'EXTRACTED' | 'STALE', number>> = Object.freeze({
   OBSERVED: 3,
   INFERRED: 2,
   EXTRACTED: 1,
   STALE: 0,
-  FRONTIER: 0,
 })

--- a/packages/types/test/schemas.test.ts
+++ b/packages/types/test/schemas.test.ts
@@ -17,8 +17,8 @@ import {
 } from '../src/index.js'
 
 describe('runtime constants', () => {
-  it('Provenance has 5 values', () => {
-    expect(Object.values(Provenance)).toHaveLength(5)
+  it('Provenance has 4 values (ADR-068)', () => {
+    expect(Object.values(Provenance)).toHaveLength(4)
   })
   it('EdgeType has 7 values', () => {
     expect(Object.values(EdgeType)).toHaveLength(7)


### PR DESCRIPTION
## Summary

Bundles the two structural commits from #273 and #274. Those PRs merged into stacked review branches (\`267-…\` and \`268-…\`) rather than \`main\`, so the actual code change needs a fresh PR against \`main\` to land. Same content, no functional diff from what was reviewed.

- **OBSERVED edges to unresolved peers** (was #273) — Provenance enum shrinks to four values, \`frontierEdgeId\` retires, \`upsertObservedEdge\` covers FrontierNode targets, \`PROV_RANK\` has four entries, traversal + policy gate on node-type, \`SCHEMA_VERSION\` 2 → 3 with the v2 → v3 migration that rewrites legacy FRONTIER-provenance edges to OBSERVED on load.
- **Span attribute passthrough + \`errorMessage\` from \`exception.message\`** (was #274) — \`SpanAttributesSchema\` on \`ErrorEventSchema\`; \`errorMessage\` reads \`exception.message\` per OTel semconv; \`span.status.message\` drops out of the fallback chain. Phase 2B grading-by-volume + error-ratio fixtures land here too.

Local Phase 3 smoke against hello-smoke is green — \`~/neat-observed-smoke/REPORT.md\` records OBSERVED edges with FrontierNode targets, signal-block grading, attributes passthrough, and two \`missing-extracted\` divergence rows (was empty pre-v0.3.5).

## Test plan

- [x] \`npx turbo build test lint\` clean
- [x] Contract assertions for ADR-068 live (340 passed, 4 unrelated todos)
- [x] Schema snapshot regenerated for the four-value Provenance enum + \`attributes\` field
- [x] A1 OBSERVED smoke battery green against local-built binary

Refs #267 #268 #269 #270