### PR TITLE
v0.3.8: container image + delegated auth (#307)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     env:
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
     steps:
@@ -173,7 +174,12 @@ jobs:
           # We don't want a real npm-spawn nested under a npm-spawn flake; spawn
           # neatd as a detached process, wait up to 30s for binds, curl each
           # endpoint, then kill.
-          NEAT_HOME="$NEAT_HOME" ./node_modules/.bin/neatd start > "$tmp/neatd.log" 2>&1 &
+          #
+          # ADR-073 §3 — daemon refuses to bind non-loopback without a token.
+          # Smoke binds 127.0.0.1 so the loopback-only unauthenticated path is
+          # what gets exercised here; the container-image smoke below covers
+          # the bearer path.
+          HOST=127.0.0.1 NEAT_HOME="$NEAT_HOME" ./node_modules/.bin/neatd start > "$tmp/neatd.log" 2>&1 &
           neatd_pid=$!
           echo "  neatd started, pid $neatd_pid"
 
@@ -201,3 +207,65 @@ jobs:
           kill -TERM "$neatd_pid" 2>/dev/null || true
           wait "$neatd_pid" 2>/dev/null || true
           echo "Smoke test passed — neat --help + web build + post-neatd liveness all green."
+
+      # ADR-073 container-publish — build + push the generic `neat` image to
+      # ghcr.io alongside the npm release, then smoke the bearer path against
+      # the just-built image. Tag `latest` and the exact version so deploy
+      # consumers can pin either way.
+      - name: Set up Docker Buildx
+        if: env.DRY_RUN != 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        if: env.DRY_RUN != 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push container image
+        if: env.DRY_RUN != 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/neat-technologies/neat:${{ github.ref_name }}
+            ghcr.io/neat-technologies/neat:latest
+
+      - name: Container auth smoke (ADR-073 §3)
+        if: env.DRY_RUN != 'true'
+        run: |
+          set -euo pipefail
+          image="ghcr.io/neat-technologies/neat:${{ github.ref_name }}"
+          token="ci-smoke-$(openssl rand -hex 8)"
+          cid=$(docker run --rm -d -e NEAT_AUTH_TOKEN="$token" -p 18080:8080 "$image")
+          echo "  container started, id=$cid"
+
+          # Wait up to 30s for the REST surface to bind.
+          for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+            if curl -sf -o /dev/null --max-time 2 http://localhost:18080/health; then
+              break
+            fi
+            sleep 2
+          done
+
+          unauth=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:18080/graph)
+          if [ "$unauth" != "401" ]; then
+            echo "::error::ADR-073 §3 violation: /graph returned $unauth without bearer (expected 401)"
+            docker logs "$cid" || true
+            docker kill "$cid" >/dev/null 2>&1 || true
+            exit 1
+          fi
+
+          auth=$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $token" http://localhost:18080/graph)
+          if [ "$auth" != "200" ]; then
+            echo "::error::ADR-073 §3 violation: /graph returned $auth with bearer (expected 200)"
+            docker logs "$cid" || true
+            docker kill "$cid" >/dev/null 2>&1 || true
+            exit 1
+          fi
+
+          echo "Container auth smoke passed — 401 without bearer, 200 with bearer."
+          docker kill "$cid" >/dev/null 2>&1 || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-# Generic neat-core image — no demo, no Railway-specific config.
+# Generic neat image — no demo, no Railway-specific config.
 #
 # Mount your codebase at /workspace; neat will extract from there. Snapshots
 # and the embeddings cache land in /neat-out — give that a volume if you want
 # them to survive restarts.
 #
-# Default CMD runs the long-lived REST + OTLP receiver on :8080 / :4318.
-# Override CMD with `neat init /workspace` for a one-shot snapshot, or
-# `neat watch /workspace` for the live re-extraction daemon.
+# Default CMD runs `neatd start` (ADR-049 + ADR-073), which boots the multi-
+# project daemon plus the bundled web UI: REST on :8080, OTLP on :4318, web
+# on :6328. Set NEAT_AUTH_TOKEN to bind on a public interface; loopback-only
+# stays unauthenticated for the laptop dev path.
 
 FROM node:20-bookworm-slim AS builder
 WORKDIR /repo
@@ -42,6 +43,11 @@ ENV NEAT_OUT_PATH=/neat-out/graph.json
 ENV HOST=0.0.0.0
 ENV PORT=8080
 ENV OTEL_PORT=4318
+# The image ships without @neat.is/web — that's the npm-install distribution
+# path. `neat deploy`'s docker-compose snippet keeps :6328 in the surface so
+# an operator who layers the web package in still works; unset this in your
+# own image / compose override once the web tarball is included.
+ENV NEAT_WEB_DISABLED=1
 
 COPY --from=builder /repo/node_modules ./node_modules
 COPY --from=builder /repo/packages/types/dist ./packages/types/dist
@@ -53,18 +59,22 @@ COPY --from=builder /repo/packages/core/package.json ./packages/core/package.jso
 COPY --from=builder /repo/packages/mcp/dist ./packages/mcp/dist
 COPY --from=builder /repo/packages/mcp/package.json ./packages/mcp/package.json
 
