### PR TITLE
v0.3.7: three-pass token-aware routing for OBSERVED edge attribution

### DIFF
--- a/docs/contracts/daemon.md
+++ b/docs/contracts/daemon.md
@@ -8,7 +8,7 @@ governs:
   - "packages/core/src/ingest.ts"
   - "packages/core/src/extract/index.ts"
   - "packages/core/src/persist.ts"
-adr: [ADR-049, ADR-063, ADR-048, ADR-026, ADR-027, ADR-071]
+adr: [ADR-049, ADR-063, ADR-048, ADR-026, ADR-027, ADR-071, ADR-072]
 ---
 
 # Daemon contract
@@ -61,11 +61,17 @@ The OTLP/gRPC receiver on `:4317` stays opt-in via `NEAT_OTLP_GRPC=true` per the
 
 Spans route to a project by `service.name` lookup across registered projects. Spans for unknown services route to a fallback `'default'` project for FrontierNode auto-creation per ADR-033.
 
+`routeSpanToProject(serviceName, projects)` matches in three passes (ADR-072):
+
+1. **Exact** — `entry.name === serviceName`.
+2. **Token prefix** — `entry.name` is the first hyphen/underscore-separated token of `serviceName`. `brief` matches `brief-api`, `brief_worker`; `briefcase` does not match `brief`. Longest project name wins (so `brief-api` outranks `brief` when both are registered and the span says `brief-api-staging`).
+3. **Token containment** — `entry.name` appears as a separator-delimited token inside `serviceName`. `api` matches `brief-api-staging` only when no prefix match was found.
+
 Routing eligibility by status:
 
-- `active` matches by `service.name` (steady state).
-- `broken` also matches by name. The router selects the broken slot so the ingest-time recovery path (below) can attempt a single re-bootstrap before the span is dropped. If recovery fails, the span is dropped with a rate-limited warning that points at `neatd reload`.
-- `paused` never matches — the operator paused the project on purpose. The span falls through to the `default` project's FrontierNode flow.
+- `active` matches by `service.name` at every pass (steady state).
+- `broken` also matches at every pass. The router selects the broken slot so the ingest-time recovery path (below) can attempt a single re-bootstrap before the span is dropped. If recovery fails, the span is dropped with a rate-limited warning that points at `neatd reload`.
+- `paused` never matches — the operator paused the project on purpose. The span falls through to the `default` project's FrontierNode flow per ADR-033.
 
 ## Ingest-time recovery for broken projects (ADR-071)
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2506,3 +2506,47 @@ The daemon treats `broken` as a recoverable, observable state. Spans for broken 
 - **Backoff between recovery attempts.** The 60s rate limit on the warning is the user-visible backoff. Internal recovery work is gated only by the next span's arrival.
 
 **First application.** v0.3.7.
