### PR TITLE
v0.4.1: extractor skips Python venv directories

### DIFF
--- a/packages/core/src/extract/aliases.ts
+++ b/packages/core/src/extract/aliases.ts
@@ -9,6 +9,7 @@ import {
   CONFIG_FILE_EXTENSIONS,
   IGNORED_DIRS,
   exists,
+  isPythonVenvDir,
   readYaml,
   type DiscoveredService,
 } from './shared.js'
@@ -176,7 +177,9 @@ async function walkYamlFiles(start: string, depth = 0, max = 5): Promise<string[
   for (const entry of entries) {
     if (entry.isDirectory()) {
       if (IGNORED_DIRS.has(entry.name)) continue
-      out.push(...(await walkYamlFiles(path.join(start, entry.name), depth + 1, max)))
+      const child = path.join(start, entry.name)
+      if (await isPythonVenvDir(child)) continue
+      out.push(...(await walkYamlFiles(child, depth + 1, max)))
     } else if (entry.isFile() && CONFIG_FILE_EXTENSIONS.has(path.extname(entry.name))) {
       out.push(path.join(start, entry.name))
     }

--- a/packages/core/src/extract/calls/shared.ts
+++ b/packages/core/src/extract/calls/shared.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import type { EdgeEvidence, ExtractedConfidenceKind } from '@neat.is/types'
-import { IGNORED_DIRS, SERVICE_FILE_EXTENSIONS } from '../shared.js'
+import { IGNORED_DIRS, SERVICE_FILE_EXTENSIONS, isPythonVenvDir } from '../shared.js'
 
 export interface SourceFile {
   path: string
@@ -30,7 +30,9 @@ export async function walkSourceFiles(dir: string): Promise<string[]> {
     for (const entry of entries) {
       const full = path.join(current, entry.name)
       if (entry.isDirectory()) {
-        if (!IGNORED_DIRS.has(entry.name)) await walk(full)
+        if (IGNORED_DIRS.has(entry.name)) continue
+        if (await isPythonVenvDir(full)) continue
+        await walk(full)
       } else if (entry.isFile() && SERVICE_FILE_EXTENSIONS.has(path.extname(entry.name))) {
         out.push(full)
       }

--- a/packages/core/src/extract/configs.ts
+++ b/packages/core/src/extract/configs.ts
@@ -9,7 +9,13 @@ import {
   confidenceForExtracted,
 } from '@neat.is/types'
 import type { NeatGraph } from '../graph.js'
-import { IGNORED_DIRS, isConfigFile, makeEdgeId, type DiscoveredService } from './shared.js'
+import {
+  IGNORED_DIRS,
+  isConfigFile,
+  isPythonVenvDir,
+  makeEdgeId,
+  type DiscoveredService,
+} from './shared.js'
 
 // Walk a service directory and collect every config file path
 // (yaml/yml + .env-shaped). We deliberately stop at file paths here so nothing
@@ -22,7 +28,9 @@ export async function walkConfigFiles(dir: string): Promise<string[]> {
     for (const entry of entries) {
       const full = path.join(current, entry.name)
       if (entry.isDirectory()) {
-        if (!IGNORED_DIRS.has(entry.name)) await walk(full)
+        if (IGNORED_DIRS.has(entry.name)) continue
+        if (await isPythonVenvDir(full)) continue
+        await walk(full)
       } else if (entry.isFile() && isConfigFile(entry.name).match) {
         out.push(full)
       }

--- a/packages/core/src/extract/infra/k8s.ts
+++ b/packages/core/src/extract/infra/k8s.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import { parseAllDocuments } from 'yaml'
 import type { NeatGraph } from '../../graph.js'
-import { CONFIG_FILE_EXTENSIONS, IGNORED_DIRS } from '../shared.js'
+import { CONFIG_FILE_EXTENSIONS, IGNORED_DIRS, isPythonVenvDir } from '../shared.js'
 import { makeInfraNode } from './shared.js'
 
 interface K8sDoc {
@@ -27,7 +27,9 @@ async function walkYamlFiles(start: string, depth = 0, max = 5): Promise<string[
   for (const entry of entries) {
     if (entry.isDirectory()) {
       if (IGNORED_DIRS.has(entry.name)) continue
-      out.push(...(await walkYamlFiles(path.join(start, entry.name), depth + 1, max)))
+      const child = path.join(start, entry.name)
+      if (await isPythonVenvDir(child)) continue
+      out.push(...(await walkYamlFiles(child, depth + 1, max)))
     } else if (entry.isFile() && CONFIG_FILE_EXTENSIONS.has(path.extname(entry.name))) {
       out.push(path.join(start, entry.name))
     }

--- a/packages/core/src/extract/infra/terraform.ts
+++ b/packages/core/src/extract/infra/terraform.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import type { NeatGraph } from '../../graph.js'
-import { IGNORED_DIRS } from '../shared.js'
+import { IGNORED_DIRS, isPythonVenvDir } from '../shared.js'
 import { makeInfraNode } from './shared.js'
 
 // Light pass: catalogue `resource "aws_*" "name"` blocks in any *.tf file.
@@ -17,7 +17,9 @@ async function walkTfFiles(start: string, depth = 0, max = 5): Promise<string[]>
   for (const entry of entries) {
     if (entry.isDirectory()) {
       if (IGNORED_DIRS.has(entry.name) || entry.name === '.terraform') continue
-      out.push(...(await walkTfFiles(path.join(start, entry.name), depth + 1, max)))
+      const child = path.join(start, entry.name)
+      if (await isPythonVenvDir(child)) continue
+      out.push(...(await walkTfFiles(child, depth + 1, max)))
     } else if (entry.isFile() && entry.name.endsWith('.tf')) {
       out.push(path.join(start, entry.name))
     }

--- a/packages/core/src/extract/services.ts
+++ b/packages/core/src/extract/services.ts
@@ -8,6 +8,7 @@ import type { NeatGraph } from '../graph.js'
 import {
   IGNORED_DIRS,
   exists,
+  isPythonVenvDir,
   readJson,
   type DiscoveredService,
   type PackageJson,
@@ -69,6 +70,12 @@ async function walkDirs(
         // distinguishes file vs. directory tests.
         if (rel && options.ig.ignores(rel + '/')) continue
       }
+      // Issue #344 — `pyvenv.cfg` marks every directory that `python -m venv`
+      // or `virtualenv` creates, regardless of what the wrapper dir is called.
+      // The `IGNORED_DIRS` name list catches the common shapes (`.venv`,
+      // `venv`, `.tox`); this catches the long-tail ones (`env-3.11`,
+      // `.direnv`, ad-hoc names).
+      if (await isPythonVenvDir(child)) continue
       await visit(child)
       await recurse(child, depth + 1)
     }

--- a/packages/core/src/extract/shared.ts
+++ b/packages/core/src/extract/shared.ts
@@ -26,7 +26,42 @@ export const IGNORED_DIRS = new Set([
   'dist',
   'build',
   '.next',
+  // Python virtualenv shapes (issue #344). Walking into a venv pulls in the
+  // entire CPython stdlib + every installed package as if it were first-party
+  // service code — 20k+ files, none of which the user wrote. The shape names
+  // cover the three common venv tools (`venv` / `python -m venv`,
+  // `virtualenv`) and the tox + PEP 582 conventions.
+  '.venv',
+  'venv',
+  '__pypackages__',
+  '.tox',
+  // `site-packages` shows up nested inside venvs that don't carry one of the
+  // outer names (system Python on macOS, in-place pyenv layouts). Listing it
+  // here means we stop the walk at the boundary even when the wrapper dir
+  // wasn't recognisable.
+  'site-packages',
 ])
+
+// Marker file `python -m venv` and `virtualenv` both drop at the venv root.
+// Used by the walkers to recognise venvs whose top-level directory doesn't
+// happen to match one of the canonical `IGNORED_DIRS` names (issue #344).
+// Cached per process to keep the recursion hot path off the fs after the
+// first walk; venv contents don't change inside one extract pass.
+const PYVENV_MARKER_CACHE = new Map<string, boolean>()
+
+export async function isPythonVenvDir(dir: string): Promise<boolean> {
+  const cached = PYVENV_MARKER_CACHE.get(dir)
+  if (cached !== undefined) return cached
+  try {
+    const stat = await fs.stat(path.join(dir, 'pyvenv.cfg'))
+    const ok = stat.isFile()
+    PYVENV_MARKER_CACHE.set(dir, ok)
+    return ok
+  } catch {
+    PYVENV_MARKER_CACHE.set(dir, false)
+    return false
+  }
+}
 
 export function isConfigFile(name: string): { match: boolean; fileType: string } {
   const ext = path.extname(name)

--- a/packages/core/src/watch.ts
+++ b/packages/core/src/watch.ts
@@ -218,6 +218,14 @@ const IGNORED_WATCH_GLOBS = [
   '**/.turbo/**',
   '**/.next/**',
   '**/neat-out/**',
+  // Python venv shapes (issue #344). chokidar opens one watch handle per
+  // descended dir; a CPython venv carries 20k+ files and trivially blows
+  // through the macOS kqueue cap before extraction even runs.
+  '**/.venv/**',
+  '**/venv/**',
+  '**/__pypackages__/**',
+  '**/.tox/**',
+  '**/site-packages/**',
   '**/.DS_Store',
 ]
 
@@ -233,6 +241,11 @@ const IGNORED_WATCH_PATHS = [
   /(?:^|[\\/])\.turbo[\\/]/,
   /(?:^|[\\/])\.next[\\/]/,
   /(?:^|[\\/])neat-out[\\/]/,
+  /(?:^|[\\/])\.venv[\\/]/,
+  /(?:^|[\\/])venv[\\/]/,
+  /(?:^|[\\/])__pypackages__[\\/]/,
+  /(?:^|[\\/])\.tox[\\/]/,
+  /(?:^|[\\/])site-packages[\\/]/,
   /[\\/]?\.DS_Store$/,
 ]
 

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -606,6 +606,46 @@ describe('Static-extraction contract (ADR-032)', () => {
   it.todo(
     'extract/services.ts populates ServiceNode.framework from known framework packages (issue #142)',
   )
+
+  it('issue #344 — extractor skips Python venv shapes by name and by pyvenv.cfg marker', async () => {
+    const shared = await import('../../src/extract/shared.js')
+    // The canonical names that walk-time stops at without an fs probe.
+    for (const name of ['.venv', 'venv', '__pypackages__', '.tox', 'site-packages']) {
+      expect(shared.IGNORED_DIRS.has(name), `IGNORED_DIRS missing "${name}"`).toBe(true)
+    }
+    // `pyvenv.cfg` covers the long-tail venv directory names (`env-3.11`,
+    // ad-hoc shapes) the static name list doesn't catch.
+    const fs2 = await import('node:fs/promises')
+    const os2 = await import('node:os')
+    const path2 = await import('node:path')
+    const tmp = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-venv-'))
+    try {
+      const venvDir = path2.join(tmp, 'env-3.11')
+      await fs2.mkdir(venvDir)
+      await fs2.writeFile(path2.join(venvDir, 'pyvenv.cfg'), 'home = /usr/bin\n')
+      expect(await shared.isPythonVenvDir(venvDir)).toBe(true)
+
+      const plainDir = path2.join(tmp, 'src')
+      await fs2.mkdir(plainDir)
+      expect(await shared.isPythonVenvDir(plainDir)).toBe(false)
+    } finally {
+      await fs2.rm(tmp, { recursive: true, force: true })
+    }
+
+    // Every walker that descends user code has to honour both gates.
+    const walkers = [
+      'extract/services.ts',
+      'extract/configs.ts',
+      'extract/aliases.ts',
+      'extract/calls/shared.ts',
+      'extract/infra/k8s.ts',
+      'extract/infra/terraform.ts',
+    ]
+    for (const rel of walkers) {
+      const src = readFileSync(join(CORE_SRC, rel), 'utf8')
+      expect(src, `${rel} must guard with isPythonVenvDir`).toMatch(/isPythonVenvDir/)
+    }
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
The extractor's directory walker now skips Python venv shapes alongside `node_modules`. Two gates layered:

- A name list — `.venv`, `venv`, `__pypackages__`, `.tox`, nested `site-packages` — catches the canonical shapes at descent time, with no fs probe.
- A `pyvenv.cfg` marker check picks up venvs whose wrapper directory has a project-specific name (`env-3.11`, `.direnv`, ad-hoc). `python -m venv` and `virtualenv` both drop that file at the venv root.

`watch.ts`'s chokidar glob set + regex backstop ride the same list. Venv contents would otherwise blow through macOS kqueue handle caps before extraction even starts.

## Test plan
- [x] `npx turbo build test lint --filter=@neat.is/core`
- [x] New contract test exercises `IGNORED_DIRS`, `isPythonVenvDir`, and the six walkers

Refs #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)