### PR TITLE
Fix #361: `npx neat.is` runs the orchestrator

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1119,7 +1119,7 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
 // from tests must not start the parser; otherwise vitest sees a stray
 // `process.exit` from `main()` running with no argv.
 const entry = process.argv[1] ?? ''
-if (/[\\/]cli\.(?:cjs|js)$/.test(entry) || entry.endsWith('/cli') || entry.endsWith('/neat')) {
+if (/[\\/]cli\.(?:cjs|js)$/.test(entry) || entry.endsWith('/cli') || entry.endsWith('/neat') || entry.endsWith('/neat.is')) {
   main().catch((err) => {
     console.error(err)
     process.exit(1)

--- a/packages/neat.is/package.json
+++ b/packages/neat.is/package.json
@@ -17,6 +17,7 @@
   },
   "bin": {
     "neat": "./bin/neat",
+    "neat.is": "./bin/neat",
     "neatd": "./bin/neatd",
     "neat-mcp": "./bin/neat-mcp"
   },


### PR DESCRIPTION
## Summary

- Umbrella exposes a `neat.is` bin alongside `neat`, both pointing at the same wrapper.
- Core CLI's entry-detection regex matches `argv[1]` ending in `/neat.is` as well as `/neat`.

`npx neat.is .` — the README's headline command — runs the orchestrator instead of bouncing with `could not determine executable to run`.

## Verification

```
$ ln -s packages/neat.is/bin/neat /tmp/neat.is
$ /tmp/neat.is --version
0.4.2
```

Mirrors the symlink npm creates at `node_modules/.bin/neat.is` after `npm i -g neat.is` or `npx neat.is`. The rebuilt `dist/cli.cjs` recognises the new tail and dispatches `main()`.

Core vitest suite: 745 / 745 pass.

## Test plan

- [ ] Tag a patch release (likely v0.4.3 since this needs republished tarballs to reach end users).
- [ ] On a fresh shell against the new tag: `cd /tmp/anywhere && npx --yes neat.is@latest .` — orchestrator runs the six steps; dashboard opens.
- [ ] `npx --yes neat.is@latest --version` — prints the release version.
- [ ] Existing `npx -p neat.is neat .` workaround still works (no regression on direct `neat` bin).

Refs #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)