### PR TITLE
v0.4.1: publish workflow gains a fast cold boot and a GitHub Release on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # contents: write so the final step can create the GitHub Release for
+      # this tag. The publish job is single-flight on tag push; the Release
+      # rides the same surface so the npm + ghcr + Release trio land together.
+      contents: write
       id-token: write
       packages: write
     env:
@@ -243,13 +246,28 @@ jobs:
           cid=$(docker run --rm -d -e NEAT_AUTH_TOKEN="$token" -p 18080:8080 "$image")
           echo "  container started, id=$cid"
 
-          # Wait up to 30s for the REST surface to bind.
+          # Wait up to 30s for the REST surface to bind. The image ships a
+          # default project pointed at /workspace so `neatd start` reaches
+          # 'active' immediately on a bare `docker run` — no volume mount,
+          # no NEAT_HOME, no registry seeding. /health is bearer-gated when
+          # NEAT_AUTH_TOKEN is set, so the probe carries the bearer too.
+          ready=
           for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
-            if curl -sf -o /dev/null --max-time 2 http://localhost:18080/health; then
+            if curl -sf -o /dev/null --max-time 2 \
+              -H "Authorization: Bearer $token" \
+              http://localhost:18080/health; then
+              ready=yes
+              echo "  REST :8080 reachable after ~$((i * 2))s"
               break
             fi
             sleep 2
           done
+          if [ -z "$ready" ]; then
+            echo "::error::container REST surface never bound on :8080 within 30s"
+            docker logs "$cid" || true
+            docker kill "$cid" >/dev/null 2>&1 || true
+            exit 1
+          fi
 
           unauth=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:18080/graph)
           if [ "$unauth" != "401" ]; then
@@ -269,3 +287,18 @@ jobs:
 
           echo "Container auth smoke passed — 401 without bearer, 200 with bearer."
           docker kill "$cid" >/dev/null 2>&1 || true
+
+      # #336 — the publish trio is npm + ghcr + Release. With the npm publish
+      # and container publish steps green and the smoke gate clear, this final
+      # step creates the GitHub Release for the tag with auto-generated notes
+      # from merged PRs. The maintainer edits the body afterwards with the
+      # curated forward-looking prose (comms-voice rules apply).
+      - name: Create GitHub Release
+        if: env.DRY_RUN != 'true' && startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            --latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,27 @@ RUN printf '#!/bin/sh\nexec node /app/packages/core/dist/cli.cjs "$@"\n' > /usr/
   && printf '#!/bin/sh\nexec node /app/packages/mcp/dist/index.cjs "$@"\n' > /usr/local/bin/neat-mcp \
   && chmod +x /usr/local/bin/neat-mcp
 
+# ADR-049 #6 — neatd refuses to boot without a registry, by design for the
+# laptop dev path ("you forgot to run `neat init`"). The container ships
+# the opposite default: a registry with a single `default` project pointed
+# at /workspace, so `docker run` brings the daemon up immediately and the
+# operator's repo at `-v $(pwd):/workspace` becomes the project on next
+# extract. /workspace is mkdir'd so the slot still bootstraps to active on
+# a bare `docker run` with no volume mount (empty extraction).
+RUN mkdir -p /workspace /root/.neat \
+  && printf '%s\n' '{' \
+    '  "version": 1,' \
+    '  "projects": [' \
+    '    {' \
+    '      "name": "default",' \
+    '      "path": "/workspace",' \
+    '      "registeredAt": "1970-01-01T00:00:00.000Z",' \
+    '      "languages": [],' \
+    '      "status": "active"' \
+    '    }' \
+    '  ]' \
+    '}' > /root/.neat/projects.json
+
 VOLUME ["/workspace", "/neat-out"]
 EXPOSE 8080 4318 6328
 

--- a/docs/runbook-publish.md
+++ b/docs/runbook-publish.md
@@ -34,6 +34,25 @@ Or via the web UI: repo Settings → Secrets and variables → Actions → New r
 
 The publish workflow at `.github/workflows/publish.yml` references this secret as `NODE_AUTH_TOKEN` and won't run without it.
 
+## What lands on a tag push
+
+A successful `vX.Y.Z` push lights up three publish surfaces in one workflow run:
+
+1. **npm** — six lockstep packages (`@neat.is/{types,core,mcp,claude-skill,web}` plus the `neat.is` umbrella).
+2. **ghcr.io** — the generic `neat` container image, tagged `vX.Y.Z` and `latest`.
+3. **GitHub Release** — auto-created via `gh release create --generate-notes --latest`. The default body lists merged PRs since the previous tag; the maintainer edits it afterwards with curated forward-looking prose (comms-voice rules apply).
+
+The README's release badge and the GitHub repo header reflect the new tag the moment all three land.
+
+## Cold-boot budget for the container smoke gate
+
+The container publish step pushes the image to ghcr.io and then runs an auth smoke against it: `docker run -e NEAT_AUTH_TOKEN=test image` and a 30-second wait loop on `/health`, followed by 401-without-bearer and 200-with-bearer checks on `/graph`. Two facts about that budget worth knowing:
+
+- **Cold-boot wall-clock is around 2 seconds** on the GitHub Actions runner against the locally-built image — well inside the 30s budget. Fastify's listen plus the default project's empty-`/workspace` extraction is what dominates; nothing in the image pulls or builds at runtime.
+- **The image ships an active `default` project pointed at `/workspace`.** `neatd start` refuses to boot without a registry per ADR-049 #6 — the laptop CLI's "you forgot `neat init`" guardrail. The container's complementary shape is `docker run image` as the "bring up the daemon" command, so the Dockerfile pre-seeds `/root/.neat/projects.json` and `/workspace` to satisfy the same guardrail in this surface. An operator's `-v $(pwd):/workspace` mount turns their repo into the default project on next extract.
+
+If a future container smoke regresses past 30 seconds, the dominant step won't be Fastify or the auth wiring — it'll be something new the image started pulling at boot. Check `docker logs` against a locally-built image first.
+
 ## Routine publish (CI path)
 
 Five steps from a clean working tree on `main`:

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -6510,6 +6510,47 @@ describe('Publish system contract (ADR-052)', () => {
     expect(yml).toMatch(/NEAT_AUTH_TOKEN=/)
     expect(yml).toMatch(/401/)
   })