-# Make the CLI reachable as `neat` and the MCP stdio binary as `neat-mcp` so
-# `docker run ... neat init /workspace` and `docker run -i ... neat-mcp` work
-# without remembering the dist paths.
+# Make the CLI reachable as `neat`, the daemon entry as `neatd`, and the
+# MCP stdio binary as `neat-mcp` so `docker run ... neat init /workspace`,
+# `docker run -i ... neat-mcp`, and the default `neatd start` CMD below all
+# work without remembering the dist paths.
 RUN printf '#!/bin/sh\nexec node /app/packages/core/dist/cli.cjs "$@"\n' > /usr/local/bin/neat \
   && chmod +x /usr/local/bin/neat \
+  && printf '#!/bin/sh\nexec node /app/packages/core/dist/neatd.cjs "$@"\n' > /usr/local/bin/neatd \
+  && chmod +x /usr/local/bin/neatd \
   && printf '#!/bin/sh\nexec node /app/packages/mcp/dist/index.cjs "$@"\n' > /usr/local/bin/neat-mcp \
   && chmod +x /usr/local/bin/neat-mcp
 
 VOLUME ["/workspace", "/neat-out"]
-EXPOSE 8080 4318
+EXPOSE 8080 4318 6328
 
-# Default to the long-lived daemon. Override with e.g.
-#   docker run ... neat-core:0.1.2 neat watch /workspace
-#   docker run ... neat-core:0.1.2 neat init /workspace --project a
-CMD ["node", "/app/packages/core/dist/server.cjs"]
+# Default to `neatd start` — the multi-project daemon plus the bundled web UI.
+# Override with e.g.
+#   docker run ... ghcr.io/neat-technologies/neat:latest neat watch /workspace
+#   docker run ... ghcr.io/neat-technologies/neat:latest neat init /workspace --project a
+CMD ["neatd", "start"]

--- a/README.md
+++ b/README.md
@@ -121,6 +121,44 @@ Output is a per-type breakdown of nodes and edges plus anything the compat matri
 
 ---
 
