### PR TITLE
Web SSE proxy carries the bearer and keeps the chip on the active project

### DIFF
--- a/packages/web/app/api/events/route.ts
+++ b/packages/web/app/api/events/route.ts
@@ -7,10 +7,18 @@ export async function GET(request: NextRequest): Promise<Response> {
   const base = project && project !== 'default'
     ? `/projects/${encodeURIComponent(project)}/events`
     : '/events'
+  // ADR-073 §3 — carry the operator's bearer through to the daemon. Without
+  // this, every SSE attempt against a bearer-protected daemon comes back 401
+  // and the dashboard's "sse: reconnecting" chip never resolves.
+  const headers: Record<string, string> = { Accept: 'text/event-stream' }
+  const auth = request.headers.get('authorization')
+  if (auth) headers.Authorization = auth
+  const lastEventId = request.headers.get('last-event-id')
+  if (lastEventId) headers['Last-Event-ID'] = lastEventId
   try {
     const upstream = await fetch(`${CORE_URL}${base}`, {
       cache: 'no-store',
-      headers: { Accept: 'text/event-stream' },
+      headers,
     })
 
     if (!upstream.ok || !upstream.body) {
@@ -29,7 +37,48 @@ export async function GET(request: NextRequest): Promise<Response> {
       })
     }
 
-    return new Response(upstream.body, {
+    // Wrap the upstream body so we (a) flush headers immediately with a
+    // keep-alive comment — the daemon emits nothing until a graph event,
+    // and otherwise the Next.js runtime buffers our response indefinitely,
+    // leaving the client `EventSource` stuck without `onopen` — and
+    // (b) emit a periodic comment so the underlying HTTP connection
+    // doesn't get clipped at the runtime's 5s idle timeout, which causes
+    // EventSource to fire `onerror` and reconnect on a tight loop. Both
+    // are ignored by `EventSource` per the SSE spec.
+    const encoder = new TextEncoder()
+    const reader = upstream.body.getReader()
+    let heartbeat: ReturnType<typeof setInterval> | null = null
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(': connected\n\n'))
+        // 3s is well inside the Node runtime's 5s idle timeout that
+        // otherwise clips a quiet upstream and forces EventSource into a
+        // tight reconnect loop.
+        heartbeat = setInterval(() => {
+          try { controller.enqueue(encoder.encode(': keepalive\n\n')) } catch {}
+        }, 3_000)
+        function pump(): void {
+          reader.read().then(({ done, value }) => {
+            if (done) {
+              if (heartbeat) clearInterval(heartbeat)
+              controller.close()
+              return
+            }
+            if (value) controller.enqueue(value)
+            pump()
+          }).catch(() => {
+            if (heartbeat) clearInterval(heartbeat)
+            try { controller.close() } catch {}
+          })
+        }
+        pump()
+      },
+      cancel() {
+        if (heartbeat) clearInterval(heartbeat)
+        reader.cancel().catch(() => {})
+      },
+    })
+    return new Response(stream, {
       status: 200,
       headers: {
         'content-type': 'text/event-stream',

--- a/packages/web/app/components/StatusBar.tsx
+++ b/packages/web/app/components/StatusBar.tsx
@@ -223,9 +223,11 @@ export function StatusBar({ project, graphData }: StatusBarProps) {
   }, [project])
 
   // ADR-058 #2 — track SSE connection state. EventSource auto-reconnects
-  // per spec; we surface the state transitions.
+  // per spec; we surface the state transitions. ADR-057 #5 — scope the
+  // stream to the active project so a daemon with no default-project
+  // registry entry still serves us events for the project we're viewing.
   useEffect(() => {
-    const sse = new EventSource('/api/events')
+    const sse = new EventSource(`/api/events?project=${encodeURIComponent(project)}`)
     setSseState('reconnecting')
 
     sse.onopen = () => {
@@ -248,7 +250,7 @@ export function StatusBar({ project, graphData }: StatusBarProps) {
     sse.addEventListener('edge-removed', record('edge-removed'))
 
     return () => sse.close()
-  }, [])
+  }, [project])
 
   const nodeCount = graphData?.nodes.length ?? '—'
   const edgeCount = graphData?.edges.length ?? '—'


### PR DESCRIPTION
## Summary

Two granular fixes uncovered by a v0.4.2 frontend smoke pass against the
dashboard at `localhost:6328`:

- **/api/events forwards the bearer.** Before this, every SSE call against
  a `NEAT_AUTH_TOKEN`-gated daemon (the deploy-platform shape) came back
  401, the proxy fell through to its `"unavailable"` envelope, and the
  StatusBar "sse" chip lived at "reconnecting" forever. The route now
  forwards `Authorization` (and `Last-Event-ID` for replay), and prepends
  a `: connected` keep-alive comment so Next.js flushes response headers
  immediately — without that, the runtime buffers the response until the
  daemon emits its first event, which on a quiet graph is never, so
  `EventSource.onopen` never fires.
- **StatusBar's EventSource opens on the active project.** It was hitting
  `/api/events` unqualified, which the proxy routes to the daemon's
  default-project SSE bus. On any daemon that has no project literally
  named `default` (the common shape with a single named project), that's a
  404; the proxy returns "unavailable" and the chip stays
  "reconnecting". The active project already flows in as a prop and now
  rides on the URL, matching GraphCanvas's behaviour and the multi-project
  routing contract.

## Smoke verdicts (against fresh `~/.neat`, `demo` project, one OBSERVED edge from a synthetic OTLP batch)

| # | scenario | verdict |
|---|---|---|
| 1 | Cold login surface — redirect to `/login?next=%2F`, paste `test`, lands on dashboard with bearer in `localStorage` and `/api/projects` 200 | ✅ PASS |
| 2 | Bad-token rejection — inline error, no redirect, daemon 401 on `/api/projects` | ✅ PASS |
| 3 | Dashboard core surface — `data-connection-state=ok`, env chip `local`, nodes/edges counts >0, TopBar shows `demo`, Inspector reports `—` for spans / err% on services with no OBSERVED traffic per recent #358 honest-signal fix | ✅ PASS |
| 4 | SSE live updates — proxy now establishes the connection (`onopen` fires) but the persistent stream still drops within a frame in Chromium; live updates don't reliably reach the browser. See `NEAT-BUG-22`. | 🟡 PARTIAL |
| 5 | Project switcher — second project registers; switcher lists both; click switches `?project=` and re-fetches | ✅ PASS |
| 6 | Sign out — `localStorage` cleared, redirect to `/login`, button hidden when no token in storage | ✅ PASS |
| 7 | Public-read mode — couldn't isolate from a parallel-session daemon already bound to `:8080` on the same host; the scenario is exercised by the existing `packages/web/test/public-read-indicator.test.tsx` unit | ⏭ SKIPPED |
| 8 | SSE reconnect — same port contention; depends on the persistent-stream fix from `NEAT-BUG-22` to land first | ⏭ SKIPPED |

## Filed locally

`NEAT-BUG-22-web-sse-stream-drops-after-onopen.md` — Chromium-side SSE
drops within milliseconds of `onopen` against the bearer-protected daemon
despite my heartbeat. `curl` holds the same stream open for the full
timeout. Working hypothesis: Next.js 14.2 `Response(ReadableStream)`
handling of `text/event-stream` over Node's HTTP server, or the
`Keep-Alive: timeout=5` header interaction with Chromium. Live updates
work intermittently; the proxy fix here moves the chip from
"unavailable-forever" to "connected-then-drops". Kept local per the
launch-window discipline; mention in PR review if the maintainer wants it
opened publicly.

`NEAT-BUG-13` (already filed) — `/api/health` and `/api/incidents` and
`/api/policies/violations` return 404 with `project=default` during the
brief window before AppShell's `/projects` resolution completes. Visible
in console as `404` noise. Same default-project routing papercut.

## Test plan

- [x] `npx turbo build test lint` clean (FULL TURBO from cache)
- [x] `packages/web/test/` — 12 tests pass
- [ ] Reviewer manually verifies SSE chip flips to "connected" briefly on a fresh `neat init ./demo && neatd start` (will oscillate per `NEAT-BUG-22` until that lands)

Refs #355 (the same default-project routing papercut on `/api/events` and `/api/health`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)