### PR TITLE
v0.3.7: route spans loudly + auto-recover broken projects + SIGHUP shortcut fix

### DIFF
--- a/docs/contracts/daemon.md
+++ b/docs/contracts/daemon.md
@@ -8,7 +8,7 @@ governs:
   - "packages/core/src/ingest.ts"
   - "packages/core/src/extract/index.ts"
   - "packages/core/src/persist.ts"
-adr: [ADR-049, ADR-063, ADR-048, ADR-026, ADR-027]
+adr: [ADR-049, ADR-063, ADR-048, ADR-026, ADR-027, ADR-071]
 ---
 
 # Daemon contract
@@ -61,11 +61,31 @@ The OTLP/gRPC receiver on `:4317` stays opt-in via `NEAT_OTLP_GRPC=true` per the
 
 Spans route to a project by `service.name` lookup across registered projects. Spans for unknown services route to a fallback `'default'` project for FrontierNode auto-creation per ADR-033.
 
+Routing eligibility by status:
+
+- `active` matches by `service.name` (steady state).
+- `broken` also matches by name. The router selects the broken slot so the ingest-time recovery path (below) can attempt a single re-bootstrap before the span is dropped. If recovery fails, the span is dropped with a rate-limited warning that points at `neatd reload`.
+- `paused` never matches — the operator paused the project on purpose. The span falls through to the `default` project's FrontierNode flow.
+
+## Ingest-time recovery for broken projects (ADR-071)
+
+A broken project slot is recoverable territory. When a span arrives for a project whose slot is `broken`, the daemon attempts a single inline re-bootstrap via `bootstrapProject(entry)`:
+
+- Success → the slot transitions to `active`, its `status` updates in the registry via `setStatus`, the span lands as a normal OBSERVED edge.
+- Failure → the slot stays `broken`, the span is dropped, and the receiver logs a single warning per project per 60 seconds carrying the original error reason and the `neatd reload` hint.
+
+Per-project recovery never affects other slots. The recovery attempt runs the same `bootstrapProject` path used at daemon start, so any rule that holds at bootstrap holds on recovery.
+
+## SIGHUP rebuilds broken slots
+
+`neatd reload` re-reads the registry. New entries get bootstrapped, removed ones get their persist loops stopped, **and any slot currently in `broken` is re-bootstrapped** — the operator's mental model for `reload` is "look at the world again," which includes giving broken slots a second chance against the current disk state. Already-`active` slots are left in place.
+
 ## Graceful degradation
 
 - Registry file missing → daemon refuses to boot with a clear error.
