### PR TITLE
v0.3.9: web shell gains a login surface

### DIFF
--- a/docs/contracts/web-debugging.md
+++ b/docs/contracts/web-debugging.md
@@ -84,6 +84,16 @@ Live assertions in `packages/web/test/environment-indicator.test.tsx` cover the 
 - Orange `"remote · <hostname>"` chip for any non-loopback host.
 - Adjacent info affordance carries the multi-instance explanation as its tooltip — so the operator running NEAT against a deployed daemon never confuses its graph with the local dev one.
 
+### Login surface and bearer attachment (ADR-073 §3)
+
+Live assertions in `packages/web/test/login-surface.test.tsx` cover the operator-facing auth surface:
+
+- `/login` renders the single masked NEAT-token input, the deploy-platform caption, and the "Open dashboard" submit — the prior login-02 affordances (Email, Password, GitHub, Sign up, Forgot password) are gone.
+- The logo animation mounts in the right pane and starts on the letter "N".
+- `authedFetch` attaches `Authorization: Bearer <token>` when `localStorage['neat:authToken']` is set, and omits the header when it isn't — so the dashboard works against an unauthenticated dev daemon and a bearer-protected production daemon from the same bundle.
+
+`StatusBar.tsx` also exports a `SignOutButton` that renders only when a token is in storage and clears it on click before bouncing the operator back to `/login`. The `useAuthGate` hook in `packages/web/lib/use-auth-gate.ts` is the route-level guard AppShell and IncidentsClient call from on mount; it short-circuits when `NEXT_PUBLIC_NEAT_AUTH_PROXY=true` so reverse-proxy deployments don't see the login surface.
+
 ## Out of scope
 
 - **Telemetry / analytics.** Not collecting user actions, not phoning home. The debug panel is local-only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -945,7 +945,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -997,6 +996,66 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui/react": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.1.tgz",
+      "integrity": "sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.2.8",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1911,6 +1970,44 @@
         "@fastify/forwarded": "^3.0.0",
         "ipaddr.js": "^2.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.3",
@@ -4632,14 +4729,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -5814,6 +5911,18 @@
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "license": "MIT"
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -5832,6 +5941,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color": {
@@ -6050,7 +6168,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cytoscape": {
@@ -8222,6 +8340,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
+      "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -9799,6 +9926,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -10555,6 +10688,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
@@ -11227,6 +11370,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -12244,11 +12396,16 @@
       "version": "0.3.8",
       "license": "BUSL-1.1",
       "dependencies": {
+        "@base-ui/react": "^1.4.1",
         "@neat.is/types": "^0.3.8",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "cytoscape": "^3.33.3",
+        "lucide-react": "^1.16.0",
         "next": "14.2.35",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.0",

--- a/packages/web/app/api/graph/blast-radius/[id]/route.ts
+++ b/packages/web/app/api/graph/blast-radius/[id]/route.ts
@@ -15,5 +15,6 @@ export async function GET(
   return proxyGet(
     `${CORE_URL}${base}/${encodeURIComponent(params.id)}?depth=${depth}`,
     () => Response.json(fixtureBlastRadius(params.id)),
+    request,
   )
 }

--- a/packages/web/app/api/graph/node/[id]/route.ts
+++ b/packages/web/app/api/graph/node/[id]/route.ts
@@ -13,5 +13,6 @@ export async function GET(
   return proxyGet(
     `${CORE_URL}${base}/${encodeURIComponent(params.id)}`,
     () => Response.json(fixtureNodeDetail(params.id)),
+    request,
   )
 }

--- a/packages/web/app/api/graph/root-cause/[id]/route.ts
+++ b/packages/web/app/api/graph/root-cause/[id]/route.ts
@@ -13,5 +13,6 @@ export async function GET(
   return proxyGet(
     `${CORE_URL}${base}/${encodeURIComponent(params.id)}`,
     () => Response.json(fixtureRootCause(params.id)),
+    request,
   )
 }

--- a/packages/web/app/api/graph/route.ts
+++ b/packages/web/app/api/graph/route.ts
@@ -8,5 +8,5 @@ export async function GET(request: Request): Promise<Response> {
     project && project !== 'default'
       ? `/projects/${encodeURIComponent(project)}/graph`
       : '/graph'
-  return proxyGet(`${CORE_URL}${path}`, () => Response.json(FIXTURE_GRAPH))
+  return proxyGet(`${CORE_URL}${path}`, () => Response.json(FIXTURE_GRAPH), request)
 }

--- a/packages/web/app/api/health/route.ts
+++ b/packages/web/app/api/health/route.ts
@@ -9,5 +9,5 @@ export async function GET(request: Request): Promise<Response> {
   const path = project && project !== 'default'
     ? `/projects/${encodeURIComponent(project)}/health`
     : '/health'
-  return proxyGet(`${CORE_URL}${path}`, () => Response.json(FIXTURE_HEALTH))
+  return proxyGet(`${CORE_URL}${path}`, () => Response.json(FIXTURE_HEALTH), request)
 }

--- a/packages/web/app/api/incidents/route.ts
+++ b/packages/web/app/api/incidents/route.ts
@@ -12,5 +12,6 @@ export async function GET(request: Request): Promise<Response> {
   return proxyGet(
     `${CORE_URL}${base}?limit=${limit}`,
     () => Response.json(FIXTURE_INCIDENTS),
+    request,
   )
 }

--- a/packages/web/app/api/policies/violations/route.ts
+++ b/packages/web/app/api/policies/violations/route.ts
@@ -7,5 +7,5 @@ export async function GET(request: Request): Promise<Response> {
   const path = project && project !== 'default'
     ? `/projects/${encodeURIComponent(project)}/policies/violations`
     : '/policies/violations'
-  return proxyGet(`${CORE_URL}${path}`, () => Response.json(FIXTURE_VIOLATIONS))
+  return proxyGet(`${CORE_URL}${path}`, () => Response.json(FIXTURE_VIOLATIONS), request)
 }

--- a/packages/web/app/api/projects/route.ts
+++ b/packages/web/app/api/projects/route.ts
@@ -7,5 +7,5 @@ import { FIXTURE_PROJECTS } from '../../../lib/fixtures'
 export async function GET(request: Request): Promise<Response> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const project = new URL(request.url).searchParams.get('project')
-  return proxyGet(`${CORE_URL}/projects`, () => Response.json(FIXTURE_PROJECTS))
+  return proxyGet(`${CORE_URL}/projects`, () => Response.json(FIXTURE_PROJECTS), request)
 }

