### PR TITLE
v0.3.6: OTLP /v1/traces matches response Content-Type to request

### DIFF
--- a/docs/contracts/otel-ingest.md
+++ b/docs/contracts/otel-ingest.md
@@ -75,6 +75,8 @@ The HTTP receiver dispatches on `Content-Type`:
 - `application/x-protobuf` — buffered as raw bytes, decoded against the bundled `.proto` definitions (ADR-020) via `protobufjs`, reshaped through `reshapeGrpcRequest` (the same path the gRPC receiver uses), then fed into `parseOtlpRequest`. A decode failure returns 400.
 - Anything else returns 415.
 
+**Response Content-Type matches the request.** The OTLP spec requires the encoding to be symmetric: a JSON exporter receives a JSON-encoded `ExportTraceServiceResponse`, a protobuf exporter receives a protobuf-encoded one. Mismatched encodings cause client SDKs to log decode errors every batch. Both branches reply with the semantic equivalent of `partialSuccess: {}` (all spans accepted); the protobuf branch encodes `ExportTraceServiceResponse` via the bundled `.proto` (cached after first encode), the JSON branch sends the historical JSON shape with an explicit `Content-Type: application/json` header.
+
 gRPC continues to handle protobuf natively in `otel-grpc.ts`.
 
 ## `db.system` is data, not a switch

