### PR TITLE
Parse span code.* into OBSERVED edge evidence

### DIFF
--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import type {
   DatabaseNode,
+  EdgeEvidence,
   ErrorEvent,
   FrontierNode,
   GraphEdge,
@@ -154,6 +155,25 @@ function hostFromUrl(u: string | undefined): string | undefined {
   } catch {
     return undefined
   }
+}
+
+// Call-site evidence from the `code.*` attributes NEAT's injected
+// instrumentation attaches on CLIENT/PRODUCER spans (ADR-087, file-awareness
+// §2/§3). `code.filepath` is the user-code frame the call originated from;
+// `code.lineno` its line. Returns undefined when `code.filepath` is absent —
+// SERVER spans and any span without the call-site processor carry no origin,
+// and we never synthesize one (file-awareness §3). `line` is dropped, not
+// faked, when `code.lineno` isn't a usable non-negative integer; the file
+// still stands on its own as honest partial evidence.
+function evidenceFromSpan(span: ParsedSpan): EdgeEvidence | undefined {
+  const file = pickAttr(span, 'code.filepath')
+  if (!file) return undefined
+  const rawLine = span.attributes['code.lineno']
+  const line =
+    typeof rawLine === 'number' && Number.isInteger(rawLine) && rawLine >= 0
+      ? rawLine
+      : undefined
+  return { file, ...(line !== undefined ? { line } : {}) }
 }
 
 // OTel HTTP/db semconv has gone through several names for "the host on the
@@ -370,6 +390,12 @@ function upsertObservedEdge(
   target: string,
   ts: string,
   isError = false,
+  // Call-site evidence parsed from the span's `code.*` attributes, when the
+  // span carried them (ADR-087, file-awareness §2). Additive — it never
+  // touches signal / callCount / lastObserved / provenance. Undefined when the
+  // span had no call-site origin; in that case existing evidence is left as-is
+  // and no edge gains a synthesized file/line (file-awareness §3).
+  evidence?: EdgeEvidence,
 ): UpsertResult | null {
   if (!graph.hasNode(source) || !graph.hasNode(target)) return null
 
@@ -385,7 +411,9 @@ function upsertObservedEdge(
     }
     // ADR-066 §2 — confidence grades from the signal block. PROV_RANK stays;
     // the grade reflects volume + recency + error ratio within the OBSERVED
-    // tier.
+    // tier. `...existing` carries any prior evidence forward; a fresh span with
+    // its own `code.*` refreshes it to the latest call site, while a span
+    // without `code.*` leaves the prior (real) evidence untouched.
     const updated: GraphEdge = {
       ...existing,
       provenance: Provenance.OBSERVED,
@@ -393,6 +421,7 @@ function upsertObservedEdge(
       callCount: newSpanCount,
       signal: newSignal,
       confidence: confidenceForObservedSignal(newSignal),
+      ...(evidence ? { evidence } : {}),
     }
     graph.replaceEdgeAttributes(id, updated)
     return { edge: updated, created: false }
@@ -413,6 +442,7 @@ function upsertObservedEdge(
     lastObserved: ts,
     callCount: 1,
     signal,
+    ...(evidence ? { evidence } : {}),
   }
   graph.addEdgeWithKey(id, source, target, edge)
   return { edge, created: true }
@@ -575,6 +605,14 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
   // when the span carries an env signal.
   const sourceId = ensureServiceNode(ctx.graph, span.service, env)
   const isError = span.statusCode === 2
+  // Call-site origin from the span's `code.*` attributes (ADR-087). Present on
+  // CLIENT/PRODUCER spans the injected instrumentation tagged; absent on SERVER
+  // spans and anything without the call-site processor. The edges below that
+  // represent *this* span's outbound call (DB CONNECTS_TO, address-resolved
+  // CALLS, frontier CALLS) take it as additive evidence. The parent-span
+  // fallback edge does not — there the current span is the server side, so its
+  // origin isn't the call site of that parent → current edge (file-awareness §2).
+  const evidence = evidenceFromSpan(span)
   // Stash this span in the parent-span cache so any later child whose address
   // resolution misses can still resolve the cross-service edge via parentSpanId.
   cacheSpanService(span, nowMs)
@@ -596,6 +634,7 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
         targetId,
         ts,
         isError,
+        evidence,
       )
       if (result) affectedNode = targetId
     }