-- Project path missing → mark `status: 'broken'`, continue with others.
+- Project path missing → mark `status: 'broken'`, continue with others. The ingest-time recovery path retries on the next span; SIGHUP reload also retries.
 - OTel ingest overwhelmed → backpressure via the queue (ADR-033 #1); spans drop, never block.
+- Span arrives for a broken project, recovery still fails → drop with a rate-limited warning (1 line per project per 60s) carrying the broken-state reason and the `neatd reload` hint. Never silent.
 
 ## No automatic restart on crash
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2464,3 +2464,45 @@ The next maturity layer of the SDK installer's entry-resolution heuristic. ADR-0
 - **`pkg.exports` parsing.** ADR-069 §2 didn't read `exports`; ADR-070 doesn't either. Service packages publish their entry through `main`/`scripts`, not `exports`.
 
 **First application.** v0.3.6.
+
+---
+
+## ADR-071 — Broken project slots are recoverable on ingest and on SIGHUP
+
+**Date:** 2026-05-17
+**Status:** Active. Amends ADR-049 (daemon contract).
+
+The daemon treats `broken` as a recoverable, observable state. Spans for broken projects either lift the slot back to `active` through an inline re-bootstrap or get dropped with a rate-limited, actionable warning. SIGHUP reload also re-bootstraps any broken slot it finds. The per-project isolation property (ADR-049) is preserved.
+
+**Context.** ADR-049 codified `broken` as the status a project's slot takes when bootstrap fails — typically a missing path. The status is durable across the registry. The next maturity layer makes `broken` an observable, recoverable state at the ingest boundary: spans arriving for a broken slot become a recovery trigger, and the operator gains a clear surface to diagnose any slot that stays broken. The brief project on the v0.3.7 OTel-substrate-completion milestone is the first real-world target — a transient path condition at daemon start that the receiver should be able to resolve on the next span.
+
+**Decision.**
+
+1. **Routing eligibility extends to broken slots.** `routeSpanToProject(serviceName, projects)` matches any registered project with status `active` or `broken` by name. `paused` is still skipped — that's the operator's explicit "don't route here." Unknown service names continue to fall through to `DEFAULT_PROJECT` per ADR-033.
+
+2. **Ingest-time recovery.** When the OTel receiver resolves a span to a broken slot, the daemon calls `bootstrapProject(entry)` inline as a single recovery attempt before delivering the span. Success → the slot transitions to `active`, the registry is updated via `setStatus`, the span lands. Failure → the slot stays `broken` and the receiver drops the span with a rate-limited warning.
+
+3. **Rate-limited drop log.** The warning is `[neatd] dropping span for project "<name>" — project status: broken (<reason>). Run \`neatd reload\` to retry bootstrap.` Rate-limited to one line per project per 60 seconds via an in-memory `Map<name, ms>`. The error reason from the original bootstrap is carried verbatim so the operator can reason about the cause without grepping startup logs.
+
+4. **SIGHUP re-bootstraps broken slots.** `loadAll` (run on SIGHUP) iterates the registry. For each entry that already has a slot, it checks the slot status: if `broken`, it re-bootstraps the entry. Already-`active` slots are left in place, preserving the SIGHUP-is-cheap property. The operator's mental model for `reload` is "look at the world again," which includes giving broken slots a second chance.
+
+5. **No automatic respawn.** ADR-049's no-self-restart rule holds at the daemon process level. The recovery this ADR codifies is per-project slot recovery within an otherwise-running daemon. If the daemon process itself crashes, the supervisor restarts it per ADR-049.
+
+6. **Per-project isolation preserved.** A failed recovery attempt for one project does not stop, retry, or affect any other project's slot. The recovery runs the same `bootstrapProject` path used at daemon start, so any invariant the bootstrap path maintains (mutation authority via `ingest.ts` per ADR-030, graph reset via `resetGraph`, persist loop start) is preserved on recovery.
+
+**Authority.** `packages/core/src/daemon.ts` — `routeSpanToProject`, the new `tryRecoverSlot`, `warnDroppedSpan`, and the resolve-target-slot helper wired into both `onSpan` and `onErrorSpanSync`. `loadAll` extended to call `tryRecoverSlot` for slots already present in `broken`.
+
+**Enforcement.** New `it`s under the existing `describe('Daemon contract (ADR-049)')` block:
+
+- `routeSpanToProject` returns broken project name when service.name matches (paused still skipped).
+- Span arriving for a broken slot triggers an inline recovery attempt; success transitions to `active` and the span lands.
+- Span arriving for a still-broken slot after a failed recovery emits the rate-limited drop log; the second span within 60s does not re-log.
+- SIGHUP/`reload` re-bootstraps a slot currently in `broken` and lifts it to `active` when the path is now reachable.
+
+**Out of scope.**
+
+- **Time-based auto-retry of broken slots.** No background retry loop. The trigger is either a span or a SIGHUP. Background retries are a successor ADR if real-world traffic patterns show recovery needs to happen without ingest.
+- **Multi-attempt recovery on a single span.** One inline attempt per span. If recovery fails, the span drops; the next arriving span triggers a fresh attempt. This bounds the receiver's per-span work.
+- **Backoff between recovery attempts.** The 60s rate limit on the warning is the user-visible backoff. Internal recovery work is gated only by the next span's arrival.
+
+**First application.** v0.3.7.

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -106,6 +106,16 @@ function neatHomeFor(opts: DaemonOptions): string {
  *
  * Pure function. Daemon callers pass a snapshot of the registry to avoid
  * per-span fs reads.
+ *
+ * Routing eligibility:
+ * - `active` matches by name (the steady-state path).
+ * - `broken` also matches by name — the daemon needs the span to reach
+ *   the broken slot so the ingest-time auto-recover path can attempt a
+ *   bootstrap and lift the project back to `active`. The router only
+ *   chooses the target; whether the span actually lands is the ingest
+ *   handler's decision.
+ * - `paused` is intentionally not routed; the operator paused it on
+ *   purpose, so the span falls through to the default-project flow.
  */
 export function routeSpanToProject(
   serviceName: string | undefined,
@@ -113,10 +123,7 @@ export function routeSpanToProject(
 ): string {
   if (!serviceName) return DEFAULT_PROJECT
   for (const entry of projects) {
-    if (entry.status !== 'active') continue
-    if (entry.languages.length === 0) {
-      // No language data yet — still acceptable to match by name.
-    }
+    if (entry.status === 'paused') continue
     if (entry.name === serviceName) return entry.name
   }
   return DEFAULT_PROJECT
@@ -217,6 +224,22 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
   // reads from this; we keep it in sync as slots come and go.
   const registry = new Projects()
 
+  // Rate-limit the dropped-span warning to one log line per project per
+  // 60 seconds. OTel exporters retry on a tight cadence; without this we
+  // flood the console with the same line per batch when a broken project
+  // is sitting in the registry.
+  const DROP_WARN_INTERVAL_MS = 60_000
+  const lastDropWarnAt = new Map<string, number>()
+  function warnDroppedSpan(project: string, reason: string): void {
+    const now = Date.now()
+    const prev = lastDropWarnAt.get(project) ?? 0
+    if (now - prev < DROP_WARN_INTERVAL_MS) return
+    lastDropWarnAt.set(project, now)
+    console.warn(
+      `[neatd] dropping span for project "${project}" — project status: broken (${reason}). Run \`neatd reload\` to retry bootstrap.`,
+    )
+  }
+
   function upsertRegistryFromSlot(slot: ProjectSlot): void {
     if (slot.status !== 'active') return
     registry.set(slot.entry.name, {
@@ -226,12 +249,46 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
     })
   }
 
+  // Attempt to bring a broken slot back online. Used both on SIGHUP reload
+  // and inline on ingest when a span arrives for a broken project. Returns
+  // the new slot status so callers can decide whether to deliver the span.
+  async function tryRecoverSlot(entry: RegistryEntry): Promise<ProjectSlot> {
+    try {
+      const fresh = await bootstrapProject(entry)
+      slots.set(entry.name, fresh)
+      upsertRegistryFromSlot(fresh)
+      if (fresh.status === 'active') {
+        await setStatus(entry.name, 'active').catch(() => {})
+        console.log(
+          `neatd: project "${entry.name}" recovered from broken — active`,
+        )
+      }
+      return fresh
+    } catch (err) {
+      console.warn(
+        `neatd: project "${entry.name}" still broken after recovery attempt — ${(err as Error).message}`,
+      )
+      // Leave the existing broken slot in place; nothing changed.
+      return slots.get(entry.name)!
+    }
+  }
+
   async function loadAll(): Promise<void> {
     const projects = await listProjects()
     const seen = new Set<string>()
     for (const entry of projects) {
       seen.add(entry.name)
-      if (slots.has(entry.name)) continue
+      const existing = slots.get(entry.name)
+      if (existing) {
+        // SIGHUP shortcut: re-bootstrap any slot currently in `broken`. The
+        // operator's mental model for `neatd reload` is "look at the world
+        // again," so a broken slot that became reachable between boots gets
+        // a second chance.
+        if (existing.status === 'broken') {
+          await tryRecoverSlot(entry)
+        }
+        continue
+      }
       try {
         const slot = await bootstrapProject(entry)
         slots.set(entry.name, slot)
@@ -300,16 +357,40 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
       )
     }
 
+    // Resolve a span's target slot — running the broken-state recovery
+    // when the routed slot is currently broken. Returns null when the span
+    // can't be delivered after the recovery attempt; the caller drops with
+    // a rate-limited warning.
+    async function resolveTargetSlot(
+      serviceName: string | undefined,
+    ): Promise<ProjectSlot | null> {
+      const liveEntries = await listProjects().catch(() => [])
+      const target = routeSpanToProject(serviceName, liveEntries)
+      let slot = slots.get(target) ?? slots.get(DEFAULT_PROJECT)
+      if (!slot) return null
+      if (slot.status === 'broken') {
+        const entry = liveEntries.find((e) => e.name === slot!.entry.name)
+        if (entry) {
+          slot = await tryRecoverSlot(entry)
+        }
+        if (slot.status !== 'active') {
+          warnDroppedSpan(slot.entry.name, slot.errorReason ?? 'unknown')
+          return null
+        }
+      }
+      return slot.status === 'active' ? slot : null
+    }
+
     try {
       otlpApp = await buildOtelReceiver({
         onSpan: async (span) => {
-          // ADR-049 OTel routing — dispatch by service.name across active
-          // registry entries. Unknown services route to DEFAULT_PROJECT so
-          // the FrontierNode auto-creation flow keeps working (ADR-033).
-          const liveEntries = await listProjects().catch(() => [])
-          const target = routeSpanToProject(span.service, liveEntries)
-          const slot = slots.get(target) ?? slots.get(DEFAULT_PROJECT)
-          if (!slot || slot.status !== 'active') return
+          // ADR-049 OTel routing — dispatch by service.name. Broken slots
+          // get a single inline recovery attempt before the span is dropped
+          // with a rate-limited log line. Unknown services route to
+          // DEFAULT_PROJECT so the FrontierNode auto-creation flow keeps
+          // working (ADR-033).
+          const slot = await resolveTargetSlot(span.service)
+          if (!slot) return
           await handleSpan(
             {
               graph: slot.graph,
@@ -322,10 +403,8 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
           )
         },
         onErrorSpanSync: async (span) => {
-          const liveEntries = await listProjects().catch(() => [])
-          const target = routeSpanToProject(span.service, liveEntries)
-          const slot = slots.get(target) ?? slots.get(DEFAULT_PROJECT)
-          if (!slot || slot.status !== 'active') return
+          const slot = await resolveTargetSlot(span.service)
+          if (!slot) return
           await makeErrorSpanWriter(slot.paths.errorsPath)(span)
         },
       })

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -4567,6 +4567,229 @@ describe('Daemon contract (ADR-049)', () => {
       await cleanup()
     }
   })
+
+  // ── ADR-071 — broken-slot recoverability ────────────────────────────────
+
+  it('ADR-071 — routeSpanToProject returns broken project name when service.name matches', async () => {
+    const { routeSpanToProject } = await import('../../src/daemon.js')
+    const { DEFAULT_PROJECT } = await import('../../src/graph.js')
+    const projects = [
+      {
+        name: 'brief',
+        path: '/tmp/brief',
+        registeredAt: '2026-05-17T00:00:00.000Z',
+        languages: ['javascript'],
+        status: 'broken' as const,
+      },
+      {
+        name: 'paused-svc',
+        path: '/tmp/paused-svc',
+        registeredAt: '2026-05-17T00:00:00.000Z',
+        languages: [],
+        status: 'paused' as const,
+      },
+    ]
+    // Broken matches by name so the daemon can attempt ingest-time recovery.
+    expect(routeSpanToProject('brief', projects)).toBe('brief')
+    // Paused stays off-route — the operator paused on purpose.
+    expect(routeSpanToProject('paused-svc', projects)).toBe(DEFAULT_PROJECT)
+  })
+
+  it('ADR-071 — span arriving for a broken slot lifts it back to active on inline recovery', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { home, addedPaths, cleanup } = await setupDaemonSandbox({
+      projects: [
+        // Start broken — path is missing.
+        { name: 'recoverable', missingPath: true },
+      ],
+    })
+    const prevWarn = console.warn
+    const prevLog = console.log
+    console.warn = () => {}
+    console.log = () => {}
+    try {
+      const { startDaemon } = await import('../../src/daemon.js')
+      const handle = await startDaemon()
+      try {
+        // Slot starts broken because the path was yanked.
+        expect(handle.slots.get('recoverable')?.status).toBe('broken')
+
+        // Re-create the path so the next bootstrap attempt succeeds.
+        const recoveredPath = addedPaths.get('recoverable')!
+        await fs2.mkdir(recoveredPath, { recursive: true })
+        await fs2.writeFile(
+          path2.join(recoveredPath, 'package.json'),
+          JSON.stringify({ name: 'recoverable', version: '0.0.0' }),
+        )
+
+        // Hit /v1/traces on the bound OTLP listener with a span carrying the
+        // matching service.name. The receiver routes to the broken slot,
+        // attempts recovery, succeeds, and lands the span.
+        const res = await fetch(`${handle.otlpAddress}/v1/traces`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            resourceSpans: [
+              {
+                resource: {
+                  attributes: [
+                    { key: 'service.name', value: { stringValue: 'recoverable' } },
+                  ],
+                },
+                scopeSpans: [
+                  {
+                    spans: [
+                      {
+                        traceId: 'aabbccddeeff00112233445566778899',
+                        spanId: '1111111111111111',
+                        name: 'op',
+                        startTimeUnixNano: '0',
+                        endTimeUnixNano: '0',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          }),
+        })
+        expect(res.status).toBe(200)
+
+        // Drain the receiver queue, then assert the slot is active.
+        const otlpFlush = (handle as unknown as {
+          slots: Map<string, unknown>
+        })
+        void otlpFlush
+        // The slots map records the slot transition.
+        // Poll briefly — the recovery runs inline, but the assertion after
+        // the 200 still races with the queue drain on slower runners.
+        const deadline = Date.now() + 2000
+        while (Date.now() < deadline) {
+          if (handle.slots.get('recoverable')?.status === 'active') break
+          await new Promise((r) => setTimeout(r, 25))
+        }
+        expect(handle.slots.get('recoverable')?.status).toBe('active')
+      } finally {
+        await handle.stop()
+      }
+      void home
+    } finally {
+      console.warn = prevWarn
+      console.log = prevLog
+      await cleanup()
+    }
+  })
+
+  it('ADR-071 — span for a still-broken slot emits the rate-limited drop log once per minute', async () => {
+    const { home, cleanup } = await setupDaemonSandbox({
+      projects: [{ name: 'unrecoverable', missingPath: true }],
+    })
+    const prevWarn = console.warn
+    const prevLog = console.log
+    const warnings: string[] = []
+    console.warn = (msg?: unknown) => {
+      if (typeof msg === 'string') warnings.push(msg)
+    }
+    console.log = () => {}
+    try {
+      const { startDaemon } = await import('../../src/daemon.js')
+      const handle = await startDaemon()
+      try {
+        async function postSpan(): Promise<void> {
+          await fetch(`${handle.otlpAddress}/v1/traces`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              resourceSpans: [
+                {
+                  resource: {
+                    attributes: [
+                      {
+                        key: 'service.name',
+                        value: { stringValue: 'unrecoverable' },
+                      },
+                    ],
+                  },
+                  scopeSpans: [
+                    {
+                      spans: [
+                        {
+                          traceId: 'aabbccddeeff00112233445566778899',
+                          spanId: '2222222222222222',
+                          name: 'op',
+                          startTimeUnixNano: '0',
+                          endTimeUnixNano: '0',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            }),
+          })
+        }
+        // Two spans within the rate-limit window. Recovery fails both times
+        // (path is still missing), so the warning surfaces once for the
+        // first span and is suppressed for the second.
+        await postSpan()
+        await postSpan()
+        // Drain.
+        await new Promise((r) => setTimeout(r, 100))
+
+        const dropWarnings = warnings.filter((w) =>
+          /dropping span for project "unrecoverable"/.test(w),
+        )
+        expect(dropWarnings.length).toBe(1)
+        expect(dropWarnings[0]).toMatch(/neatd reload/)
+      } finally {
+        await handle.stop()
+      }
+      void home
+    } finally {
+      console.warn = prevWarn
+      console.log = prevLog
+      await cleanup()
+    }
+  })
+
+  it('ADR-071 — SIGHUP reload re-bootstraps a broken slot when the path is now reachable', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { home, addedPaths, cleanup } = await setupDaemonSandbox({
+      projects: [{ name: 'sighup-recoverable', missingPath: true }],
+    })
+    const prevWarn = console.warn
+    const prevLog = console.log
+    console.warn = () => {}
+    console.log = () => {}
+    try {
+      const { startDaemon } = await import('../../src/daemon.js')
+      const handle = await startDaemon()
+      try {
+        expect(handle.slots.get('sighup-recoverable')?.status).toBe('broken')
+
+        // Re-create the path, then trigger the reload directly via the
+        // handle (equivalent to SIGHUP — both call into the same reload()).
+        const recoveredPath = addedPaths.get('sighup-recoverable')!
+        await fs2.mkdir(recoveredPath, { recursive: true })
+        await fs2.writeFile(
+          path2.join(recoveredPath, 'package.json'),
+          JSON.stringify({ name: 'sighup-recoverable', version: '0.0.0' }),
+        )
+
+        await handle.reload()
+        expect(handle.slots.get('sighup-recoverable')?.status).toBe('active')
+      } finally {
+        await handle.stop()
+      }
+      void home
+    } finally {
+      console.warn = prevWarn
+      console.log = prevLog
+      await cleanup()
+    }
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Refs #284. Implements ADR-071. routeSpanToProject now logs (rate-limited 1/min/project) when dropping for broken slots, attempts inline bootstrapProject recovery on ingest, and loadAll force-rebuilds broken slots on SIGHUP. Verified against synthetic broken-state span ingest.