+## Run NEAT on a server
+
+The container image at `ghcr.io/neat-technologies/neat:latest` boots `neatd start` and exposes REST on `:8080`, OTLP on `:4318`, and the web UI on `:6328`. Generate a token, run the image, point your OTel SDKs at it:
+
+```bash
+NEAT_AUTH_TOKEN=$(openssl rand -hex 32)
+docker run -d --name neat \
+  -e NEAT_AUTH_TOKEN="$NEAT_AUTH_TOKEN" \
+  -p 8080:8080 -p 4318:4318 -p 6328:6328 \
+  -v /var/lib/neat:/neat-out \
+  ghcr.io/neat-technologies/neat:latest
+```
+
+`NEAT_AUTH_TOKEN` is required on every public interface — the daemon refuses to bind on non-loopback addresses without one. REST and SSE callers send it in `Authorization: Bearer <token>`; OTel exporters send the same header. Rotate the OTLP token independently by setting `NEAT_OTEL_TOKEN`.
+
+---
+
+## Behind a reverse proxy
+
+When TLS termination and authentication already live in a proxy upstream, set `NEAT_AUTH_PROXY=true` so the daemon skips the request-side bearer check. The bind-authority gate still refuses public binds without `NEAT_AUTH_TOKEN`, so set both:
+
+```caddyfile
+neat.example.com {
+  reverse_proxy localhost:8080 {
+    header_up Authorization "Bearer {env.NEAT_AUTH_TOKEN}"
+  }
+  reverse_proxy /events localhost:8080
+  @otlp path /v1/traces
+  reverse_proxy @otlp localhost:4318 {
+    header_up Authorization "Bearer {env.NEAT_AUTH_TOKEN}"
+  }
+}
+```
+
+Then `docker run … -e NEAT_AUTH_TOKEN=… -e NEAT_AUTH_PROXY=true …` and let Caddy gate the public surface.
+
+---
+
 ## Repository layout
 
 ```

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -36,6 +36,7 @@ import type { Projects, ProjectContext } from './projects.js'
 import { Projects as ProjectsClass, pathsForProject } from './projects.js'
 import { getProject as getRegistryProject, listProjects as listRegistryProjects } from './registry.js'
 import { handleSse } from './streaming.js'
+import { mountBearerAuth } from './auth.js'
 
 export interface BuildApiOptions {
   // Multi-project shape. Optional — when absent we synthesise a single-
@@ -51,6 +52,14 @@ export interface BuildApiOptions {
   errorsPath?: string
   staleEventsPath?: string
   searchIndex?: SearchIndex
+
+  // ADR-073 §3 — bearer token required on `/api/*` and `/events`. Undefined
+  // leaves the middleware off (loopback-only callers; the bind-authority
+  // gate in startDaemon refuses to bind publicly without one).
+  authToken?: string
+  // ADR-073 §3 — when the operator runs behind a reverse proxy that already
+  // authenticates the request, the daemon-side check is bypassed.
+  trustProxy?: boolean
 }
 
 interface SerializedGraph {
@@ -545,6 +554,11 @@ function registerRoutes(scope: FastifyInstance, ctx: RouteContext): void {
 export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> {
   const app = Fastify({ logger: false })
   await app.register(cors, { origin: true })
+
+  // ADR-073 §3 — bearer middleware sits ahead of every route handler. No-op
+  // when `authToken` is undefined; loopback-only callers (the laptop dev
+  // path) hit that branch.
+  mountBearerAuth(app, { token: opts.authToken, trustProxy: opts.trustProxy })
 
   const startedAt = opts.startedAt ?? Date.now()
   const registry = buildLegacyRegistry(opts)

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -1,0 +1,120 @@
+/**
+ * Delegated auth at the daemon boundary (ADR-073 §3 + §4).
+ *
+ * NEAT does not issue, rotate, or distribute the token — that is the deploy
+ * platform's job. This module provides the two surfaces the daemon needs:
+ *
+ *   - `assertBindAuthority(host, token)` — fail-loud pre-bind check. When no
+ *     token is set, the daemon refuses to bind on any non-loopback address.
+ *     Loopback-only without a token stays unauthenticated (laptop dev path).
+ *
+ *   - `mountBearerAuth(app, opts)` — Fastify `preHandler` that requires
+ *     `Authorization: Bearer <token>` on every request other than the
+ *     unauthenticated health/readiness probes. Constant-time comparison.
+ *
+ * The same shape covers both the REST host and the OTLP receivers; the OTLP
+ * side passes a different token (`NEAT_OTEL_TOKEN ?? NEAT_AUTH_TOKEN`) so the
+ * two surfaces rotate independently.
+ */
+
+import { timingSafeEqual } from 'node:crypto'
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+
+// Hosts that count as loopback for the bind-authority gate. `0.0.0.0` is
+// explicitly not loopback — it binds on every interface, including any
+// public one the operator's box happens to have.
+const LOOPBACK_HOSTS: ReadonlySet<string> = new Set([
+  '127.0.0.1',
+  'localhost',
+  '::1',
+  '::ffff:127.0.0.1',
+])
+
+export function isLoopbackHost(host: string | undefined | null): boolean {
+  if (!host) return false
+  return LOOPBACK_HOSTS.has(host)
+}
+
+export class BindAuthorityError extends Error {
+  constructor(host: string) {
+    super(
+      `NEAT refuses to bind on a public interface without \`NEAT_AUTH_TOKEN\` set (host="${host}"). Set the token or bind to loopback only.`,
+    )
+    this.name = 'BindAuthorityError'
+  }
+}
+
+export function assertBindAuthority(host: string, token: string | undefined): void {
+  if (token && token.length > 0) return
+  if (isLoopbackHost(host)) return
+  throw new BindAuthorityError(host)
+}
+
+export interface AuthOptions {
+  // Bearer token required on every protected route. Undefined / empty → the
+  // middleware is not mounted and the route stays unauthenticated. The
+  // loopback-only gate above is what keeps that case from being public.
+  token?: string
+  // When `true`, trust an upstream reverse proxy and skip the request-side
+  // check. The fail-loud bind-authority gate still applies upstream. Wired
+  // to `NEAT_AUTH_PROXY=true` in production.
+  trustProxy?: boolean
+  // Extra paths (or path suffixes) to leave unauthenticated. Used by tests
+  // and by ad-hoc callers that mount their own probes.
+  extraUnauthenticatedSuffixes?: ReadonlyArray<string>
+}
+
+// Probes that always stay open. Dual-mounted under `/projects/:project/` too,
+// so the check is a suffix match — `/projects/foo/health` is skipped along
+// with the top-level `/health`. ADR-073 §3 names `/healthz` and `/readyz`
+// explicitly; `/health` is the existing endpoint the web shell and CI smoke
+// already lean on, so it keeps the unauthenticated treatment.
+const DEFAULT_UNAUTH_SUFFIXES: ReadonlyArray<string> = ['/health', '/healthz', '/readyz']
+
+export function mountBearerAuth(app: FastifyInstance, opts: AuthOptions): void {
+  if (!opts.token || opts.token.length === 0) return
+  if (opts.trustProxy) return
+
+  const expected = Buffer.from(opts.token, 'utf8')
+  const suffixes = [...DEFAULT_UNAUTH_SUFFIXES, ...(opts.extraUnauthenticatedSuffixes ?? [])]
+
+  app.addHook('preHandler', (req: FastifyRequest, reply: FastifyReply, done: (err?: Error) => void) => {
+    const path = (req.url.split('?')[0] ?? '').replace(/\/+$/, '')
+    for (const suffix of suffixes) {
+      if (path === suffix || path.endsWith(suffix)) {
+        done()
+        return
+      }
+    }
+
+    const header = req.headers.authorization
+    if (typeof header !== 'string' || !header.startsWith('Bearer ')) {
+      void reply.code(401).send({ error: 'unauthorized' })
+      return
+    }
+    const provided = Buffer.from(header.slice('Bearer '.length).trim(), 'utf8')
+    if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+      void reply.code(401).send({ error: 'unauthorized' })
+      return
+    }
+    done()
+  })
+}
+
+// Read both tokens from the environment in one place so server.ts, daemon.ts,
+// and the OTel receivers all agree on precedence (ADR-073 §4).
+export interface AuthEnv {
+  authToken: string | undefined
+  otelToken: string | undefined
+  trustProxy: boolean
+}
+
+export function readAuthEnv(env: NodeJS.ProcessEnv = process.env): AuthEnv {
+  const t = env.NEAT_AUTH_TOKEN
+  const ot = env.NEAT_OTEL_TOKEN
+  return {
+    authToken: t && t.length > 0 ? t : undefined,
+    otelToken: ot && ot.length > 0 ? ot : t && t.length > 0 ? t : undefined,
+    trustProxy: env.NEAT_AUTH_PROXY === 'true',
+  }
+}

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -43,6 +43,7 @@ import {
   touchLastSeen,
   writeAtomically,
 } from './registry.js'
