### PR TITLE
Fix #354: web shell client calls pass the project on /api/events, /api/health

### DIFF
--- a/packages/web/app/components/GraphCanvas.tsx
+++ b/packages/web/app/components/GraphCanvas.tsx
@@ -436,8 +436,11 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
       if (zOut) zOut.onclick = () => cy.zoom({ level: cy.zoom() / 1.2, renderedPosition: { x: cy.width() / 2, y: cy.height() / 2 } })
       if (zFit) zFit.onclick = () => cy.fit(undefined, 60)
 
-      // SSE live updates (graceful — pre-v0.2.8 will get unavailable error and stop)
-      const sse = new EventSource('/api/events')
+      // SSE live updates, scoped to the active project (ADR-051 dual-mount).
+      // Without the project param the daemon streams the default-project bus
+      // and every other registered project's events land on the same canvas,
+      // which reads as one merged graph across projects.
+      const sse = new EventSource(`/api/events?project=${encodeURIComponent(project)}`)
       sseRef.current = sse
 
       function pushGraphUpdate() {

--- a/packages/web/app/components/StatusBar.tsx
+++ b/packages/web/app/components/StatusBar.tsx
@@ -192,7 +192,7 @@ export function StatusBar({ project, graphData }: StatusBarProps) {
     async function check(): Promise<void> {
       const start = performance.now()
       try {
-        const r = await authedFetch('/api/health', { cache: 'no-store' })
+        const r = await authedFetch(`/api/health?project=${encodeURIComponent(project)}`, { cache: 'no-store' })
         const rtt = Math.round(performance.now() - start)
         const ok = r.ok
         if (!ok) {

--- a/packages/web/app/components/TopBar.tsx
+++ b/packages/web/app/components/TopBar.tsx
@@ -48,14 +48,14 @@ export function TopBar({ project, onProjectChange, onNodeSelect, onRelayout, onT
 
   useEffect(() => {
     const check = () =>
-      authedFetch('/api/health')
+      authedFetch(`/api/health?project=${encodeURIComponent(project)}`)
         .then((r) => r.json())
         .then((d: { ok: boolean }) => setIsLive(d.ok === true))
         .catch(() => setIsLive(false))
     check()
     const id = setInterval(check, 15_000)
     return () => clearInterval(id)
-  }, [])
+  }, [project])
 
   // ADR-057 #5 — search is project-scoped.
   useEffect(() => {


### PR DESCRIPTION
## Summary

Three client-side calls in `packages/web/` opened Next.js proxy routes<br>without a project query param, so the proxy defaulted to<br>`project=default` and routed to `/projects/default/<endpoint>` on the<br>daemon. When no project named `default` is registered (the common<br>case), this either streams the wrong project or 404s, and the dashboard<br>misreports state on a working daemon.

Three one-line fixes:

* `GraphCanvas.tsx:440` — SSE subscribes per project. Without this the<br>daemon streams the default-project bus and every registered project's<br>node/edge events land on the same canvas. The user sees brief +<br>medusa + northsea-code blended into one view.
* `StatusBar.tsx:195` — `/api/health` heartbeat carries the project,<br>so the daemon's `/projects/:project/health` answers from the slot<br>the dashboard is actually rendering. The `down` classification<br>(which renders "core offline") stops firing on a healthy daemon.
* `TopBar.tsx:51` — same `/api/health` shape, same fix; this one<br>drives the live/offline pill at the top of the shell.

`StatusBar`'s effect already had `project` in its deps. `TopBar`'s<br>heartbeat effect picks it up alongside the URL change so the probe<br>reopens on project switch.

## Test plan

- [X] Restart neatd against a registry with several active projects<br>    and no `default` slot.
- [X] Open `?project=brief`. Confirm:
  - Only `service:brief-api` events arrive on the canvas (no<br>`service:northsea-code`, no `service:@medusajs/...`).
  - StatusBar shows the live/ok indicator, not "core offline".
  - TopBar's offline pill clears.
- [ ] Switch project via the picker — confirm SSE reopens against the<br>    new project's stream and the health pill stays green.

Refs NEAT-Technologies/Neat#354