--- a/packages/core/src/otel.ts
+++ b/packages/core/src/otel.ts
@@ -230,9 +230,9 @@ export interface OtelReceiver {
 // .proto tree at packages/core/proto/ is shared with the gRPC receiver
 // (ADR-020). Cached after first load so successive receiver builds reuse it.
 let exportTraceServiceRequestType: protobuf.Type | null = null
+let exportTraceServiceResponseType: protobuf.Type | null = null
 
-function loadProtobufDecoder(): protobuf.Type {
-  if (exportTraceServiceRequestType) return exportTraceServiceRequestType
+function loadProtoRoot(): protobuf.Root {
   const here = path.dirname(fileURLToPath(import.meta.url))
   const protoRoot = path.resolve(here, '..', 'proto')
   const root = new protobuf.Root()
@@ -241,10 +241,41 @@ function loadProtobufDecoder(): protobuf.Type {
     'opentelemetry/proto/collector/trace/v1/trace_service.proto',
     { keepCase: true },
   )
+  return root
+}
+
+function loadProtobufDecoder(): protobuf.Type {
+  if (exportTraceServiceRequestType) return exportTraceServiceRequestType
+  const root = loadProtoRoot()
   exportTraceServiceRequestType = root.lookupType(
     'opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest',
   )
   return exportTraceServiceRequestType
+}
+
+function loadProtobufResponseEncoder(): protobuf.Type {
+  if (exportTraceServiceResponseType) return exportTraceServiceResponseType
+  const root = loadProtoRoot()
+  exportTraceServiceResponseType = root.lookupType(
+    'opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse',
+  )
+  return exportTraceServiceResponseType
+}
+
+// Empty-partial-success response, encoded once and cached. Per ADR-033 the
+// receiver always reports "all accepted" today — there's no per-span reject
+// path. Caching the bytes avoids re-running the protobuf encoder per request.
+let cachedProtobufResponseBody: Buffer | null = null
+
+function encodeProtobufResponseBody(): Buffer {
+  if (cachedProtobufResponseBody) return cachedProtobufResponseBody
+  const Type = loadProtobufResponseEncoder()
+  // `partial_success` left unset = empty submessage = "everything accepted".
+  // verify() returns null on success; the empty payload is always valid.
+  const msg = Type.create({})
+  const encoded = Type.encode(msg).finish()
+  cachedProtobufResponseBody = Buffer.from(encoded)
+  return cachedProtobufResponseBody
 }
 
 async function decodeProtobufBody(buf: Buffer): Promise<OtlpTracesRequest> {
@@ -315,9 +346,14 @@ export async function buildOtelReceiver(
   app.post('/v1/traces', async (req, reply) => {
     // Content-Type dispatch (ADR-033). Both JSON and protobuf decode to the
     // same OtlpTracesRequest shape, then feed parseOtlpRequest unchanged.
+    // The response encoding mirrors the request encoding per the OTLP spec —
+    // a JSON exporter receives JSON, a protobuf exporter receives protobuf.
+    // Mismatched encodings cause client SDKs to log decode errors every batch.
     const ct = (req.headers['content-type'] ?? '').toString().split(';')[0]!.trim().toLowerCase()
     let body: OtlpTracesRequest
+    let responseFlavor: 'json' | 'protobuf'
     if (ct === 'application/x-protobuf') {
+      responseFlavor = 'protobuf'
       try {
         body = await decodeProtobufBody(req.body as Buffer)
       } catch (err) {
@@ -326,6 +362,7 @@ export async function buildOtelReceiver(
         })
       }
     } else if (!ct || ct === 'application/json') {
+      responseFlavor = 'json'
       body = (req.body ?? {}) as OtlpTracesRequest
     } else {
       return reply.code(415).send({ error: `unsupported content-type: ${ct}` })
@@ -347,7 +384,20 @@ export async function buildOtelReceiver(
     }
     enqueue(spans)
     // OTLP success response is `{ partialSuccess: {} }` for "all accepted".
-    return reply.code(200).send({ partialSuccess: {} })
+    // Match the response Content-Type to the request: protobuf in → protobuf
+    // out, JSON in → JSON out. Default Fastify JSON reply path stays as the
+    // historical shape for JSON callers.
+    if (responseFlavor === 'protobuf') {
+      const buf = encodeProtobufResponseBody()
+      return reply
+        .code(200)
+        .header('content-type', 'application/x-protobuf')
+        .send(buf)
+    }
+    return reply
+      .code(200)
+      .header('content-type', 'application/json')
+      .send({ partialSuccess: {} })
   })
 
   // Attach flushPending so tests can wait for the queue without exporting a

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -1562,6 +1562,74 @@ describe('OTel ingest contract (ADR-033)', () => {
     expect(ev!.errorMessage).toBe('unknown error')
     expect(ev!.errorMessage).not.toBe('POST')
   })
+
+  it('HTTP receiver matches response Content-Type to request encoding (issue #293)', async () => {
+    const { buildOtelReceiver } = await import('../../src/otel.js')
+    const protobuf = (await import('protobufjs')).default
+    const pathMod = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const here = pathMod.dirname(fileURLToPath(import.meta.url))
+    const protoRoot = pathMod.resolve(here, '..', '..', 'proto')
+    const root = new protobuf.Root()
+    root.resolvePath = (_o, t) => pathMod.resolve(protoRoot, t)
+    root.loadSync(
+      'opentelemetry/proto/collector/trace/v1/trace_service.proto',
+      { keepCase: true },
+    )
+    const RequestType = root.lookupType(
+      'opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest',
+    )
+    const ResponseType = root.lookupType(
+      'opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse',
+    )
+
+    const app = await buildOtelReceiver({ onSpan: () => {} })
+    try {
+      // Protobuf in → protobuf out.
+      const reqBuf = Buffer.from(
+        RequestType.encode({
+          resource_spans: [
+            {
+              resource: {
+                attributes: [{ key: 'service.name', value: { string_value: 'svc' } }],
+              },
+              scope_spans: [
+                {
+                  spans: [
+                    { name: 'op', start_time_unix_nano: '0', end_time_unix_nano: '0' },
+                  ],
+                },
+              ],
+            },
+          ],
+        }).finish(),
+      )
+      const pbRes = await app.inject({
+        method: 'POST',
+        url: '/v1/traces',
+        headers: { 'content-type': 'application/x-protobuf' },
+        payload: reqBuf,
+      })
+      expect(pbRes.statusCode).toBe(200)
+      expect(pbRes.headers['content-type']).toBe('application/x-protobuf')
+      // Body decodes against the OTLP response schema — the test that proved
+      // the bug was a client SDK throwing on this exact decode.
+      expect(() => ResponseType.decode(pbRes.rawPayload)).not.toThrow()
+
+      // JSON in → JSON out.
+      const jsonRes = await app.inject({
+        method: 'POST',
+        url: '/v1/traces',
+        headers: { 'content-type': 'application/json' },
+        payload: { resourceSpans: [] },
+      })
+      expect(jsonRes.statusCode).toBe(200)
+      expect((jsonRes.headers['content-type'] ?? '').toString()).toMatch(/application\/json/)
+      expect(JSON.parse(jsonRes.payload)).toEqual({ partialSuccess: {} })
+    } finally {
+      await app.close()
+    }
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/core/test/otel.test.ts
+++ b/packages/core/test/otel.test.ts
@@ -269,4 +269,70 @@ describe('buildOtelReceiver', () => {
     await (app as unknown as { flushPending: () => Promise<void> }).flushPending()
     expect(collected.find((s) => s.service === 'service-pb' && s.name === 'op-pb')).toBeDefined()
   })
+
+  it('replies with protobuf-encoded ExportTraceServiceResponse for protobuf requests', async () => {
+    const protobuf = (await import('protobufjs')).default
+    const path = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const here = path.dirname(fileURLToPath(import.meta.url))
+    const protoRoot = path.resolve(here, '..', 'proto')
+    const root = new protobuf.Root()
+    root.resolvePath = (_o, t) => path.resolve(protoRoot, t)
+    root.loadSync(
+      'opentelemetry/proto/collector/trace/v1/trace_service.proto',
+      { keepCase: true },
+    )
+    const RequestType = root.lookupType(
+      'opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest',
+    )
+    const ResponseType = root.lookupType(
+      'opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse',
+    )
+    const reqBuf = Buffer.from(
+      RequestType.encode({
+        resource_spans: [
+          {
+            resource: {
+              attributes: [
+                { key: 'service.name', value: { string_value: 'svc-resp-pb' } },
+              ],
+            },
+            scope_spans: [
+              { spans: [{ name: 'op', start_time_unix_nano: '0', end_time_unix_nano: '0' }] },
+            ],
+          },
+        ],
+      }).finish(),
+    )
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/traces',
+      headers: { 'content-type': 'application/x-protobuf' },
+      payload: reqBuf,
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['content-type']).toBe('application/x-protobuf')
+    // Body decodes cleanly against the OTLP response schema; partial_success
+    // either unset or with no rejected spans means "all accepted".
+    const body = res.rawPayload
+    expect(Buffer.isBuffer(body)).toBe(true)
+    const decoded = ResponseType.decode(body).toJSON() as {
+      partial_success?: { rejected_spans?: number | string; error_message?: string }
+    }
+    const rejected = decoded.partial_success?.rejected_spans
+    expect(rejected === undefined || rejected === 0 || rejected === '0').toBe(true)
+  })
+
+  it('replies with JSON for JSON requests', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/traces',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify(SAMPLE_BODY),
+    })
+    expect(res.statusCode).toBe(200)
+    expect((res.headers['content-type'] ?? '').toString()).toMatch(/application\/json/)
+    expect(JSON.parse(res.payload)).toEqual({ partialSuccess: {} })
+  })
 })


### PR DESCRIPTION
## Summary
- Match the response encoding on `/v1/traces` to the request encoding: protobuf in → protobuf-encoded `ExportTraceServiceResponse` out, JSON in → JSON envelope out with explicit `Content-Type: application/json`
- Cache the empty-`partialSuccess` protobuf body after first encode — same allocation pattern as the request decoder
- Contract amendment: `otel-ingest.md` § HTTP receiver gains a "Response Content-Type matches the request" rule

## Test plan
- [x] `npx turbo test --filter=@neat.is/core` — 605 pass, 4 todo (baseline)
- [x] New `otel.test.ts` cases assert protobuf-in → protobuf-out (body decodes against `ExportTraceServiceResponse`) and JSON-in → JSON-out
- [x] Contract assertion in `contracts.test.ts` under the OTel ingest contract block

Refs #293