+
+  it('Dockerfile ships a default project so `neatd start` reaches active on bare `docker run` (refs #335)', () => {
+    const df = readFileSync(join(REPO_ROOT, 'Dockerfile'), 'utf8')
+    // ADR-049 #6 — the daemon refuses to boot without a registry, by design
+    // for the laptop dev path. The container image inverts that default by
+    // pre-seeding /root/.neat/projects.json with a single `default` project
+    // pointed at /workspace; without it the container exits 1 immediately
+    // and the smoke gate's curl loop times out against a dead socket.
+    expect(df).toMatch(/\/root\/\.neat/)
+    expect(df).toMatch(/projects\.json/)
+    expect(df).toMatch(/"name":\s*"default"/)
+    expect(df).toMatch(/"path":\s*"\/workspace"/)
+    expect(df).toMatch(/"status":\s*"active"/)
+    // /workspace exists in the image even without a volume mount so the
+    // default slot bootstraps to active on an empty extraction.
+    expect(df).toMatch(/mkdir -p .*\/workspace/)
+  })
+
+  it('container smoke probe carries the bearer when waiting for /health (refs #335)', () => {
+    const yml = readFileSync(join(REPO_ROOT, '.github/workflows/publish.yml'), 'utf8')
+    // /health is bearer-gated when NEAT_AUTH_TOKEN is set, so the wait loop
+    // probe must carry the bearer or it polls a 401 forever and the gate
+    // misses regressions where the listener never actually binds.
+    const smoke = yml.slice(yml.indexOf('Container auth smoke'))
+    expect(smoke).toMatch(/Authorization: Bearer .*\n.*health/s)
+    expect(smoke).toMatch(/container REST surface never bound/)
+  })
+
+  it('publish workflow creates a GitHub Release on tag push (refs #336)', () => {
+    const yml = readFileSync(join(REPO_ROOT, '.github/workflows/publish.yml'), 'utf8')
+    // The publish trio is npm + ghcr + Release. The final step creates the
+    // Release with auto-generated notes so the rollup badge in the README
+    // updates the moment the tag pipeline finishes; the maintainer's job
+    // narrows to editing the body with curated prose.
+    expect(yml).toMatch(/gh release create/)
+    expect(yml).toMatch(/--generate-notes/)
+    expect(yml).toMatch(/--latest/)
+    expect(yml).toMatch(/startsWith\(github\.ref, 'refs\/tags\/v'\)/)
+    // contents: write is required for the Release API call to succeed.
+    expect(yml).toMatch(/contents:\s*write/)
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
The publish workflow's container smoke gate clears the cold-boot budget on a bare `docker run`, and the same workflow now creates the GitHub Release alongside npm + ghcr on tag push.

## Container cold boot

The image ships `/root/.neat/projects.json` carrying a single `default` project pointed at `/workspace`, with `/workspace` itself mkdir'd into the layer. `neatd start`'s ADR-049 #6 registry guard is satisfied the moment the container starts, the default slot bootstraps to active on an empty extraction, and the smoke gate's `/health` probe answers within ~2s on a locally-built image. An operator's `-v \$(pwd):/workspace` mount turns their repo into the default project on next extract, matching the Dockerfile header's documented intent.

The smoke wait loop now carries `Authorization: Bearer` on the `/health` probe — the path is bearer-gated when `NEAT_AUTH_TOKEN` is set, so the loop exits the moment the listener binds rather than relying on the container surviving long enough for the `unauth` curl to assert 401 on `/graph`. When the listener never binds, the gate surfaces a clear `container REST surface never bound on :8080 within 30s` error instead of timing out into a downstream `curl exit 7`.

## GitHub Release on tag push

Final workflow step calls `gh release create \"\${GITHUB_REF_NAME}\" --title \"\${GITHUB_REF_NAME}\" --generate-notes --latest`, gated on `refs/tags/v*`. The job carries `contents: write` so the Release API call has the scope it needs. The release rollup badge in the README and the GitHub repo header reflect the new tag the moment the publish trio (npm + ghcr + Release) lands. The maintainer edits the auto-generated body afterwards with curated forward-looking prose.

## Contract coverage

\`contracts.test.ts\` gains four assertions in the publish-system block: Dockerfile registry preseed shape, smoke-probe bearer, `gh release create` invocation form, and the `contents: write` job permission. \`docs/runbook-publish.md\` gains a section naming the npm + ghcr + Release trio and a "cold-boot budget" entry recording the ~2s wall-clock so the next maintainer reading the runbook sees the shape without re-investigating.

Refs #335
Refs #336

## Test plan

- [x] Local image build (\`docker build -t neat:smoke-test .\`) succeeds.
- [x] Local container run with \`NEAT_AUTH_TOKEN\` set reaches \`/health\` 200 in ~2.1s and answers \`/graph\` 401/200 against the unauth/auth bearer pair.
- [x] All 17 publish-system contract assertions pass under \`vitest run\`.
- [x] All 498 active contract assertions pass under \`vitest run\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)