### PR TITLE
The neat banner reflects the v0.4 surface

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -320,7 +320,7 @@ function printBanner(): void {
   console.log('╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝   ╚═╝   ')
   console.log('')
   console.log('  Network Expressive Architecting Tool')
-  console.log('  neat.is  ·  v0.2.5  ·  BSL 1.1')
+  console.log('  neat.is  ·  v0.4.0  ·  Apache 2.0')
   console.log('')
 }
 


### PR DESCRIPTION
## Summary

The `neat init` banner reads `neat.is · v0.4.0 · Apache 2.0` to match the actual published version and license. Spotted by [@K-JayM](https://github.com/K-JayM).

## Follow-up

Sourcing the version string from `package.json` at runtime so the banner stays current through future tag bumps lands as v0.4.1 work alongside the other publish-workflow polish issues. Tracked separately.

## Verification

- [x] `npx turbo build --filter=@neat.is/core` clean
- [x] Banner line manually verified in `packages/core/src/cli.ts`