### PR TITLE
v0.4.1: daemon-wide /health

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -153,6 +153,13 @@ function buildLegacyRegistry(opts: BuildApiOptions): Projects {
 interface RouteContext {
   registry: Projects
   startedAt: number
+  // Where the routes are getting mounted. `'root'` is the legacy unprefixed
+  // mount that historically resolved every request to the `default` project;
+  // `'project'` is the `/projects/:project` plugin scope where the project
+  // segment is always present. The /health handler branches on this so the
+  // root mount can answer daemon-wide while the scoped mount stays
+  // per-project (issue #343).
+  scope: 'root' | 'project'
   // Legacy callers passed `errorsPath`/`staleEventsPath` explicitly and
   // expected absent values to disable the read. Track that intent so the
   // /incidents handlers don't accidentally read a phantom file.
@@ -183,23 +190,30 @@ function registerRoutes(scope: FastifyInstance, ctx: RouteContext): void {
     handleSse(req, reply, { project: proj.name })
   })
 
-  scope.get<{ Params: { project?: string } }>('/health', async (req, reply) => {
-    const proj = resolveProject(registry, req, reply, ctx.bootstrap)
-    if (!proj) return
-    const uptimeMs = Date.now() - startedAt
-    return {
-      ok: true,
-      project: proj.name,
-      uptimeMs,
-      // Legacy fields kept additively. The web shell's StatusBar reads
-      // nodeCount / edgeCount; ADR-061's HealthResponseSchema validates
-      // the canonical triple and lets the extras pass through.
-      uptime: Math.floor(uptimeMs / 1000),
-      nodeCount: proj.graph.order,
-      edgeCount: proj.graph.size,
-      lastUpdated: new Date().toISOString(),
-    }
-  })
+  // Per-project /health stays scoped. The unscoped `/health` at the root
+  // mount is handled by the daemon-wide handler below (issue #343) —
+  // daemon-wide readiness mustn't pivot on whether the `default` project
+  // exists. The scoped variant carries the bootstrap-aware shape from
+  // issue #340.
+  if (ctx.scope === 'project') {
+    scope.get<{ Params: { project?: string } }>('/health', async (req, reply) => {
+      const proj = resolveProject(registry, req, reply, ctx.bootstrap)
+      if (!proj) return
+      const uptimeMs = Date.now() - startedAt
+      return {
+        ok: true,
+        project: proj.name,
+        uptimeMs,
+        // Legacy fields kept additively. The web shell's StatusBar reads
+        // nodeCount / edgeCount; ADR-061's HealthResponseSchema validates
+        // the canonical triple and lets the extras pass through.
+        uptime: Math.floor(uptimeMs / 1000),
+        nodeCount: proj.graph.order,
+        edgeCount: proj.graph.size,
+        lastUpdated: new Date().toISOString(),
+      }
+    })
+  }
 
   scope.get<{ Params: { project?: string } }>('/graph', async (req, reply) => {
     const proj = resolveProject(registry, req, reply, ctx.bootstrap)
@@ -672,11 +686,46 @@ export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> 
   const routeCtx: RouteContext = {
     registry,
     startedAt,
+    scope: 'root',
     errorsPathFor,
     staleEventsPathFor,
     policyFilePathFor,
     bootstrap: opts.bootstrap,
   }
+
+  // Daemon-wide /health (issue #343). Per ADR-049 the daemon is the unit of
+  // readiness; the response answers "is this process up and what's it
+  // currently serving?" without depending on a `default` project. Probes —
+  // orchestrator, kubelet readiness, systemd, supervisors — read this.
+  //
+  // The `projects` array surfaces every slot the daemon knows about. When
+  // the bootstrap tracker is wired (issue #340), the per-entry `status`
+  // and `elapsedMs` come from there so the orchestrator's wait loop can
+  // tell `bootstrapping` apart from `active` without per-project probes.
+  app.get('/health', async () => {
+    const uptimeMs = Date.now() - startedAt
+    const bootstrapList = opts.bootstrap?.list() ?? []
+    const byName = new Map(bootstrapList.map((p) => [p.name, p]))
+    const names = new Set<string>([
+      ...registry.list(),
+      ...bootstrapList.map((p) => p.name),
+    ])
+    const projects = [...names].sort().map((name) => {
+      const proj = registry.get(name)
+      const tracked = byName.get(name)
+      return {
+        name,
+        nodeCount: proj?.graph.order ?? 0,
+        edgeCount: proj?.graph.size ?? 0,
+        ...(tracked ? { status: tracked.status, elapsedMs: tracked.elapsedMs } : {}),
+      }
+    })
+    return {
+      ok: true,
+      uptimeMs,
+      projects,
+    }
+  })
 
   // Multi-project switcher (ADR-051 #4). Direct passthrough of the
   // machine-level registry from registry.ts (ADR-048) — distinct from the
@@ -713,13 +762,16 @@ export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> 
     }
   })
 
