### PR TITLE
README: v0.4.2 ships the validated surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A live semantic architecture of your code, your infrastructure, and what's actually happening in production. Query it. Assert policies against it. Point agents at it.
 
-Warning: ⚠️ NEAT Is currently in its MVP State. Therefore, It is unstable, and all engineering decisions where made to optimise dev speed and rapid prototyping. 
+NEAT is in active development. Capability ships as patch releases on the `npx neat.is` surface; see [open issues](https://github.com/NEAT-Technologies/Neat/issues) for what's on deck.
 
 ## One command
 


### PR DESCRIPTION
The intro line orients readers toward the active-development cadence and points at open issues for what's coming next. The substrate has matured into the validated `npx neat.is` surface the rest of the README already walks through, so the opener now reads consistent with the body.

Refs the v0.4.2 release: https://github.com/NEAT-Technologies/neat/releases/tag/v0.4.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)