### PR TITLE
Keep every distinct call site on EXTRACTED edges

### DIFF
--- a/packages/core/src/extract/calls/aws.ts
+++ b/packages/core/src/extract/calls/aws.ts
@@ -1,6 +1,13 @@
 import path from 'node:path'
 import { infraId } from '@neat.is/types'
-import { lineOf, snippet, type ExternalEndpoint, type SourceFile } from './shared.js'
+import {
+  lineAt,
+  lineOf,
+  mergeEndpointSite,
+  snippet,
+  type ExternalEndpoint,
+  type SourceFile,
+} from './shared.js'
 
 // AWS SDK v3 calls. We catch S3 (`Bucket: "x"` near a `S3Client`-using
 // PutObjectCommand / GetObjectCommand / DeleteObjectCommand) and DynamoDB
@@ -29,14 +36,21 @@ export function awsEndpointsFromFile(
   file: SourceFile,
   serviceDir: string,
 ): ExternalEndpoint[] {
-  const out: ExternalEndpoint[] = []
-  const seen = new Set<string>()
-  const make = (kind: string, name: string): void => {
+  const byKey = new Map<string, ExternalEndpoint>()
+  const rel = path.relative(serviceDir, file.path)
+  const make = (kind: string, name: string, index: number): void => {
     const key = `${kind}|${name}`
-    if (seen.has(key)) return
-    seen.add(key)
+    const existing = byKey.get(key)
+    if (existing) {
+      // Same bucket/table referenced again — keep it as a distinct call site
+      // (#396 / ADR-087). Line comes from this match's offset.
+      const line = lineAt(file.content, index)
+      mergeEndpointSite(existing, { file: rel, line, snippet: snippet(file.content, line) })
+      return
+    }
+    // Primary evidence keeps `lineOf` so single-site emissions stay identical.
     const line = lineOf(file.content, name)
-    out.push({
+    byKey.set(key, {
       infraId: infraId(kind, name),
       name,
       kind,
@@ -46,7 +60,7 @@ export function awsEndpointsFromFile(
       // (ADR-066).
       confidenceKind: 'verified-call-site',
       evidence: {
-        file: path.relative(serviceDir, file.path),
+        file: rel,
         line,
         snippet: snippet(file.content, line),
       },
@@ -54,7 +68,7 @@ export function awsEndpointsFromFile(
   }
 
   if (hasMarker(file.content, ['S3Client', 'PutObjectCommand', 'GetObjectCommand', 'DeleteObjectCommand'])) {
-    for (const { name } of findAll(S3_BUCKET_RE, file.content)) make('s3-bucket', name)
+    for (const { name, index } of findAll(S3_BUCKET_RE, file.content)) make('s3-bucket', name, index)
   }
   if (
     hasMarker(file.content, [
@@ -67,7 +81,7 @@ export function awsEndpointsFromFile(
       'DeleteCommand',
     ])
   ) {
-    for (const { name } of findAll(DYNAMO_TABLE_RE, file.content)) make('dynamodb-table', name)
+    for (const { name, index } of findAll(DYNAMO_TABLE_RE, file.content)) make('dynamodb-table', name, index)
   }
-  return out
+  return [...byKey.values()]
 }

--- a/packages/core/src/extract/calls/grpc.ts
+++ b/packages/core/src/extract/calls/grpc.ts
@@ -1,6 +1,13 @@
 import path from 'node:path'
 import { infraId } from '@neat.is/types'
-import { lineOf, snippet, type ExternalEndpoint, type SourceFile } from './shared.js'
+import {
+  lineAt,
+  lineOf,
+  mergeEndpointSite,
+  snippet,
+  type ExternalEndpoint,
+  type SourceFile,
+} from './shared.js'
 
 // Client-construction in JS/TS:
 //
@@ -77,8 +84,8 @@ export function grpcEndpointsFromFile(
   file: SourceFile,
   serviceDir: string,
 ): ExternalEndpoint[] {
-  const out: ExternalEndpoint[] = []
-  const seen = new Set<string>()
+  const byName = new Map<string, ExternalEndpoint>()
+  const rel = path.relative(serviceDir, file.path)
   const ctx = readImports(file.content)
   GRPC_CLIENT_RE.lastIndex = 0
   let m: RegExpExecArray | null
@@ -86,13 +93,20 @@ export function grpcEndpointsFromFile(
     const symbol = m[1]!
     const addr = m[2]?.trim()
     const name = isLikelyAddress(addr) ? addr! : symbol
-    if (seen.has(name)) continue
     const classified = classifyClient(symbol, ctx)
     if (!classified) continue
-    seen.add(name)
+    const existing = byName.get(name)
+    if (existing) {
+      // The same client constructed again — keep it as a distinct call site
+      // (#396 / ADR-087). Line comes from this `new …Client(` match.
+      const line = lineAt(file.content, m.index)
+      mergeEndpointSite(existing, { file: rel, line, snippet: snippet(file.content, line) })
+      continue
+    }
     const { kind } = classified
+    // Primary evidence keeps `lineOf` so single-site emissions stay identical.
     const line = lineOf(file.content, m[0])
-    out.push({
+    byName.set(name, {
       infraId: infraId(kind, name),
       name,
       kind,
@@ -102,11 +116,11 @@ export function grpcEndpointsFromFile(
       // tier (ADR-066).
       confidenceKind: 'verified-call-site',
       evidence: {
-        file: path.relative(serviceDir, file.path),
+        file: rel,
         line,
         snippet: snippet(file.content, line),
       },
     })
   }
-  return out
+  return [...byName.values()]
 }

--- a/packages/core/src/extract/calls/http.ts
+++ b/packages/core/src/extract/calls/http.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import Parser from 'tree-sitter'
 import JavaScript from 'tree-sitter-javascript'
 import Python from 'tree-sitter-python'
-import type { GraphEdge } from '@neat.is/types'
+import type { EdgeEvidence, GraphEdge } from '@neat.is/types'
 import {
   EdgeType,
   Provenance,
@@ -132,7 +132,10 @@ export async function addHttpCallEdges(
   let edgesAdded = 0
   for (const service of services) {
     const files = await loadSourceFiles(service.dir)
-    const seenTargets = new Map<string, { file: string; host: string }>()
+    // Every distinct call site per target instead of the first file only
+    // (#396 / ADR-087). Insertion order is file-walk order, so `sites[0]`
+    // stays the same primary evidence first-write-wins produced before.
+    const sitesByTarget = new Map<string, EdgeEvidence[]>()
     for (const file of files) {
       // ADR-065 #1 — test-scope exclusion.
       if (isTestPath(file.path)) continue
@@ -147,25 +150,32 @@ export async function addHttpCallEdges(
       for (const t of targets) {
         const targetId = hostToNodeId.get(t)
         if (!targetId || targetId === service.node.id) continue
-        if (!seenTargets.has(targetId)) {
-          seenTargets.set(targetId, { file: file.path, host: t })
+        // `callsFromSource` dedupes hosts per file, so each file contributes at
+        // most one site per target — the URL literal's line. `//${host}` is the
+        // scheme-relative form so this lands on the URL, matching the prior
+        // primary-evidence line computation exactly.
+        const line = lineOf(file.content, `//${t}`)
+        const ev: EdgeEvidence = {
+          file: path.relative(service.dir, file.path),
+          line,
+          snippet: snippet(file.content, line),
+        }
+        const sites = sitesByTarget.get(targetId)
+        if (sites) {
+          if (!sites.some((s) => s.file === ev.file && s.line === ev.line)) sites.push(ev)
+        } else {
+          sitesByTarget.set(targetId, [ev])
         }
       }
     }
-    for (const [targetId, evidenceFile] of seenTargets) {
-      const fileContent = files.find((f) => f.path === evidenceFile.file)?.content ?? ''
-      const line = lineOf(fileContent, `//${evidenceFile.host}`)
+    for (const [targetId, sites] of sitesByTarget) {
+      const ev = sites[0]!
       // URL-string match against a registered service hostname is the
       // hostname-shape tier per ADR-066 — structurally tight (urlMatchesHost
       // requires scheme + exact hostname) but no framework-aware recognizer
       // confirms the call. Drops below the default precision floor (0.7) and
       // never enters the graph unless the floor is lowered for diagnostics.
       const confidence = confidenceForExtracted('hostname-shape-match')
-      const ev = {
-        file: path.relative(service.dir, evidenceFile.file),
-        line,
-        snippet: snippet(fileContent, line),
-      }
       const edgeId = makeEdgeId(service.node.id, targetId, EdgeType.CALLS)
       if (!passesExtractedFloor(confidence)) {
         noteExtractedDropped({
@@ -186,6 +196,9 @@ export async function addHttpCallEdges(
         provenance: Provenance.EXTRACTED,
         confidence,
         evidence: ev,
+        // Only carry `sites` when there's more than one — single-site edges
+        // stay byte-identical to the prior shape.
+        ...(sites.length > 1 ? { sites } : {}),
       }
       if (!graph.hasEdge(edge.id)) {
         graph.addEdgeWithKey(edge.id, edge.source, edge.target, edge)

--- a/packages/core/src/extract/calls/index.ts
+++ b/packages/core/src/extract/calls/index.ts
@@ -1,4 +1,4 @@
-import type { GraphEdge, InfraNode } from '@neat.is/types'
+import type { EdgeEvidence, GraphEdge, InfraNode } from '@neat.is/types'
 import {
   EdgeType,
   NodeType,
@@ -74,7 +74,8 @@ async function addExternalEndpointEdges(
     }
     if (endpoints.length === 0) continue
 
-    const seenEdges = new Set<string>()
+    // Create the InfraNode for each distinct target (idempotent, first-wins on
+    // attributes — unchanged from before).
     for (const ep of endpoints) {
       if (!graph.hasNode(ep.infraId)) {
         const node: InfraNode = {
@@ -90,11 +91,31 @@ async function addExternalEndpointEdges(
         graph.addNode(node.id, node)
         nodesAdded++
       }
+    }
 
+    // Aggregate every distinct call site per service→target edge (#396 /
+    // ADR-087). The first endpoint for an edge sets the primary evidence and
+    // confidence (unchanged first-write-wins); later endpoints — from the same
+    // file or other files — contribute additional sites.
+    const byEdge = new Map<
+      string,
+      { ep: ExternalEndpoint; edgeType: (typeof EdgeType)[keyof typeof EdgeType]; sites: EdgeEvidence[] }
+    >()
+    for (const ep of endpoints) {
       const edgeType = edgeTypeFromEndpoint(ep)
       const edgeId = makeEdgeId(service.node.id, ep.infraId, edgeType)
-      if (seenEdges.has(edgeId)) continue
-      seenEdges.add(edgeId)
+      const epSites = ep.sites ?? [ep.evidence]
+      const acc = byEdge.get(edgeId)
+      if (acc) {
+        for (const s of epSites) {
+          if (!acc.sites.some((x) => x.file === s.file && x.line === s.line)) acc.sites.push(s)
+        }
+      } else {
+        byEdge.set(edgeId, { ep, edgeType, sites: [...epSites] })
+      }
+    }
+
+    for (const [edgeId, { ep, edgeType, sites }] of byEdge) {
       const confidence = confidenceForExtracted(ep.confidenceKind)
       // Precision floor (ADR-066 §3). Sub-threshold candidates are computed
       // but never added to the graph; the banner reports the drop count.
@@ -118,6 +139,9 @@ async function addExternalEndpointEdges(
           provenance: Provenance.EXTRACTED,
           confidence,
           evidence: ep.evidence,
+          // Only carry `sites` when there's more than one — single-site edges
+          // stay byte-identical to the prior shape.
+          ...(sites.length > 1 ? { sites } : {}),
         }
         graph.addEdgeWithKey(edgeId, edge.source, edge.target, edge)
         edgesAdded++

--- a/packages/core/src/extract/calls/kafka.ts
+++ b/packages/core/src/extract/calls/kafka.ts
@@ -1,6 +1,13 @@
 import path from 'node:path'
 import { infraId } from '@neat.is/types'
-import { lineOf, snippet, type ExternalEndpoint, type SourceFile } from './shared.js'
+import {
+  lineAt,
+  lineOf,
+  mergeEndpointSite,
+  snippet,
+  type ExternalEndpoint,
+  type SourceFile,
+} from './shared.js'
 
 // Match `producer.send({ topic: "orders" ... })` and `producer.send({
 // topic: 'orders' })` plus the two-arg form `producer.send("orders", ...)`.
@@ -25,14 +32,25 @@ export function kafkaEndpointsFromFile(
   file: SourceFile,
   serviceDir: string,
 ): ExternalEndpoint[] {
-  const out: ExternalEndpoint[] = []
-  const seen = new Set<string>()
-  const make = (topic: string, edgeType: 'PUBLISHES_TO' | 'CONSUMES_FROM'): void => {
+  const byKey = new Map<string, ExternalEndpoint>()
+  const rel = path.relative(serviceDir, file.path)
+  const make = (
+    topic: string,
+    edgeType: 'PUBLISHES_TO' | 'CONSUMES_FROM',
+    index: number,
+  ): void => {
     const key = `${edgeType}|${topic}`
-    if (seen.has(key)) return
-    seen.add(key)
+    const existing = byKey.get(key)
+    if (existing) {
+      // Same topic produced/consumed again from another statement — keep it as
+      // a distinct call site (#396 / ADR-087). Line comes from this match.
+      const line = lineAt(file.content, index)
+      mergeEndpointSite(existing, { file: rel, line, snippet: snippet(file.content, line) })
+      return
+    }
+    // Primary evidence keeps `lineOf` so single-site emissions stay identical.
     const line = lineOf(file.content, topic)
-    out.push({
+    byKey.set(key, {
       infraId: infraId('kafka-topic', topic),
       name: topic,
       kind: 'kafka-topic',
@@ -42,14 +60,16 @@ export function kafkaEndpointsFromFile(
       // tier (ADR-066).
       confidenceKind: 'verified-call-site',
       evidence: {
-        file: path.relative(serviceDir, file.path),
+        file: rel,
         line,
         snippet: snippet(file.content, line),
       },
     })
   }
 
-  for (const { topic } of findAll(PRODUCER_TOPIC_RE, file.content)) make(topic, 'PUBLISHES_TO')
-  for (const { topic } of findAll(CONSUMER_TOPIC_RE, file.content)) make(topic, 'CONSUMES_FROM')
-  return out
+  for (const { topic, index } of findAll(PRODUCER_TOPIC_RE, file.content))
+    make(topic, 'PUBLISHES_TO', index)
+  for (const { topic, index } of findAll(CONSUMER_TOPIC_RE, file.content))
+    make(topic, 'CONSUMES_FROM', index)
+  return [...byKey.values()]
 }

--- a/packages/core/src/extract/calls/redis.ts
+++ b/packages/core/src/extract/calls/redis.ts
@@ -1,6 +1,13 @@
 import path from 'node:path'
 import { infraId } from '@neat.is/types'
-import { lineOf, snippet, type ExternalEndpoint, type SourceFile } from './shared.js'
+import {
+  lineAt,
+  lineOf,
+  mergeEndpointSite,
+  snippet,
+  type ExternalEndpoint,
+  type SourceFile,
+} from './shared.js'
 
 // Redis URLs in source — `redis://host[:port]` or `rediss://...`. We only
 // catch literal strings; env-driven URLs go through the database parsers
@@ -11,16 +18,25 @@ export function redisEndpointsFromFile(
   file: SourceFile,
   serviceDir: string,
 ): ExternalEndpoint[] {
-  const out: ExternalEndpoint[] = []
-  const seen = new Set<string>()
+  const byHost = new Map<string, ExternalEndpoint>()
+  const rel = path.relative(serviceDir, file.path)
   REDIS_URL_RE.lastIndex = 0
   let m: RegExpExecArray | null
   while ((m = REDIS_URL_RE.exec(file.content)) !== null) {
     const host = m[1]!
-    if (seen.has(host)) continue
-    seen.add(host)
+    const existing = byHost.get(host)
+    if (existing) {
+      // Another `redis://host` literal for the same host — keep it as a
+      // distinct call site rather than dropping it (#396 / ADR-087). Line
+      // comes from this match's offset, not a first-occurrence search.
+      const line = lineAt(file.content, m.index)
+      mergeEndpointSite(existing, { file: rel, line, snippet: snippet(file.content, line) })
+      continue
+    }
+    // Primary evidence keeps `lineOf` so existing single-site emissions stay
+    // byte-identical.
     const line = lineOf(file.content, host)
-    out.push({
+    byHost.set(host, {
       infraId: infraId('redis', host),
       name: host,
       kind: 'redis',
@@ -30,11 +46,11 @@ export function redisEndpointsFromFile(
       // support tier (ADR-066).
       confidenceKind: 'url-with-structural-support',
       evidence: {
-        file: path.relative(serviceDir, file.path),
+        file: rel,
         line,
         snippet: snippet(file.content, line),
       },
     })
   }
-  return out
+  return [...byHost.values()]
 }

--- a/packages/core/src/extract/calls/shared.ts
+++ b/packages/core/src/extract/calls/shared.ts
@@ -17,10 +17,26 @@ export interface ExternalEndpoint {
   kind: string
   edgeType: 'CALLS' | 'PUBLISHES_TO' | 'CONSUMES_FROM'
   evidence: EdgeEvidence
+  // Every distinct call site within this file that produced the endpoint
+  // (#396 / ADR-087). Populated only when the same target is called from more
+  // than one line; `sites[0]` mirrors `evidence`. Left undefined for the
+  // common single-site case so the orchestrator can fall back to `[evidence]`.
+  sites?: EdgeEvidence[]
   // Confidence grade per ADR-066 — set by the per-shape detector. The
   // orchestrator (calls/index.ts) writes this onto the EXTRACTED edge and
   // applies the precision floor before adding the edge to the graph.
   confidenceKind: ExtractedConfidenceKind
+}
+
+// Append a distinct call site to an endpoint, lazily seeding the `sites` array
+// with the primary `evidence` on the first additional site (#396 / ADR-087).
+// Distinct means a unique file:line pair, so the same target hit twice on the
+// same line collapses to one site. Not named `addX` — that prefix is reserved
+// for producer entry points by the static-extraction contract.
+export function mergeEndpointSite(ep: ExternalEndpoint, site: EdgeEvidence): void {
+  if (!ep.sites) ep.sites = [ep.evidence]
+  if (ep.sites.some((s) => s.file === site.file && s.line === site.line)) return
+  ep.sites.push(site)
 }
 
 export async function walkSourceFiles(dir: string): Promise<string[]> {
@@ -63,6 +79,14 @@ export function lineOf(text: string, needle: string): number {
   const idx = text.indexOf(needle)
   if (idx < 0) return 1
   return text.slice(0, idx).split('\n').length
+}
+
+// Line (1-indexed) of a known character offset into `text`. Used for the
+// second-and-later call sites of a target, where `lineOf`'s first-occurrence
+// search would keep pointing back at the first site (#396 / ADR-087).
+export function lineAt(text: string, index: number): number {
+  if (index < 0) return 1
+  return text.slice(0, index).split('\n').length
 }
 
 export function snippet(text: string, line: number): string {

--- a/packages/core/src/extract/databases/index.ts
+++ b/packages/core/src/extract/databases/index.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import type {
   CompatibleDriver,
   DatabaseNode,
+  EdgeEvidence,
   GraphEdge,
   GraphNode,
   ServiceNode,
@@ -192,6 +193,14 @@ export async function addDatabasesAndCompat(
 
   for (const service of services) {
     const merged = new Map<string, DbConfig>()
+    // Every distinct config file that points at a given host, in parser /
+    // discovery order (#396 / ADR-087). The host's canonical config still
+    // comes from `merged` (first-wins), but each file it was declared in is
+    // kept as a CONNECTS_TO site. File-only evidence — config/infra stay
+    // line-less per the file-awareness contract.
+    const sitesByHost = new Map<string, EdgeEvidence[]>()
+    const relSource = (config: DbConfig): string =>
+      path.relative(scanPath, config.sourceFile).split(path.sep).join('/')
     for (const parser of DB_PARSERS) {
       let configs: DbConfig[]
       try {
@@ -205,6 +214,13 @@ export async function addDatabasesAndCompat(
       for (const config of configs) {
         if (!config.host) continue
         if (!merged.has(config.host)) merged.set(config.host, config)
+        const file = relSource(config)
+        const sites = sitesByHost.get(config.host)
+        if (sites) {
+          if (!sites.some((s) => s.file === file)) sites.push({ file })
+        } else {
+          sitesByHost.set(config.host, [{ file }])
+        }
       }
     }
 
@@ -229,6 +245,7 @@ export async function addDatabasesAndCompat(
       }
       // DB connection from a parsed config file is a direct AST/file fact —
       // structural tier per ADR-066.
+      const sites = sitesByHost.get(config.host) ?? []
       const edge: GraphEdge = {
         id: makeEdgeId(service.node.id, dbNode.id, EdgeType.CONNECTS_TO),
         source: service.node.id,
@@ -240,8 +257,13 @@ export async function addDatabasesAndCompat(
         // Ghost-edge cleanup keys retirement on this; the conditional
         // sourceFile spread that used to live here was a v0.1.x leftover.
         evidence: {
-          file: path.relative(scanPath, config.sourceFile).split(path.sep).join('/'),
+          file: relSource(config),
         },
+        // #396 / ADR-087 — when the same host is declared in more than one
+        // config file, keep each as a distinct site. `sites[0]` mirrors
+        // `evidence` (both come from the first-wins config). Single-file hosts
+        // stay byte-identical with no `sites` key.
+        ...(sites.length > 1 ? { sites } : {}),
       }
       if (!graph.hasEdge(edge.id)) {
         graph.addEdgeWithKey(edge.id, edge.source, edge.target, edge)

--- a/packages/core/test/audits/extracted-sites.test.ts
+++ b/packages/core/test/audits/extracted-sites.test.ts
@@ -1,0 +1,245 @@
+/**
+ * #396 / ADR-087 — EXTRACTED edges keep every distinct call site.
+ *
+ * Before this, the call extractors collapsed a multi-call-site relationship to
+ * the first site per target (`http.ts` `seenTargets`, the per-file `seen` sets
+ * in kafka/redis/aws/grpc, the cross-file `seenEdges` in calls/index.ts, and
+ * the host merge in databases/index.ts all dropped later sites). Now each edge
+ * keeps a `sites` array of every distinct site, with `evidence` (and
+ * `sites[0]`) staying the first/primary site so single-evidence consumers and
+ * retire.ts are unaffected.
+ *
+ * The contract: a multi-call-site edge retains all sites; a single-site edge
+ * carries no `sites` key (byte-identical to the prior shape); identity and
+ * retirement still key on `evidence.file`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { MultiDirectedGraph } from 'graphology'
+import type { GraphEdge, GraphNode } from '@neat.is/types'
+import { extractedEdgeId } from '@neat.is/types'
+import type { NeatGraph } from '../../src/graph.js'
+import { extractFromDirectory } from '../../src/extract.js'
+import { kafkaEndpointsFromFile } from '../../src/extract/calls/kafka.js'
+import { redisEndpointsFromFile } from '../../src/extract/calls/redis.js'
+import { awsEndpointsFromFile } from '../../src/extract/calls/aws.js'
+import { grpcEndpointsFromFile } from '../../src/extract/calls/grpc.js'
+import type { SourceFile } from '../../src/extract/calls/shared.js'
+
+const SVC = '/svc'
+const file = (content: string): SourceFile => ({ path: path.join(SVC, 'index.js'), content })
+
+describe('#396 — per-file extractors keep distinct call sites', () => {
+  it('kafka: the same topic published twice keeps both sites', () => {
+    const eps = kafkaEndpointsFromFile(
+      file(
+        [
+          "const producer = kafka.producer()",
+          "producer.send({ topic: 'orders', messages: [] })",
+          "// later, somewhere else in the file",
+          "producer.send({ topic: 'orders', messages: [] })",
+        ].join('\n'),
+      ),
+      SVC,
+    )
+    expect(eps).toHaveLength(1)
+    const ep = eps[0]!
+    expect(ep.infraId).toBe('infra:kafka-topic:orders')
+    expect(ep.sites).toBeDefined()
+    expect(ep.sites).toHaveLength(2)
+    // sites[0] mirrors the primary evidence.
+    expect(ep.sites![0]).toEqual(ep.evidence)
+    // Two distinct lines, both pointing at the same file.
+    expect(ep.sites![0]!.line).not.toBe(ep.sites![1]!.line)
+    expect(ep.sites!.every((s) => s.file === 'index.js')).toBe(true)
+  })
+
+  it('kafka: a single publish carries no sites array', () => {
+    const eps = kafkaEndpointsFromFile(
+      file("const producer = kafka.producer()\nproducer.send({ topic: 'orders' })"),
+      SVC,
+    )
+    expect(eps).toHaveLength(1)
+    expect(eps[0]!.sites).toBeUndefined()
+    expect(eps[0]!.evidence.file).toBe('index.js')
+  })
+
+  it('redis: two redis:// literals for one host keep both sites', () => {
+    const eps = redisEndpointsFromFile(
+      file(
+        [
+          "const a = createClient({ url: 'redis://cache.internal:6379' })",
+          "const b = createClient({ url: 'redis://cache.internal:6379' })",
+        ].join('\n'),
+      ),
+      SVC,
+    )
+    expect(eps).toHaveLength(1)
+    expect(eps[0]!.infraId).toBe('infra:redis:cache.internal')
+    expect(eps[0]!.sites).toHaveLength(2)
+    expect(eps[0]!.sites![0]).toEqual(eps[0]!.evidence)
+    expect(eps[0]!.sites![0]!.line).not.toBe(eps[0]!.sites![1]!.line)
+  })
+
+  it('aws: one bucket referenced twice keeps both sites', () => {
+    const eps = awsEndpointsFromFile(
+      file(
+        [
+          "const s3 = new S3Client({})",
+          "await s3.send(new PutObjectCommand({ Bucket: 'invoices', Key: 'a' }))",
+          "await s3.send(new GetObjectCommand({ Bucket: 'invoices', Key: 'b' }))",
+        ].join('\n'),
+      ),
+      SVC,
+    )
+    const bucket = eps.find((e) => e.infraId === 'infra:s3-bucket:invoices')
+    expect(bucket).toBeDefined()
+    expect(bucket!.sites).toHaveLength(2)
+    expect(bucket!.sites![0]).toEqual(bucket!.evidence)
+  })
+
+  it('grpc: one client constructed twice keeps both sites', () => {
+    const eps = grpcEndpointsFromFile(
+      file(
+        [
+          "const grpc = require('@grpc/grpc-js')",
+          "const a = new OrderServiceClient('orders.internal:50051')",
+          "const b = new OrderServiceClient('orders.internal:50051')",
+        ].join('\n'),
+      ),
+      SVC,
+    )
+    expect(eps).toHaveLength(1)
+    expect(eps[0]!.kind).toBe('grpc-service')
+    expect(eps[0]!.sites).toHaveLength(2)
+    expect(eps[0]!.sites![0]).toEqual(eps[0]!.evidence)
+  })
+})
+
+function newGraph(): NeatGraph {
+  return new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+}
+
+async function writeFile(dir: string, rel: string, content: string): Promise<void> {
+  const abs = path.join(dir, rel)
+  await fs.mkdir(path.dirname(abs), { recursive: true })
+  await fs.writeFile(abs, content, 'utf8')
+}
+
+describe('#396 — extraction aggregates distinct sites across files', () => {
+  let tmp: string
+  // hostname-shape (http) and url-with-structural-support (redis) edges sit
+  // below the default precision floor; drop it so this test exercises full
+  // recall, matching calls.test.ts.
+  let prevFloor: string | undefined
+
+  beforeAll(() => {
+    prevFloor = process.env.NEAT_EXTRACTED_PRECISION_FLOOR
+    process.env.NEAT_EXTRACTED_PRECISION_FLOOR = '0'
+  })
+  afterAll(() => {
+    if (prevFloor === undefined) delete process.env.NEAT_EXTRACTED_PRECISION_FLOOR
+    else process.env.NEAT_EXTRACTED_PRECISION_FLOOR = prevFloor
+  })
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-sites-'))
+  })
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true })
+  })
+
+  it('http: a target called from two files keeps a site per file', async () => {
+    await writeFile(tmp, 'alpha/package.json', JSON.stringify({ name: 'fixture-alpha-sites' }))
+    await writeFile(tmp, 'alpha/a.js', "fetch('http://beta/orders')\n")
+    await writeFile(tmp, 'alpha/b.js', "fetch('http://beta/refunds')\n")
+    await writeFile(tmp, 'beta/package.json', JSON.stringify({ name: 'fixture-beta-sites' }))
+    await writeFile(tmp, 'beta/index.js', 'module.exports = {}\n')
+
+    const graph = newGraph()
+    await extractFromDirectory(graph, tmp)
+
+    const edgeId = extractedEdgeId('service:fixture-alpha-sites', 'service:fixture-beta-sites', 'CALLS')
+    expect(graph.hasEdge(edgeId)).toBe(true)
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.sites).toBeDefined()
+    expect(edge.sites!.map((s) => s.file).sort()).toEqual(['a.js', 'b.js'])
+    // Primary evidence stays the first site.
+    expect(edge.sites![0]).toEqual(edge.evidence)
+  })
+
+  it('kafka: a topic published from two files aggregates into one edge with both sites', async () => {
+    await writeFile(tmp, 'pkg/package.json', JSON.stringify({ name: 'fixture-kafka-sites' }))
+    await writeFile(
+      tmp,
+      'pkg/publish-a.js',
+      "const producer = kafka.producer()\nproducer.send({ topic: 'orders' })\n",
+    )
+    await writeFile(
+      tmp,
+      'pkg/publish-b.js',
+      "const producer = kafka.producer()\nproducer.send({ topic: 'orders' })\n",
+    )
+
+    const graph = newGraph()
+    await extractFromDirectory(graph, tmp)
+
+    const edgeId = extractedEdgeId(
+      'service:fixture-kafka-sites',
+      'infra:kafka-topic:orders',
+      'PUBLISHES_TO',
+    )
+    expect(graph.hasEdge(edgeId)).toBe(true)
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.sites).toBeDefined()
+    expect(edge.sites!.map((s) => s.file).sort()).toEqual(['publish-a.js', 'publish-b.js'])
+    expect(edge.sites![0]).toEqual(edge.evidence)
+  })
+
+  it('db: a host declared in two config files keeps a CONNECTS_TO site per file', async () => {
+    await writeFile(tmp, 'pkg/package.json', JSON.stringify({ name: 'fixture-db-sites' }))
+    await writeFile(tmp, 'pkg/.env', 'DATABASE_URL=postgres://pgdb:5432/app\n')
+    await writeFile(
+      tmp,
+      'pkg/ormconfig.json',
+      JSON.stringify({ type: 'postgres', host: 'pgdb', database: 'app' }),
+    )
+
+    const graph = newGraph()
+    await extractFromDirectory(graph, tmp)
+
+    const edgeId = extractedEdgeId('service:fixture-db-sites', 'database:pgdb', 'CONNECTS_TO')
+    expect(graph.hasEdge(edgeId)).toBe(true)
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.sites).toBeDefined()
+    expect(edge.sites!.map((s) => s.file).sort()).toEqual(['pkg/.env', 'pkg/ormconfig.json'])
+    // Identity / retirement still key on evidence.file, which mirrors sites[0].
+    expect(edge.sites![0]).toEqual(edge.evidence)
+    expect(edge.evidence!.file).toBe('pkg/.env')
+  })
+
+  it('single-site edge carries no sites key (back-compat with single-evidence consumers)', async () => {
+    await writeFile(tmp, 'pkg/package.json', JSON.stringify({ name: 'fixture-single-site' }))
+    await writeFile(
+      tmp,
+      'pkg/index.js',
+      "const producer = kafka.producer()\nproducer.send({ topic: 'orders' })\n",
+    )
+
+    const graph = newGraph()
+    await extractFromDirectory(graph, tmp)
+
+    const edgeId = extractedEdgeId(
+      'service:fixture-single-site',
+      'infra:kafka-topic:orders',
+      'PUBLISHES_TO',
+    )
+    expect(graph.hasEdge(edgeId)).toBe(true)
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.sites).toBeUndefined()
+    expect(edge.evidence?.file).toBe('index.js')
+  })
+})

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -148,6 +148,26 @@
                           }
                         }
                       },
+                      "sites": {
+                        "_optional": {
+                          "_array": {
+                            "_object": {
+                              "file": "_string",
+                              "line": {
+                                "_optional": {
+                                  "_number": [
+                                    "int",
+                                    "min"
+                                  ]
+                                }
+                              },
+                              "snippet": {
+                                "_optional": "_string"
+                              }
+                            }
+                          }
+                        }
+                      },
                       "source": "_string",
                       "target": "_string",
                       "type": {
@@ -264,6 +284,26 @@
                                 "int",
                                 "min"
                               ]
+                            }
+                          }
+                        }
+                      },
+                      "sites": {
+                        "_optional": {
+                          "_array": {
+                            "_object": {
+                              "file": "_string",
+                              "line": {
+                                "_optional": {
+                                  "_number": [
+                                    "int",
+                                    "min"
+                                  ]
+                                }
+                              },
+                              "snippet": {
+                                "_optional": "_string"
+                              }
                             }
                           }
                         }
@@ -422,6 +462,26 @@
                           }
                         }
                       },
+                      "sites": {
+                        "_optional": {
+                          "_array": {
+                            "_object": {
+                              "file": "_string",
+                              "line": {
+                                "_optional": {
+                                  "_number": [
+                                    "int",
+                                    "min"
+                                  ]
+                                }
+                              },
+                              "snippet": {
+                                "_optional": "_string"
+                              }
+                            }
+                          }
+                        }
+                      },
                       "source": "_string",
                       "target": "_string",
                       "type": {
@@ -573,6 +633,26 @@
                     }
                   }
                 },
+                "sites": {
+                  "_optional": {
+                    "_array": {
+                      "_object": {
+                        "file": "_string",
+                        "line": {
+                          "_optional": {
+                            "_number": [
+                              "int",
+                              "min"
+                            ]
+                          }
+                        },
+                        "snippet": {
+                          "_optional": "_string"
+                        }
+                      }
+                    }
+                  }
+                },
                 "source": "_string",
                 "target": "_string",
                 "type": {
@@ -689,6 +769,26 @@
                           "int",
                           "min"
                         ]
+                      }
+                    }
+                  }
+                },
+                "sites": {
+                  "_optional": {
+                    "_array": {
+                      "_object": {
+                        "file": "_string",
+                        "line": {
+                          "_optional": {
+                            "_number": [
+                              "int",
+                              "min"
+                            ]
+                          }
+                        },
+                        "snippet": {
+                          "_optional": "_string"
+                        }
                       }
                     }
                   }
@@ -843,6 +943,26 @@
                           "int",
                           "min"
                         ]
+                      }
+                    }
+                  }
+                },
+                "sites": {
+                  "_optional": {
+                    "_array": {
+                      "_object": {
+                        "file": "_string",
+                        "line": {
+                          "_optional": {
+                            "_number": [
+                              "int",
+                              "min"
+                            ]
+                          }
+                        },
+                        "snippet": {
+                          "_optional": "_string"
+                        }
                       }
                     }
                   }
@@ -1020,6 +1140,26 @@
                 "int",
                 "min"
               ]
+            }
+          }
+        }
+      },
+      "sites": {
+        "_optional": {
+          "_array": {
+            "_object": {
+              "file": "_string",
+              "line": {
+                "_optional": {
+                  "_number": [
+                    "int",
+                    "min"
+                  ]
+                }
+              },
+              "snippet": {
+                "_optional": "_string"
+              }
             }
           }
         }

--- a/packages/types/src/edges.ts
+++ b/packages/types/src/edges.ts
@@ -57,6 +57,15 @@ export const GraphEdgeSchema = z.object({
   lastObserved: z.string().datetime().optional(),
   callCount: z.number().int().nonnegative().optional(),
   evidence: EdgeEvidenceSchema.optional(),
+  // #396 / ADR-087 — a single service→target edge can be born at several call
+  // sites. `evidence` keeps the first/primary site so retire.ts (which keys
+  // ghost-edge cleanup on `evidence.file`) and every single-evidence consumer
+  // read it exactly as before. `sites` additively lists every distinct site
+  // the edge was extracted from, with `sites[0]` mirroring `evidence`. It's
+  // only written when there's more than one site, so single-site edges and
+  // older snapshots stay byte-identical; sibling #395's single-evidence writes
+  // are unaffected.
+  sites: z.array(EdgeEvidenceSchema).optional(),
   signal: EdgeSignalSchema.optional(),
 })
 export type GraphEdge = z.infer<typeof GraphEdgeSchema>


### PR DESCRIPTION
EXTRACTED edges collapsed a relationship to its first call site per target. `http.ts` kept the first file, the per-file dedup in `kafka`/`redis`/`aws`/`grpc` kept the first line, `calls/index.ts` kept the first endpoint across files, and the DB host merge kept the first config file. Now each edge carries a `sites` array of every distinct `file:line` it was extracted from.

`evidence` stays the first/primary site, so `retire.ts` (which keys ghost-edge cleanup on `evidence.file`) and every single-evidence consumer read it exactly as before — sibling #395's single-evidence writes included. `sites` is written only when there's more than one site, so single-site edges stay byte-identical to the prior shape.

`sites` is an additive optional array on `GraphEdgeSchema` (schema growth per ADR-031); the schema snapshot is regenerated in the same commit. Config/infra stay file-only, edge identity and retirement are unchanged.

This is the EXTRACTED half of ADR-087 / the file-awareness contract.

## Tests
`packages/core/test/audits/extracted-sites.test.ts`:
- per-file extractors (kafka/redis/aws/grpc) keep both sites when a target is hit twice; a single hit carries no `sites`
- http keeps a site per file across two callers
- kafka aggregates two files into one edge with both sites
- a DB host declared in two config files keeps a CONNECTS_TO site per file
- single-site edges carry no `sites` key (back-compat), and `sites[0]` always mirrors `evidence`

Refs #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)