-  // Default mount: /health, /graph, /incidents, etc. all hit project=default.
+  // Default mount: /graph, /incidents, etc. resolve to project=default.
+  // `/health` at this scope is the daemon-wide handler registered above,
+  // not the per-project one (issue #343).
   registerRoutes(app, routeCtx)
 
-  // Project-scoped mount: same handlers, URL params include `:project`.
+  // Project-scoped mount: same handlers, URL params include `:project`,
+  // and `/health` answers per project.
   await app.register(
     async (scope) => {
-      registerRoutes(scope, routeCtx)
+      registerRoutes(scope, { ...routeCtx, scope: 'project' })
     },
     { prefix: '/projects/:project' },
   )

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -32,8 +32,21 @@ describe('REST API (fastify.inject)', () => {
     else process.env.NEAT_EXTRACTED_PRECISION_FLOOR = prevFloor
   })
 
-  it('GET /health returns the expected shape', async () => {
+  it('GET /health returns the daemon-wide readiness shape', async () => {
+    // Issue #343 — unscoped /health answers daemon-wide; per-project shape
+    // moved to /projects/:project/health.
     const res = await app.inject({ method: 'GET', url: '/health' })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body).toMatchObject({
+      ok: true,
+      uptimeMs: expect.any(Number),
+      projects: expect.any(Array),
+    })
+  })
+
+  it('GET /projects/:project/health returns the per-project shape', async () => {
+    const res = await app.inject({ method: 'GET', url: '/projects/default/health' })
     expect(res.statusCode).toBe(200)
     const body = res.json()
     // ADR-061 canonical triple plus legacy extras (passthrough).

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -2422,12 +2422,15 @@ describe('REST API contract (ADR-040)', () => {
     expect(api).toMatch(/registerRoutes\(app, routeCtx\)/)
     expect(api).toMatch(/prefix:\s*['"]\/projects\/:project['"]/)
     // No bare app.get / app.post outside the documented exceptions.
-    const bareGet = api.match(/\bapp\.(get|post)\s*</g) ?? []
+    const bareGet = api.match(/\bapp\.(get|post)\s*[<(]/g) ?? []
     // Documented exceptions to dual-mount routing:
     //  1. /projects — machine registry list (ADR-051 #4)
     //  2. /projects/:project — singular registry lookup (ADR-061 #7)
+    //  3. /api/config — unauthenticated public-read negotiation (ADR-073 §3)
+    //  4. /health — daemon-wide readiness; per-project /health stays at
+    //     /projects/:project/health (issue #343)
     // Everything else routes through registerRoutes.
-    expect(bareGet.length).toBeLessThanOrEqual(2)
+    expect(bareGet.length).toBeLessThanOrEqual(4)
   })
 
   it('error responses are JSON-shaped { error, status, details? }', () => {
@@ -4756,6 +4759,46 @@ describe('Daemon contract (ADR-049)', () => {
         for (const p of settled) {
           expect(['active', 'broken']).toContain(p.status)
         }
+      } finally {
+        await handle.stop()
+      }
+      void home
+    } finally {
+      console.warn = prevWarn
+      console.log = prevLog
+      await cleanup()
+    }
+  })
+
+  it('issue #343 — daemon-wide /health answers 200 even when no `default` project is registered', async () => {
+    const { home, cleanup } = await setupDaemonSandbox({
+      projects: [{ name: 'only-one' }],
+    })
+    const prevWarn = console.warn
+    const prevLog = console.log
+    console.warn = () => {}
+    console.log = () => {}
+    try {
+      const { startDaemon } = await import('../../src/daemon.js')
+      const handle = await startDaemon()
+      // The daemon-wide /health probe must answer before the per-project
+      // slot finishes bootstrapping — that's the whole point of this
+      // contract — so we deliberately don't await initialBootstrap here.
+      try {
+        const res = await fetch(`${handle.restAddress}/health`)
+        expect(res.status).toBe(200)
+        const body = (await res.json()) as {
+          ok: boolean
+          uptimeMs: number
+          projects: { name: string }[]
+        }
+        expect(body.ok).toBe(true)
+        expect(typeof body.uptimeMs).toBe('number')
+        expect(body.projects.map((p) => p.name)).toContain('only-one')
+        // Per-project /health for a missing slot still 404s; daemon-wide
+        // readiness deliberately doesn't fall back to the legacy `default`.
+        const missing = await fetch(`${handle.restAddress}/projects/default/health`)
+        expect(missing.status).toBe(404)
       } finally {
         await handle.stop()
       }
@@ -8213,6 +8256,7 @@ describe('REST API canonicalization (ADR-061)', () => {
         GraphNode: types.GraphNodeResponseSchema,
         GraphEdges: types.GraphEdgesResponseSchema,
         Health: types.HealthResponseSchema,
+        DaemonHealth: types.DaemonHealthResponseSchema,
         SingleProject: types.SingleProjectResponseSchema,
         Search: types.SearchResponseSchema,
         SerializedGraph: types.SerializedGraphSchema,
@@ -8259,8 +8303,11 @@ describe('REST API canonicalization (ADR-061)', () => {
     it('GET /graph/edges/:id response parses through GraphEdgesResponseSchema (ADR-061 #3)', async () => {
       await expectShape('/graph/edges/service:service-b', schemas.GraphEdges)
     })
-    it('GET /health response parses through HealthResponseSchema (ADR-061 #3)', async () => {
-      await expectShape('/health', schemas.Health)
+    it('GET /health response parses through DaemonHealthResponseSchema (ADR-061 #3 + issue #343)', async () => {
+      await expectShape('/health', schemas.DaemonHealth)
+    })
+    it('GET /projects/:project/health response parses through HealthResponseSchema (ADR-061 #3)', async () => {
+      await expectShape('/projects/default/health', schemas.Health)
     })
     it('GET /projects/:project response parses through SingleProjectResponseSchema (ADR-061 #3)', async () => {
       await expectShape('/projects/default', schemas.SingleProject)

--- a/packages/types/src/responses.ts
+++ b/packages/types/src/responses.ts
@@ -52,6 +52,26 @@ export const HealthResponseSchema = z
   .passthrough()
 export type HealthResponse = z.infer<typeof HealthResponseSchema>
 
+// Daemon-wide /health (issue #343). Distinct from `HealthResponseSchema`
+// because the unscoped probe doesn't have a single project to report on —
+// readiness lives at the daemon level. `projects` is a flat array of every
+// slot currently loaded so a probe consumer can decide which subset to
+// poll per-project /health on.
+export const DaemonHealthResponseSchema = z
+  .object({
+    ok: z.boolean(),
+    uptimeMs: z.number().int().nonnegative(),
+    projects: z.array(
+      z.object({
+        name: z.string(),
+        nodeCount: z.number().int().nonnegative(),
+        edgeCount: z.number().int().nonnegative(),
+      }).passthrough(),
+    ),
+  })
+  .passthrough()
+export type DaemonHealthResponse = z.infer<typeof DaemonHealthResponseSchema>
+
 export const SingleProjectResponseSchema = z.object({
   project: RegistryEntrySchema,
 })

--- a/packages/web/app/api/health/route.ts
+++ b/packages/web/app/api/health/route.ts
@@ -2,12 +2,12 @@ import { CORE_URL, proxyGet } from '../../../lib/proxy'
 import { FIXTURE_HEALTH } from '../../../lib/fixtures'
 
 // ADR-057 #5 — health is project-aware so the dashboard reflects the project
-// the operator is actually viewing.
+// the operator is actually viewing. Always routes to /projects/<name>/health
+// (issue #343) — daemon-wide /health doesn't carry the per-project shape
+// (node count, last update) the StatusBar consumes.
 export async function GET(request: Request): Promise<Response> {
   const { searchParams } = new URL(request.url)
-  const project = searchParams.get('project') ?? ''
-  const path = project && project !== 'default'
-    ? `/projects/${encodeURIComponent(project)}/health`
-    : '/health'
+  const project = searchParams.get('project') || 'default'
+  const path = `/projects/${encodeURIComponent(project)}/health`
   return proxyGet(`${CORE_URL}${path}`, () => Response.json(FIXTURE_HEALTH), request)
 }


### PR DESCRIPTION
## Summary
`GET /health` at the unscoped mount reports daemon-level readiness — `{ ok, uptimeMs, projects: [...] }` — and stops depending on whether a `default` project is registered. Probes (orchestrator, kubelet, systemd, supervisors) want to know the daemon is up, not whether \`default\` is up.

Per-project health stays at `/projects/:project/health` with the existing shape so the web shell's StatusBar keeps reading node counts and last-update timestamps from the project it's viewing. The web's `/api/health` proxy now always routes through the project-scoped path.

Schema: adds `DaemonHealthResponseSchema` to `@neat.is/types` for the unscoped shape.

## Test plan
- [x] Contract test: daemon-wide /health 200 with only-non-default project registered
- [x] Schema-snapshot regenerated
- [x] `npx turbo build test lint`

Refs #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)