+
+---
+
+## ADR-072 — OTel span routing matches by service.name with token-aware fallback
+
+**Date:** 2026-05-17
+**Status:** Active. Amends ADR-049 (daemon contract).
+
+`routeSpanToProject` matures from a single-pass exact match to a three-pass match that recognises the monorepo-package shape `service.name` takes in real-world Node services. The pure-function signature stays unchanged.
+
+**Context.** ADR-049 §OTel routing codified routing by `service.name === entry.name`. Production OTel SDKs emit per-package service names — `brief-api`, `medusa-server`, `payments-worker` — while operators register the project under the repo's top-level name (`brief`, `medusa`, `payments`). The next maturity layer of the routing function recognises the cross-shape pattern and keeps the span on the project the operator actually registered, instead of falling through to `DEFAULT_PROJECT` and the FrontierNode auto-creation flow (ADR-033). The fallback path remains intact for genuinely unregistered services.
+
+**Decision.**
+
+1. **Three-pass match order.** Routing iterates the registered projects up to three times, returning on the first hit:
+
+   1. **Exact** — `entry.name === serviceName`. Preserves the v0.2.5 behaviour for callers that registered with the matching name.
+   2. **Token prefix** — `entry.name` is the leading hyphen/underscore-separated token of `serviceName`. `brief` matches `brief-api` and `brief_worker` but not `briefcase`. When multiple projects qualify, the longest project name wins (so `brief-api` outranks `brief` when both are registered and the span carries `brief-api-staging`).
+   3. **Token containment** — `entry.name` appears in `serviceName` as a separator-delimited token (`api` inside `brief-api-staging`). This last-resort match only fires when the prefix pass produced no candidate.
+
+2. **`paused` is still off-route.** The status filter from ADR-049 stands at every pass.
+
+3. **`DEFAULT_PROJECT` is still the fallback.** Unmatched spans (no project name resembles the service) flow to `default` for FrontierNode auto-creation per ADR-033.
+
+4. **Pure-function contract preserved.** Caller signature, return type, and side-effect properties (none) are unchanged. The function still consumes a registry snapshot; daemon callers still pass a snapshot.
+
+**Authority.** `packages/core/src/daemon.ts` — `routeSpanToProject` plus two private helpers (`isTokenPrefix`, `isTokenContained`).
+
+**Enforcement.** New `it`s under the existing `describe('Daemon contract (ADR-049)')` block:
+
+- Token-prefix match: `brief-api` routes to `brief` when `brief` is registered.
+- Token-prefix match with underscore: `brief_worker` routes to `brief`.
+- Longest-prefix wins: when `brief` and `brief-api` are both registered, `brief-api-staging` routes to `brief-api`.
+- Non-token substring rejection: `briefcase` does not route to `brief`.
+- Containment match: `api` inside `brief-api-staging` routes to `api` only when no project is a token-prefix.
+- Exact match still wins when present.
+
+**Out of scope.**
+
+- **ServiceNode-membership routing.** Looking up `serviceName` against each project's `ServiceNode` set is the next logical layer. This ADR stays at the registry/name layer because monorepo extraction is still warming up on the projects this milestone targets.
+- **OTel `service.namespace` parsing.** When real-world traces carry `service.namespace`, a future ADR can layer that on top of the three-pass match.
+- **User-configurable aliases.** No `aliases:` field on the registry entry. The token-aware match covers the cases this ADR can defend in the current corpus.
+
+**First application.** v0.3.7.

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -107,26 +107,75 @@ function neatHomeFor(opts: DaemonOptions): string {
  * Pure function. Daemon callers pass a snapshot of the registry to avoid
  * per-span fs reads.
  *
- * Routing eligibility:
- * - `active` matches by name (the steady-state path).
- * - `broken` also matches by name — the daemon needs the span to reach
- *   the broken slot so the ingest-time auto-recover path can attempt a
- *   bootstrap and lift the project back to `active`. The router only
- *   chooses the target; whether the span actually lands is the ingest
- *   handler's decision.
+ * Matching order (ADR-072 — real-world `service.name` rarely equals project
+ * name; monorepos publish per-package names like `brief-api` under a
+ * project named `brief`):
+ *
+ *   1. Exact: `entry.name === serviceName`.
+ *   2. Hyphen/underscore-separated prefix: `entry.name` is a leading token
+ *      of `serviceName` (`brief` matches `brief-api`, `brief_worker`).
+ *      Longest-match wins so `brief-api` beats `brief` when both are
+ *      registered.
+ *   3. Containment as a separator-delimited token (`api` inside
+ *      `brief-api-staging`).
+ *
+ * Routing eligibility (ADR-071):
+ * - `active` matches at every pass (the steady-state path).
+ * - `broken` also matches — the daemon needs the span to reach the broken
+ *   slot so the ingest-time auto-recover path can attempt a bootstrap and
+ *   lift the project back to `active`. The router only chooses the target;
+ *   whether the span actually lands is the ingest handler's decision.
  * - `paused` is intentionally not routed; the operator paused it on
  *   purpose, so the span falls through to the default-project flow.
+ *
+ * Falls back to `DEFAULT_PROJECT` when nothing matches.
  */
 export function routeSpanToProject(
   serviceName: string | undefined,
   projects: ReadonlyArray<RegistryEntry>,
 ): string {
   if (!serviceName) return DEFAULT_PROJECT
+  // Pass 1 — exact match.
   for (const entry of projects) {
     if (entry.status === 'paused') continue
     if (entry.name === serviceName) return entry.name
   }
+  // Pass 2 — hyphen/underscore-separated prefix. Longest project name wins
+  // so a registered `brief-api` outranks a registered `brief` when the
+  // span's service.name is `brief-api-staging`.
+  const candidates: RegistryEntry[] = []
+  for (const entry of projects) {
+    if (entry.status === 'paused') continue
+    if (isTokenPrefix(entry.name, serviceName)) candidates.push(entry)
+  }
+  if (candidates.length > 0) {
+    candidates.sort((a, b) => b.name.length - a.name.length)
+    return candidates[0]!.name
+  }
+  // Pass 3 — containment as a separator-delimited token. Last-resort match
+  // for `api` inside `brief-api-staging` when only `api` is registered.
+  for (const entry of projects) {
+    if (entry.status === 'paused') continue
+    if (isTokenContained(entry.name, serviceName)) return entry.name
+  }
   return DEFAULT_PROJECT
+}
+
+// True when `prefix` matches the first hyphen/underscore-separated token(s)
+// of `full`. `brief` matches `brief-api`, `brief_worker`, but not `briefcase`.
+function isTokenPrefix(prefix: string, full: string): boolean {
+  if (prefix.length >= full.length) return false
+  if (!full.startsWith(prefix)) return false
+  const sep = full.charAt(prefix.length)
+  return sep === '-' || sep === '_'
+}
+
+// True when `needle` appears in `haystack` bordered by separators on both
+// sides (so it's a complete token, not a substring of a longer word).
+function isTokenContained(needle: string, haystack: string): boolean {
+  if (!haystack.includes(needle)) return false
+  const tokens = haystack.split(/[-_]/)
+  return tokens.includes(needle)
 }
 
 async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -4382,6 +4382,116 @@ describe('Daemon contract (ADR-049)', () => {
     expect(routeSpanToProject(undefined, projects)).toBe(DEFAULT_PROJECT)
   })
 
+  // ── ADR-072 — token-aware service.name routing ──────────────────────────
+
+  it('ADR-072 — token-prefix match: brief-api routes to brief, brief_worker routes to brief', async () => {
+    const { routeSpanToProject } = await import('../../src/daemon.js')
+    const projects = [
+      {
+        name: 'brief',
+        path: '/tmp/brief',
+        registeredAt: '2026-05-17T00:00:00.000Z',
+        languages: ['javascript'],
+        status: 'active' as const,
+      },
+    ]
+    expect(routeSpanToProject('brief-api', projects)).toBe('brief')
+    expect(routeSpanToProject('brief_worker', projects)).toBe('brief')
+  })
+
+  it('ADR-072 — longest token-prefix wins when multiple projects qualify', async () => {
+    const { routeSpanToProject } = await import('../../src/daemon.js')
+    const projects = [
+      {
+        name: 'brief',
+        path: '/tmp/brief',
+        registeredAt: '2026-05-17T00:00:00.000Z',
+        languages: ['javascript'],
+        status: 'active' as const,
+      },
+      {
+        name: 'brief-api',
+        path: '/tmp/brief-api',
+        registeredAt: '2026-05-17T00:00:00.000Z',
+        languages: ['javascript'],
+        status: 'active' as const,
+      },
+    ]
+    // Both `brief` and `brief-api` are token-prefixes of `brief-api-staging`.
+    // The longer one wins.
+    expect(routeSpanToProject('brief-api-staging', projects)).toBe('brief-api')
+  })
+
+  it('ADR-072 — non-token substring is rejected: briefcase does not route to brief', async () => {
+    const { routeSpanToProject } = await import('../../src/daemon.js')
+    const { DEFAULT_PROJECT } = await import('../../src/graph.js')
+    const projects = [
+      {
+        name: 'brief',
+        path: '/tmp/brief',
+        registeredAt: '2026-05-17T00:00:00.000Z',
+        languages: ['javascript'],
+        status: 'active' as const,
+      },
+    ]
+    expect(routeSpanToProject('briefcase', projects)).toBe(DEFAULT_PROJECT)
+  })
+
+  it('ADR-072 — token-containment fires only when no prefix matches', async () => {
+    const { routeSpanToProject } = await import('../../src/daemon.js')
+    const projects = [
+      {
+        name: 'api',
+        path: '/tmp/api',
+        registeredAt: '2026-05-17T00:00:00.000Z',
+        languages: ['javascript'],
+        status: 'active' as const,
+      },
+    ]
+    // `api` is a token inside `brief-api-staging` (separator-delimited).
+    expect(routeSpanToProject('brief-api-staging', projects)).toBe('api')
+  })
+
+  it('ADR-072 — exact match still wins ahead of token passes', async () => {
+    const { routeSpanToProject } = await import('../../src/daemon.js')
+    const projects = [
+      {
+        name: 'brief-api',
+        path: '/tmp/brief-api',
+        registeredAt: '2026-05-17T00:00:00.000Z',
+        languages: ['javascript'],
+        status: 'active' as const,
+      },
+      {
+        name: 'brief',
+        path: '/tmp/brief',
+        registeredAt: '2026-05-17T00:00:00.000Z',
+        languages: ['javascript'],
+        status: 'active' as const,
+      },
+    ]
+    // Exact match against `brief-api` wins before the token-prefix pass
+    // could surface `brief`.
+    expect(routeSpanToProject('brief-api', projects)).toBe('brief-api')
+  })
+
+  it('ADR-072 — paused entries are skipped at every pass', async () => {
+    const { routeSpanToProject } = await import('../../src/daemon.js')
+    const { DEFAULT_PROJECT } = await import('../../src/graph.js')
+    const projects = [
+      {
+        name: 'brief',
+        path: '/tmp/brief',
+        registeredAt: '2026-05-17T00:00:00.000Z',
+        languages: ['javascript'],
+        status: 'paused' as const,
+      },
+    ]
+    // Paused entries don't qualify for any of the three passes.
+    expect(routeSpanToProject('brief-api', projects)).toBe(DEFAULT_PROJECT)
+    expect(routeSpanToProject('brief', projects)).toBe(DEFAULT_PROJECT)
+  })
+
   it('graceful degradation: missing registry → boot refuses with clear error (ADR-049 #6)', async () => {
     const os2 = await import('node:os')
     const fs2 = await import('node:fs/promises')


### PR DESCRIPTION
Refs #294. Implements ADR-072. routeSpanToProject matures from exact-name match to three-pass match (exact → token-prefix → token-containment). Root cause of NEAT-BUG-19 — without this cross-shape service.name spans land in DEFAULT_PROJECT and drop. Verified by end-to-end OBSERVED edge production on brief-env.