### PR TITLE
Keep every call site on an extracted edge

### DIFF
--- a/packages/core/src/extract/calls/http.ts
+++ b/packages/core/src/extract/calls/http.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import Parser from 'tree-sitter'
 import JavaScript from 'tree-sitter-javascript'
 import Python from 'tree-sitter-python'
-import type { GraphEdge } from '@neat.is/types'
+import type { EdgeEvidence, GraphEdge } from '@neat.is/types'
 import {
   EdgeType,
   Provenance,
@@ -132,7 +132,14 @@ export async function addHttpCallEdges(
   let edgesAdded = 0
   for (const service of services) {
     const files = await loadSourceFiles(service.dir)
-    const seenTargets = new Map<string, { file: string; host: string }>()
+    // targetId → every distinct call site that reaches it. The first site is
+    // the representative (keeps `evidence.file`/`line` byte-identical to the
+    // pre-#396 first-write-wins behaviour, which retire.ts keys on); the rest
+    // used to be dropped and are now preserved per ADR-087 / #396.
+    const sitesByTarget = new Map<
+      string,
+      { sites: EdgeEvidence[]; keys: Set<string> }
+    >()
     for (const file of files) {
       // ADR-065 #1 — test-scope exclusion.
       if (isTestPath(file.path)) continue
@@ -147,25 +154,32 @@ export async function addHttpCallEdges(
       for (const t of targets) {
         const targetId = hostToNodeId.get(t)
         if (!targetId || targetId === service.node.id) continue
-        if (!seenTargets.has(targetId)) {
-          seenTargets.set(targetId, { file: file.path, host: t })
+        const line = lineOf(file.content, `//${t}`)
+        const ev: EdgeEvidence = {
+          file: path.relative(service.dir, file.path),
+          line,
+          snippet: snippet(file.content, line),
+        }
+        let entry = sitesByTarget.get(targetId)
+        if (!entry) {
+          entry = { sites: [], keys: new Set() }
+          sitesByTarget.set(targetId, entry)
+        }
+        const key = `${ev.file}|${ev.line ?? ''}`
+        if (!entry.keys.has(key)) {
+          entry.keys.add(key)
+          entry.sites.push(ev)
         }
       }
     }
-    for (const [targetId, evidenceFile] of seenTargets) {
-      const fileContent = files.find((f) => f.path === evidenceFile.file)?.content ?? ''
-      const line = lineOf(fileContent, `//${evidenceFile.host}`)
+    for (const [targetId, entry] of sitesByTarget) {
       // URL-string match against a registered service hostname is the
       // hostname-shape tier per ADR-066 — structurally tight (urlMatchesHost
       // requires scheme + exact hostname) but no framework-aware recognizer
       // confirms the call. Drops below the default precision floor (0.7) and
       // never enters the graph unless the floor is lowered for diagnostics.
       const confidence = confidenceForExtracted('hostname-shape-match')
-      const ev = {
-        file: path.relative(service.dir, evidenceFile.file),
-        line,
-        snippet: snippet(fileContent, line),
-      }
+      const rep = entry.sites[0]!
       const edgeId = makeEdgeId(service.node.id, targetId, EdgeType.CALLS)
       if (!passesExtractedFloor(confidence)) {
         noteExtractedDropped({
@@ -174,10 +188,14 @@ export async function addHttpCallEdges(
           type: EdgeType.CALLS,
           confidence,
           confidenceKind: 'hostname-shape-match',
-          evidence: ev,
+          evidence: rep,
         })
         continue
       }
+      // `sites` only when more than one origin backs the edge, so a
+      // single-site edge is unchanged from before #396.
+      const evidence: EdgeEvidence =
+        entry.sites.length > 1 ? { ...rep, sites: entry.sites } : rep
       const edge: GraphEdge = {
         id: edgeId,
         source: service.node.id,
@@ -185,7 +203,7 @@ export async function addHttpCallEdges(
         type: EdgeType.CALLS,
         provenance: Provenance.EXTRACTED,
         confidence,
-        evidence: ev,
+        evidence,
       }
       if (!graph.hasEdge(edge.id)) {
         graph.addEdgeWithKey(edge.id, edge.source, edge.target, edge)

--- a/packages/core/src/extract/calls/index.ts
+++ b/packages/core/src/extract/calls/index.ts
@@ -1,4 +1,4 @@
-import type { GraphEdge, InfraNode } from '@neat.is/types'
+import type { EdgeEvidence, GraphEdge, InfraNode } from '@neat.is/types'
 import {
   EdgeType,
   NodeType,
@@ -74,7 +74,20 @@ async function addExternalEndpointEdges(
     }
     if (endpoints.length === 0) continue
 
-    const seenEdges = new Set<string>()
+    // Group every endpoint by the edge it implies, keeping each distinct
+    // (file, line) call site instead of the first-write-wins collapse that
+    // used to drop the rest (ADR-087 / #396). The same target called from
+    // several files produces several endpoints; they all belong to one edge
+    // and each contributes a call site. `rep` is the first site seen, which
+    // keeps the representative `evidence.file`/`line` byte-identical to the
+    // pre-#396 behaviour (retire.ts keys ghost-edge cleanup on it).
+    interface EdgeAgg {
+      ep: ExternalEndpoint
+      edgeType: (typeof EdgeType)[keyof typeof EdgeType]
+      sites: EdgeEvidence[]
+      siteKeys: Set<string>
+    }
+    const byEdge = new Map<string, EdgeAgg>()
     for (const ep of endpoints) {
       if (!graph.hasNode(ep.infraId)) {
         const node: InfraNode = {
@@ -93,31 +106,48 @@ async function addExternalEndpointEdges(
 
       const edgeType = edgeTypeFromEndpoint(ep)
       const edgeId = makeEdgeId(service.node.id, ep.infraId, edgeType)
-      if (seenEdges.has(edgeId)) continue
-      seenEdges.add(edgeId)
-      const confidence = confidenceForExtracted(ep.confidenceKind)
+      let agg = byEdge.get(edgeId)
+      if (!agg) {
+        agg = { ep, edgeType, sites: [], siteKeys: new Set() }
+        byEdge.set(edgeId, agg)
+      }
+      const key = `${ep.evidence.file}|${ep.evidence.line ?? ''}`
+      if (!agg.siteKeys.has(key)) {
+        agg.siteKeys.add(key)
+        agg.sites.push(ep.evidence)
+      }
+    }
+
+    for (const [edgeId, agg] of byEdge) {
+      const confidence = confidenceForExtracted(agg.ep.confidenceKind)
+      const rep = agg.sites[0]!
       // Precision floor (ADR-066 §3). Sub-threshold candidates are computed
       // but never added to the graph; the banner reports the drop count.
       if (!passesExtractedFloor(confidence)) {
         noteExtractedDropped({
           source: service.node.id,
-          target: ep.infraId,
-          type: edgeType,
+          target: agg.ep.infraId,
+          type: agg.edgeType,
           confidence,
-          confidenceKind: ep.confidenceKind,
-          evidence: ep.evidence,
+          confidenceKind: agg.ep.confidenceKind,
+          evidence: rep,
         })
         continue
       }
       if (!graph.hasEdge(edgeId)) {
+        // `sites` only when more than one origin backs the edge — a
+        // single-site edge stays exactly as it was before #396 (no `sites`
+        // field), so existing snapshots and #395's writes are unaffected.
+        const evidence: EdgeEvidence =
+          agg.sites.length > 1 ? { ...rep, sites: agg.sites } : rep
         const edge: GraphEdge = {
           id: edgeId,
           source: service.node.id,
-          target: ep.infraId,
-          type: edgeType,
+          target: agg.ep.infraId,
+          type: agg.edgeType,
           provenance: Provenance.EXTRACTED,
           confidence,
-          evidence: ep.evidence,
+          evidence,
         }
         graph.addEdgeWithKey(edgeId, edge.source, edge.target, edge)
         edgesAdded++

--- a/packages/core/src/extract/retire.ts
+++ b/packages/core/src/extract/retire.ts
@@ -4,20 +4,38 @@ import type { GraphEdge } from '@neat.is/types'
 import { Provenance } from '@neat.is/types'
 import type { NeatGraph } from '../graph.js'
 
-// Drop every EXTRACTED edge whose evidence.file matches the given path.
-// Called from watch.ts before re-running an extract phase, so the producer's
-// idempotent re-write recreates only the edges that still apply. Edges from
-// the deleted code stay deleted. See docs/contracts/static-extraction.md
-// §Ghost-edge cleanup. Mutation authority lives under extract/* per
-// ADR-030, so the dropEdge call must happen here, not in watch.ts.
+// Every file an EXTRACTED edge is backed by: the representative `evidence.file`
+// plus each call site in `evidence.sites` (ADR-087 / #396). A single-site edge
+// carries no `sites`, so this returns just the representative — identical to
+// the pre-#396 behaviour. A multi-site edge returns one entry per distinct
+// backing file.
+function evidenceFiles(edge: GraphEdge): string[] {
+  const files: string[] = []
+  const push = (f: string | undefined): void => {
+    if (f && !files.includes(f)) files.push(f)
+  }
+  push(edge.evidence?.file)
+  for (const site of edge.evidence?.sites ?? []) push(site.file)
+  return files
+}
+
+// Drop every EXTRACTED edge that is backed by the given path — its
+// representative `evidence.file` or any call site in `evidence.sites`. Called
+// from watch.ts before re-running an extract phase, so the producer's
+// idempotent re-write recreates only the edges that still apply (with their
+// surviving call sites). Edges from the deleted code stay deleted. Matching on
+// any backing site means a change to one file of a multi-site edge re-derives
+// the whole edge rather than leaving a stale site behind. See
+// docs/contracts/static-extraction.md §Ghost-edge cleanup. Mutation authority
+// lives under extract/* per ADR-030, so the dropEdge call must happen here,
+// not in watch.ts.
 export function retireEdgesByFile(graph: NeatGraph, file: string): number {
   const normalized = file.split('\\').join('/')
   const toDrop: string[] = []
   graph.forEachEdge((id, attrs) => {
     const edge = attrs as GraphEdge
     if (edge.provenance !== Provenance.EXTRACTED) return
-    if (!edge.evidence?.file) return
-    if (edge.evidence.file === normalized) toDrop.push(id)
+    if (evidenceFiles(edge).includes(normalized)) toDrop.push(id)
   })
   for (const id of toDrop) graph.dropEdge(id)
   return toDrop.length
@@ -46,18 +64,19 @@ export function retireExtractedEdgesByMissingFile(
 ): number {
   const toDrop: string[] = []
   const bases = [scanPath, ...serviceDirs]
+  const resolves = (file: string): boolean => {
+    if (path.isAbsolute(file)) return existsSync(file)
+    // Tolerant: the file is "present" if any base resolves it.
+    return bases.some((base) => existsSync(path.join(base, file)))
+  }
   graph.forEachEdge((id, attrs) => {
     const edge = attrs as GraphEdge
     if (edge.provenance !== Provenance.EXTRACTED) return
-    const evidenceFile = edge.evidence?.file
-    if (!evidenceFile) return
-    if (path.isAbsolute(evidenceFile)) {
-      if (!existsSync(evidenceFile)) toDrop.push(id)
-      return
-    }
-    // Tolerant: the file is "present" if any base resolves it.
-    const found = bases.some((base) => existsSync(path.join(base, evidenceFile)))
-    if (!found) toDrop.push(id)
+    const files = evidenceFiles(edge)
+    if (files.length === 0) return
+    // A multi-site edge survives as long as one backing file is still on
+    // disk; only drop when every call site has vanished.
+    if (!files.some(resolves)) toDrop.push(id)
   })
   for (const id of toDrop) graph.dropEdge(id)
   return toDrop.length

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -5733,6 +5733,182 @@ describe('Queued contracts (v0.2.1 leftovers — #141, #142, #145)', () => {
   it.todo('Drop unused graphology-traversal/-shortest-path deps (issue #145)')
 })
 
+// ──────────────────────────────────────────────────────────────────────────
+// ADR-087 / #396 — EXTRACTED file-grain. The CALLS-family producers used to
+// keep the first call site per service edge and drop the rest. They now
+// preserve every distinct (file, line) origin in `evidence.sites`, additively:
+// `evidence.file`/`line`/`snippet` stay as the representative site so
+// retire.ts and #395's single-evidence writes are unaffected, and `sites` is
+// attached only when more than one origin backs the edge.
+// ──────────────────────────────────────────────────────────────────────────
+describe('EXTRACTED file-grain — multi-call-site retention (ADR-087 / #396)', () => {
+  it('keeps every call site when one target is reached from several files', async () => {
+    const { extractFromDirectory } = await import('../../src/extract.js')
+    const fs2 = await import('node:fs/promises')
+    const os2 = await import('node:os')
+    const path2 = await import('node:path')
+
+    const root = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'adr-087-grain-'))
+    try {
+      await fs2.writeFile(
+        path2.join(root, 'package.json'),
+        JSON.stringify({ name: 'multi-site-svc', version: '1.0.0' }),
+      )
+      // Two files publish to the same Kafka topic. Kafka is graded
+      // verified-call-site (0.85), so the edge clears the default precision
+      // floor without lowering it.
+      const send = `await producer.send({ topic: 'orders', messages: [{ value: 'x' }] })`
+      await fs2.writeFile(path2.join(root, 'publish-a.js'), `async function a(producer) { ${send} }\nmodule.exports = { a }\n`)
+      await fs2.writeFile(path2.join(root, 'publish-b.js'), `async function b(producer) { ${send} }\nmodule.exports = { b }\n`)
+
+      const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+      await extractFromDirectory(g, root)
+
+      expect(g.hasNode('infra:kafka-topic:orders')).toBe(true)
+      const publishEdges: GraphEdge[] = []
+      g.forEachEdge((_id, attrs) => {
+        const e = attrs as GraphEdge
+        if (e.type === EdgeType.PUBLISHES_TO && e.target === 'infra:kafka-topic:orders') {
+          publishEdges.push(e)
+        }
+      })
+      // One edge — both files collapse to the single service→topic edge.
+      expect(publishEdges).toHaveLength(1)
+      const edge = publishEdges[0]!
+
+      // Every distinct call site is retained, not just the first.
+      const sites = edge.evidence?.sites
+      expect(sites).toBeDefined()
+      const siteFiles = sites!.map((s) => s.file).sort()
+      expect(siteFiles).toEqual(['publish-a.js', 'publish-b.js'])
+
+      // The representative evidence stays a real, single call site (the first),
+      // so consumers that read only `evidence.file` — including retire.ts —
+      // keep working.
+      expect(edge.evidence?.file).toBe(sites![0]!.file)
+      expect(GraphEdgeSchema.parse(edge)).toBeTruthy()
+    } finally {
+      await fs2.rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('leaves `sites` unset when a single call site backs the edge (back-compat)', async () => {
+    const { extractFromDirectory } = await import('../../src/extract.js')
+    const fs2 = await import('node:fs/promises')
+    const os2 = await import('node:os')
+    const path2 = await import('node:path')
+
+    const root = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'adr-087-single-'))
+    try {
+      await fs2.writeFile(
+        path2.join(root, 'package.json'),
+        JSON.stringify({ name: 'single-site-svc', version: '1.0.0' }),
+      )
+      await fs2.writeFile(
+        path2.join(root, 'publish.js'),
+        `async function a(producer) { await producer.send({ topic: 'orders', messages: [] }) }\nmodule.exports = { a }\n`,
+      )
+
+      const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+      await extractFromDirectory(g, root)
+
+      let edge: GraphEdge | undefined
+      g.forEachEdge((_id, attrs) => {
+        const e = attrs as GraphEdge
+        if (e.type === EdgeType.PUBLISHES_TO && e.target === 'infra:kafka-topic:orders') edge = e
+      })
+      expect(edge).toBeDefined()
+      expect(edge!.evidence?.file).toBe('publish.js')
+      // No multi-site array on a single-origin edge — byte-identical to pre-#396.
+      expect(edge!.evidence?.sites).toBeUndefined()
+    } finally {
+      await fs2.rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('retireEdgesByFile drops a multi-site edge when any backing file changes', async () => {
+    const { retireEdgesByFile } = await import('../../src/extract/retire.js')
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:a', { id: 'service:a', type: NodeType.ServiceNode, name: 'a', language: 'javascript' })
+    g.addNode('infra:kafka-topic:orders', { id: 'infra:kafka-topic:orders', type: NodeType.InfraNode, name: 'orders', kind: 'kafka-topic', provider: 'self' })
+
+    const multiId = 'PUBLISHES_TO:service:a->infra:kafka-topic:orders'
+    g.addEdgeWithKey(multiId, 'service:a', 'infra:kafka-topic:orders', {
+      id: multiId,
+      source: 'service:a',
+      target: 'infra:kafka-topic:orders',
+      type: EdgeType.PUBLISHES_TO,
+      provenance: Provenance.EXTRACTED,
+      evidence: {
+        file: 'publish-a.js',
+        line: 1,
+        sites: [
+          { file: 'publish-a.js', line: 1 },
+          { file: 'publish-b.js', line: 1 },
+        ],
+      },
+    })
+
+    // The changed file is the second site, not the representative `evidence.file`.
+    // The edge still retires so the producer re-derives its surviving sites.
+    const dropped = retireEdgesByFile(g, 'publish-b.js')
+    expect(dropped).toBe(1)
+    expect(g.hasEdge(multiId)).toBe(false)
+  })
+
+  it('retireExtractedEdgesByMissingFile keeps a multi-site edge while one site survives', async () => {
+    const { retireExtractedEdgesByMissingFile } = await import('../../src/extract/retire.js')
+    const fs2 = await import('node:fs/promises')
+    const os2 = await import('node:os')
+    const path2 = await import('node:path')
+
+    const root = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'adr-087-missing-'))
+    try {
+      await fs2.writeFile(path2.join(root, 'present.js'), '// still here')
+      // absent.js is intentionally never created.
+
+      const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+      g.addNode('service:a', { id: 'service:a', type: NodeType.ServiceNode, name: 'a', language: 'javascript' })
+      g.addNode('infra:kafka-topic:orders', { id: 'infra:kafka-topic:orders', type: NodeType.InfraNode, name: 'orders', kind: 'kafka-topic', provider: 'self' })
+      g.addNode('infra:kafka-topic:gone', { id: 'infra:kafka-topic:gone', type: NodeType.InfraNode, name: 'gone', kind: 'kafka-topic', provider: 'self' })
+
+      const survivorId = 'PUBLISHES_TO:service:a->infra:kafka-topic:orders'
+      g.addEdgeWithKey(survivorId, 'service:a', 'infra:kafka-topic:orders', {
+        id: survivorId,
+        source: 'service:a',
+        target: 'infra:kafka-topic:orders',
+        type: EdgeType.PUBLISHES_TO,
+        provenance: Provenance.EXTRACTED,
+        evidence: {
+          file: 'absent.js',
+          sites: [{ file: 'absent.js' }, { file: 'present.js' }],
+        },
+      })
+
+      // Every backing site is gone — fully orphaned, must be dropped.
+      const ghostId = 'PUBLISHES_TO:service:a->infra:kafka-topic:gone'
+      g.addEdgeWithKey(ghostId, 'service:a', 'infra:kafka-topic:gone', {
+        id: ghostId,
+        source: 'service:a',
+        target: 'infra:kafka-topic:gone',
+        type: EdgeType.PUBLISHES_TO,
+        provenance: Provenance.EXTRACTED,
+        evidence: {
+          file: 'absent.js',
+          sites: [{ file: 'absent.js' }, { file: 'also-absent.js' }],
+        },
+      })
+
+      const dropped = retireExtractedEdgesByMissingFile(g, root)
+      expect(dropped).toBe(1)
+      expect(g.hasEdge(survivorId)).toBe(true)
+      expect(g.hasEdge(ghostId)).toBe(false)
+    } finally {
+      await fs2.rm(root, { recursive: true, force: true })
+    }
+  })
+})
+
 describe('CLI surface contract (ADR-050)', () => {
   // v0.2.8 #23. Nine `neat <verb>` commands mirroring the MCP allowlist.
   // Implementation lives in packages/core/src/cli.ts (dispatcher) +

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -101,6 +101,26 @@
                                 ]
                               }
                             },
+                            "sites": {
+                              "_optional": {
+                                "_array": {
+                                  "_object": {
+                                    "file": "_string",
+                                    "line": {
+                                      "_optional": {
+                                        "_number": [
+                                          "int",
+                                          "min"
+                                        ]
+                                      }
+                                    },
+                                    "snippet": {
+                                      "_optional": "_string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
                             "snippet": {
                               "_optional": "_string"
                             }
@@ -219,6 +239,26 @@
                                   "int",
                                   "min"
                                 ]
+                              }
+                            },
+                            "sites": {
+                              "_optional": {
+                                "_array": {
+                                  "_object": {
+                                    "file": "_string",
+                                    "line": {
+                                      "_optional": {
+                                        "_number": [
+                                          "int",
+                                          "min"
+                                        ]
+                                      }
+                                    },
+                                    "snippet": {
+                                      "_optional": "_string"
+                                    }
+                                  }
+                                }
                               }
                             },
                             "snippet": {
@@ -375,6 +415,26 @@
                                 ]
                               }
                             },
+                            "sites": {
+                              "_optional": {
+                                "_array": {
+                                  "_object": {
+                                    "file": "_string",
+                                    "line": {
+                                      "_optional": {
+                                        "_number": [
+                                          "int",
+                                          "min"
+                                        ]
+                                      }
+                                    },
+                                    "snippet": {
+                                      "_optional": "_string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
                             "snippet": {
                               "_optional": "_string"
                             }
@@ -526,6 +586,26 @@
                           ]
                         }
                       },
+                      "sites": {
+                        "_optional": {
+                          "_array": {
+                            "_object": {
+                              "file": "_string",
+                              "line": {
+                                "_optional": {
+                                  "_number": [
+                                    "int",
+                                    "min"
+                                  ]
+                                }
+                              },
+                              "snippet": {
+                                "_optional": "_string"
+                              }
+                            }
+                          }
+                        }
+                      },
                       "snippet": {
                         "_optional": "_string"
                       }
@@ -644,6 +724,26 @@
                             "int",
                             "min"
                           ]
+                        }
+                      },
+                      "sites": {
+                        "_optional": {
+                          "_array": {
+                            "_object": {
+                              "file": "_string",
+                              "line": {
+                                "_optional": {
+                                  "_number": [
+                                    "int",
+                                    "min"
+                                  ]
+                                }
+                              },
+                              "snippet": {
+                                "_optional": "_string"
+                              }
+                            }
+                          }
                         }
                       },
                       "snippet": {
@@ -798,6 +898,26 @@
                             "int",
                             "min"
                           ]
+                        }
+                      },
+                      "sites": {
+                        "_optional": {
+                          "_array": {
+                            "_object": {
+                              "file": "_string",
+                              "line": {
+                                "_optional": {
+                                  "_number": [
+                                    "int",
+                                    "min"
+                                  ]
+                                }
+                              },
+                              "snippet": {
+                                "_optional": "_string"
+                              }
+                            }
+                          }
                         }
                       },
                       "snippet": {
@@ -975,6 +1095,26 @@
                   "int",
                   "min"
                 ]
+              }
+            },
+            "sites": {
+              "_optional": {
+                "_array": {
+                  "_object": {
+                    "file": "_string",
+                    "line": {
+                      "_optional": {
+                        "_number": [
+                          "int",
+                          "min"
+                        ]
+                      }
+                    },
+                    "snippet": {
+                      "_optional": "_string"
+                    }
+                  }
+                }
               }
             },
             "snippet": {

--- a/packages/types/src/edges.ts
+++ b/packages/types/src/edges.ts
@@ -18,16 +18,38 @@ export const EdgeTypeSchema = z.enum([
   EdgeType.RUNS_ON,
 ])
 
+// One call-site origin for an EXTRACTED edge: file, plus optional line and
+// source snippet. Same shape as the representative evidence fields below —
+// `EdgeEvidence.sites` carries the full set when an edge is backed by more
+// than one call site (ADR-087 / #396).
+export const CallSiteSchema = z.object({
+  file: z.string(),
+  line: z.number().int().nonnegative().optional(),
+  snippet: z.string().optional(),
+})
+export type CallSite = z.infer<typeof CallSiteSchema>
+
 // Static-extraction evidence for an EXTRACTED edge (ADR-029, contract #5).
 // `file` is required — retire.ts keys ghost-edge cleanup off it. `line` and
 // `snippet` are optional because the existing extractors (configs.ts,
 // docker-compose.ts) record file-level evidence only; loosening lets those
 // edges through ADR-061's response-shape validation without forcing the
 // extractors to fabricate line numbers.
+//
+// ADR-087 / #396 — file-grain. A single EXTRACTED edge can be born from more
+// than one call site (the same target called from several files, or several
+// lines in one file). The CALLS-family producers used to keep the first site
+// and drop the rest; `sites` now carries every distinct origin.
+// `file`/`line`/`snippet` stay as the representative (first) site so
+// single-evidence consumers keep working: retire.ts keys ghost-edge cleanup
+// on `evidence.file`, and #395's single-evidence OBSERVED writes simply leave
+// `sites` unset. The field is optional and additive — an edge backed by
+// exactly one site may omit it. #393 (the file-native model) consumes `sites`.
 export const EdgeEvidenceSchema = z.object({
   file: z.string(),
   line: z.number().int().nonnegative().optional(),
   snippet: z.string().optional(),
+  sites: z.array(CallSiteSchema).optional(),
 })
 export type EdgeEvidence = z.infer<typeof EdgeEvidenceSchema>
 


### PR DESCRIPTION
Makes the EXTRACTED layer file-native at the source. The CALLS-family extractors recorded one evidence location per service edge — `http.ts`'s `seenTargets` and the orchestrator's `seenEdges` kept the first call site and dropped the rest. When a target is reached from several files, the discarded sites are where most of the relationship actually lives.

## What changed

- **`packages/types/src/edges.ts`** — `EdgeEvidenceSchema` gains an optional `sites` array, additively. The existing `file`/`line`/`snippet` stay as the *representative* (first) call site; `sites` carries every distinct origin. New `CallSiteSchema` describes one site (same `{ file, line?, snippet? }` shape).
- **`extract/calls/index.ts`** and **`extract/calls/http.ts`** — group call sites by the edge they imply and keep every distinct `(file, line)` origin instead of first-write-wins. The per-shape detectors (`aws`/`redis`/`grpc`/`kafka`) already emit per-file evidence; the collapse lived entirely in these two aggregation points.
- **`extract/retire.ts`** — ghost-edge cleanup now walks the full backing set (`evidence.file` + `evidence.sites[].file`). A change to any backing file re-derives the edge; a multi-site edge survives `retireExtractedEdgesByMissingFile` as long as one of its files is still on disk.
- Schema snapshot regenerated (ADR-031 growth path — additive optional field only).

## Evidence shape for #393

`#393` consumes this shape:

```ts
evidence: {
  file: string            // representative call site (first); retire.ts keys on this
  line?: number
  snippet?: string
  sites?: Array<{ file: string; line?: number; snippet?: string }>
}
```

- `sites` is **additive and optional**. It is present only when **more than one** distinct call site backs the edge. A single-site edge omits it entirely, so existing snapshots and #395's single-evidence OBSERVED writes are byte-identical to before.
- When present, `sites[0]` equals the representative `file`/`line`/`snippet`. Consumers that read only `evidence.file` keep working unchanged.
- `sites` entries are deduped by `(file, line)`.

## Scope held

- Config/infra extractors stay file-only (the database parsers read config files and carry a single `sourceFile`; not call-site grained).
- Edge identity (`makeEdgeId`) and ghost-edge retirement keying on `evidence.file` are preserved.

## Verification

`npx turbo build test lint` clean. New contract assertions in `contracts.test.ts` cover: multi-file retention into `evidence.sites`, single-site back-compat (no `sites` field), retire-on-any-site, and survive-while-one-site-exists.

Refs #396