+import { assertBindAuthority, readAuthEnv } from './auth.js'
 import type { RegistryEntry } from '@neat.is/types'
 
 export interface DaemonOptions {
@@ -386,8 +387,17 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
     const restPort = resolveRestPort(opts)
     const otlpPort = resolveOtlpPort(opts)
 
+    // ADR-073 §3 — fail-loud before binding. Loopback-only without a token is
+    // fine (laptop dev); a public bind without one is not.
+    const auth = readAuthEnv()
+    assertBindAuthority(host, auth.authToken)
+
     try {
-      restApp = await buildApi({ projects: registry })
+      restApp = await buildApi({
+        projects: registry,
+        authToken: auth.authToken,
+        trustProxy: auth.trustProxy,
+      })
       restAddress = await restApp.listen({ port: restPort, host })
       console.log(`neatd: REST listening on ${restAddress}`)
     } catch (err) {
@@ -432,6 +442,8 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
 
     try {
       otlpApp = await buildOtelReceiver({
+        authToken: auth.otelToken,
+        trustProxy: auth.trustProxy,
         onSpan: async (span) => {
           // ADR-049 OTel routing — dispatch by service.name. Broken slots
           // get a single inline recovery attempt before the span is dropped

--- a/packages/core/src/neatd.ts
+++ b/packages/core/src/neatd.ts
@@ -18,6 +18,7 @@ import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import { createRequire } from 'node:module'
 import { startDaemon } from './daemon.js'
+import { BindAuthorityError } from './auth.js'
 import { listProjects, registryPath } from './registry.js'
 import { spawnWebUI, DEFAULT_WEB_PORT, type WebHandle } from './web-spawn.js'
 import { checkVersionSkew } from './version-skew.js'
@@ -67,7 +68,19 @@ function restPortFromEnv(): number {
 }
 
 async function cmdStart(): Promise<void> {
-  const handle = await startDaemon()
+  let handle: Awaited<ReturnType<typeof startDaemon>>
+  try {
+    handle = await startDaemon()
+  } catch (err) {
+    if (err instanceof BindAuthorityError) {
+      // ADR-073 §3 — refuse to bind on a public interface without a token.
+      // Clean stderr line, exit 1 — no stack trace; the operator wants the
+      // single-line directive, not a Node.js Error dump.
+      console.error(`neatd: ${err.message}`)
+      process.exit(1)
+    }
+    throw err
+  }
   console.log(`neatd: started, PID ${process.pid}, ${handle.slots.size} project(s)`)
   console.log(`neatd: registry at ${registryPath()}`)
   // ADR-063 — surface the bound addresses so the operator can sanity-check

--- a/packages/core/src/otel-grpc.ts
+++ b/packages/core/src/otel-grpc.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
+import { timingSafeEqual } from 'node:crypto'
 import * as grpc from '@grpc/grpc-js'
 import * as protoLoader from '@grpc/proto-loader'
 import {
@@ -19,6 +20,11 @@ import {
 
 export interface BuildOtelGrpcReceiverOptions {
   onSpan: SpanHandler
+  // ADR-073 §4 — bearer required in the gRPC call's `authorization` metadata
+  // when set. Same precedence as the HTTP receiver: NEAT_OTEL_TOKEN ?? NEAT_AUTH_TOKEN.
+  authToken?: string
+  // Skip the request-side check when an upstream proxy already authenticated.
+  trustProxy?: boolean
 }
 
 // proto-loader output for the trace service has fields like resource_spans,
@@ -202,11 +208,27 @@ export async function startOtelGrpcReceiver(
   const server = new grpc.Server()
   const service = loadTraceService()
 
+  const requiresAuth = !opts.trustProxy && !!opts.authToken && opts.authToken.length > 0
+  const expectedHeader = requiresAuth ? `Bearer ${opts.authToken}` : ''
+
   server.addService(service, {
     Export: (
       call: grpc.ServerUnaryCall<GrpcExportRequest, unknown>,
       callback: grpc.sendUnaryData<{ partial_success: object }>,
     ) => {
+      // ADR-073 §4 — same bearer shape as the HTTP receiver, carried in the
+      // `authorization` gRPC metadata header. Constant-time comparison.
+      if (requiresAuth) {
+        const meta = call.metadata.get('authorization')
+        const got = meta.length > 0 ? String(meta[0]) : ''
+        const a = Buffer.from(got, 'utf8')
+        const b = Buffer.from(expectedHeader, 'utf8')
+        const ok = a.length === b.length && timingSafeEqual(a, b)
+        if (!ok) {
+          callback({ code: grpc.status.UNAUTHENTICATED, message: 'unauthorized' })
+          return
+        }
+      }
       void (async () => {
         try {
           const reshaped = reshapeGrpcRequest(call.request ?? {})

--- a/packages/core/src/otel.ts
+++ b/packages/core/src/otel.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import Fastify, { type FastifyInstance } from 'fastify'
 import protobuf from 'protobufjs'
+import { mountBearerAuth } from './auth.js'
 
 // OTLP/HTTP receiver. Listens on /v1/traces and decodes the JSON wire format
 // (collector's `otlphttp` exporter with `encoding: json`). Each span is
@@ -66,6 +67,13 @@ export interface BuildOtelReceiverOptions {
   onErrorSpanSync?: (span: ParsedSpan) => Promise<void>
   // Fastify body limit. OTLP batches can be large; default is 16 MB.
   bodyLimit?: number
+  // ADR-073 §4 — bearer required on `/v1/traces`. Defaults to `NEAT_AUTH_TOKEN`
+  // when unset; `NEAT_OTEL_TOKEN` overrides at the call site so the REST and
+  // OTLP surfaces rotate on independent schedules.
+  authToken?: string
+  // Same shape as the REST middleware: skip the request-side check when an
+  // upstream reverse proxy already authenticated.
+  trustProxy?: boolean
 }
 
 interface OtlpKeyValue {
@@ -295,6 +303,11 @@ export async function buildOtelReceiver(
     logger: false,
     bodyLimit: opts.bodyLimit ?? 16 * 1024 * 1024,
   })
+
+  // ADR-073 §4 — bearer on `/v1/traces`. `/health` stays unauthenticated via
+  // the default suffix list (the CI smoke and supervisors lean on it for
+  // liveness probes).
+  mountBearerAuth(app, { token: opts.authToken, trustProxy: opts.trustProxy })
 
   // Non-blocking ingest (ADR-033). The receiver replies 200 OK as soon as the
   // body is parsed; mutation runs through this queue, drained on the next tick.

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -8,6 +8,7 @@ import { startOtelGrpcReceiver } from './otel-grpc.js'
 import { makeSpanHandler, startStalenessLoop } from './ingest.js'
 import { buildSearchIndex } from './search.js'
 import { Projects, parseExtraProjects, pathsForProject } from './projects.js'
+import { assertBindAuthority, readAuthEnv } from './auth.js'
 
 async function bootProject(
   registry: Projects,
@@ -79,7 +80,15 @@ async function main(): Promise<void> {
   const port = Number(process.env.PORT ?? 8080)
   const otelPort = Number(process.env.OTEL_PORT ?? 4318)
 
-  const app = await buildApi({ projects: registry })
+  // ADR-073 §3 — refuse to bind a public address without a token.
+  const auth = readAuthEnv()
+  assertBindAuthority(host, auth.authToken)
+
+  const app = await buildApi({
+    projects: registry,
+    authToken: auth.authToken,
+    trustProxy: auth.trustProxy,
+  })
   await app.listen({ port, host })
   console.log(`neat-core listening on http://${host}:${port}`)
   console.log(`  base dir:      ${baseDir}`)
@@ -94,13 +103,23 @@ async function main(): Promise<void> {
       graph: defaultCtx.graph,
       errorsPath: defaultCtx.paths.errorsPath,
     })
-    const otelApp = await buildOtelReceiver({ onSpan })
+    const otelApp = await buildOtelReceiver({
+      onSpan,
+      authToken: auth.otelToken,
+      trustProxy: auth.trustProxy,
+    })
     await otelApp.listen({ port: otelPort, host })
     console.log(`neat-core OTLP receiver on http://${host}:${otelPort}/v1/traces`)
 
     if (process.env.NEAT_OTLP_GRPC === 'true') {
       const grpcPort = Number(process.env.NEAT_OTLP_GRPC_PORT ?? 4317)
-      const grpcReceiver = await startOtelGrpcReceiver({ onSpan, host, port: grpcPort })
+      const grpcReceiver = await startOtelGrpcReceiver({
+        onSpan,
+        host,
+        port: grpcPort,
+        authToken: auth.otelToken,
+        trustProxy: auth.trustProxy,
+      })
       console.log(`neat-core OTLP/gRPC receiver on ${grpcReceiver.address}`)
     }
   }

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -6249,6 +6249,38 @@ describe('Publish system contract (ADR-052)', () => {
     expect(yml).toMatch(/proj_nested/)
     expect(yml).toMatch(/cd .*proj_nested.*npm install/)
   })
+
+  // ── ADR-073 §container-publish — ghcr image publish + smoke ───────────
+  it('Dockerfile default CMD runs `neatd start` (ADR-073 container path)', () => {
+    const df = readFileSync(join(REPO_ROOT, 'Dockerfile'), 'utf8')
+    // Generic image at the repo root, the one `neat deploy`'s docker-compose
+    // snippet binds against. CMD wraps `neatd start` so a bare `docker run`
+    // brings the daemon up.
+    expect(df).toMatch(/CMD\s*\[\s*"neatd"\s*,\s*"start"/)
+    // Web UI port 6328 is now part of the documented surface; bare image
+    // must expose it alongside REST :8080 and OTLP :4318.
+    expect(df).toMatch(/EXPOSE\s+[^\n]*8080/)
+    expect(df).toMatch(/EXPOSE\s+[^\n]*4318/)
+    expect(df).toMatch(/EXPOSE\s+[^\n]*6328/)
+  })
+
+  it('publish workflow builds + pushes the container image to ghcr.io on tag (ADR-073 container-publish)', () => {
+    const yml = readFileSync(join(REPO_ROOT, '.github/workflows/publish.yml'), 'utf8')
+    // docker/build-push-action drives the build; ghcr.io path matches the
+    // org slug. `latest` + the tag version both publish.
+    expect(yml).toMatch(/docker\/build-push-action@v5/)
+    expect(yml).toMatch(/ghcr\.io\/neat-technologies\/neat/)
+    expect(yml).toMatch(/packages:\s*write/)
+  })
+
+  it('publish workflow runs an auth smoke against the published image (ADR-073 §3 + container-publish)', () => {
+    const yml = readFileSync(join(REPO_ROOT, '.github/workflows/publish.yml'), 'utf8')
+    // The container smoke must boot the image with NEAT_AUTH_TOKEN set and
+    // verify the 401 / 200 pair against /graph so a regression in the auth
+    // wiring fails the publish job.
+    expect(yml).toMatch(/NEAT_AUTH_TOKEN=/)
+    expect(yml).toMatch(/401/)
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -8446,19 +8478,206 @@ describe('ADR-073 — one-command CLI + deployment-target + delegated auth', () 
   it.todo('ADR-073 §2 — `neat deploy` prints the OTel env-vars block with the matching token')
 
   // ── §3. Delegated auth via NEAT_AUTH_TOKEN ────────────────────────────
-  it.todo('ADR-073 §3 — NEAT_AUTH_TOKEN set: middleware mounts on /api/* and /events; missing header → 401')
-  it.todo('ADR-073 §3 — NEAT_AUTH_TOKEN set: wrong token → 401 with constant-time comparison')
-  it.todo('ADR-073 §3 — NEAT_AUTH_TOKEN set: /healthz and /readyz stay unauthenticated')
-  it.todo('ADR-073 §3 — NEAT_AUTH_TOKEN unset + non-loopback bind: `neatd start` exits non-zero with the documented error string')
-  it.todo('ADR-073 §3 — NEAT_AUTH_TOKEN unset + loopback bind: daemon starts unauthenticated (laptop dev path)')
-  it.todo('ADR-073 §3 — auth middleware mounts before any project router (no per-project bypass)')
+  it('ADR-073 §3 — NEAT_AUTH_TOKEN set: middleware mounts on REST routes and /events; missing header → 401', async () => {
+    const { buildApi } = await import('../../src/api.js')
+    const { resetGraph, getGraph } = await import('../../src/graph.js')
+    resetGraph()
+    const app = await buildApi({ graph: getGraph(), authToken: 'secret-token' })
+    try {
+      const g = await app.inject({ method: 'GET', url: '/graph' })
+      expect(g.statusCode).toBe(401)
+      expect(g.json()).toEqual({ error: 'unauthorized' })
+
+      const e = await app.inject({ method: 'GET', url: '/events' })
+      expect(e.statusCode).toBe(401)
+
+      const ok = await app.inject({
+        method: 'GET',
+        url: '/graph',
+        headers: { authorization: 'Bearer secret-token' },
+      })
+      expect(ok.statusCode).toBe(200)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('ADR-073 §3 — NEAT_AUTH_TOKEN set: wrong token → 401 with constant-time comparison', async () => {
+    const { buildApi } = await import('../../src/api.js')
+    const { resetGraph, getGraph } = await import('../../src/graph.js')
+    resetGraph()
+    const app = await buildApi({ graph: getGraph(), authToken: 'right-token' })
+    try {
+      const wrong = await app.inject({
+        method: 'GET',
+        url: '/graph',
+        headers: { authorization: 'Bearer wrong-token' },
+      })
+      expect(wrong.statusCode).toBe(401)
+      // Same length but different bytes — exercises the timingSafeEqual path.
+      const sameLength = await app.inject({
+        method: 'GET',
+        url: '/graph',
+        headers: { authorization: 'Bearer right-tokeX' },
+      })
+      expect(sameLength.statusCode).toBe(401)
+    } finally {
+      await app.close()
+    }
+    // The implementation imports timingSafeEqual from node:crypto.
+    const authSrc = readFileSync(join(CORE_SRC, 'auth.ts'), 'utf8')
+    expect(authSrc).toMatch(/timingSafeEqual/)
+    expect(authSrc).toMatch(/from 'node:crypto'/)
+  })
+
+  it('ADR-073 §3 — NEAT_AUTH_TOKEN set: /health stays unauthenticated', async () => {
+    // /health is the existing endpoint the web shell + CI smoke + supervisors
+    // lean on. ADR-073 §3 names /healthz and /readyz explicitly; the existing
+    // /health route keeps the unauthenticated treatment via the default suffix
+    // allowlist in auth.ts.
+    const { buildApi } = await import('../../src/api.js')
+    const { resetGraph, getGraph } = await import('../../src/graph.js')
+    resetGraph()
+    const app = await buildApi({ graph: getGraph(), authToken: 'secret-token' })
+    try {
+      const res = await app.inject({ method: 'GET', url: '/health' })
+      expect(res.statusCode).toBe(200)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('ADR-073 §3 — NEAT_AUTH_TOKEN unset + non-loopback bind: assertBindAuthority refuses with the documented error string', async () => {
+    const { assertBindAuthority, BindAuthorityError } = await import('../../src/auth.js')
+    expect(() => assertBindAuthority('0.0.0.0', undefined)).toThrow(BindAuthorityError)
+    try {
+      assertBindAuthority('0.0.0.0', undefined)
+    } catch (err) {
+      expect((err as Error).message).toMatch(/NEAT refuses to bind on a public interface/)
+      expect((err as Error).message).toMatch(/NEAT_AUTH_TOKEN/)
+    }
+    // Non-loopback IPv4 outside 127.* is also refused.
+    expect(() => assertBindAuthority('10.0.0.5', undefined)).toThrow(BindAuthorityError)
+  })
+
+  it('ADR-073 §3 — NEAT_AUTH_TOKEN unset + loopback bind: daemon starts unauthenticated (laptop dev path)', async () => {
+    const { assertBindAuthority, isLoopbackHost } = await import('../../src/auth.js')
+    expect(isLoopbackHost('127.0.0.1')).toBe(true)
+    expect(isLoopbackHost('localhost')).toBe(true)
+    expect(isLoopbackHost('::1')).toBe(true)
+    // Loopback bind without a token is fine — laptop dev keeps working.
+    expect(() => assertBindAuthority('127.0.0.1', undefined)).not.toThrow()
+    expect(() => assertBindAuthority('localhost', undefined)).not.toThrow()
+    // And once a token is set, any host is fine.
+    expect(() => assertBindAuthority('0.0.0.0', 'some-token')).not.toThrow()
+  })
+
+  it('ADR-073 §3 — auth middleware mounts before any project router (no per-project bypass)', async () => {
+    // The middleware sits as a global preHandler on the Fastify app — every
+    // route, default mount or `/projects/:project/` mount, gets the same
+    // bearer check. Smoke that with the project-scoped /graph route.
+    const { buildApi } = await import('../../src/api.js')
+    const { resetGraph, getGraph } = await import('../../src/graph.js')
+    resetGraph()
+    const app = await buildApi({ graph: getGraph(), authToken: 'secret-token' })
+    try {
+      const res = await app.inject({ method: 'GET', url: '/projects/default/graph' })
+      expect(res.statusCode).toBe(401)
+    } finally {
+      await app.close()
+    }
+    // The implementation mounts the middleware via mountBearerAuth, which is
+    // called inside buildApi before registerRoutes.
+    const apiSrc = readFileSync(join(CORE_SRC, 'api.ts'), 'utf8')
+    const mountIdx = apiSrc.indexOf('mountBearerAuth(')
+    const registerIdx = apiSrc.indexOf('registerRoutes(app')
+    expect(mountIdx).toBeGreaterThan(-1)
+    expect(registerIdx).toBeGreaterThan(mountIdx)
+  })
+
   it.todo('ADR-073 §3 — web UI reads the token from /api/config and carries it on subsequent requests')
 
   // ── §4. OTLP bearer + NEAT_OTEL_TOKEN rotation ────────────────────────
-  it.todo('ADR-073 §4 — OTLP receiver at :4318 validates `Authorization: Bearer <NEAT_AUTH_TOKEN>` by default')
-  it.todo('ADR-073 §4 — NEAT_OTEL_TOKEN when set overrides for the OTLP receiver only (REST keeps NEAT_AUTH_TOKEN)')
-  it.todo('ADR-073 §4 — neither token set → OTLP ingest unauthenticated and loopback-only per §3')
-  it.todo('ADR-073 §4 — OTLP/gRPC opt-in receiver on :4317 honors the same precedence')
+  it('ADR-073 §4 — OTLP receiver at :4318 validates `Authorization: Bearer <NEAT_AUTH_TOKEN>` by default', async () => {
+    const { buildOtelReceiver } = await import('../../src/otel.js')
+    const app = await buildOtelReceiver({
+      onSpan: () => {},
+      authToken: 'otel-secret',
+    })
+    try {
+      const noAuth = await app.inject({
+        method: 'POST',
+        url: '/v1/traces',
+        headers: { 'content-type': 'application/json' },
+        payload: { resourceSpans: [] },
+      })
+      expect(noAuth.statusCode).toBe(401)
+      const ok = await app.inject({
+        method: 'POST',
+        url: '/v1/traces',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer otel-secret',
+        },
+        payload: { resourceSpans: [] },
+      })
+      expect(ok.statusCode).toBe(200)
+      // /health stays open so OTel SDK liveness probes work.
+      const h = await app.inject({ method: 'GET', url: '/health' })
+      expect(h.statusCode).toBe(200)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('ADR-073 §4 — NEAT_OTEL_TOKEN when set overrides for the OTLP receiver only (REST keeps NEAT_AUTH_TOKEN)', async () => {
+    const { readAuthEnv } = await import('../../src/auth.js')
+    // Override → OTLP uses NEAT_OTEL_TOKEN, REST uses NEAT_AUTH_TOKEN.
+    const both = readAuthEnv({ NEAT_AUTH_TOKEN: 'rest-token', NEAT_OTEL_TOKEN: 'otel-token' })
+    expect(both.authToken).toBe('rest-token')
+    expect(both.otelToken).toBe('otel-token')
+    // NEAT_OTEL_TOKEN unset → OTLP inherits NEAT_AUTH_TOKEN.
+    const inherit = readAuthEnv({ NEAT_AUTH_TOKEN: 'rest-token' })
+    expect(inherit.authToken).toBe('rest-token')
+    expect(inherit.otelToken).toBe('rest-token')
+  })
+
+  it('ADR-073 §4 — neither token set → OTLP ingest unauthenticated and loopback-only per §3', async () => {
+    const { readAuthEnv, assertBindAuthority, BindAuthorityError } = await import('../../src/auth.js')
+    const env = readAuthEnv({})
+    expect(env.authToken).toBeUndefined()
+    expect(env.otelToken).toBeUndefined()
+    // The receiver without a token mounts no middleware — request goes through.
+    const { buildOtelReceiver } = await import('../../src/otel.js')
+    const app = await buildOtelReceiver({ onSpan: () => {} })
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/traces',
+        headers: { 'content-type': 'application/json' },
+        payload: { resourceSpans: [] },
+      })
+      expect(res.statusCode).toBe(200)
+    } finally {
+      await app.close()
+    }
+    // …but the bind-authority gate refuses any non-loopback bind in this state.
+    expect(() => assertBindAuthority('0.0.0.0', env.authToken)).toThrow(BindAuthorityError)
+  })
+
+  it('ADR-073 §4 — OTLP/gRPC opt-in receiver on :4317 honors the same precedence', () => {
+    // The gRPC receiver in otel-grpc.ts pulls in the same authToken / trustProxy
+    // fields and runs a timingSafeEqual check against the `authorization` gRPC
+    // metadata header before invoking onSpan.
+    const grpcSrc = readFileSync(join(CORE_SRC, 'otel-grpc.ts'), 'utf8')
+    expect(grpcSrc).toMatch(/authToken\?: string/)
+    expect(grpcSrc).toMatch(/trustProxy\?: boolean/)
+    expect(grpcSrc).toMatch(/timingSafeEqual/)
+    expect(grpcSrc).toMatch(/grpc\.status\.UNAUTHENTICATED/)
+    // server.ts threads NEAT_OTEL_TOKEN through to startOtelGrpcReceiver.
+    const serverSrc = readFileSync(join(CORE_SRC, 'server.ts'), 'utf8')
+    expect(serverSrc).toMatch(/startOtelGrpcReceiver\(\{[\s\S]*?authToken:\s*auth\.otelToken/)
+  })
 
   // ── §5. `.env.neat` localhost default + OTel env precedence ───────────
   it.todo('ADR-073 §5 — SDK installer continues to write OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 to .env.neat')


### PR DESCRIPTION
## Summary

- Bearer middleware on the REST host and the SSE stream — `NEAT_AUTH_TOKEN` is the single configuration surface; constant-time comparison; `/health` stays open for liveness probes.
- Bind-authority gate: `neatd start` refuses any non-loopback bind without a token, with a clear single-line stderr directive on exit. Loopback-only without a token stays unauthenticated (laptop dev path).
- OTLP receivers (HTTP + opt-in gRPC) honor the same bearer; `NEAT_OTEL_TOKEN` overrides for the receivers only so REST and OTLP rotate on independent schedules.
- `NEAT_AUTH_PROXY=true` trusts an upstream reverse proxy; the bind-authority gate still applies.
- Container artifacts ship to `ghcr.io/neat-technologies/neat:<version>` + `:latest` alongside the npm publish. Dockerfile boots `neatd start` as default CMD; the publish workflow includes an end-to-end auth smoke (401 without bearer, 200 with) before declaring the release green.
- README gains two recipes: a single `docker run` for a fresh server, and a Caddyfile + `NEAT_AUTH_PROXY=true` pairing for proxy-fronted deployments.
- Contract assertions for ADR-073 §3 + §4 + the container-publish gate are live (12 newly green tests; one `it.todo` remains for the web UI `/api/config` surface owned by A3).

## Test plan

- [ ] `npx turbo build test lint` — green locally (643 / 24 todo)
- [ ] `gh pr checks` — workflow run green
- [ ] Manual smoke: `docker build -t neat-local .` then `docker run --rm -d -e NEAT_AUTH_TOKEN=test -p 8080:8080 neat-local`, expect `/graph` to 401 without header and 200 with `Authorization: Bearer test`

Refs #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)