### PR TITLE
v0.3.6: read errorMessage from exception.message, not span.name

### DIFF
--- a/docs/contracts/otel-ingest.md
+++ b/docs/contracts/otel-ingest.md
@@ -58,12 +58,10 @@ Both paths go through `upsertObservedEdge`, which writes the `signal` block (`sp
 
 `OtlpSpan` is extended with `events: Array<{ name, timeUnixNano, attributes }>`. When a span has an `events[]` entry with `name === 'exception'`, the parser extracts `exception.type`, `exception.message`, and `exception.stacktrace` from its attributes.
 
-`handleSpan`'s ErrorEvent path prefers exception data over `status.message`:
+`handleSpan`'s ErrorEvent path reads exception data directly. `span.name` is intentionally absent from the fallback chain — OTel HTTP server instrumentation populates it with the request method (`"GET"`, `"POST"`), which is misleading at the incident surface. `span.status.message` is similarly absent for the same reason. When neither layer carries an exception, the literal `'unknown error'` keeps the schema's required-string contract intact while surfacing the gap:
 
 ```
 exceptionMessage = events.find(e => e.name === 'exception')?.attributes['exception.message']
-                ?? span.status.message
-                ?? span.name
                 ?? 'unknown error'
 ```
 

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -437,11 +437,14 @@ async function appendErrorEvent(ctx: IngestContext, ev: ErrorEvent): Promise<voi
 // the queued handleSpan path may reach a more precise target later, but the
 // durable record is what the receiver writes here.
 //
-// errorMessage prefers the exception event's `exception.message` (OTel
-// semconv), falls back to the span name, then the literal 'unknown error'.
-// `span.status.message` is intentionally not in the chain — OTel
-// auto-instrumentation often pollutes that field with the HTTP method for
-// HTTP server errors, which is misleading at the incident surface.
+// errorMessage reads from the exception event's `exception.message` (OTel
+// semconv) so the incident surface shows the actual thrown error string.
+// When the span carries no exception event the field falls back to the
+// literal 'unknown error' rather than `span.name` — OTel HTTP server
+// instrumentation routinely populates `span.name` with the HTTP method,
+// which produces incidents that read 'GET' or 'POST' instead of the
+// underlying failure. `span.status.message` is intentionally out of the
+// chain for the same reason.
 // Span attributes pass through verbatim so consumers can read source
 // attribution (`code.filepath`, `code.lineno`, `code.function`) and other
 // SDK-emitted context without ingest enumerating every key it cares about.
@@ -470,7 +473,7 @@ export function buildErrorEventForReceiver(span: ParsedSpan): ErrorEvent | null 
     service: span.service,
     traceId: span.traceId,
     spanId: span.spanId,
-    errorMessage: span.exception?.message ?? span.name ?? 'unknown error',
+    errorMessage: span.exception?.message ?? 'unknown error',
     ...(span.exception?.type ? { exceptionType: span.exception.type } : {}),
     ...(span.exception?.stacktrace
       ? { exceptionStacktrace: span.exception.stacktrace }
@@ -607,7 +610,7 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
         service: span.service,
         traceId: span.traceId,
         spanId: span.spanId,
-        errorMessage: span.exception?.message ?? span.name ?? 'unknown error',
+        errorMessage: span.exception?.message ?? 'unknown error',
         ...(span.exception?.type ? { exceptionType: span.exception.type } : {}),
         ...(span.exception?.stacktrace
           ? { exceptionStacktrace: span.exception.stacktrace }

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -1504,6 +1504,64 @@ describe('OTel ingest contract (ADR-033)', () => {
     expect(written[0].exceptionType).toBe('TimeoutError')
     expect(written[0].exceptionStacktrace).toBe('at fetch (a.js:1)')
   })
+
+  it('handleSpan errorMessage falls back to literal `unknown error`, never span.name (issue #285)', async () => {
+    const { handleSpan } = await import('../../src/ingest.js')
+    const { mkdtempSync, readFileSync: rfs } = await import('node:fs')
+    const { tmpdir } = await import('node:os')
+
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:caller', {
+      id: 'service:caller',
+      type: NodeType.ServiceNode,
+      name: 'caller',
+      language: 'javascript',
+    })
+
+    const dir = mkdtempSync(join(tmpdir(), 'contract-test-'))
+    const errorsPath = join(dir, 'errors.ndjson')
+    await handleSpan(
+      { graph: g, errorsPath, now: () => Date.parse('2026-05-05T12:00:00.000Z') },
+      {
+        traceId: 't1',
+        spanId: 's1',
+        service: 'caller',
+        // span.name carries the HTTP method per OTel HTTP server semconv.
+        // It must not bleed into errorMessage at the incident surface.
+        name: 'GET',
+        statusCode: 2,
+        startTimeUnixNano: '0',
+        endTimeUnixNano: '0',
+        durationNanos: 0n,
+        attributes: {},
+        // No exception event recorded.
+      },
+    )
+
+    const written = rfs(errorsPath, 'utf8').trim().split('\n').map((l) => JSON.parse(l))
+    expect(written).toHaveLength(1)
+    expect(written[0].errorMessage).toBe('unknown error')
+    expect(written[0].errorMessage).not.toBe('GET')
+  })
+
+  it('buildErrorEventForReceiver errorMessage falls back to literal `unknown error`, never span.name (issue #285)', async () => {
+    const { buildErrorEventForReceiver } = await import('../../src/ingest.js')
+
+    const ev = buildErrorEventForReceiver({
+      traceId: 't1',
+      spanId: 's1',
+      service: 'caller',
+      name: 'POST',
+      statusCode: 2,
+      startTimeUnixNano: '0',
+      endTimeUnixNano: '0',
+      durationNanos: 0n,
+      attributes: {},
+    })
+    expect(ev).not.toBeNull()
+    expect(ev!.errorMessage).toBe('unknown error')
+    expect(ev!.errorMessage).not.toBe('POST')
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -382,9 +382,12 @@ describe('handleSpan', () => {
     expect(events[0]!.errorMessage).toBe('synthetic failure (counter=3)')
   })
 
-  it('errorMessage falls back to span.name when no exception event is recorded (ADR-068 follow-up)', async () => {
-    // No exception event — falls through to span.name. status.message
-    // (the auto-instrumentation pollution from NEAT-BUG-11) is not used.
+  it('errorMessage falls back to literal `unknown error`, never span.name (issue #285)', async () => {
+    // No exception event — the field reads the literal 'unknown error' so
+    // the schema's required-string contract holds. span.name is reserved for
+    // OTel HTTP server instrumentation's request-method payload and stays
+    // out of the chain. status.message (the auto-instrumentation pollution
+    // from NEAT-BUG-11) is also out.
     await handleSpan(
       ctx,
       dbSpan({
@@ -395,7 +398,8 @@ describe('handleSpan', () => {
     )
     const events = await readErrorEvents(ctx.errorsPath)
     expect(events).toHaveLength(1)
-    expect(events[0]!.errorMessage).toBe('pg.query')
+    expect(events[0]!.errorMessage).toBe('unknown error')
+    expect(events[0]!.errorMessage).not.toBe('pg.query')
   })
 
   it('does not log an ErrorEvent for a successful span', async () => {


### PR DESCRIPTION
## Summary

- `errorMessage` on ErrorEvents now reads from `span.exception?.message` only. The fallback chain ends at the literal `'unknown error'`; `span.name` is no longer in the chain.
- OTel HTTP server instrumentation populates `span.name` with the request method, which was producing incidents that read `'GET'` instead of the actual thrown error. The fix removes that bleed-through.
- The `otel-ingest.md` contract is updated to match — exception data is the only source, with `'unknown error'` as the schema-required-string fallback.

## Test plan

- [x] New contract assertions: `handleSpan` and `buildErrorEventForReceiver` both produce `errorMessage: 'unknown error'` for an error span with `name: 'GET'` and no exception event.
- [x] Existing `errorMessage prefers exception event message over span.status.message` test still passes.
- [x] `npx vitest run` in `packages/core` green across all 22 files.
- [x] `npx turbo lint --filter=@neat.is/core` clean.

Refs #285