### PR TITLE
v0.3.6: src/ + scripts-based entry detection for neat init --apply

### DIFF
--- a/packages/core/src/installers/javascript.ts
+++ b/packages/core/src/installers/javascript.ts
@@ -94,23 +94,81 @@ async function detect(serviceDir: string): Promise<boolean> {
   return pkg !== null && typeof pkg.name === 'string'
 }
 
-// ADR-069 §2 — entry resolution order: pkg.main → pkg.bin → index.{ts,tsx,js,mjs,cjs}.
+// ADR-069 §2 + ADR-070 — entry resolution: pkg.main → pkg.bin → scripts.start
+// → scripts.dev → src/index.* → src/{server,main,app}.* → root index.*.
 // Returns the absolute path to the resolved entry, or null when the package
 // is lib-only (no resolvable entry).
-const INDEX_CANDIDATES = ['index.ts', 'index.tsx', 'index.js', 'index.mjs', 'index.cjs']
+const INDEX_EXTENSIONS = ['.ts', '.tsx', '.js', '.mjs', '.cjs']
+const INDEX_CANDIDATES = INDEX_EXTENSIONS.map((ext) => `index${ext}`)
+const SRC_INDEX_CANDIDATES = INDEX_EXTENSIONS.map((ext) => `src/index${ext}`)
+const SRC_NAMED_CANDIDATES = ['server', 'main', 'app'].flatMap((name) =>
+  INDEX_EXTENSIONS.map((ext) => `src/${name}${ext}`),
+)
+
+// ADR-070 — script-entry tokeniser. Launchers and similar wrappers we strip
+// before reading the first file-shaped argument. Anything not in this set is
+// treated as a candidate entry if it looks like a relative file path.
+const SCRIPT_LAUNCHERS = new Set([
+  'node',
+  'ts-node',
+  'tsx',
+  'ts-node-dev',
+  'nodemon',
+  'npx',
+  'pnpm',
+  'yarn',
+  'npm',
+  'cross-env',
+  'dotenv',
+  '--',
+])
+
+// True when the token resembles a path inside the package — contains a `/` or
+// ends in one of the JS/TS extensions we instrument.
+function looksLikeEntryPath(token: string): boolean {
+  if (token.length === 0) return false
+  if (token.startsWith('-')) return false
+  if (token.includes('=')) return false // env-var assignments
+  if (token.includes('/')) return true
+  return /\.(?:m?[jt]sx?|c[jt]s)$/.test(token)
+}
+
+// Bail when the script chains commands or pipes — those scripts mean an
+// orchestrator runs multiple things and our heuristic can't pick safely.
+function scriptHasShellChain(script: string): boolean {
+  return /(?:&&|\|\||;|\|(?!\|))/.test(script)
+}
+
+// Pull the first file-shaped argument out of a script invocation, after
+// stripping recognised launchers and inline env-var assignments. Returns
+// undefined when no candidate surfaces (or when shell chaining bails us out).
+export function entryFromScript(script: string | undefined): string | undefined {
+  if (!script) return undefined
+  if (scriptHasShellChain(script)) return undefined
+  const tokens = script.split(/\s+/).filter((t) => t.length > 0)
+  for (const token of tokens) {
+    const lower = token.toLowerCase()
+    if (SCRIPT_LAUNCHERS.has(lower)) continue
+    // Strip a leading `./` so the existence check resolves cleanly.
+    const cleaned = token.startsWith('./') ? token.slice(2) : token
+    if (looksLikeEntryPath(cleaned)) return cleaned
+  }
+  return undefined
+}
 
 export async function resolveEntry(
   serviceDir: string,
   pkg: PackageJsonShape,
 ): Promise<string | null> {
+  // 1) pkg.main — but only when it actually exists on disk (ADR-070).
   if (typeof pkg.main === 'string' && pkg.main.length > 0) {
     const candidate = path.resolve(serviceDir, pkg.main)
     if (await exists(candidate)) return candidate
-    // Some manifests point `main` at a compiled dist file that doesn't exist
-    // pre-build. The contract says we resolve the path the manifest names; if
-    // it isn't on disk we fall through to bin/index, because injection has to
-    // land in a file that exists.
+    // Manifest points main at a missing build output (e.g. dist/index.js
+    // pre-build). Fall through to bin/scripts/src heuristics rather than
+    // marking lib-only.
   }
+  // 2) pkg.bin (string or pkg.name-keyed map).
   if (pkg.bin) {
     let binEntry: string | undefined
     if (typeof pkg.bin === 'string') {
@@ -118,7 +176,6 @@ export async function resolveEntry(
     } else if (pkg.name && typeof pkg.bin[pkg.name] === 'string') {
       binEntry = pkg.bin[pkg.name]
     } else {
-      // Map form, but no entry keyed on pkg.name. Take the first value.
       const first = Object.values(pkg.bin)[0]
       if (typeof first === 'string') binEntry = first
     }
@@ -127,6 +184,29 @@ export async function resolveEntry(
       if (await exists(candidate)) return candidate
     }
   }
+  // 3) scripts.start — ADR-070.
+  const startEntry = entryFromScript(pkg.scripts?.start)
+  if (startEntry) {
+    const candidate = path.resolve(serviceDir, startEntry)
+    if (await exists(candidate)) return candidate
+  }
+  // 4) scripts.dev — ADR-070.
+  const devEntry = entryFromScript(pkg.scripts?.dev)
+  if (devEntry) {
+    const candidate = path.resolve(serviceDir, devEntry)
+    if (await exists(candidate)) return candidate
+  }
+  // 5) src/index.* — ADR-070.
+  for (const rel of SRC_INDEX_CANDIDATES) {
+    const candidate = path.join(serviceDir, rel)
+    if (await exists(candidate)) return candidate
+  }
+  // 6) src/server.*, src/main.*, src/app.* — ADR-070.
+  for (const rel of SRC_NAMED_CANDIDATES) {
+    const candidate = path.join(serviceDir, rel)
+    if (await exists(candidate)) return candidate
+  }
+  // 7) root index.* — original ADR-069 §3 fallback.
   for (const name of INDEX_CANDIDATES) {
     const candidate = path.join(serviceDir, name)
     if (await exists(candidate)) return candidate

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -3957,16 +3957,147 @@ describe('SDK install — apply-side (ADR-069)', () => {
   })
 
   // ── ADR-070 — extended entry detection ──────────────────────────────────
-  // These flip live as the v0.3.6 implementation lands.
 
-  it.todo('ADR-070 — pkg.main pointing at missing dist/ falls through to next step')
-  it.todo('ADR-070 — scripts.start = "node dist/server.js" resolves to dist/server.js')
-  it.todo('ADR-070 — scripts.start = "ts-node src/index.ts" resolves to src/index.ts')
-  it.todo('ADR-070 — scripts.dev = "tsx watch src/server.ts" resolves to src/server.ts')
-  it.todo('ADR-070 — src/index.{ts,tsx,js,mjs,cjs} heuristic')
-  it.todo('ADR-070 — src/server.ts, src/main.ts, src/app.ts each resolved when present')
-  it.todo('ADR-070 — chained shell (a && b) in scripts.start bails out cleanly')
-  it.todo('ADR-070 — entry resolution stays deterministic across runs')
+  it('ADR-070 — pkg.main pointing at missing dist/ falls through to next step', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+    const { dir, cleanup } = await makeNodeService()
+    try {
+      // main points at dist/server.js but only src/index.ts exists. The seven-
+      // step heuristic should bypass main and land on src/index.ts.
+      await writePkg(dir, { name: 'svc', main: 'dist/server.js' })
+      await fs2.mkdir(path2.join(dir, 'src'), { recursive: true })
+      await fs2.writeFile(path2.join(dir, 'src/index.ts'), `console.log('hi')\n`)
+      const plan = await javascriptInstaller.plan(dir)
+      expect(plan.entryFile).toBe(path2.join(dir, 'src/index.ts'))
+      expect(plan.libOnly).toBeFalsy()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('ADR-070 — scripts.start = "node dist/server.js" resolves to dist/server.js', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+    const { dir, cleanup } = await makeNodeService()
+    try {
+      await writePkg(dir, { name: 'svc', scripts: { start: 'node dist/server.js' } })
+      await fs2.mkdir(path2.join(dir, 'dist'), { recursive: true })
+      await fs2.writeFile(path2.join(dir, 'dist/server.js'), `console.log('hi')\n`)
+      const plan = await javascriptInstaller.plan(dir)
+      expect(plan.entryFile).toBe(path2.join(dir, 'dist/server.js'))
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('ADR-070 — scripts.start = "ts-node src/index.ts" resolves to src/index.ts', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+    const { dir, cleanup } = await makeNodeService()
+    try {
+      await writePkg(dir, { name: 'svc', scripts: { start: 'ts-node src/index.ts' } })
+      await fs2.mkdir(path2.join(dir, 'src'), { recursive: true })
+      await fs2.writeFile(path2.join(dir, 'src/index.ts'), `console.log('hi')\n`)
+      const plan = await javascriptInstaller.plan(dir)
+      expect(plan.entryFile).toBe(path2.join(dir, 'src/index.ts'))
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('ADR-070 — scripts.dev = "tsx watch src/server.ts" resolves to src/server.ts', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+    const { dir, cleanup } = await makeNodeService()
+    try {
+      await writePkg(dir, { name: 'svc', scripts: { dev: 'tsx watch src/server.ts' } })
+      await fs2.mkdir(path2.join(dir, 'src'), { recursive: true })
+      await fs2.writeFile(path2.join(dir, 'src/server.ts'), `console.log('hi')\n`)
+      const plan = await javascriptInstaller.plan(dir)
+      expect(plan.entryFile).toBe(path2.join(dir, 'src/server.ts'))
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('ADR-070 — src/index.{ts,tsx,js,mjs,cjs} heuristic', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+    for (const name of ['index.ts', 'index.tsx', 'index.js', 'index.mjs', 'index.cjs']) {
+      const { dir, cleanup } = await makeNodeService()
+      try {
+        await writePkg(dir, { name: 'svc' })
+        await fs2.mkdir(path2.join(dir, 'src'), { recursive: true })
+        await fs2.writeFile(path2.join(dir, 'src', name), `console.log('hi')\n`)
+        const plan = await javascriptInstaller.plan(dir)
+        expect(plan.entryFile).toBe(path2.join(dir, 'src', name))
+      } finally {
+        await cleanup()
+      }
+    }
+  })
+
+  it('ADR-070 — src/server.ts, src/main.ts, src/app.ts each resolved when present', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+    for (const name of ['server.ts', 'main.ts', 'app.ts']) {
+      const { dir, cleanup } = await makeNodeService()
+      try {
+        await writePkg(dir, { name: 'svc' })
+        await fs2.mkdir(path2.join(dir, 'src'), { recursive: true })
+        await fs2.writeFile(path2.join(dir, 'src', name), `console.log('hi')\n`)
+        const plan = await javascriptInstaller.plan(dir)
+        expect(plan.entryFile).toBe(path2.join(dir, 'src', name))
+      } finally {
+        await cleanup()
+      }
+    }
+  })
+
+  it('ADR-070 — chained shell (a && b) in scripts.start bails out cleanly', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+    const { dir, cleanup } = await makeNodeService()
+    try {
+      // Chained shell — the tokeniser bails. src/index.ts is the next match
+      // through the heuristic, so the plan resolves there cleanly.
+      await writePkg(dir, {
+        name: 'svc',
+        scripts: { start: 'npm run build && node dist/server.js' },
+      })
+      await fs2.mkdir(path2.join(dir, 'src'), { recursive: true })
+      await fs2.writeFile(path2.join(dir, 'src/index.ts'), `console.log('hi')\n`)
+      const plan = await javascriptInstaller.plan(dir)
+      expect(plan.entryFile).toBe(path2.join(dir, 'src/index.ts'))
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('ADR-070 — entry resolution stays deterministic across runs', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+    const { dir, cleanup } = await makeNodeService()
+    try {
+      await writePkg(dir, { name: 'svc', scripts: { start: 'ts-node src/index.ts' } })
+      await fs2.mkdir(path2.join(dir, 'src'), { recursive: true })
+      await fs2.writeFile(path2.join(dir, 'src/index.ts'), `console.log('hi')\n`)
+      const a = await javascriptInstaller.plan(dir)
+      const b = await javascriptInstaller.plan(dir)
+      expect(JSON.stringify(b)).toBe(JSON.stringify(a))
+    } finally {
+      await cleanup()
+    }
+  })
 })
 
 describe('Machine-level project registry contract (ADR-048)', () => {


### PR DESCRIPTION
## Summary
- Extends \`resolveEntry\` to the ADR-070 seven-step heuristic: \`pkg.main\` (must exist on disk) → \`pkg.bin\` → \`scripts.start\` tokenised → \`scripts.dev\` tokenised → \`src/index.*\` → \`src/{server,main,app}.*\` → root \`index.*\`
- Adds an \`entryFromScript\` tokeniser exported for reuse and contract testing. Strips recognised launchers (\`node\`, \`ts-node\`, \`tsx\`, \`ts-node-dev\`, \`nodemon\`, \`npx\`, \`pnpm\`, \`yarn\`, \`npm\`, \`cross-env\`, \`dotenv\`) plus env-var assignments. Bails on chained shells
- Lands 8 ADR-070 contract assertions live in \`contracts.test.ts\` (sibling PR #296 added the contract text)

## Test plan
- [x] \`npx turbo test --filter=@neat.is/core\` — 610 pass, 4 todo (baseline unchanged)
- [x] \`npx turbo lint --filter=@neat.is/core\` — clean
- [x] New tests cover: missing \`main\` → src fallback, \`node dist/server.js\`, \`ts-node src/index.ts\`, \`tsx watch src/server.ts\`, all five \`src/index.*\` extensions, \`src/{server,main,app}.ts\`, chained-shell bail, deterministic across runs

Refs #292