### PR TITLE
v0.4.3: orchestrator handles create-next-app's src-dir layout and survives Turbopack bundling

### DIFF
--- a/packages/core/src/installers/javascript.ts
+++ b/packages/core/src/installers/javascript.ts
@@ -59,6 +59,7 @@ import {
   SVELTEKIT_OTEL_INIT_JS,
   SVELTEKIT_OTEL_INIT_TS,
   renderEnvNeat,
+  renderNextInstrumentationNode,
 } from './templates.js'
 
 const SDK_PACKAGES = [
@@ -429,11 +430,28 @@ function lineIsOtelInjection(line: string): boolean {
   return /(?:require\(|import\s+)['"]\.\/otel-init[^'"]*['"]/.test(trimmed)
 }
 
+// `create-next-app --src-dir` puts source under `src/` and Next then resolves
+// the instrumentation hook from `src/instrumentation.ts`. Routing the
+// generated files to root in that case means the hook never loads. We detect
+// src-layout by the presence of `src/app/` or `src/pages/` AND the absence of
+// the same at the package root — a project with both is treated as flat, the
+// safer default for monorepos that vendor a `src/` subpackage.
+async function detectsSrcLayout(serviceDir: string): Promise<boolean> {
+  const [hasSrcApp, hasSrcPages, hasRootApp, hasRootPages] = await Promise.all([
+    exists(path.join(serviceDir, 'src', 'app')),
+    exists(path.join(serviceDir, 'src', 'pages')),
+    exists(path.join(serviceDir, 'app')),
+    exists(path.join(serviceDir, 'pages')),
+  ])
+  return (hasSrcApp || hasSrcPages) && !hasRootApp && !hasRootPages
+}
+
 // ADR-073 §1 — Next.js apply path. Emits `instrumentation.{ts,js}` and
-// `instrumentation.node.{ts,js}` at the package root, plus `.env.neat`.
-// Skips entry-point injection entirely — Next loads the instrumentation
-// file through its own runtime hook. Queues a next.config edit only when
-// the declared major is < 15 (the flag is on-by-default from Next 15 on).
+// `instrumentation.node.{ts,js}` at the package root (or under `src/` for
+// `--src-dir` layouts), plus `.env.neat` co-located with them. Skips
+// entry-point injection entirely — Next loads the instrumentation file
+// through its own runtime hook. Queues a next.config edit only when the
+// declared major is < 15 (the flag is on-by-default from Next 15 on).
 async function planNext(
   serviceDir: string,
   pkg: PackageJsonShape,
@@ -442,17 +460,29 @@ async function planNext(
   project: string | undefined,
 ): Promise<InstallPlan> {
   const useTs = await isTypeScriptProject(serviceDir)
-  const instrumentationFile = path.join(serviceDir, useTs ? 'instrumentation.ts' : 'instrumentation.js')
+  const srcLayout = await detectsSrcLayout(serviceDir)
+  // Co-locate the generated files with where Next looks for the hook. When
+  // src-layout is detected the framework resolves `src/instrumentation.{ts,js}`
+  // and we route the .env.neat alongside so an operator reading the codebase
+  // finds the wiring in one place. The flat layout keeps the existing root
+  // placement.
+  const baseDir = srcLayout ? path.join(serviceDir, 'src') : serviceDir
+  const instrumentationFile = path.join(baseDir, useTs ? 'instrumentation.ts' : 'instrumentation.js')
   const instrumentationNodeFile = path.join(
-    serviceDir,
+    baseDir,
     useTs ? 'instrumentation.node.ts' : 'instrumentation.node.js',
   )
-  const envNeatFile = path.join(serviceDir, '.env.neat')
+  const envNeatFile = path.join(baseDir, '.env.neat')
 
-  // Dependency edits — same four-deps invariant as the plain Node path.
+  // Dependency edits — the generated instrumentation inlines env vars via
+  // `process.env.X ||=`, so `dotenv` is no longer part of the Next path's
+  // dependency footprint. The plain Node + meta-framework templates still
+  // load `.env.neat` through dotenv, so SDK_PACKAGES keeps the full set; we
+  // filter it here for the Next branch only.
   const existingDeps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) }
   const dependencyEdits: DependencyEdit[] = []
   for (const sdk of SDK_PACKAGES) {
+    if (sdk.name === 'dotenv') continue
     if (sdk.name in existingDeps) continue
     dependencyEdits.push({
       file: manifestPath,
@@ -464,7 +494,11 @@ async function planNext(
 
   // Generated files — instrumentation pair + .env.neat. Existing files are
   // preserved (skipIfExists honours user customisations and keeps the apply
-  // phase idempotent per ADR-069 §6).
+  // phase idempotent per ADR-069 §6). The instrumentation.node template
+  // carries a `__PROJECT_NAME__` placeholder we substitute here so the
+  // bundler-survivable `process.env.OTEL_SERVICE_NAME ||= '<name>'` line
+  // lands with the registered project name verbatim.
+  const projectName = envServiceName(pkg, serviceDir, project)
   const generatedFiles: GeneratedFile[] = []
   if (!(await exists(instrumentationFile))) {
     generatedFiles.push({
@@ -476,14 +510,17 @@ async function planNext(
   if (!(await exists(instrumentationNodeFile))) {
     generatedFiles.push({
       file: instrumentationNodeFile,
-      contents: useTs ? NEXT_INSTRUMENTATION_NODE_TS : NEXT_INSTRUMENTATION_NODE_JS,
+      contents: renderNextInstrumentationNode(
+        useTs ? NEXT_INSTRUMENTATION_NODE_TS : NEXT_INSTRUMENTATION_NODE_JS,
+        projectName,
+      ),
       skipIfExists: true,
     })
   }
   if (!(await exists(envNeatFile))) {
     generatedFiles.push({
       file: envNeatFile,
-      contents: renderEnvNeat(envServiceName(pkg, serviceDir, project)),
+      contents: renderEnvNeat(projectName),
       skipIfExists: true,
     })
   }
@@ -1040,11 +1077,18 @@ function isAllowedWritePath(serviceDir: string, target: string): boolean {
   if (base === 'package.json') return true
   if (base === '.env.neat') return true
   if (/^otel-init\.(?:js|cjs|mjs|ts)$/.test(base)) return true
-  // ADR-073 §1 — Next framework files at the package root.
-  if (/^instrumentation(?:\.node)?\.(?:js|cjs|mjs|ts)$/.test(base)) return true
+  // ADR-073 §1 — Next framework files at the package root, or under src/
+  // when create-next-app's --src-dir layout is in use. The instrumentation
+  // hook resolves from `src/` in that layout; routing files there is the
+  // load-bearing fix for the src-dir shape.
+  const relPosix = rel.split(path.sep).join('/')
+  if (/^instrumentation(?:\.node)?\.(?:js|cjs|mjs|ts)$/.test(base)) {
+    if (relPosix === base) return true
+    if (relPosix === `src/${base}`) return true
+    return false
+  }
   if (/^next\.config\.(?:js|mjs|ts)$/.test(base)) return true
   // ADR-074 §3 — meta-framework hook surfaces.
-  const relPosix = rel.split(path.sep).join('/')
   if (relPosix === 'app/otel.server.ts' || relPosix === 'app/otel.server.js') return true
   if (/^app\/entry\.server\.(?:tsx?|jsx?)$/.test(relPosix)) return true
   if (relPosix === 'src/otel-init.ts' || relPosix === 'src/otel-init.js') return true

--- a/packages/core/src/installers/templates.ts
+++ b/packages/core/src/installers/templates.ts
@@ -100,43 +100,43 @@ export async function register() {
 }
 `
 
+// Env vars are inlined as process.env defaults so they survive Turbopack /
+// Webpack bundling — `import.meta.url` resolves to a path under .next/dev/
+// server/chunks/ once Next compiles this file, which would miss .env.neat.
+// `process.env.X ||=` keeps platform env (Vercel / Railway / Fly / etc.)
+// authoritative at deploy time while the local default carries the registry
+// routing key the daemon needs to map spans back to this project. The OTel
+// SDK reads OTEL_SERVICE_NAME and OTEL_EXPORTER_OTLP_ENDPOINT from the same
+// process.env, so no file-system lookup is required at runtime.
 export const NEXT_INSTRUMENTATION_NODE_TS = `${NEXT_INSTRUMENTATION_HEADER}
-// Loads .env.neat (OTEL_SERVICE_NAME, OTEL_EXPORTER_OTLP_ENDPOINT) before
-// the OTel SDK starts so the exporter target and service name are in scope.
-import { fileURLToPath } from 'node:url'
-import path from 'node:path'
-import dotenv from 'dotenv'
+process.env.OTEL_SERVICE_NAME ||= '__PROJECT_NAME__'
+process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||= 'http://localhost:4318'
+
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
 
-const here = path.dirname(fileURLToPath(import.meta.url))
-dotenv.config({ path: path.join(here, '.env.neat') })
-
-const sdk = new NodeSDK({
-  serviceName: process.env.OTEL_SERVICE_NAME,
-  instrumentations: [getNodeAutoInstrumentations()],
-})
-sdk.start()
+new NodeSDK({ instrumentations: [getNodeAutoInstrumentations()] }).start()
 `
 
 export const NEXT_INSTRUMENTATION_NODE_JS = `${NEXT_INSTRUMENTATION_HEADER}
-// Loads .env.neat (OTEL_SERVICE_NAME, OTEL_EXPORTER_OTLP_ENDPOINT) before
-// the OTel SDK starts so the exporter target and service name are in scope.
-import { fileURLToPath } from 'node:url'
-import path from 'node:path'
-import dotenv from 'dotenv'
-import { NodeSDK } from '@opentelemetry/sdk-node'
-import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
+process.env.OTEL_SERVICE_NAME ||= '__PROJECT_NAME__'
+process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||= 'http://localhost:4318'
 
-const here = path.dirname(fileURLToPath(import.meta.url))
-dotenv.config({ path: path.join(here, '.env.neat') })
+const { NodeSDK } = require('@opentelemetry/sdk-node')
+const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node')
 
-const sdk = new NodeSDK({
-  serviceName: process.env.OTEL_SERVICE_NAME,
-  instrumentations: [getNodeAutoInstrumentations()],
-})
-sdk.start()
+new NodeSDK({ instrumentations: [getNodeAutoInstrumentations()] }).start()
 `
+
+// Substitute the placeholder at apply time so the generated file carries the
+// registered project name verbatim. Falls back to the package's own name when
+// the orchestrator hasn't threaded one through (ad-hoc / test usage).
+export function renderNextInstrumentationNode(
+  template: string,
+  projectName: string,
+): string {
+  return template.replace(/__PROJECT_NAME__/g, projectName)
+}
 
 // ── Meta-framework templates (ADR-074 §3). ──────────────────────────────
 //

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -9460,18 +9460,24 @@ describe('ADR-073 — one-command CLI + deployment-target + delegated auth', () 
     expect(NEXT_INSTRUMENTATION_TS).toMatch(/await\s+import\(['"]\.\/instrumentation\.node['"]\)/)
   })
 
-  it('ADR-073 §1 — instrumentation.node.{ts,js} loads .env.neat then starts NodeSDK with auto-instrumentations', async () => {
+  it('ADR-073 §1 — instrumentation.node.{ts,js} inlines OTEL env defaults and starts NodeSDK with auto-instrumentations', async () => {
     const { NEXT_INSTRUMENTATION_NODE_TS, NEXT_INSTRUMENTATION_NODE_JS } = await import(
       '../../src/installers/templates.js'
     )
     for (const tpl of [NEXT_INSTRUMENTATION_NODE_TS, NEXT_INSTRUMENTATION_NODE_JS]) {
-      expect(tpl).toMatch(/dotenv\.config\(\{\s*path:\s*path\.join\(here,\s*['"]\.env\.neat['"]\)\s*\}\)/)
+      // Bundler-survivable env defaults — process.env access isn't rewritten
+      // by Turbopack / Webpack, while `import.meta.url` is. The template
+      // must not depend on a runtime file-system lookup.
+      expect(tpl).toMatch(/process\.env\.OTEL_SERVICE_NAME\s*\|\|=\s*['"][^'"]+['"]/)
+      expect(tpl).toMatch(/process\.env\.OTEL_EXPORTER_OTLP_ENDPOINT\s*\|\|=\s*['"]http:\/\/localhost:4318['"]/)
+      expect(tpl).not.toContain('import.meta.url')
+      expect(tpl).not.toMatch(/['"]dotenv['"]/)
       expect(tpl).toMatch(/new\s+NodeSDK\s*\(/)
       expect(tpl).toMatch(/getNodeAutoInstrumentations\s*\(\s*\)/)
     }
   })
 
-  it('ADR-073 §1 — Next plan adds the same four OTel deps as the plain Node path', async () => {
+  it('ADR-073 §1 — Next plan adds OTel deps and omits dotenv (the generated instrumentation no longer imports it)', async () => {
     const { javascriptInstaller } = await import('../../src/installers/javascript.js')
     const fixture = join(__dirname, '../fixtures/next-baseline')
     const result = await javascriptInstaller.plan(fixture)
@@ -9480,8 +9486,77 @@ describe('ADR-073 — one-command CLI + deployment-target + delegated auth', () 
       '@opentelemetry/api',
       '@opentelemetry/auto-instrumentations-node',
       '@opentelemetry/sdk-node',
-      'dotenv',
     ])
+    expect(names).not.toContain('dotenv')
+  })
+
+  it('ADR-073 §1 — Next plan substitutes the project name into the inlined OTEL_SERVICE_NAME default', async () => {
+    const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+    const fixture = join(__dirname, '../fixtures/next-baseline')
+    const result = await javascriptInstaller.plan(fixture, { project: 'demo-routed' })
+    const node = (result.generatedFiles ?? []).find((g) =>
+      g.file.endsWith('instrumentation.node.ts') || g.file.endsWith('instrumentation.node.js'),
+    )
+    expect(node).toBeDefined()
+    expect(node!.contents).toContain("process.env.OTEL_SERVICE_NAME ||= 'demo-routed'")
+    expect(node!.contents).not.toContain('__PROJECT_NAME__')
+  })
+
+  it('ADR-073 §1 — Next plan routes instrumentation files to src/ when create-next-app --src-dir layout is present', async () => {
+    const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+    const fixture = join(__dirname, '../fixtures/next-baseline-src')
+    const result = await javascriptInstaller.plan(fixture)
+    expect(result.framework).toBe('next')
+    const files = (result.generatedFiles ?? []).map((g) => g.file)
+    // The instrumentation pair + .env.neat all land under src/, not at root.
+    expect(files.some((f) => f.endsWith('/src/instrumentation.ts'))).toBe(true)
+    expect(files.some((f) => f.endsWith('/src/instrumentation.node.ts'))).toBe(true)
+    expect(files.some((f) => f.endsWith('/src/.env.neat'))).toBe(true)
+    // Nothing slipped through at the package root.
+    expect(files.some((f) => /\/next-baseline-src\/instrumentation\.ts$/.test(f))).toBe(false)
+    expect(files.some((f) => /\/next-baseline-src\/instrumentation\.node\.ts$/.test(f))).toBe(false)
+  })
+
+  it('ADR-073 §1 — flat-layout next-baseline still emits to the package root (regression guard)', async () => {
+    const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+    const fixture = join(__dirname, '../fixtures/next-baseline')
+    const result = await javascriptInstaller.plan(fixture)
+    const files = (result.generatedFiles ?? []).map((g) => g.file)
+    expect(files.some((f) => f.endsWith('/next-baseline/instrumentation.ts'))).toBe(true)
+    expect(files.some((f) => f.endsWith('/next-baseline/instrumentation.node.ts'))).toBe(true)
+    expect(files.some((f) => f.endsWith('/next-baseline/.env.neat'))).toBe(true)
+    expect(files.some((f) => f.includes('/src/'))).toBe(false)
+  })
+
+  it('ADR-073 §1 — Next apply on a src-dir layout lands the instrumentation pair under src/', async () => {
+    const fs2 = await import('node:fs/promises')
+    const os2 = await import('node:os')
+    const root = await fs2.mkdtemp(join(os2.tmpdir(), 'next-src-apply-'))
+    await fs2.writeFile(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'demo-next-src', dependencies: { next: '^15.0.0' } }, null, 2),
+    )
+    await fs2.writeFile(
+      join(root, 'next.config.js'),
+      "/** @type {import('next').NextConfig} */\nmodule.exports = { reactStrictMode: true }\n",
+    )
+    await fs2.mkdir(join(root, 'src', 'app'), { recursive: true })
+    await fs2.writeFile(join(root, 'src', 'app', 'page.tsx'), 'export default () => null\n')
+    await fs2.writeFile(
+      join(root, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { jsx: 'preserve' } }, null, 2),
+    )
+
+    const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+    const plan = await javascriptInstaller.plan(root)
+    const outcome = await javascriptInstaller.apply(plan)
+    expect(outcome.outcome).toBe('instrumented')
+
+    expect(existsSync(join(root, 'src', 'instrumentation.ts'))).toBe(true)
+    expect(existsSync(join(root, 'src', 'instrumentation.node.ts'))).toBe(true)
+    expect(existsSync(join(root, 'src', '.env.neat'))).toBe(true)
+    expect(existsSync(join(root, 'instrumentation.ts'))).toBe(false)
+    expect(existsSync(join(root, 'instrumentation.node.ts'))).toBe(false)
   })
 
   it('ADR-073 §1 — Next 15+ leaves next.config alone (instrumentationHook is on by default)', async () => {

--- a/packages/core/test/fixtures/next-baseline-src/next.config.js
+++ b/packages/core/test/fixtures/next-baseline-src/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/packages/core/test/fixtures/next-baseline-src/package.json
+++ b/packages/core/test/fixtures/next-baseline-src/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "next-baseline-src",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^15.0.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  }
+}

--- a/packages/core/test/fixtures/next-baseline-src/src/app/page.tsx
+++ b/packages/core/test/fixtures/next-baseline-src/src/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <main>next-baseline-src fixture</main>
+}

--- a/packages/core/test/fixtures/next-baseline-src/tsconfig.json
+++ b/packages/core/test/fixtures/next-baseline-src/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
The Next.js installer learns the `--src-dir` layout convention and the generated instrumentation inlines its env defaults so Turbopack / Webpack rewrites don't break the wiring.

## What changes

**`detectsSrcLayout` routes generated files to where Next looks for them.** `src/app/` or `src/pages/` at a package — plus the absence of the same at the root — is the signal. When true, `planNext` emits `src/instrumentation.{ts,js}`, `src/instrumentation.node.{ts,js}`, and `src/.env.neat`. The flat layout keeps the existing root placement. `isAllowedWritePath` recognises both shapes.

**Generated instrumentation reads env from `process.env` directly.** The Next template now opens with `process.env.OTEL_SERVICE_NAME ||= '<project>'` and `process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||= 'http://localhost:4318'`. The orchestrator substitutes `__PROJECT_NAME__` at apply time with the registered project name. `process.env` access isn't bundler-rewritten the way `import.meta.url` is, so the previous `path.join(here, '.env.neat')` lookup — which resolved into `.next/dev/server/chunks/` after Turbopack compiled the file — is gone. Platform env (Vercel / Railway / Fly) still wins at deploy time through the `||=` precedence.

**dotenv falls out of the Next dispatch's dep footprint.** The Next template no longer imports it. The plain-Node + meta-framework templates still load `.env.neat` via dotenv, so `SDK_PACKAGES` keeps the full set; the Next branch filters it locally. Net effect for `create-next-app`: three OTel deps land in `package.json`, no dotenv.

## Local smoke evidence

Built locally and re-ran the smoke against both layouts:

```
cd /tmp/v043-smoke/smoke-flat   # create-next-app --app (root layout)
node packages/core/dist/cli.cjs . --no-open
# → instrumentation.ts, instrumentation.node.ts, .env.neat at root
# → process.env.OTEL_SERVICE_NAME ||= 'smoke-flat'
# → no import.meta.url anywhere
# → npm: @opentelemetry/api, sdk-node, auto-instrumentations-node (no dotenv)

cd /tmp/v043-smoke/smoke-src    # create-next-app --app --src-dir
node packages/core/dist/cli.cjs . --no-open
# → src/instrumentation.ts, src/instrumentation.node.ts, src/.env.neat
# → process.env.OTEL_SERVICE_NAME ||= 'smoke-src'
# → no files at package root

# Bonus: npm install && next dev on smoke-flat, 5 GETs to /
# OTel SDK boots, exports spans (visible at OTEL_LOG_LEVEL=debug)
# Daemon accepts them — ~/.neat/errors.ndjson stays empty (no 'no-project-match')
```

OBSERVED edges don't materialise on the dashboard yet — Next-internal spans don't reach a second service so no edge gets inferred. That's NEAT-BUG-25 (`observed-empty-single-service`), a separate investigation: this PR's job is to unblock the headline `create-next-app` shape, which it does.

## Test plan

- [x] `npx turbo build` green
- [x] `npx turbo test` green (749 passed across `@neat.is/core`)
- [x] `npx turbo lint` green (one unrelated pre-existing warning in `orchestrator.ts`)
- [x] New assertions land alongside existing ADR-073 §1 block: src-dir routing, flat-layout regression guard, inlined env defaults, `__PROJECT_NAME__` substitution, no `import.meta.url` / dotenv in the Next template, `Next plan adds OTel deps and omits dotenv`
- [x] Local smoke against `create-next-app@latest` for both `--app` and `--app --src-dir` shapes

Refs NEAT-BUG-23 (orchestrator places instrumentation at root, breaks Next.js `--src-dir` layout) and NEAT-BUG-24 (`.env.neat` lookup via `import.meta.url` fails under Turbopack). The bug files are maintainer-local — no public GitHub issue to link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)