### PR TITLE
v0.3.6: warn on neatd start when published neat.is is ahead of local install

### DIFF
--- a/packages/core/src/neatd.ts
+++ b/packages/core/src/neatd.ts
@@ -16,9 +16,28 @@
 
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import { createRequire } from 'node:module'
 import { startDaemon } from './daemon.js'
 import { listProjects, registryPath } from './registry.js'
 import { spawnWebUI, DEFAULT_WEB_PORT, type WebHandle } from './web-spawn.js'
+import { checkVersionSkew } from './version-skew.js'
+
+// Resolve the running @neat.is/core version from the bundled package.json.
+// Lockstep publishing (ADR-052) keeps this in step with the `neat.is` meta
+// package, which is what the operator installs globally. Tests stub by
+// setting NEAT_LOCAL_VERSION.
+function localVersion(): string {
+  if (process.env.NEAT_LOCAL_VERSION && process.env.NEAT_LOCAL_VERSION.length > 0) {
+    return process.env.NEAT_LOCAL_VERSION
+  }
+  try {
+    const req = createRequire(import.meta.url)
+    const pkg = req('../package.json') as { version?: string }
+    return typeof pkg.version === 'string' ? pkg.version : '0.0.0'
+  } catch {
+    return '0.0.0'
+  }
+}
 
 function neatHome(): string {
   if (process.env.NEAT_HOME && process.env.NEAT_HOME.length > 0) {
@@ -55,6 +74,18 @@ async function cmdStart(): Promise<void> {
   // the documented happy path without grepping startup logs.
   if (handle.restAddress) console.log(`neatd: REST  → ${handle.restAddress}`)
   if (handle.otlpAddress) console.log(`neatd: OTLP  → ${handle.otlpAddress}`)
+
+  // Version-skew advisory — non-fatal, fail-open. Surfaces the gap when the
+  // operator's globally installed `neat.is` binary lags the published
+  // version. Set NEAT_DISABLE_VERSION_CHECK=1 to silence the check (e.g. in
+  // air-gapped environments).
+  if (process.env.NEAT_DISABLE_VERSION_CHECK !== '1') {
+    void checkVersionSkew({ localVersion: localVersion() }).catch(() => {
+      // Fail-open: any thrown error from the helper resolves silently. The
+      // helper already catches its own internals; this catches anything
+      // exotic the Promise chain bubbles up.
+    })
+  }
 
   // ADR-059 — bring up the web UI alongside the daemon. Failure here aborts
   // start with the clear-error pattern from ADR-049 instead of silently

--- a/packages/core/src/version-skew.ts
+++ b/packages/core/src/version-skew.ts
@@ -1,0 +1,127 @@
+/**
+ * Version-skew check for `neatd start` (ADR-049 §Lifecycle — non-fatal
+ * advisory).
+ *
+ * A globally installed `neat.is` binary may run an older version than the
+ * `neat.is` available on npm — happens when the operator has not run
+ * `npm install -g neat.is@latest` since the last publish. The six packages
+ * move in lockstep (publish-system contract / ADR-052), so the registry
+ * version of `neat.is` mirrors the local `@neat.is/core` version.
+ *
+ * On daemon start we compare the two and log a single advisory line when
+ * the registry is ahead. The check is fail-open by design — registry
+ * unreachable, slow, or returning an unexpected payload all resolve to
+ * "no warning, daemon proceeds normally."
+ */
+
+import { setTimeout as delay } from 'node:timers/promises'
+
+const NPM_REGISTRY_URL = 'https://registry.npmjs.org/neat.is/latest'
+const DEFAULT_TIMEOUT_MS = 2000
+
+export interface VersionSkewCheckOptions {
+  // The local version the running daemon reports. Production: read from the
+  // bundled @neat.is/core package.json. Tests pass a literal.
+  localVersion: string
+  // Override the registry URL (tests point at a mock server).
+  registryUrl?: string
+  // Timeout for the registry fetch. Defaults to 2s.
+  timeoutMs?: number
+  // Injected so tests can simulate slow responses without real timers.
+  fetchImpl?: typeof fetch
+  // Sink for the advisory line. Defaults to console.warn.
+  warn?: (message: string) => void
+}
+
+export interface VersionSkewCheckResult {
+  // The version the registry reported, or null on any fetch / parse failure.
+  remoteVersion: string | null
+  // Whether the local version is behind the registry's.
+  skewed: boolean
+  // Whether the advisory was emitted.
+  warned: boolean
+}
+
+/**
+ * Fail-open registry lookup. Returns the version string or null on any
+ * non-success path (network, timeout, parse, missing field).
+ */
+async function fetchRegistryVersion(
+  url: string,
+  timeoutMs: number,
+  fetchImpl: typeof fetch,
+): Promise<string | null> {
+  const controller = new AbortController()
+  let timedOut = false
+  const timer = delay(timeoutMs).then(() => {
+    timedOut = true
+    controller.abort()
+  })
+  try {
+    const res = await Promise.race([
+      fetchImpl(url, { signal: controller.signal, headers: { accept: 'application/json' } }),
+      timer.then(() => null),
+    ])
+    if (timedOut || !res) return null
+    if (!res.ok) return null
+    const body = (await res.json()) as { version?: unknown }
+    if (typeof body.version !== 'string' || body.version.length === 0) return null
+    return body.version
+  } catch {
+    return null
+  } finally {
+    // Make sure the abort fires so the delay promise resolves even on
+    // success — keeps the process from hanging on test teardown.
+    if (!timedOut) controller.abort()
+  }
+}
+
+/**
+ * Compare two semver-shaped strings. Returns true when `local` is strictly
+ * older than `remote`. We don't use a real semver library because the
+ * advisory is intentionally coarse — any non-equal pair where the registry
+ * looks newer is enough to suggest a re-install. The implementation does a
+ * plain segment-by-segment integer compare and tolerates pre-release
+ * suffixes by stripping them off.
+ */
+export function isLocalBehind(local: string, remote: string): boolean {
+  if (local === remote) return false
+  const parse = (v: string): number[] => {
+    const core = v.split(/[-+]/)[0] ?? v
+    return core.split('.').map((s) => {
+      const n = Number.parseInt(s, 10)
+      return Number.isFinite(n) ? n : 0
+    })
+  }
+  const a = parse(local)
+  const b = parse(remote)
+  const len = Math.max(a.length, b.length)
+  for (let i = 0; i < len; i++) {
+    const av = a[i] ?? 0
+    const bv = b[i] ?? 0
+    if (av < bv) return true
+    if (av > bv) return false
+  }
+  return false
+}
+
+export async function checkVersionSkew(
+  opts: VersionSkewCheckOptions,
+): Promise<VersionSkewCheckResult> {
+  const url = opts.registryUrl ?? NPM_REGISTRY_URL
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const fetchImpl = opts.fetchImpl ?? fetch
+  const warn = opts.warn ?? ((m) => console.warn(m))
+
+  const remote = await fetchRegistryVersion(url, timeoutMs, fetchImpl)
+  if (!remote) return { remoteVersion: null, skewed: false, warned: false }
+
+  if (!isLocalBehind(opts.localVersion, remote)) {
+    return { remoteVersion: remote, skewed: false, warned: false }
+  }
+
+  warn(
+    `[neatd] running neat.is@${opts.localVersion} but neat.is@${remote} is on npm — run \`npm install -g neat.is@latest\` to update`,
+  )
+  return { remoteVersion: remote, skewed: true, warned: true }
+}

--- a/packages/core/test/version-skew.test.ts
+++ b/packages/core/test/version-skew.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest'
+import { checkVersionSkew, isLocalBehind } from '../src/version-skew.js'
+
+describe('isLocalBehind', () => {
+  it('returns true when local is strictly older', () => {
+    expect(isLocalBehind('0.3.4', '0.3.5')).toBe(true)
+    expect(isLocalBehind('0.3.5', '0.4.0')).toBe(true)
+    expect(isLocalBehind('0.2.99', '0.3.0')).toBe(true)
+  })
+
+  it('returns false when local equals remote', () => {
+    expect(isLocalBehind('0.3.5', '0.3.5')).toBe(false)
+  })
+
+  it('returns false when local is newer', () => {
+    expect(isLocalBehind('0.3.6', '0.3.5')).toBe(false)
+    expect(isLocalBehind('0.4.0', '0.3.99')).toBe(false)
+  })
+
+  it('strips pre-release suffixes before compare', () => {
+    expect(isLocalBehind('0.3.5-rc.1', '0.3.5')).toBe(false)
+    expect(isLocalBehind('0.3.4', '0.3.5-rc.1')).toBe(true)
+  })
+})
+
+describe('checkVersionSkew', () => {
+  function jsonResponse(body: unknown): Response {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+
+  it('emits the advisory when registry is ahead of local (issue #282)', async () => {
+    const warn = vi.fn()
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ version: '0.3.6' }))
+    const result = await checkVersionSkew({
+      localVersion: '0.3.5',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      warn,
+    })
+    expect(result.remoteVersion).toBe('0.3.6')
+    expect(result.skewed).toBe(true)
+    expect(result.warned).toBe(true)
+    expect(warn).toHaveBeenCalledTimes(1)
+    const msg = warn.mock.calls[0]![0] as string
+    expect(msg).toContain('neat.is@0.3.5')
+    expect(msg).toContain('neat.is@0.3.6')
+    expect(msg).toContain('npm install -g neat.is@latest')
+  })
+
+  it('does not warn when local matches registry (issue #282)', async () => {
+    const warn = vi.fn()
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ version: '0.3.5' }))
+    const result = await checkVersionSkew({
+      localVersion: '0.3.5',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      warn,
+    })
+    expect(result.skewed).toBe(false)
+    expect(result.warned).toBe(false)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when local is ahead of registry (e.g. local dev build)', async () => {
+    const warn = vi.fn()
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ version: '0.3.5' }))
+    const result = await checkVersionSkew({
+      localVersion: '0.3.6',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      warn,
+    })
+    expect(result.skewed).toBe(false)
+    expect(result.warned).toBe(false)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('fails open when the registry fetch throws (issue #282)', async () => {
+    const warn = vi.fn()
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('ENOTFOUND'))
+    const result = await checkVersionSkew({
+      localVersion: '0.3.5',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      warn,
+    })
+    expect(result.remoteVersion).toBeNull()
+    expect(result.skewed).toBe(false)
+    expect(result.warned).toBe(false)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('fails open when the registry returns a malformed body', async () => {
+    const warn = vi.fn()
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ notVersion: '0.3.6' }))
+    const result = await checkVersionSkew({
+      localVersion: '0.3.5',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      warn,
+    })
+    expect(result.remoteVersion).toBeNull()
+    expect(result.warned).toBe(false)
+  })
+
+  it('fails open when the registry returns a non-success status', async () => {
+    const warn = vi.fn()
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response('not found', { status: 404 }),
+    )
+    const result = await checkVersionSkew({
+      localVersion: '0.3.5',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      warn,
+    })
+    expect(result.remoteVersion).toBeNull()
+    expect(result.warned).toBe(false)
+  })
+
+  it('fails open and does not throw when the fetch times out', async () => {
+    const warn = vi.fn()
+    // fetchImpl never resolves before the timeout fires.
+    const fetchImpl = vi.fn().mockImplementation(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new Error('aborted'))
+          })
+        }),
+    )
+    const result = await checkVersionSkew({
+      localVersion: '0.3.5',
+      timeoutMs: 25,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      warn,
+    })
+    expect(result.remoteVersion).toBeNull()
+    expect(result.warned).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- `neatd start` now performs a non-blocking, fail-open version-skew check against `https://registry.npmjs.org/neat.is/latest`.
- When the registry reports a higher version than the local install, the daemon prints a single advisory line pointing at `npm install -g neat.is@latest`.
- The check times out at 2s. Any failure (network, malformed body, non-200) resolves silently — the daemon proceeds normally.
- `NEAT_DISABLE_VERSION_CHECK=1` opts out entirely for air-gapped setups.

## Test plan

- [x] 11 new assertions in `packages/core/test/version-skew.test.ts` cover warn / no-warn / fail-open / timeout / malformed-body paths.
- [x] `npx vitest run` green across all 23 core test files (578 tests).
- [x] `npx turbo lint --filter=@neat.is/core` clean.
- [x] Manual verification deferred to v0.3.6 phase-3 (Faking local version against a live registry response).

Refs #282