@@ -622,6 +661,7 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
           targetId,
           ts,
           isError,
+          evidence,
         )
         affectedNode = targetId
         resolvedViaAddress = true
@@ -634,6 +674,7 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
           frontierNodeId,
           ts,
           isError,
+          evidence,
         )
         affectedNode = frontierNodeId
         resolvedViaAddress = true

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -510,6 +510,156 @@ describe('Lifecycle contract — FrontierNode promotion preserves provenance (AD
 })
 
 // ──────────────────────────────────────────────────────────────────────────
+// File-awareness contract — OBSERVED gets file origin from span `code.*`
+// (ADR-087 §2/§3, docs/contracts/file-awareness.md)
+// ──────────────────────────────────────────────────────────────────────────
+describe('File-awareness contract — OBSERVED evidence from span code.* (ADR-087)', () => {
+  function callerCalleeGraph(): NeatGraph {
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:caller', {
+      id: 'service:caller',
+      type: NodeType.ServiceNode,
+      name: 'caller',
+      language: 'javascript',
+    })
+    g.addNode('service:callee', {
+      id: 'service:callee',
+      type: NodeType.ServiceNode,
+      name: 'callee',
+      language: 'javascript',
+    })
+    return g
+  }
+
+  function clientSpan(overrides: Record<string, unknown> = {}) {
+    return {
+      service: 'caller',
+      traceId: 't1',
+      spanId: 's1',
+      name: 'GET /things',
+      kind: 3,
+      statusCode: 0,
+      startTimeUnixNano: '0',
+      endTimeUnixNano: '0',
+      durationNanos: 0n,
+      env: 'unknown',
+      attributes: {
+        'server.address': 'callee',
+        'http.method': 'GET',
+      } as Record<string, unknown>,
+      ...overrides,
+    }
+  }
+
+  it('span carrying code.* lands file + line on the OBSERVED edge evidence', async () => {
+    const { handleSpan } = await import('../../src/ingest.js')
+    const { observedEdgeId } = await import('@neat.is/types')
+    const g = callerCalleeGraph()
+    await handleSpan(
+      { graph: g, errorsPath: '/dev/null' },
+      clientSpan({
+        attributes: {
+          'server.address': 'callee',
+          'http.method': 'GET',
+          'code.filepath': 'src/checkout.ts',
+          'code.lineno': 42,
+          'code.function': 'placeOrder',
+        },
+      }) as never,
+    )
+    const id = observedEdgeId('service:caller', 'service:callee', EdgeType.CALLS)
+    const edge = g.getEdgeAttributes(id) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.evidence?.file).toBe('src/checkout.ts')
+    expect(edge.evidence?.line).toBe(42)
+  })
+
+  it('span without code.* leaves the OBSERVED edge with no evidence (no fabrication)', async () => {
+    const { handleSpan } = await import('../../src/ingest.js')
+    const { observedEdgeId } = await import('@neat.is/types')
+    const g = callerCalleeGraph()
+    await handleSpan({ graph: g, errorsPath: '/dev/null' }, clientSpan() as never)
+    const id = observedEdgeId('service:caller', 'service:callee', EdgeType.CALLS)
+    const edge = g.getEdgeAttributes(id) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.evidence).toBeUndefined()
+  })
+
+  it('code.filepath without code.lineno records the file but never a synthesized line', async () => {
+    const { handleSpan } = await import('../../src/ingest.js')
+    const { observedEdgeId } = await import('@neat.is/types')
+    const g = callerCalleeGraph()
+    await handleSpan(
+      { graph: g, errorsPath: '/dev/null' },
+      clientSpan({
+        attributes: {
+          'server.address': 'callee',
+          'http.method': 'GET',
+          'code.filepath': 'src/checkout.ts',
+        },
+      }) as never,
+    )
+    const id = observedEdgeId('service:caller', 'service:callee', EdgeType.CALLS)
+    const edge = g.getEdgeAttributes(id) as GraphEdge
+    expect(edge.evidence?.file).toBe('src/checkout.ts')
+    expect(edge.evidence?.line).toBeUndefined()
+  })
+
+  it('evidence is additive — signal, callCount, lastObserved, provenance unchanged across a code.* span', async () => {
+    const { handleSpan } = await import('../../src/ingest.js')
+    const { observedEdgeId } = await import('@neat.is/types')
+    const g = callerCalleeGraph()
+    // First a plain span (no code.*), then one carrying code.* — the second
+    // adds evidence without disturbing the running signal block.
+    await handleSpan({ graph: g, errorsPath: '/dev/null' }, clientSpan() as never)
+    await handleSpan(
+      { graph: g, errorsPath: '/dev/null' },
+      clientSpan({
+        spanId: 's2',
+        attributes: {
+          'server.address': 'callee',
+          'http.method': 'GET',
+          'code.filepath': 'src/checkout.ts',
+          'code.lineno': 42,
+        },
+      }) as never,
+    )
+    const id = observedEdgeId('service:caller', 'service:callee', EdgeType.CALLS)
+    const edge = g.getEdgeAttributes(id) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.callCount).toBe(2)
+    expect(edge.signal?.spanCount).toBe(2)
+    expect(edge.evidence?.file).toBe('src/checkout.ts')
+    expect(edge.evidence?.line).toBe(42)
+  })
+
+  it('a later span without code.* keeps prior real evidence rather than erasing it', async () => {
+    const { handleSpan } = await import('../../src/ingest.js')
+    const { observedEdgeId } = await import('@neat.is/types')
+    const g = callerCalleeGraph()
+    await handleSpan(
+      { graph: g, errorsPath: '/dev/null' },
+      clientSpan({
+        attributes: {
+          'server.address': 'callee',
+          'http.method': 'GET',
+          'code.filepath': 'src/checkout.ts',
+          'code.lineno': 42,
+        },
+      }) as never,
+    )
+    await handleSpan(
+      { graph: g, errorsPath: '/dev/null' },
+      clientSpan({ spanId: 's2' }) as never,
+    )
+    const id = observedEdgeId('service:caller', 'service:callee', EdgeType.CALLS)
+    const edge = g.getEdgeAttributes(id) as GraphEdge
+    expect(edge.evidence?.file).toBe('src/checkout.ts')
+    expect(edge.evidence?.line).toBe(42)
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────
 // Static-extraction contract — producer interface, evidence, idempotency (ADR-032)
 // ──────────────────────────────────────────────────────────────────────────
 describe('Static-extraction contract (ADR-032)', () => {


### PR DESCRIPTION
Sibling #394 makes NEAT's injected instrumentation attach `code.filepath` / `code.lineno` / `code.function` on CLIENT/PRODUCER spans. This turns those attributes into file-grained `evidence` on the OBSERVED edges at ingest, so the load-bearing runtime layer carries a call-site origin instead of only a service name (ADR-087, file-awareness §2/§3).

## What changed

- `evidenceFromSpan(span)` reads `code.filepath` (and `code.lineno` when it's a usable non-negative integer) off a span. Absent `code.filepath` → no evidence; a missing or bad `code.lineno` drops the line but keeps the file as honest partial evidence. Nothing is synthesized.
- `upsertObservedEdge` takes an optional `evidence` argument and writes it additively — `signal`, `callCount`, `lastObserved`, and `provenance` are untouched. On update a fresh `code.*` span refreshes the call site; a code-less span leaves any prior real evidence in place.
- `handleSpan` computes the span's evidence once and passes it to the edges that represent *this* span's outbound call: DB `CONNECTS_TO`, address-resolved `CALLS`, and frontier `CALLS`. The parent-span fallback edge does **not** get it — there the current span is the server side, so its origin isn't the call site of that parent → current edge.

## Tests

A new file-awareness contract block in `contracts.test.ts` covers: `code.*` present → `evidence.file` + `evidence.line`; `code.*` absent → no evidence (no fabrication); `code.filepath` without `code.lineno` → file only, never a synthesized line; evidence is additive (signal/callCount/provenance unchanged); a later code-less span preserves prior evidence.

`npx turbo build test lint` clean.

Refs #395