### PR TITLE
v0.4: NEAT_PUBLIC_READ — read-anonymous, write-authenticated

### DIFF
--- a/docs/contracts/one-command-cli.md
+++ b/docs/contracts/one-command-cli.md
@@ -72,13 +72,38 @@ The token is the daemon-side configuration surface. NEAT does not issue, rotate,
 - Wrong token → `401`. Constant-time comparison only.
 - The bundled web UI carries the token via the same header, reading it from an env-injected config payload at `/api/config`.
 - Lifecycle probes `/healthz` and `/readyz` stay unauthenticated — orchestrator probes need to reach them.
-- Mounted **before** any project router; no per-project bypass, no read/write split.
+- Mounted **before** any project router; no per-project bypass.
+- The read/write split is opt-in via `NEAT_PUBLIC_READ` — see §3a below.
 
 **`NEAT_AUTH_TOKEN` unset:**
 
 - Daemon refuses to bind on any address other than `127.0.0.1`.
 - Setting any future bind-override env-var to a non-loopback value with no token → `neatd start` exits non-zero with: `NEAT_AUTH_TOKEN is required when binding outside loopback`.
 - Loopback-only binds remain unauthenticated. The laptop dev experience is unchanged.
+
+## 3a. `NEAT_PUBLIC_READ` — read-anonymous, write-authenticated
+
+Reference deployments (e.g. `try.neat.is`) want the dashboard publicly readable without losing the bearer gate on writes. `NEAT_PUBLIC_READ=true` (or `=1`) flips that split:
+
+- The bearer hook lets `GET` / `HEAD` / `OPTIONS` through anonymously. SSE `/events` is a GET, so the live event stream passes through too.
+- Every other verb (`POST` / `PUT` / `PATCH` / `DELETE`) keeps the existing `401`-without-token treatment. Constant-time comparison still applies.
+- OTLP ingest at `:4318` (and `:4317` when opt-in) is **not** part of the split — that surface mounts its own middleware against `NEAT_AUTH_TOKEN` / `NEAT_OTEL_TOKEN` and stays gated unconditionally. Randoms can't push spans into a publicly readable reference daemon.
+- The bind-authority gate is unchanged. `NEAT_PUBLIC_READ=true` does **not** unlock public binding without a token — `NEAT_HOST=0.0.0.0` plus `NEAT_AUTH_TOKEN` unset still throws `BindAuthorityError`. Public-read enables anonymous reads on top of an already-bound, token-authorized daemon.
+- Default: `false`. Anything other than literal `'true'` or `'1'` reads as off. The laptop dev path and the existing reference-implementation auth posture are unchanged.
+
+### `/api/config` — the negotiation surface
+
+`GET /api/config` is **always unauthenticated** — even when the daemon is fully token-gated. It returns exactly two booleans and nothing else:
+
+```json
+{ "publicRead": true, "authProxy": false }
+```
+
+- `publicRead` mirrors the `NEAT_PUBLIC_READ` env.
+- `authProxy` mirrors `NEAT_AUTH_PROXY` so the web shell knows when an upstream reverse proxy terminates auth.
+- No project list, no version, no environment info, no whoami. The web UI uses the two booleans to decide whether to push the operator through `/login` and which mutation affordances to render disabled; nothing else belongs on this surface.
+
+The web shell hits `/api/config` before any bearer-carrying call, caches the result in a module-level singleton, and renders `public read-only` in the StatusBar when `publicRead === true`. The dashboard mounts read-only; mutation buttons disable; the login redirect on 401 is suppressed.
 
 ## 4. OTLP ingest honors the same bearer; `NEAT_OTEL_TOKEN` rotates independently
 

--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -47,6 +47,7 @@ Bare arrays from REST endpoints are a contract violation. Why: an object can gro
 | `GET /policies/violations?severity=X&policyId=X` | current violations, filterable | `{ violations: PolicyViolation[] }` |
 | `GET /projects` | machine-registered projects (single-mount; not dual-mounted) | `Array<RegistryEntry>` *(the one bare-array exception — `/projects` is the switcher entry-point and its consumers (web, MCP) treat it as a list primitive)* |
 | `GET /projects/:project` | singular project lookup | `{ project: RegistryEntry }` |
+| `GET /api/config` | daemon auth-mode negotiation (ADR-073 §3a); always unauthenticated | `{ publicRead: boolean, authProxy: boolean }` |
 
 ## Write-side endpoints
 