--- a/packages/web/app/api/search/route.ts
+++ b/packages/web/app/api/search/route.ts
@@ -13,5 +13,6 @@ export async function GET(request: Request): Promise<Response> {
   return proxyGet(
     `${CORE_URL}${base}?q=${encodeURIComponent(q)}`,
     () => Response.json(fixtureSearch(q)),
+    request,
   )
 }

--- a/packages/web/app/api/stale-events/route.ts
+++ b/packages/web/app/api/stale-events/route.ts
@@ -11,5 +11,6 @@ export async function GET(request: Request): Promise<Response> {
   return proxyGet(
     `${CORE_URL}${base}?limit=${limit}`,
     () => Response.json({ events: [], count: 0, total: 0 }),
+    request,
   )
 }

--- a/packages/web/app/components/AppShell.tsx
+++ b/packages/web/app/components/AppShell.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import { authedFetch } from '../../lib/authed-fetch'
 import { TopBar } from './TopBar'
 import { Rail } from './Rail'
 import { GraphCanvas } from './GraphCanvas'
@@ -67,7 +68,7 @@ export function AppShell() {
   useEffect(() => {
     if (resolvedRef.current) return
     resolvedRef.current = true
-    fetch('/api/projects')
+    authedFetch('/api/projects')
       .then((r) => (r.ok ? r.json() : []))
       .then((data: ProjectEntry[] | { projects?: ProjectEntry[] }) => {
         const list = Array.isArray(data) ? data : Array.isArray(data?.projects) ? data.projects : []

--- a/packages/web/app/components/AppShell.tsx
+++ b/packages/web/app/components/AppShell.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { authedFetch } from '../../lib/authed-fetch'
+import { useAuthGate } from '../../lib/use-auth-gate'
 import { TopBar } from './TopBar'
 import { Rail } from './Rail'
 import { GraphCanvas } from './GraphCanvas'
@@ -36,6 +37,9 @@ function readStoredProject(): string | null {
 }
 
 export function AppShell() {
+  // ADR-073 §3 — gate the dashboard behind a bearer; reverse-proxy
+  // operators opt out via NEXT_PUBLIC_NEAT_AUTH_PROXY=true.
+  useAuthGate()
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
   const [graphData, setGraphData] = useState<GraphData | null>(null)
   // ADR-057 #2 — start with URL or localStorage (synchronous), then resolve

--- a/packages/web/app/components/GraphCanvas.tsx
+++ b/packages/web/app/components/GraphCanvas.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useCallback } from 'react'
 import type { GraphNode, GraphEdge } from '@neat.is/types'
 import type { GraphData } from './AppShell'
+import { authedFetch } from '../../lib/authed-fetch'
 
 // Map NEAT node types to design visual types
 function visualType(node: GraphNode): string {
@@ -128,7 +129,7 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
       const cytoscape = (await import('cytoscape')).default
 
       // ADR-057 #5 — every API call carries the active project.
-      const res = await fetch(`/api/graph?project=${encodeURIComponent(project)}`).catch(() => null)
+      const res = await authedFetch(`/api/graph?project=${encodeURIComponent(project)}`).catch(() => null)
       if (!res || !res.ok || destroyed) return
       const data: GraphData = await res.json()
       if (destroyed) return

--- a/packages/web/app/components/Inspector.tsx
+++ b/packages/web/app/components/Inspector.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { GraphNode, GraphEdge } from '@neat.is/types'
 import type { GraphData } from './AppShell'
+import { authedFetch } from '../../lib/authed-fetch'
 
 interface RootCauseResult {
   origin: string
@@ -82,12 +83,12 @@ export function Inspector({ project, selectedNodeId, graphData }: InspectorProps
       return
     }
     const proj = `?project=${encodeURIComponent(project)}`
-    fetch(`/api/graph/node/${encodeURIComponent(selectedNodeId)}${proj}`)
+    authedFetch(`/api/graph/node/${encodeURIComponent(selectedNodeId)}${proj}`)
       .then((r) => r.json())
       .then((d: { node: GraphNode }) => setNode(d.node))
       .catch(() => {})
 
-    fetch(`/api/graph/root-cause/${encodeURIComponent(selectedNodeId)}${proj}`)
+    authedFetch(`/api/graph/root-cause/${encodeURIComponent(selectedNodeId)}${proj}`)
       .then((r) => r.json())
       .then((d: RootCauseResult) => setRootCause(d.rootCauseNode ? d : null))
       .catch(() => {})

--- a/packages/web/app/components/Rail.tsx
+++ b/packages/web/app/components/Rail.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { authedFetch } from '../../lib/authed-fetch'
 
 interface RailProps {
   project: string
@@ -14,7 +15,7 @@ export function Rail({ project }: RailProps) {
   // ADR-057 #3 — re-fetch on project change.
   useEffect(() => {
     const proj = `?project=${encodeURIComponent(project)}`
-    fetch(`/api/policies/violations${proj}`)
+    authedFetch(`/api/policies/violations${proj}`)
       .then((r) => r.json())
       .then((d: { violations: unknown[] }) => {
         if (Array.isArray(d.violations)) {
@@ -23,7 +24,7 @@ export function Rail({ project }: RailProps) {
       })
       .catch(() => {})
 
-    fetch(`/api/incidents?limit=1&project=${encodeURIComponent(project)}`)
+    authedFetch(`/api/incidents?limit=1&project=${encodeURIComponent(project)}`)
       .then((r) => r.json())
       .then((d: { total: number }) => {
         if (typeof d.total === 'number') setIncidentBadge(Math.min(d.total, 9))

--- a/packages/web/app/components/StatusBar.tsx
+++ b/packages/web/app/components/StatusBar.tsx
@@ -9,6 +9,7 @@ import {
   type ConnectionEvent,
   type SseEvent,
 } from '../../lib/proxy-client'
+import { authedFetch } from '../../lib/authed-fetch'
 
 const ENV_TOOLTIP =
   "Each NEAT instance has its own graph. Local sees your dev environment; remote sees what you've deployed it to."
@@ -106,7 +107,7 @@ export function StatusBar({ project, graphData }: StatusBarProps) {
     async function check(): Promise<void> {
       const start = performance.now()
       try {
-        const r = await fetch('/api/health', { cache: 'no-store' })
+        const r = await authedFetch('/api/health', { cache: 'no-store' })
         const rtt = Math.round(performance.now() - start)
         const ok = r.ok
         if (!ok) {

--- a/packages/web/app/components/StatusBar.tsx
+++ b/packages/web/app/components/StatusBar.tsx
@@ -77,6 +77,57 @@ interface StatusBarProps {
   graphData: GraphData | null
 }
 
+// ADR-073 §3 — the operator can drop the bearer they pasted at /login and
+// land back on the login surface without poking devtools. Hidden when no
+// token is in storage (e.g. operator behind a reverse proxy terminating
+// auth — NEXT_PUBLIC_NEAT_AUTH_PROXY=true).
+export function SignOutButton() {
+  const [hasToken, setHasToken] = useState(false)
+
+  useEffect(() => {
+    try {
+      setHasToken(!!window.localStorage.getItem('neat:authToken'))
+    } catch {
+      /* private mode — keep hidden */
+    }
+  }, [])
+
+  if (!hasToken) return null
+
+  function onSignOut(): void {
+    try {
+      window.localStorage.removeItem('neat:authToken')
+    } catch {
+      /* ignore */
+    }
+    window.location.href = '/login'
+  }
+
+  return (
+    <div className="st-item">
+      <button
+        type="button"
+        onClick={onSignOut}
+        data-testid="sign-out"
+        title="Clear the bearer token and return to the login screen"
+        style={{
+          background: 'rgba(255,255,255,0.04)',
+          color: 'var(--paper-3)',
+          border: '1px solid var(--rule)',
+          borderRadius: 999,
+          padding: '1px 8px',
+          fontSize: 10.5,
+          letterSpacing: 0.2,
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+        }}
+      >
+        sign out
+      </button>
+    </div>
+  )
+}
+
 type ConnState = 'ok' | 'slow' | 'down'
 type SseState = 'connected' | 'reconnecting' | 'disconnected'
 
@@ -205,6 +256,7 @@ export function StatusBar({ project, graphData }: StatusBarProps) {
         <span className="v">{sseState}</span>
       </div>
       <EnvironmentIndicator />
+      <SignOutButton />
       <div className="st-item">
         <span className="k">nodes</span>
         <span className="v" id="st-nodes">{nodeCount}</span>

--- a/packages/web/app/components/TopBar.tsx
+++ b/packages/web/app/components/TopBar.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { CORE_URL_PUBLIC } from '../../lib/proxy-client'
+import { authedFetch } from '../../lib/authed-fetch'
 
 interface Project {
   name: string
@@ -36,7 +37,7 @@ export function TopBar({ project, onProjectChange, onNodeSelect, onRelayout, onT
 
   // ADR-051 — list projects via GET /projects, used by the switcher (ADR-057 #7).
   useEffect(() => {
-    fetch('/api/projects')
+    authedFetch('/api/projects')
       .then((r) => (r.ok ? r.json() : []))
       .then((data: Project[] | { projects?: Project[] }) => {
         const list = Array.isArray(data) ? data : Array.isArray(data?.projects) ? data.projects : []
@@ -47,7 +48,7 @@ export function TopBar({ project, onProjectChange, onNodeSelect, onRelayout, onT
 
   useEffect(() => {
     const check = () =>
-      fetch('/api/health')
+      authedFetch('/api/health')
         .then((r) => r.json())
         .then((d: { ok: boolean }) => setIsLive(d.ok === true))
         .catch(() => setIsLive(false))
@@ -65,7 +66,7 @@ export function TopBar({ project, onProjectChange, onNodeSelect, onRelayout, onT
       return
     }
     debounceRef.current = setTimeout(() => {
-      fetch(`/api/search?q=${encodeURIComponent(query)}&project=${encodeURIComponent(project)}`)
+      authedFetch(`/api/search?q=${encodeURIComponent(query)}&project=${encodeURIComponent(project)}`)
         .then((r) => r.json())
         .then((d: { results: SearchResult[] }) => {
           if (Array.isArray(d.results)) {

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -889,3 +889,30 @@ html, body {
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: var(--ink-3); border-radius: 4px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--ink-4); }
+
+/* ------------------------------------------------------------------
+   shadcn primitive tokens — single dark theme. The login surface
+   uses these via `bg-background`, `text-foreground`, etc. The app
+   shell ignores them; its palette is defined above.
+   ------------------------------------------------------------------ */
+:root {
+  --background: var(--ink-0);
+  --foreground: var(--paper-1);
+  --card: var(--ink-1);
+  --card-foreground: var(--paper-1);
+  --popover: var(--ink-1);
+  --popover-foreground: var(--paper-1);
+  --primary: var(--paper-0);
+  --primary-foreground: var(--ink-0);
+  --secondary: var(--ink-2);
+  --secondary-foreground: var(--paper-1);
+  --muted: var(--ink-2);
+  --muted-foreground: var(--paper-3);
+  --accent: var(--accent);
+  --accent-foreground: var(--ink-0);
+  --destructive: #e87a7a;
+  --border: var(--rule);
+  --input: var(--rule);
+  --ring: var(--accent);
+  --radius: 0.5rem;
+}

--- a/packages/web/app/incidents/IncidentsClient.tsx
+++ b/packages/web/app/incidents/IncidentsClient.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { authedFetch } from '../../lib/authed-fetch'
 
 interface Incident {
   nodeId: string
@@ -52,7 +53,7 @@ export function IncidentsClient() {
   // ADR-057 #3 — re-fetch when project changes.
   useEffect(() => {
     setLoading(true)
-    fetch(`/api/incidents?limit=100&project=${encodeURIComponent(project)}`)
+    authedFetch(`/api/incidents?limit=100&project=${encodeURIComponent(project)}`)
       .then((r) => r.json())
       .then((d: IncidentsResponse) => {
         setData(d)

--- a/packages/web/app/incidents/IncidentsClient.tsx
+++ b/packages/web/app/incidents/IncidentsClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { authedFetch } from '../../lib/authed-fetch'
+import { useAuthGate } from '../../lib/use-auth-gate'
 
 interface Incident {
   nodeId: string
@@ -28,6 +29,8 @@ function formatTs(iso: string): string {
 }
 
 export function IncidentsClient() {
+  // ADR-073 §3 — same bearer gate AppShell uses.
+  useAuthGate()
   const [data, setData] = useState<IncidentsResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
-          href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@400;500;600&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Cormorant+Garamond:wght@300;400;600&family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@400;500;600&display=swap"
           rel="stylesheet"
         />
       </head>

--- a/packages/web/app/login/page.tsx
+++ b/packages/web/app/login/page.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { LoginForm } from "@/components/login-form"
+import { GalleryVerticalEndIcon } from "lucide-react"
+
+export default function LoginPage() {
+  return (
+    <div className="grid min-h-svh lg:grid-cols-2">
+      <div className="flex flex-col gap-4 p-6 md:p-10">
+        <div className="flex justify-center gap-2 md:justify-start">
+          <a href="#" className="flex items-center gap-2 font-medium">
+            <div className="flex size-6 items-center justify-center rounded-md bg-primary text-primary-foreground">
+              <GalleryVerticalEndIcon className="size-4" />
+            </div>
+            Acme Inc.
+          </a>
+        </div>
+        <div className="flex flex-1 items-center justify-center">
+          <div className="w-full max-w-xs">
+            <LoginForm />
+          </div>
+        </div>
+      </div>
+      <div className="relative hidden bg-muted lg:block">
+        <img
+          src="/placeholder.svg"
+          alt="Image"
+          className="absolute inset-0 h-full w-full object-cover dark:brightness-[0.2] dark:grayscale"
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/web/app/login/page.tsx
+++ b/packages/web/app/login/page.tsx
@@ -1,32 +1,30 @@
-"use client"
+import dynamic from 'next/dynamic'
+import { Suspense } from 'react'
+import { LoginForm } from '@/components/login-form'
 
-import { LoginForm } from "@/components/login-form"
-import { GalleryVerticalEndIcon } from "lucide-react"
+// LogoAnimation reaches for `window.setTimeout` and is purely decorative;
+// load it client-only so the static HTML stays small.
+const LogoAnimation = dynamic(
+  () => import('@/components/logo-animation').then((m) => m.LogoAnimation),
+  { ssr: false },
+)
 
 export default function LoginPage() {
   return (
-    <div className="grid min-h-svh lg:grid-cols-2">
+    <div className="grid min-h-svh bg-background text-foreground lg:grid-cols-2">
       <div className="flex flex-col gap-4 p-6 md:p-10">
-        <div className="flex justify-center gap-2 md:justify-start">
-          <a href="#" className="flex items-center gap-2 font-medium">
-            <div className="flex size-6 items-center justify-center rounded-md bg-primary text-primary-foreground">
-              <GalleryVerticalEndIcon className="size-4" />
-            </div>
-            Acme Inc.
-          </a>
-        </div>
         <div className="flex flex-1 items-center justify-center">
-          <div className="w-full max-w-xs">
-            <LoginForm />
+          <div className="w-full max-w-sm">
+            {/* `LoginForm` reads from useSearchParams — Suspense keeps the
+                client transition from blocking the static shell. */}
+            <Suspense fallback={null}>
+              <LoginForm />
+            </Suspense>
           </div>
         </div>
       </div>
-      <div className="relative hidden bg-muted lg:block">
-        <img
-          src="/placeholder.svg"
-          alt="Image"
-          className="absolute inset-0 h-full w-full object-cover dark:brightness-[0.2] dark:grayscale"
-        />
+      <div className="relative hidden items-center justify-center overflow-hidden bg-black lg:flex">
+        <LogoAnimation />
       </div>
     </div>
   )

--- a/packages/web/components.json
+++ b/packages/web/components.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-nova",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "rtl": false,
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "menuColor": "default",
+  "menuAccent": "subtle",
+  "registries": {}
+}

--- a/packages/web/components/login-form.tsx
+++ b/packages/web/components/login-form.tsx
@@ -1,0 +1,65 @@
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Field,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldSeparator,
+} from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+
+export function LoginForm({
+  className,
+  ...props
+}: React.ComponentProps<"form">) {
+  return (
+    <form className={cn("flex flex-col gap-6", className)} {...props}>
+      <FieldGroup>
+        <div className="flex flex-col items-center gap-1 text-center">
+          <h1 className="text-2xl font-bold">Login to your account</h1>
+          <p className="text-sm text-balance text-muted-foreground">
+            Enter your email below to login to your account
+          </p>
+        </div>
+        <Field>
+          <FieldLabel htmlFor="email">Email</FieldLabel>
+          <Input id="email" type="email" placeholder="m@example.com" required />
+        </Field>
+        <Field>
+          <div className="flex items-center">
+            <FieldLabel htmlFor="password">Password</FieldLabel>
+            <a
+              href="#"
+              className="ml-auto text-sm underline-offset-4 hover:underline"
+            >
+              Forgot your password?
+            </a>
+          </div>
+          <Input id="password" type="password" required />
+        </Field>
+        <Field>
+          <Button type="submit">Login</Button>
+        </Field>
+        <FieldSeparator>Or continue with</FieldSeparator>
+        <Field>
+          <Button variant="outline" type="button">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <path
+                d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
+                fill="currentColor"
+              />
+            </svg>
+            Login with GitHub
+          </Button>
+          <FieldDescription className="text-center">
+            Don&apos;t have an account?{" "}
+            <a href="#" className="underline underline-offset-4">
+              Sign up
+            </a>
+          </FieldDescription>
+        </Field>
+      </FieldGroup>
+    </form>
+  )
+}

--- a/packages/web/components/login-form.tsx
+++ b/packages/web/components/login-form.tsx
@@ -1,63 +1,125 @@
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+'use client'
+
+import { useState, type FormEvent } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
 import {
   Field,
   FieldDescription,
   FieldGroup,
   FieldLabel,
-  FieldSeparator,
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
+} from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
 
-export function LoginForm({
-  className,
-  ...props
-}: React.ComponentProps<"form">) {
+type SubmitState = { kind: 'idle' } | { kind: 'submitting' } | { kind: 'error'; message: string }
+
+const ERR_WRONG_TOKEN = "That token doesn't match this NEAT instance."
+const ERR_NETWORK = "Can't reach the daemon; check the URL."
+
+function safeNext(raw: string | null): string {
+  if (!raw) return '/'
+  // Only accept same-origin paths starting with a single slash.
+  if (!raw.startsWith('/') || raw.startsWith('//')) return '/'
+  return raw
+}
+
+export function LoginForm({ className, ...props }: React.ComponentProps<'form'>) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [token, setToken] = useState('')
+  const [state, setState] = useState<SubmitState>({ kind: 'idle' })
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault()
+    const trimmed = token.trim()
+    if (!trimmed) return
+
+    setState({ kind: 'submitting' })
+    try {
+      window.localStorage.setItem('neat:authToken', trimmed)
+    } catch {
+      // Storage quota / private-mode — keep going; the fetch below will fail.
+    }
+
+    let res: Response
+    try {
+      res = await fetch('/api/projects', {
+        headers: { Authorization: `Bearer ${trimmed}` },
+        cache: 'no-store',
+      })
+    } catch {
+      setState({ kind: 'error', message: ERR_NETWORK })
+      return
+    }
+
+    if (res.status === 401) {
+      try {
+        window.localStorage.removeItem('neat:authToken')
+      } catch {
+        /* ignore */
+      }
+      setState({ kind: 'error', message: ERR_WRONG_TOKEN })
+      return
+    }
+
+    if (!res.ok) {
+      setState({ kind: 'error', message: `Daemon returned ${res.status}; try again.` })
+      return
+    }
+
+    const next = safeNext(searchParams?.get('next') ?? null)
+    router.push(next)
+  }
+
+  const submitting = state.kind === 'submitting'
+  const errorMessage = state.kind === 'error' ? state.message : null
+
   return (
-    <form className={cn("flex flex-col gap-6", className)} {...props}>
+    <form className={cn('flex flex-col gap-6', className)} onSubmit={handleSubmit} {...props}>
       <FieldGroup>
         <div className="flex flex-col items-center gap-1 text-center">
-          <h1 className="text-2xl font-bold">Login to your account</h1>
-          <p className="text-sm text-balance text-muted-foreground">
-            Enter your email below to login to your account
+          <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
+          <p className="text-sm text-muted-foreground text-balance">
+            Paste your NEAT token to open the dashboard.
           </p>
         </div>
         <Field>
-          <FieldLabel htmlFor="email">Email</FieldLabel>
-          <Input id="email" type="email" placeholder="m@example.com" required />
-        </Field>
-        <Field>
-          <div className="flex items-center">
-            <FieldLabel htmlFor="password">Password</FieldLabel>
-            <a
-              href="#"
-              className="ml-auto text-sm underline-offset-4 hover:underline"
-            >
-              Forgot your password?
-            </a>
-          </div>
-          <Input id="password" type="password" required />
-        </Field>
-        <Field>
-          <Button type="submit">Login</Button>
-        </Field>
-        <FieldSeparator>Or continue with</FieldSeparator>
-        <Field>
-          <Button variant="outline" type="button">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-              <path
-                d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
-                fill="currentColor"
-              />
-            </svg>
-            Login with GitHub
-          </Button>
-          <FieldDescription className="text-center">
-            Don&apos;t have an account?{" "}
-            <a href="#" className="underline underline-offset-4">
-              Sign up
-            </a>
+          <FieldLabel htmlFor="neat-token">NEAT token</FieldLabel>
+          <Input
+            id="neat-token"
+            name="token"
+            type="password"
+            autoComplete="off"
+            spellCheck={false}
+            autoFocus
+            required
+            value={token}
+            onChange={(e) => {
+              setToken(e.target.value)
+              if (state.kind === 'error') setState({ kind: 'idle' })
+            }}
+            aria-invalid={state.kind === 'error'}
+            aria-describedby="neat-token-hint"
+          />
+          <FieldDescription id="neat-token-hint">
+            Your token was printed when you ran <code className="font-mono">neat deploy</code> — find
+            it in your deploy platform's env vars.
           </FieldDescription>
+        </Field>
+        {errorMessage && (
+          <div
+            role="alert"
+            className="text-sm text-destructive"
+            data-testid="login-error"
+          >
+            {errorMessage}
+          </div>
+        )}
+        <Field>
+          <Button type="submit" disabled={submitting || token.trim().length === 0}>
+            {submitting ? 'Checking…' : 'Open dashboard'}
+          </Button>
         </Field>
       </FieldGroup>
     </form>

--- a/packages/web/components/logo-animation.tsx
+++ b/packages/web/components/logo-animation.tsx
@@ -1,0 +1,219 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+const LETTERS = ['N', 'E', 'A', 'T'] as const
+const HOLD_MS = 900
+const FLIP_MS = 140
+
+export function LogoAnimation() {
+  const letterRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = letterRef.current
+    if (!el) return
+
+    let current = 0
+    let cancelled = false
+    let timers: number[] = []
+
+    function schedule(fn: () => void, delay: number): void {
+      const id = window.setTimeout(() => {
+        timers = timers.filter((t) => t !== id)
+        if (!cancelled) fn()
+      }, delay)
+      timers.push(id)
+    }
+
+    function tick(): void {
+      if (!el) return
+      el.classList.remove('flip-in')
+      el.classList.add('flip-out')
+      schedule(() => {
+        current = (current + 1) % LETTERS.length
+        el.textContent = LETTERS[current]
+        el.classList.remove('flip-out')
+        el.classList.add('flip-in')
+        schedule(() => {
+          el.classList.remove('flip-in')
+          schedule(tick, HOLD_MS)
+        }, FLIP_MS)
+      }, FLIP_MS)
+    }
+
+    schedule(tick, HOLD_MS)
+    return () => {
+      cancelled = true
+      timers.forEach((id) => window.clearTimeout(id))
+    }
+  }, [])
+
+  return (
+    <div className="logo-stage" aria-hidden="true">
+      <div className="logo-diamond-outer">
+        <svg viewBox="0 0 220 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <polygon points="110,4 216,110 110,216 4,110" stroke="white" strokeWidth="1" fill="none" opacity="0.9" />
+          <line x1="110" y1="4" x2="110" y2="18" stroke="white" strokeWidth="2" opacity="0.6" />
+          <line x1="216" y1="110" x2="202" y2="110" stroke="white" strokeWidth="2" opacity="0.6" />
+          <line x1="110" y1="216" x2="110" y2="202" stroke="white" strokeWidth="2" opacity="0.6" />
+          <line x1="4" y1="110" x2="18" y2="110" stroke="white" strokeWidth="2" opacity="0.6" />
+          <rect x="107" y="1" width="6" height="6" fill="white" transform="rotate(45 110 4)" opacity="1" />
+          <rect x="213" y="107" width="6" height="6" fill="white" transform="rotate(45 216 110)" opacity="1" />
+          <rect x="107" y="213" width="6" height="6" fill="white" transform="rotate(45 110 216)" opacity="1" />
+          <rect x="1" y="107" width="6" height="6" fill="white" transform="rotate(45 4 110)" opacity="1" />
+        </svg>
+      </div>
+
+      <div className="logo-diamond-inner">
+        <svg viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <polygon points="90,6 174,90 90,174 6,90" stroke="white" strokeWidth="0.5" fill="none" opacity="0.3" />
+          <line x1="90" y1="6" x2="90" y2="14" stroke="white" strokeWidth="1" opacity="0.3" />
+          <line x1="174" y1="90" x2="166" y2="90" stroke="white" strokeWidth="1" opacity="0.3" />
+          <line x1="90" y1="174" x2="90" y2="166" stroke="white" strokeWidth="1" opacity="0.3" />
+          <line x1="6" y1="90" x2="14" y2="90" stroke="white" strokeWidth="1" opacity="0.3" />
+        </svg>
+      </div>
+
+      <div className="logo-scan" />
+
+      <div className="logo-letter-stage">
+        <div className="logo-letter-face" ref={letterRef} data-testid="logo-letter">N</div>
+      </div>
+
+      <span className="logo-pip logo-pip-top" />
+      <span className="logo-pip logo-pip-right" />
+      <span className="logo-pip logo-pip-bottom" />
+      <span className="logo-pip logo-pip-left" />
+
+      <div className="logo-label">Network Environment Architecture Tools</div>
+
+      <style jsx>{`
+        .logo-stage {
+          position: relative;
+          width: 260px;
+          height: 260px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+
+        .logo-diamond-outer {
+          position: absolute;
+          inset: 0;
+          animation: logo-spin 8s linear infinite;
+        }
+        .logo-diamond-outer svg { width: 100%; height: 100%; }
+
+        @keyframes logo-spin {
+          from { transform: rotate(0deg); }
+          to   { transform: rotate(360deg); }
+        }
+
+        .logo-diamond-inner {
+          position: absolute;
+          inset: 16px;
+          animation: logo-spin-reverse 8s linear infinite;
+        }
+        .logo-diamond-inner svg { width: 100%; height: 100%; }
+
+        @keyframes logo-spin-reverse {
+          from { transform: rotate(0deg); }
+          to   { transform: rotate(-360deg); }
+        }
+
+        .logo-letter-stage {
+          position: relative;
+          width: 100px;
+          height: 100px;
+          perspective: 500px;
+          z-index: 10;
+        }
+
+        .logo-letter-face {
+          position: absolute;
+          inset: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: 'Cormorant Garamond', Georgia, serif;
+          font-size: 86px;
+          font-weight: 300;
+          color: #fff;
+          letter-spacing: -0.02em;
+          line-height: 1;
+          backface-visibility: hidden;
+          transform-style: preserve-3d;
+          transform: rotateY(0deg);
+        }
+
+        .logo-letter-face.flip-out {
+          animation: logo-flip-out ${FLIP_MS}ms ease-in forwards;
+        }
+        .logo-letter-face.flip-in {
+          animation: logo-flip-in ${FLIP_MS}ms ease-out forwards;
+        }
+
+        @keyframes logo-flip-out {
+          from { transform: rotateY(0deg);   opacity: 1; }
+          to   { transform: rotateY(90deg);  opacity: 0.2; }
+        }
+        @keyframes logo-flip-in {
+          from { transform: rotateY(-90deg); opacity: 0.2; }
+          to   { transform: rotateY(0deg);   opacity: 1; }
+        }
+
+        .logo-pip {
+          position: absolute;
+          width: 6px;
+          height: 6px;
+          background: #fff;
+          animation: logo-pip-pulse 8s linear infinite;
+        }
+        .logo-pip-top    { top: 2px;    left: 50%; transform: translateX(-50%) rotate(45deg); }
+        .logo-pip-right  { right: 2px;  top: 50%;  transform: translateY(-50%) rotate(45deg); }
+        .logo-pip-bottom { bottom: 2px; left: 50%; transform: translateX(-50%) rotate(45deg); }
+        .logo-pip-left   { left: 2px;   top: 50%;  transform: translateY(-50%) rotate(45deg); }
+
+        @keyframes logo-pip-pulse {
+          0%, 100% { opacity: 1; }
+          50%      { opacity: 0.3; }
+        }
+
+        .logo-scan {
+          position: absolute;
+          inset: 0;
+          overflow: hidden;
+          z-index: 5;
+          pointer-events: none;
+        }
+        .logo-scan::after {
+          content: '';
+          position: absolute;
+          left: 0;
+          right: 0;
+          height: 1px;
+          background: rgba(255, 255, 255, 0.08);
+          animation: logo-scan-move 3s linear infinite;
+        }
+        @keyframes logo-scan-move {
+          from { top: -1px; }
+          to   { top: 100%; }
+        }
+
+        .logo-label {
+          position: absolute;
+          bottom: -48px;
+          left: 50%;
+          transform: translateX(-50%);
+          font-family: 'Cormorant Garamond', Georgia, serif;
+          font-size: 10px;
+          font-weight: 400;
+          letter-spacing: 0.38em;
+          text-transform: uppercase;
+          color: rgba(255, 255, 255, 0.35);
+          white-space: nowrap;
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/packages/web/components/ui/button.tsx
+++ b/packages/web/components/ui/button.tsx
@@ -1,0 +1,58 @@
+import { Button as ButtonPrimitive } from "@base-ui/react/button"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        outline:
+          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+        destructive:
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default:
+          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        icon: "size-8",
+        "icon-xs":
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm":
+          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-lg": "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  return (
+    <ButtonPrimitive
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/packages/web/components/ui/field.tsx
+++ b/packages/web/components/ui/field.tsx
@@ -1,0 +1,238 @@
+"use client"
+
+import { useMemo } from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        "flex flex-col gap-4 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLegend({
+  className,
+  variant = "legend",
+  ...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        "mb-1.5 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        "group/field-group @container/field-group flex w-full flex-col gap-5 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const fieldVariants = cva(
+  "group/field flex w-full gap-2 data-[invalid=true]:text-destructive",
+  {
+    variants: {
+      orientation: {
+        vertical: "flex-col *:w-full [&>.sr-only]:w-auto",
+        horizontal:
+          "flex-row items-center has-[>[data-slot=field-content]]:items-start *:data-[slot=field-label]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        responsive:
+          "flex-col *:w-full @md/field-group:flex-row @md/field-group:items-center @md/field-group:*:w-auto @md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:*:data-[slot=field-label]:flex-auto [&>.sr-only]:w-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+      },
+    },
+    defaultVariants: {
+      orientation: "vertical",
+    },
+  }
+)
+
+function Field({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn(
+        "group/field-content flex flex-1 flex-col gap-0.5 leading-snug",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Label>) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(
+        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border *:data-[slot=field]:p-2.5 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm font-medium group-data-[disabled=true]/field:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn(
+        "text-left text-sm leading-normal font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
+        "last:mt-0 nth-last-2:-mt-1",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  children?: React.ReactNode
+}) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={!!children}
+      className={cn(
+        "relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+        className
+      )}
+      {...props}
+    >
+      <Separator className="absolute inset-0 top-1/2" />
+      {children && (
+        <span
+          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children
+    }
+
+    if (!errors?.length) {
+      return null
+    }
+
+    const uniqueErrors = [
+      ...new Map(errors.map((error) => [error?.message, error])).values(),
+    ]
+
+    if (uniqueErrors?.length == 1) {
+      return uniqueErrors[0]?.message
+    }
+
+    return (
+      <ul className="ml-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map(
+          (error, index) =>
+            error?.message && <li key={index}>{error.message}</li>
+        )}
+      </ul>
+    )
+  }, [children, errors])
+
+  if (!content) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("text-sm font-normal text-destructive", className)}
+      {...props}
+    >
+      {content}
+    </div>
+  )
+}
+
+export {
+  Field,
+  FieldLabel,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldContent,
+  FieldTitle,
+}

--- a/packages/web/components/ui/input.tsx
+++ b/packages/web/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+import { Input as InputPrimitive } from "@base-ui/react/input"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/packages/web/components/ui/label.tsx
+++ b/packages/web/components/ui/label.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/packages/web/components/ui/separator.tsx
+++ b/packages/web/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/packages/web/lib/authed-fetch.ts
+++ b/packages/web/lib/authed-fetch.ts
@@ -1,0 +1,55 @@
+'use client'
+
+import { trackedFetch } from './proxy-client'
+
+const TOKEN_KEY = 'neat:authToken'
+
+function readToken(): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const v = window.localStorage.getItem(TOKEN_KEY)
+    return v && v.length > 0 ? v : null
+  } catch {
+    return null
+  }
+}
+
+function clearToken(): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.removeItem(TOKEN_KEY)
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Browser-side fetch that attaches the operator's NEAT token (when present)
+ * and redirects to /login when the daemon rejects it. Composes onto
+ * `trackedFetch` so the toast / debug-panel wiring from ADR-058 still fires.
+ *
+ * Server components and route handlers should keep calling raw `fetch` —
+ * they don't have access to localStorage and can't act on a 401 anyway.
+ */
+export async function authedFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  const token = readToken()
+  const headers = new Headers(init?.headers)
+  if (token) headers.set('Authorization', `Bearer ${token}`)
+
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+  const res = await trackedFetch(url, { ...init, headers })
+
+  if (res.status === 401 && typeof window !== 'undefined') {
+    clearToken()
+    const path = window.location.pathname
+    if (path !== '/login') {
+      const next = encodeURIComponent(path + window.location.search)
+      window.location.href = `/login?next=${next}`
+    }
+  }
+
+  return res
+}

--- a/packages/web/lib/proxy.ts
+++ b/packages/web/lib/proxy.ts
@@ -1,9 +1,27 @@
 export const CORE_URL = process.env.NEAT_CORE_URL ?? 'http://localhost:8080'
 export const DEMO = process.env.NEAT_DEMO === '1'
 
-export async function proxyGet(url: string, fallback: () => Response): Promise<Response> {
+// Forward the operator's bearer (ADR-073 §3) and the SSE caller's Last-Event-ID
+// so the daemon sees what the browser sent. Other headers are upstream-managed.
+const FORWARD_HEADERS = ['authorization', 'last-event-id'] as const
+
+function pickForwardableHeaders(req?: Request): HeadersInit | undefined {
+  if (!req) return undefined
+  const out: Record<string, string> = {}
+  for (const name of FORWARD_HEADERS) {
+    const v = req.headers.get(name)
+    if (v) out[name] = v
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+export async function proxyGet(
+  url: string,
+  fallback: () => Response,
+  req?: Request,
+): Promise<Response> {
   try {
-    const upstream = await fetch(url, { cache: 'no-store' })
+    const upstream = await fetch(url, { cache: 'no-store', headers: pickForwardableHeaders(req) })
     const body = await upstream.text()
     return new Response(body, {
       status: upstream.status,

--- a/packages/web/lib/use-auth-gate.ts
+++ b/packages/web/lib/use-auth-gate.ts
@@ -1,0 +1,34 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Client-side auth gate. When the operator has not yet pasted a NEAT token at
+ * /login, redirect there carrying the current path as `?next=`. Reverse-proxy
+ * deployments that already terminate auth opt out via
+ * `NEXT_PUBLIC_NEAT_AUTH_PROXY=true` (ADR-073 §3 — the bearer is delegated to
+ * the deploy platform).
+ *
+ * Mount this from any client-only page subtree that lives behind the bearer.
+ * /login itself does not call it (the page is the destination of the redirect).
+ */
+export function useAuthGate(): void {
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (process.env.NEXT_PUBLIC_NEAT_AUTH_PROXY === 'true') return
+
+    let token: string | null = null
+    try {
+      token = window.localStorage.getItem('neat:authToken')
+    } catch {
+      /* private mode — fall through to the redirect */
+    }
+    if (token) return
+
+    const path = window.location.pathname
+    if (path === '/login') return
+
+    const next = encodeURIComponent(path + window.location.search)
+    window.location.href = `/login?next=${next}`
+  }, [])
+}

--- a/packages/web/lib/utils.ts
+++ b/packages/web/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -19,6 +19,8 @@
     ".next/standalone",
     ".next/static",
     "app",
+    "components",
+    "components.json",
     "lib",
     "next.config.mjs",
     "tsconfig.json",
@@ -36,11 +38,16 @@
     "clean": "rm -rf .next .turbo"
   },
   "dependencies": {
+    "@base-ui/react": "^1.4.1",
     "@neat.is/types": "^0.3.8",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "cytoscape": "^3.33.3",
+    "lucide-react": "^1.16.0",
     "next": "14.2.35",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.0",

--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -11,6 +11,39 @@ const config: Config = {
       colors: {
         background: "var(--background)",
         foreground: "var(--foreground)",
+        card: {
+          DEFAULT: "var(--card)",
+          foreground: "var(--card-foreground)",
+        },
+        popover: {
+          DEFAULT: "var(--popover)",
+          foreground: "var(--popover-foreground)",
+        },
+        primary: {
+          DEFAULT: "var(--primary)",
+          foreground: "var(--primary-foreground)",
+        },
+        secondary: {
+          DEFAULT: "var(--secondary)",
+          foreground: "var(--secondary-foreground)",
+        },
+        muted: {
+          DEFAULT: "var(--muted)",
+          foreground: "var(--muted-foreground)",
+        },
+        accent: {
+          DEFAULT: "var(--accent)",
+          foreground: "var(--accent-foreground)",
+        },
+        destructive: "var(--destructive)",
+        border: "var(--border)",
+        input: "var(--input)",
+        ring: "var(--ring)",
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
       },
     },
   },

--- a/packages/web/test/login-surface.test.tsx
+++ b/packages/web/test/login-surface.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// next/navigation is server-aware; stub it so the component-under-test can
+// render in jsdom without a real Next router context.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(''),
+}))
+
+// next/dynamic with { ssr: false } returns a placeholder during the first
+// render in jsdom. Force the component to load eagerly so the test can
+// assert against its DOM.
+vi.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: (loader: () => Promise<{ default?: unknown; LogoAnimation?: unknown }>) => {
+    const mod: { current: React.ComponentType | null } = { current: null }
+    loader().then((m) => {
+      mod.current = (m.default ?? (m as { LogoAnimation?: React.ComponentType }).LogoAnimation) as React.ComponentType
+    })
+    return function Lazy() {
+      const C = mod.current
+      return C ? <C /> : null
+    }
+  },
+}))
+
+function makeStorage(): Storage {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v))
+    },
+    removeItem: (k: string) => {
+      store.delete(k)
+    },
+    clear: () => store.clear(),
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })))
+  // Fresh per-test localStorage — keeps assertions independent of prior test
+  // files' side effects and dodges jsdom version drift.
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: makeStorage(),
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('ADR-073 §3 — /login surface', () => {
+  it('renders the NEAT-token input, caption, and Open dashboard button', async () => {
+    const { LoginForm } = await import('../components/login-form')
+    render(<LoginForm />)
+
+    const input = screen.getByLabelText(/NEAT token/i)
+    expect(input).toBeInTheDocument()
+    expect(input.getAttribute('type')).toBe('password')
+
+    expect(
+      screen.getByText(/Your token was printed when you ran/i),
+    ).toBeInTheDocument()
+
+    expect(screen.getByRole('button', { name: /Open dashboard/i })).toBeInTheDocument()
+  })
+
+  it('strips the prior login-02 affordances — no Email, no Forgot password, no GitHub, no Sign up', async () => {
+    const { LoginForm } = await import('../components/login-form')
+    render(<LoginForm />)
+
+    expect(screen.queryByLabelText(/Email/i)).toBeNull()
+    expect(screen.queryByLabelText(/^Password$/i)).toBeNull()
+    expect(screen.queryByRole('button', { name: /GitHub/i })).toBeNull()
+    expect(screen.queryByText(/Sign up/i)).toBeNull()
+    expect(screen.queryByText(/Forgot/i)).toBeNull()
+  })
+
+  it('renders the logo animation centred on the letter "N"', async () => {
+    const { LogoAnimation } = await import('../components/logo-animation')
+    render(<LogoAnimation />)
+
+    // The animation's centre letter is the load-bearing visual; it starts at "N"
+    // and cycles N → E → A → T on the 900 / 140ms beat.
+    expect(screen.getByTestId('logo-letter').textContent).toBe('N')
+  })
+})
+
+describe('ADR-073 §3 — authedFetch bearer attachment', () => {
+  it('attaches `Authorization: Bearer <token>` when the operator is signed in', async () => {
+    const fetchStub = vi.fn(async () => new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchStub)
+    window.localStorage.setItem('neat:authToken', 'paste-this-into-prod')
+
+    const { authedFetch } = await import('../lib/authed-fetch')
+    await authedFetch('/api/projects')
+
+    const sentInit = fetchStub.mock.calls[0]?.[1] as { headers?: Headers } | undefined
+    expect(sentInit?.headers?.get('authorization')).toBe('Bearer paste-this-into-prod')
+
+    window.localStorage.removeItem('neat:authToken')
+  })
+
+  it('omits the Authorization header when no token is in storage', async () => {
+    const fetchStub = vi.fn(async () => new Response('{}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchStub)
+    window.localStorage.removeItem('neat:authToken')
+
+    const { authedFetch } = await import('../lib/authed-fetch')
+    await authedFetch('/api/projects')
+
+    const sentInit = fetchStub.mock.calls[0]?.[1] as { headers?: Headers } | undefined
+    expect(sentInit?.headers?.get('authorization')).toBeNull()
+  })
+})

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,8 +1,16 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import path from 'node:path'
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    // Mirrors the `@/*` alias in tsconfig so client components that use
+    // shadcn's import shape resolve under vitest.
+    alias: {
+      '@': path.resolve(__dirname),
+    },
+  },
   test: {
     environment: 'jsdom',
     setupFiles: ['./test/setup.ts'],


### PR DESCRIPTION
## Summary

NEAT's web shell gains a login surface. The operator pastes the bearer printed by `neat deploy` into a single masked field at `/login`, lands on the dashboard, and stays there — every browser-side call carries the token, the proxy forwards it onto the daemon, and the StatusBar offers a sign-out chip when they want to flip identities.

## What lands

- **shadcn primitive scaffold** in `packages/web/components/ui/`, hooked onto the existing NEAT palette so `bg-background` and `border-input` resolve against the same ink / paper variables the dashboard already uses.
- **`/login` page** — split layout, single NEAT-token input + caption + `Open dashboard` submit. No email, password, GitHub, sign-up, or forgot-password affordances.
- **Logo animation** at `packages/web/components/logo-animation.tsx` ported from the standalone reference — 260×260 stage, outer/inner counter-spin, N→E→A→T letter flip on the 900 / 140ms beat, pulsing pips, scan line.
- **`authedFetch` wrapper** at `packages/web/lib/authed-fetch.ts` that attaches `Authorization: Bearer <token>` from localStorage and bounces back to `/login` on 401. Every client-side fetch in `packages/web/app/` migrates to it. The Next proxy at `app/api/*/route.ts` now forwards the operator's bearer (and Last-Event-ID) onto the daemon.
- **`useAuthGate` hook** at `packages/web/lib/use-auth-gate.ts` — AppShell and IncidentsClient call it on mount; redirects to `/login?next=…` when no token is in storage; short-circuits when `NEXT_PUBLIC_NEAT_AUTH_PROXY=true` so reverse-proxy deployments don't see the login screen.
- **Sign-out chip** in StatusBar next to the environment indicator. Hidden when no token is in storage.
- **Live test coverage** in `packages/web/test/login-surface.test.tsx`. Five assertions across the form shape and `authedFetch` header attachment.
- **Contract amendment** in `docs/contracts/web-debugging.md` pointing at the new test file.

## Notes

- EventSource at `/api/events` keeps raw `fetch` — the browser can't add headers to SSE natively. Authed SSE follows in its own change.
- `packages/web/tsconfig.json` bumps `target` to `es2020` so shadcn's vendored Map iterators compile under Next's tsc pass.

## Test plan

- [x] `npx turbo build test lint` on `@neat.is/web` — 9/9 tests pass, build emits the `/login` route, lint clean (two pre-existing warnings in GraphCanvas unrelated to this PR)
- [x] `@neat.is/types` / `core` / `mcp` rebuild cleanly against the change
- [ ] Manual: `cd packages/web && npm run dev` → visit `localhost:6328` without a token → redirects to `/login` → paste token → dashboard fetches succeed → click sign-out → back to `/login`
- [ ] Manual: visit again same browser → already authed, dashboard renders directly
- [ ] Manual: with `NEXT_PUBLIC_NEAT_AUTH_PROXY=true` at build time → no `/login` redirect, dashboard renders directly

Refs #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)