--- a/docs/runbook-public-demo.md
+++ b/docs/runbook-public-demo.md
@@ -1,0 +1,127 @@
+# Public-read reference deployment
+
+How to bring up a NEAT instance whose dashboard is publicly readable while writes and OTel ingest stay token-gated. Targets `try.neat.is` — the reference deployment NEAT runs against the dogfood app (northsea today) so visitors land on a live graph with no auth dance.
+
+The shape:
+
+- One daemon container. `NEAT_PUBLIC_READ=true` + `NEAT_AUTH_TOKEN=<token>`.
+- Reverse proxy terminates TLS at the public hostname. The dashboard sits behind the same proxy.
+- The dogfooded app's OTel SDK ships spans to the daemon's OTLP receiver carrying the bearer.
+- CI pushes static-graph snapshots through `neat sync --to https://try.neat.is --token $TOKEN`.
+
+## 1. Run the daemon
+
+```bash
+docker run -d \
+  --name neat \
+  --restart=unless-stopped \
+  -p 127.0.0.1:8080:8080 \
+  -p 127.0.0.1:4318:4318 \
+  -p 127.0.0.1:6328:6328 \
+  -v /var/lib/neat:/neat-out \
+  -e NEAT_PUBLIC_READ=true \
+  -e NEAT_AUTH_TOKEN=$NEAT_AUTH_TOKEN \
+  -e NEAT_HOST=0.0.0.0 \
+  ghcr.io/neat-technologies/neat:latest
+```
+
+Notes:
+
+- Bind to `127.0.0.1` on the host. The reverse proxy below is the only thing that talks to the daemon. Public binding without a fronting proxy is not the supported shape.
+- `NEAT_HOST=0.0.0.0` inside the container lets the reverse proxy reach the daemon; the host-side port map keeps it off the public interface.
+- `NEAT_AUTH_TOKEN` is the write token. Generate once with `openssl rand -base64 32` and keep it in your secrets manager.
+
+## 2. Front the daemon with Caddy
+
+```caddyfile
+try.neat.is {
+    encode gzip
+    reverse_proxy /api/* 127.0.0.1:8080
+    reverse_proxy /events 127.0.0.1:8080
+    reverse_proxy 127.0.0.1:6328
+}
+
+otlp.neat.is {
+    reverse_proxy 127.0.0.1:4318
+}
+```
+
+Caddy handles TLS via ACME automatically. The OTLP receiver lives on a separate subdomain so the bearer can't accidentally leak through the dashboard's HSTS context.
+
+DNS:
+
+- `try.neat.is` → host's public IP, port 443.
+- `otlp.neat.is` → same host, port 443.
+
+## 3. Wire the dogfooded app's OTel SDK
+
+In the application that NEAT is graphing, set these env-vars on the deploy platform:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.neat.is
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer ${NEAT_AUTH_TOKEN}
+OTEL_SERVICE_NAME=<service>
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=prod
+```
+
+The OTel SDK reads `OTEL_EXPORTER_OTLP_HEADERS` and attaches the bearer on every export. The daemon's OTLP receiver validates it against `NEAT_AUTH_TOKEN` (or `NEAT_OTEL_TOKEN` if you rotated independently) before accepting any span — `NEAT_PUBLIC_READ` does not relax this.
+
+## 4. Push static-graph snapshots from CI
+
+Static extraction runs in CI on the dogfooded app's repo and ships the result to the public daemon:
+
+```yaml
+# .github/workflows/neat-sync.yml
+on:
+  push:
+    branches: [main]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npx neat.is sync . \
+          --to https://try.neat.is \
+          --token ${{ secrets.NEAT_AUTH_TOKEN }}
+```
+
+`neat sync` re-runs discovery + extraction locally and `POST`s the snapshot to `/snapshot` on the public daemon. The bearer goes on the same `Authorization` header — `/snapshot` is a write, so anonymous reads don't apply.
+
+## 5. Smoke the deployment
+
+```bash
+# Anonymous GETs work — the dashboard is public.
+curl -fsS https://try.neat.is/api/projects | jq
+
+# /api/config advertises the mode.
+curl -fsS https://try.neat.is/api/config
+# {"publicRead":true,"authProxy":false}
+
+# Writes refuse without the token.
+curl -i -X POST https://try.neat.is/snapshot \
+  -H 'content-type: application/json' \
+  -d '{}'
+# HTTP/1.1 401 Unauthorized
+
+# With the token, writes go through.
+curl -i -X POST https://try.neat.is/snapshot \
+  -H "authorization: Bearer $NEAT_AUTH_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"snapshot":{...}}'
+```
+
+## 6. Token rotation
+
+Two rotation surfaces, independent on purpose:
+
+- `NEAT_AUTH_TOKEN` rotates the REST write token. Update the container env, restart, refresh the CI secret, refresh the operator's local `neat sync --token` invocations.
+- `NEAT_OTEL_TOKEN` rotates the OTLP bearer. Update the container env, restart, then bump `OTEL_EXPORTER_OTLP_HEADERS` on the dogfooded app. Web shell and `neat sync` are unaffected.
+
+When only `NEAT_AUTH_TOKEN` is set, OTLP inherits it — that is the simple steady state. Setting `NEAT_OTEL_TOKEN` is a deliberate split for operators who need different rotation cadences on the two surfaces.
+
+## What this deployment does **not** do
+
+- It does not host the operator's actual codebase. The dogfooded app runs wherever the operator deploys it; only the OTel export endpoint points at NEAT.
+- It does not write to the registry on visitor traffic. `~/.neat/projects.json` inside the container is shaped by `neat sync` from CI; visitor GETs leave it alone.
+- It does not authenticate visitors. There is no concept of a "viewer" account. Anonymous read, token-bearing write. If you need per-user views, you need an upstream identity proxy and `NEAT_AUTH_PROXY=true` — that is a different shape than this runbook covers.

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -62,6 +62,10 @@ export interface BuildApiOptions {
   // ADR-073 §3 — when the operator runs behind a reverse proxy that already
   // authenticates the request, the daemon-side check is bypassed.
   trustProxy?: boolean
+  // ADR-073 §3 amendment — public-read mode. When `true`, GET / HEAD / OPTIONS
+  // bypass the bearer check; writes still require it. OTLP ingest is gated
+  // independently and is unaffected by this flag.
+  publicRead?: boolean
 }
 
 interface SerializedGraph {
@@ -599,8 +603,22 @@ export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> 
 
   // ADR-073 §3 — bearer middleware sits ahead of every route handler. No-op
   // when `authToken` is undefined; loopback-only callers (the laptop dev
-  // path) hit that branch.
-  mountBearerAuth(app, { token: opts.authToken, trustProxy: opts.trustProxy })
+  // path) hit that branch. `publicRead` opens GET / HEAD / OPTIONS to
+  // anonymous callers while keeping writes gated.
+  mountBearerAuth(app, {
+    token: opts.authToken,
+    trustProxy: opts.trustProxy,
+    publicRead: opts.publicRead,
+  })
+
+  // ADR-073 §3 amendment — `/api/config` is always unauthenticated. The web
+  // shell hits it before any bearer-carrying request to learn which mode the
+  // daemon is in. Exposes exactly two booleans — `publicRead` and
+  // `authProxy` — and nothing else; no project list, no version, no env.
+  app.get('/api/config', async () => ({
+    publicRead: opts.publicRead === true,
+    authProxy: opts.trustProxy === true,
+  }))
 
   const startedAt = opts.startedAt ?? Date.now()
   const registry = buildLegacyRegistry(opts)

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -59,17 +59,34 @@ export interface AuthOptions {
   // check. The fail-loud bind-authority gate still applies upstream. Wired
   // to `NEAT_AUTH_PROXY=true` in production.
   trustProxy?: boolean
+  // ADR-073 §3 amendment — public-read mode for reference deployments.
+  // When `true`, GET / HEAD / OPTIONS pass through without a bearer; every
+  // other verb still requires the token. OTLP ingest is excluded — that
+  // surface stays gated unconditionally (the receiver mounts its own
+  // middleware without this flag).
+  publicRead?: boolean
   // Extra paths (or path suffixes) to leave unauthenticated. Used by tests
   // and by ad-hoc callers that mount their own probes.
   extraUnauthenticatedSuffixes?: ReadonlyArray<string>
 }
 
+// Verbs the public-read split treats as reads. Everything else is a write
+// and keeps the bearer requirement.
+const PUBLIC_READ_METHODS: ReadonlySet<string> = new Set(['GET', 'HEAD', 'OPTIONS'])
+
 // Probes that always stay open. Dual-mounted under `/projects/:project/` too,
 // so the check is a suffix match — `/projects/foo/health` is skipped along
 // with the top-level `/health`. ADR-073 §3 names `/healthz` and `/readyz`
 // explicitly; `/health` is the existing endpoint the web shell and CI smoke
-// already lean on, so it keeps the unauthenticated treatment.
-const DEFAULT_UNAUTH_SUFFIXES: ReadonlyArray<string> = ['/health', '/healthz', '/readyz']
+// already lean on, so it keeps the unauthenticated treatment. `/api/config`
+// is the public-read negotiation endpoint — the web shell hits it before any
+// authed call to learn which mode the daemon is running in.
+const DEFAULT_UNAUTH_SUFFIXES: ReadonlyArray<string> = [
+  '/health',
+  '/healthz',
+  '/readyz',
+  '/api/config',
+]
 
 export function mountBearerAuth(app: FastifyInstance, opts: AuthOptions): void {
   if (!opts.token || opts.token.length === 0) return
@@ -77,6 +94,7 @@ export function mountBearerAuth(app: FastifyInstance, opts: AuthOptions): void {
 
   const expected = Buffer.from(opts.token, 'utf8')
   const suffixes = [...DEFAULT_UNAUTH_SUFFIXES, ...(opts.extraUnauthenticatedSuffixes ?? [])]
+  const publicRead = opts.publicRead === true
 
   app.addHook('preHandler', (req: FastifyRequest, reply: FastifyReply, done: (err?: Error) => void) => {
     const path = (req.url.split('?')[0] ?? '').replace(/\/+$/, '')
@@ -85,6 +103,16 @@ export function mountBearerAuth(app: FastifyInstance, opts: AuthOptions): void {
         done()
         return
       }
+    }
+
+    // Public-read split: GET / HEAD / OPTIONS pass through anonymously, every
+    // other verb keeps the bearer check. The token still authorizes writes,
+    // and the bind-authority gate above still demands a token for non-loopback
+    // binds — public-read enables anonymous reads on top of that, it doesn't
+    // replace either invariant.
+    if (publicRead && PUBLIC_READ_METHODS.has(req.method)) {
+      done()
+      return
     }
 
     const header = req.headers.authorization
@@ -102,11 +130,18 @@ export function mountBearerAuth(app: FastifyInstance, opts: AuthOptions): void {
 }
 
 // Read both tokens from the environment in one place so server.ts, daemon.ts,
-// and the OTel receivers all agree on precedence (ADR-073 §4).
+// and the OTel receivers all agree on precedence (ADR-073 §4). `publicRead`
+// rides the same shape so callers don't need a second env read.
 export interface AuthEnv {
   authToken: string | undefined
   otelToken: string | undefined
   trustProxy: boolean
+  publicRead: boolean
+}
+
+function parseBoolEnv(v: string | undefined): boolean {
+  if (!v) return false
+  return v === 'true' || v === '1'
 }
 
 export function readAuthEnv(env: NodeJS.ProcessEnv = process.env): AuthEnv {
@@ -116,5 +151,6 @@ export function readAuthEnv(env: NodeJS.ProcessEnv = process.env): AuthEnv {
     authToken: t && t.length > 0 ? t : undefined,
     otelToken: ot && ot.length > 0 ? ot : t && t.length > 0 ? t : undefined,
     trustProxy: env.NEAT_AUTH_PROXY === 'true',
+    publicRead: parseBoolEnv(env.NEAT_PUBLIC_READ),
   }
 }

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -397,6 +397,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
         projects: registry,
         authToken: auth.authToken,
         trustProxy: auth.trustProxy,
+        publicRead: auth.publicRead,
       })
       restAddress = await restApp.listen({ port: restPort, host })
       console.log(`neatd: REST listening on ${restAddress}`)

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -88,6 +88,7 @@ async function main(): Promise<void> {
     projects: registry,
     authToken: auth.authToken,
     trustProxy: auth.trustProxy,
+    publicRead: auth.publicRead,
   })
   await app.listen({ port, host })
   console.log(`neat-core listening on http://${host}:${port}`)

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -8886,6 +8886,135 @@ describe('ADR-073 — one-command CLI + deployment-target + delegated auth', () 
     expect(serverSrc).toMatch(/startOtelGrpcReceiver\(\{[\s\S]*?authToken:\s*auth\.otelToken/)
   })
 
+  // ── §3a. NEAT_PUBLIC_READ — read-anonymous, write-authenticated ───────
+  describe('ADR-073 §3a — NEAT_PUBLIC_READ public-read mode', () => {
+    it('readAuthEnv parses NEAT_PUBLIC_READ ("true" / "1" truthy; anything else false)', async () => {
+      const { readAuthEnv } = await import('../../src/auth.js')
+      expect(readAuthEnv({ NEAT_PUBLIC_READ: 'true' }).publicRead).toBe(true)
+      expect(readAuthEnv({ NEAT_PUBLIC_READ: '1' }).publicRead).toBe(true)
+      expect(readAuthEnv({ NEAT_PUBLIC_READ: 'yes' }).publicRead).toBe(false)
+      expect(readAuthEnv({ NEAT_PUBLIC_READ: 'false' }).publicRead).toBe(false)
+      expect(readAuthEnv({}).publicRead).toBe(false)
+    })
+
+    it('publicRead=true + token set → GET passes through without Authorization', async () => {
+      const { buildApi } = await import('../../src/api.js')
+      const { resetGraph, getGraph } = await import('../../src/graph.js')
+      resetGraph()
+      const app = await buildApi({
+        graph: getGraph(),
+        authToken: 'secret-token',
+        publicRead: true,
+      })
+      try {
+        const res = await app.inject({ method: 'GET', url: '/graph' })
+        expect(res.statusCode).toBe(200)
+      } finally {
+        await app.close()
+      }
+    })
+
+    it('publicRead=true + token set → POST still requires Authorization', async () => {
+      const { buildApi } = await import('../../src/api.js')
+      const { resetGraph, getGraph } = await import('../../src/graph.js')
+      resetGraph()
+      const app = await buildApi({
+        graph: getGraph(),
+        authToken: 'secret-token',
+        publicRead: true,
+      })
+      try {
+        // /graph/scan is a POST — anonymous public-read does not unlock it.
+        const noAuth = await app.inject({ method: 'POST', url: '/graph/scan' })
+        expect(noAuth.statusCode).toBe(401)
+        // Wrong token still fails.
+        const wrong = await app.inject({
+          method: 'POST',
+          url: '/graph/scan',
+          headers: { authorization: 'Bearer wrong-token' },
+        })
+        expect(wrong.statusCode).toBe(401)
+      } finally {
+        await app.close()
+      }
+    })
+
+    it('GET /api/config is always unauthenticated and returns exactly { publicRead, authProxy }', async () => {
+      const { buildApi } = await import('../../src/api.js')
+      const { resetGraph, getGraph } = await import('../../src/graph.js')
+      resetGraph()
+      const app = await buildApi({
+        graph: getGraph(),
+        authToken: 'secret-token',
+        publicRead: true,
+      })
+      try {
+        const res = await app.inject({ method: 'GET', url: '/api/config' })
+        expect(res.statusCode).toBe(200)
+        const body = res.json() as Record<string, unknown>
+        expect(body).toEqual({ publicRead: true, authProxy: false })
+      } finally {
+        await app.close()
+      }
+
+      resetGraph()
+      const proxyApp = await buildApi({
+        graph: getGraph(),
+        authToken: 'secret-token',
+        trustProxy: true,
+      })
+      try {
+        const res = await proxyApp.inject({ method: 'GET', url: '/api/config' })
+        expect(res.statusCode).toBe(200)
+        const body = res.json() as Record<string, unknown>
+        expect(body).toEqual({ publicRead: false, authProxy: true })
+      } finally {
+        await proxyApp.close()
+      }
+    })
+
+    it('publicRead unset → GET still requires Authorization (baseline §3 behavior)', async () => {
+      const { buildApi } = await import('../../src/api.js')
+      const { resetGraph, getGraph } = await import('../../src/graph.js')
+      resetGraph()
+      const app = await buildApi({ graph: getGraph(), authToken: 'secret-token' })
+      try {
+        const res = await app.inject({ method: 'GET', url: '/graph' })
+        expect(res.statusCode).toBe(401)
+      } finally {
+        await app.close()
+      }
+    })
+
+    it('OTLP :4318 stays gated regardless of NEAT_PUBLIC_READ', async () => {
+      const { buildOtelReceiver } = await import('../../src/otel.js')
+      // buildOtelReceiver has no publicRead option — that is the contract.
+      // Even when the REST host runs public-read, OTLP keeps the bearer.
+      const app = await buildOtelReceiver({ onSpan: () => {}, authToken: 'otel-secret' })
+      try {
+        const res = await app.inject({
+          method: 'POST',
+          url: '/v1/traces',
+          headers: { 'content-type': 'application/json' },
+          payload: { resourceSpans: [] },
+        })
+        expect(res.statusCode).toBe(401)
+      } finally {
+        await app.close()
+      }
+    })
+
+    it('bind-authority is unchanged: NEAT_HOST=0.0.0.0 + publicRead=true + no token still throws', async () => {
+      const { assertBindAuthority, BindAuthorityError, readAuthEnv } = await import(
+        '../../src/auth.js'
+      )
+      const env = readAuthEnv({ NEAT_PUBLIC_READ: 'true' })
+      expect(env.publicRead).toBe(true)
+      expect(env.authToken).toBeUndefined()
+      expect(() => assertBindAuthority('0.0.0.0', env.authToken)).toThrow(BindAuthorityError)
+    })
+  })
+
   // ── §5. `.env.neat` localhost default + OTel env precedence ───────────
   it('ADR-073 §5 — SDK installer continues to write OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 to .env.neat', async () => {
     const { renderEnvNeat } = await import('../../src/installers/templates.js')

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -6492,7 +6492,9 @@ describe('Web shell multi-project routing (ADR-057)', () => {
 
   it('AppShell.tsx falls back to first entry from GET /projects when registry is non-empty (ADR-057 #2.3)', () => {
     const src = readSrc(APP_SHELL)
-    expect(src).toMatch(/fetch\(['"]\/api\/projects['"]\)/)
+    // `authedFetch` from ADR-073 §3 is also acceptable — it's a thin wrapper
+    // around `fetch` that attaches the bearer when one is in storage.
+    expect(src).toMatch(/(authed)?[Ff]etch\(['"]\/api\/projects['"]\)/)
     expect(src).toMatch(/list\[0\]/)
   })
 
@@ -6532,8 +6534,15 @@ describe('Web shell multi-project routing (ADR-057)', () => {
   })
 
   it('Every API proxy route under packages/web/app/api/** forwards `project` (ADR-057 #5)', () => {
+    // /api/config is the daemon's auth-mode negotiation surface (ADR-073 §3a)
+    // — global to the daemon, not project-scoped. Always unauthenticated,
+    // returns exactly { publicRead, authProxy } regardless of which project
+    // the dashboard happens to be viewing.
+    const projectAgnosticRoutes = new Set(['api/config/route.ts'])
     const offenders: string[] = []
     for (const f of walkRoutes(API_DIR)) {
+      const rel = f.split('app/').pop() ?? f
+      if (projectAgnosticRoutes.has(rel)) continue
       const src = readSrc(f)
       if (!/searchParams\.get\(['"]project['"]\)/.test(src)) {
         offenders.push(`${f} does not read project from query string`)
@@ -6549,7 +6558,9 @@ describe('Web shell multi-project routing (ADR-057)', () => {
 
   it('Project switcher in TopBar.tsx uses GET /projects and calls setProject(name) (ADR-057 #7)', () => {
     const src = readSrc(TOPBAR)
-    expect(src).toMatch(/fetch\(['"]\/api\/projects['"]\)/)
+    // `authedFetch` is the bearer-aware wrapper from ADR-073 §3; either form
+    // satisfies the contract.
+    expect(src).toMatch(/(authed)?[Ff]etch\(['"]\/api\/projects['"]\)/)
     expect(src).toMatch(/onProjectChange\(/)
   })
 

--- a/packages/web/app/api/config/route.ts
+++ b/packages/web/app/api/config/route.ts
@@ -1,0 +1,13 @@
+import { CORE_URL, proxyGet } from '../../../lib/proxy'
+
+// ADR-073 §3 amendment — `/api/config` is the daemon's auth-mode negotiation
+// endpoint. Always unauthenticated, returns `{ publicRead, authProxy }`. The
+// Next.js side just forwards through so the browser hits one URL regardless
+// of where the daemon happens to be bound.
+export async function GET(request: Request): Promise<Response> {
+  return proxyGet(
+    `${CORE_URL}/api/config`,
+    () => Response.json({ publicRead: false, authProxy: false }),
+    request,
+  )
+}

--- a/packages/web/app/components/StatusBar.tsx
+++ b/packages/web/app/components/StatusBar.tsx
@@ -10,9 +10,43 @@ import {
   type SseEvent,
 } from '../../lib/proxy-client'
 import { authedFetch } from '../../lib/authed-fetch'
+import { useDaemonAuthConfig } from '../../lib/public-read-mode'
 
 const ENV_TOOLTIP =
   "Each NEAT instance has its own graph. Local sees your dev environment; remote sees what you've deployed it to."
+
+const PUBLIC_READ_TOOLTIP =
+  'This NEAT instance is publicly readable. Sign in to make changes.'
+
+// ADR-073 §3 amendment — small chip alongside the env indicator on reference
+// deployments. Distinct steel-blue so the operator can tell at a glance that
+// the dashboard is wired for reads only.
+export function PublicReadIndicator() {
+  const { config, ready } = useDaemonAuthConfig()
+  if (!ready || !config.publicRead) return null
+
+  return (
+    <div className="st-item" data-public-read="true">
+      <span
+        className="public-read-chip"
+        data-testid="public-read-chip"
+        title={PUBLIC_READ_TOOLTIP}
+        aria-label={PUBLIC_READ_TOOLTIP}
+        style={{
+          background: 'rgba(125,165,210,0.20)',
+          color: '#9bb7d8',
+          border: '1px solid rgba(125,165,210,0.40)',
+          borderRadius: 999,
+          padding: '1px 8px',
+          fontSize: 10.5,
+          letterSpacing: 0.2,
+        }}
+      >
+        public read-only
+      </span>
+    </div>
+  )
+}
 
 function isLocalHost(host: string): boolean {
   return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1'
@@ -256,7 +290,11 @@ export function StatusBar({ project, graphData }: StatusBarProps) {
         <span className="v">{sseState}</span>
       </div>
       <EnvironmentIndicator />
+<<<<<<< HEAD
       <SignOutButton />
+=======
+      <PublicReadIndicator />
+>>>>>>> 9d49b46 (StatusBar surfaces a public-read badge when the daemon advertises it)
       <div className="st-item">
         <span className="k">nodes</span>
         <span className="v" id="st-nodes">{nodeCount}</span>

--- a/packages/web/app/components/StatusBar.tsx
+++ b/packages/web/app/components/StatusBar.tsx
@@ -290,11 +290,8 @@ export function StatusBar({ project, graphData }: StatusBarProps) {
         <span className="v">{sseState}</span>
       </div>
       <EnvironmentIndicator />
-<<<<<<< HEAD
-      <SignOutButton />
-=======
       <PublicReadIndicator />
->>>>>>> 9d49b46 (StatusBar surfaces a public-read badge when the daemon advertises it)
+      <SignOutButton />
       <div className="st-item">
         <span className="k">nodes</span>
         <span className="v" id="st-nodes">{nodeCount}</span>

--- a/packages/web/lib/authed-fetch.ts
+++ b/packages/web/lib/authed-fetch.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { trackedFetch } from './proxy-client'
+import { loadDaemonAuthConfig } from './public-read-mode'
 
 const TOKEN_KEY = 'neat:authToken'
 
@@ -43,6 +44,13 @@ export async function authedFetch(
   const res = await trackedFetch(url, { ...init, headers })
 
   if (res.status === 401 && typeof window !== 'undefined') {
+    // ADR-073 §3a — public-read deployments serve anonymous GETs; a 401 on
+    // a read just means the operator hit a write endpoint without the
+    // bearer. Surface the 401 to the caller instead of bouncing them to
+    // /login, which they have no reason to visit.
+    const cfg = await loadDaemonAuthConfig()
+    if (cfg.publicRead) return res
+
     clearToken()
     const path = window.location.pathname
     if (path !== '/login') {

--- a/packages/web/lib/public-read-mode.ts
+++ b/packages/web/lib/public-read-mode.ts
@@ -1,0 +1,108 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * Daemon auth-mode awareness (ADR-073 §3 amendment).
+ *
+ * The daemon exposes `GET /api/config` unauthenticated. It returns two
+ * booleans — `publicRead` and `authProxy` — and nothing else. The web shell
+ * reads it once on first interest and caches the result, so subsequent
+ * checks are synchronous and don't fan out into N requests.
+ *
+ * `publicRead === true` means the daemon serves anonymous GETs (reference
+ * deployments at e.g. try.neat.is). The dashboard renders read-only without
+ * pushing the operator through /login. Mutation affordances render disabled.
+ *
+ * `authProxy === true` means an upstream reverse proxy already terminates
+ * auth and the daemon-side bearer check is bypassed. Surfaced here so the
+ * UI can also avoid the localStorage-token dance in that environment.
+ */
+export interface DaemonAuthConfig {
+  publicRead: boolean
+  authProxy: boolean
+}
+
+let cached: DaemonAuthConfig | null = null
+let inflight: Promise<DaemonAuthConfig> | null = null
+
+const DEFAULT_CONFIG: DaemonAuthConfig = { publicRead: false, authProxy: false }
+
+async function loadConfig(): Promise<DaemonAuthConfig> {
+  if (cached) return cached
+  if (inflight) return inflight
+  inflight = (async () => {
+    try {
+      const res = await fetch('/api/config', { cache: 'no-store' })
+      if (!res.ok) {
+        cached = DEFAULT_CONFIG
+        return cached
+      }
+      const body = (await res.json()) as Partial<DaemonAuthConfig>
+      cached = {
+        publicRead: body.publicRead === true,
+        authProxy: body.authProxy === true,
+      }
+      return cached
+    } catch {
+      cached = DEFAULT_CONFIG
+      return cached
+    } finally {
+      inflight = null
+    }
+  })()
+  return inflight
+}
+
+export function getCachedDaemonAuthConfig(): DaemonAuthConfig | null {
+  return cached
+}
+
+export function primeDaemonAuthConfig(cfg: DaemonAuthConfig): void {
+  cached = cfg
+}
+
+export function resetDaemonAuthConfigForTests(): void {
+  cached = null
+  inflight = null
+}
+
+/**
+ * React hook variant. Returns the cached config + a `ready` flag that flips
+ * once the first read resolves. Until then `publicRead` reads `false` — the
+ * conservative default. Callers that need to render differently *only* after
+ * the negotiation finishes should gate on `ready`.
+ */
+export function useDaemonAuthConfig(): { config: DaemonAuthConfig; ready: boolean } {
+  const [config, setConfig] = useState<DaemonAuthConfig>(cached ?? DEFAULT_CONFIG)
+  const [ready, setReady] = useState(cached !== null)
+
+  useEffect(() => {
+    if (cached) {
+      setConfig(cached)
+      setReady(true)
+      return
+    }
+    let cancelled = false
+    void loadConfig().then((cfg) => {
+      if (cancelled) return
+      setConfig(cfg)
+      setReady(true)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return { config, ready }
+}
+
+/**
+ * Shorthand: `true` iff the daemon advertises `publicRead`. Renders mutation
+ * affordances disabled, hides login redirects, surfaces the public-read
+ * badge in the StatusBar.
+ */
+export function useReadOnly(): boolean {
+  const { config } = useDaemonAuthConfig()
+  return config.publicRead
+}

--- a/packages/web/lib/public-read-mode.ts
+++ b/packages/web/lib/public-read-mode.ts
@@ -28,7 +28,7 @@ let inflight: Promise<DaemonAuthConfig> | null = null
 
 const DEFAULT_CONFIG: DaemonAuthConfig = { publicRead: false, authProxy: false }
 
-async function loadConfig(): Promise<DaemonAuthConfig> {
+export async function loadDaemonAuthConfig(): Promise<DaemonAuthConfig> {
   if (cached) return cached
   if (inflight) return inflight
   inflight = (async () => {
@@ -84,7 +84,7 @@ export function useDaemonAuthConfig(): { config: DaemonAuthConfig; ready: boolea
       return
     }
     let cancelled = false
-    void loadConfig().then((cfg) => {
+    void loadDaemonAuthConfig().then((cfg) => {
       if (cancelled) return
       setConfig(cfg)
       setReady(true)

--- a/packages/web/lib/use-auth-gate.ts
+++ b/packages/web/lib/use-auth-gate.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import { loadDaemonAuthConfig } from './public-read-mode'
 
 /**
  * Client-side auth gate. When the operator has not yet pasted a NEAT token at
@@ -8,6 +9,11 @@ import { useEffect } from 'react'
  * deployments that already terminate auth opt out via
  * `NEXT_PUBLIC_NEAT_AUTH_PROXY=true` (ADR-073 §3 — the bearer is delegated to
  * the deploy platform).
+ *
+ * Public-read reference deployments (ADR-073 §3a) also skip the redirect —
+ * the dashboard renders read-only without forcing a login. The negotiation
+ * happens against the daemon's `/api/config` endpoint and is cached after
+ * the first call, so the latency hit is paid once per session.
  *
  * Mount this from any client-only page subtree that lives behind the bearer.
  * /login itself does not call it (the page is the destination of the redirect).
@@ -28,7 +34,16 @@ export function useAuthGate(): void {
     const path = window.location.pathname
     if (path === '/login') return
 
-    const next = encodeURIComponent(path + window.location.search)
-    window.location.href = `/login?next=${next}`
+    let cancelled = false
+    void loadDaemonAuthConfig().then((cfg) => {
+      if (cancelled) return
+      if (cfg.publicRead) return
+
+      const next = encodeURIComponent(path + window.location.search)
+      window.location.href = `/login?next=${next}`
+    })
+    return () => {
+      cancelled = true
+    }
   }, [])
 }

--- a/packages/web/test/public-read-indicator.test.tsx
+++ b/packages/web/test/public-read-indicator.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+// PublicReadIndicator reads the daemon's auth-mode singleton via the
+// useDaemonAuthConfig hook. The hook fetches /api/config once and caches
+// the result, so each test resets the cache and stubs fetch to return the
+// shape it wants. StatusBar's heartbeat + SSE wiring isn't exercised here
+// — we render the indicator in isolation.
+beforeEach(async () => {
+  const { resetDaemonAuthConfigForTests } = await import('../lib/public-read-mode')
+  resetDaemonAuthConfigForTests()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function stubConfig(body: { publicRead?: boolean; authProxy?: boolean }, ok = true): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (!url.endsWith('/api/config')) {
+        return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+      }
+      return new Response(JSON.stringify(body), {
+        status: ok ? 200 : 500,
+        headers: { 'content-type': 'application/json' },
+      })
+    }),
+  )
+}
+
+describe('ADR-073 §3a — public-read indicator in StatusBar', () => {
+  it('renders the "public read-only" chip when /api/config returns publicRead=true', async () => {
+    stubConfig({ publicRead: true, authProxy: false })
+    const { PublicReadIndicator } = await import('../app/components/StatusBar')
+    render(<PublicReadIndicator />)
+
+    const chip = await screen.findByTestId('public-read-chip')
+    expect(chip.textContent).toBe('public read-only')
+    expect(chip.getAttribute('title')).toMatch(/publicly readable/i)
+  })
+
+  it('renders nothing when publicRead is false', async () => {
+    stubConfig({ publicRead: false, authProxy: false })
+    const { PublicReadIndicator } = await import('../app/components/StatusBar')
+    const { container } = render(<PublicReadIndicator />)
+
+    // Give the negotiation a tick to resolve before asserting absence.
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="public-read-chip"]')).toBeNull()
+    })
+  })
+
+  it('stays hidden when /api/config is unreachable', async () => {
+    stubConfig({}, false)
+    const { PublicReadIndicator } = await import('../app/components/StatusBar')
+    const { container } = render(<PublicReadIndicator />)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="public-read-chip"]')).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- The daemon's auth boundary gains a verb-aware split. `NEAT_PUBLIC_READ=true` (or `=1`) lets `GET` / `HEAD` / `OPTIONS` through anonymously; every other verb keeps the bearer requirement. OTLP ingest is not part of the split — `:4318` and `:4317` stay token-gated unconditionally. Bind authority is unchanged: anonymous reads do not unlock public binding without a token.
- `GET /api/config` is the negotiation surface: always unauthenticated, returns exactly `{ publicRead, authProxy }` and nothing else. The web shell hits it before any token-carrying call, caches the result, and adapts — StatusBar shows a steel-blue `public read-only` chip, `authedFetch` skips the `/login` redirect on 401, `useAuthGate` lets the dashboard mount read-only, `SignOutButton` keeps doing the right thing in both directions.
- `docs/contracts/one-command-cli.md` grows §3a covering the verb split, the OTLP carve-out, the bind-authority invariant, and the `/api/config` exposure contract. `docs/runbook-public-demo.md` is the recipe for `try.neat.is` — Docker run, Caddy reverse proxy, OTel exporter env block, CI `neat sync` workflow, smoke commands, rotation surfaces.
- `packages/core/test/audits/contracts.test.ts` gains a §3a describe block with seven assertions (env parser, anon GET pass-through, POST still 401, `/api/config` shape under both flags, baseline 401 when publicRead is unset, OTLP gated regardless, bind-authority unchanged). `packages/web/test/public-read-indicator.test.tsx` exercises the StatusBar chip against a stubbed `/api/config`.

## Test plan

- [x] `npx turbo build test lint` — 14/14 tasks pass.
- [x] `packages/core` — 489 contract assertions, 0 failures.
- [x] `packages/web` — 12 tests, 0 failures (login-surface, environment-indicator, multi-project-refetch, public-read-indicator).
- [x] Manual smoke against a built image:
  - [ ] `NEAT_PUBLIC_READ=true NEAT_AUTH_TOKEN=test neatd start` — `curl localhost:8080/api/projects` returns 200 with no header; `curl -X POST localhost:8080/snapshot` returns 401 with no header; `/api/config` returns `{"publicRead":true,"authProxy":false}`.
  - [x] Visit `http://localhost:6328` — dashboard renders without a login prompt; `public read-only` badge appears in StatusBar.
  - [x] `NEAT_HOST=0.0.0.0 NEAT_PUBLIC_READ=true neatd start` (no token) — daemon refuses to start with `BindAuthorityError`.

Refs #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)