### PR TITLE
Restyle the dashboard to the marketing identity, add service→file drill-down

### DIFF
--- a/packages/web/app/components/AppShell.tsx
+++ b/packages/web/app/components/AppShell.tsx
@@ -42,6 +42,11 @@ export function AppShell() {
   useAuthGate()
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
   const [graphData, setGraphData] = useState<GraphData | null>(null)
+  // file-awareness §2/§3 — drill-down navigates by the grouping. `expanded`
+  // is the set of service ids the operator has opened to reveal their files
+  // via CONTAINS. Empty = top view (all services collapsed). AppShell owns it
+  // so the canvas and the breadcrumb share one source of truth.
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
   // ADR-057 #2 — start with URL or localStorage (synchronous), then resolve
   // against /projects on mount if neither was set. Safe because AppShell
   // mounts client-only via dynamic({ ssr: false }) in app/page.tsx (ADR-062).
@@ -94,6 +99,26 @@ export function AppShell() {
     if (nodeId) setSelectedNodeId(nodeId)
   }, [])
 
+  // Drill into a service: reveal its files via CONTAINS. Drill back out:
+  // collapse it. Navigation by the grouping — never a rollup.
+  function expandService(serviceId: string): void {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      next.add(serviceId)
+      return next
+    })
+  }
+  function collapseService(serviceId: string): void {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      next.delete(serviceId)
+      return next
+    })
+  }
+  function collapseAll(): void {
+    setExpanded(new Set())
+  }
+
   // ADR-058 #4 — Ctrl+Shift+D / Cmd+Shift+D toggles the debug panel.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -122,8 +147,18 @@ export function AppShell() {
         onNodeSelect={setSelectedNodeId}
         onGraphLoaded={setGraphData}
         onCyReady={(cy) => { cyRef.current = cy }}
+        expanded={expanded}
+        onExpandService={expandService}
+        onCollapseService={collapseService}
+        onCollapseAll={collapseAll}
       />
-      <Inspector project={project} selectedNodeId={selectedNodeId} graphData={graphData} />
+      <Inspector
+        project={project}
+        selectedNodeId={selectedNodeId}
+        graphData={graphData}
+        onNodeSelect={setSelectedNodeId}
+        onExpandService={expandService}
+      />
       <StatusBar project={project} graphData={graphData} />
       <Toaster />
       {debugOpen && <DebugPanel project={project} onClose={() => setDebugOpen(false)} />}

--- a/packages/web/app/components/DebugPanel.tsx
+++ b/packages/web/app/components/DebugPanel.tsx
@@ -47,38 +47,39 @@ export function DebugPanel({ project, onClose }: DebugPanelProps) {
       aria-label="Debug panel"
       style={{
         position: 'fixed',
-        top: 60,
-        right: 16,
+        top: 72,
+        right: 20,
         width: 420,
         maxHeight: '70vh',
         overflow: 'auto',
-        background: 'var(--ink-2, #14141a)',
-        border: '1px solid var(--rule, #2a2a30)',
-        color: 'var(--paper-1, #d8d3c9)',
-        fontFamily: 'JetBrains Mono, monospace',
+        background: 'var(--bg, #000)',
+        border: '1px solid var(--rule, #333)',
+        color: 'var(--fg, #fff)',
+        fontFamily: 'var(--font-mono, monospace)',
         fontSize: 11,
-        padding: 12,
+        letterSpacing: '0.02em',
+        padding: 16,
         zIndex: 1000,
-        boxShadow: '0 16px 40px rgba(0,0,0,0.45)',
+        boxShadow: '0 16px 40px rgba(0,0,0,0.6)',
       }}
     >
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 8 }}>
-        <strong style={{ fontFamily: 'Spectral, serif', fontStyle: 'italic' }}>NEAT debug</strong>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 14 }}>
+        <strong style={{ fontFamily: 'var(--font-mono, monospace)', fontWeight: 400, fontSize: '0.62rem', letterSpacing: '0.14em', textTransform: 'uppercase', color: 'var(--fg-muted)' }}>NEAT debug</strong>
         <button onClick={onClose} aria-label="Close debug panel" title="Close (Ctrl+Shift+D)" style={{ background: 'transparent', border: 'none', color: 'inherit', cursor: 'pointer', fontSize: 14 }}>×</button>
       </div>
 
-      <section style={{ marginBottom: 10 }}>
-        <div style={{ color: 'var(--paper-3)', marginBottom: 4 }}>environment</div>
+      <section style={{ marginBottom: 14 }}>
+        <div style={{ color: 'var(--fg-muted)', marginBottom: 6, fontSize: '0.55rem', letterSpacing: '0.14em', textTransform: 'uppercase' }}>environment</div>
         <div>project: <code>{project}</code></div>
         <div>NEAT_API_URL: <code>{CORE_URL_PUBLIC}</code></div>
       </section>
 
       <section style={{ marginBottom: 10 }}>
-        <div style={{ color: 'var(--paper-3)', marginBottom: 4 }}>last {calls.length} api calls</div>
+        <div style={{ color: 'var(--fg-muted)', marginBottom: 6, fontSize: '0.55rem', letterSpacing: '0.14em', textTransform: 'uppercase' }}>last {calls.length} api calls</div>
         {calls.length === 0 && <div style={{ opacity: 0.5 }}>none yet</div>}
         {calls.map((c, i) => (
           <div key={i} style={{ display: 'flex', gap: 8, lineHeight: 1.5 }}>
-            <span style={{ width: 36, color: c.status >= 400 ? '#e87a7a' : c.status === 0 ? '#d3a847' : 'var(--paper-2)' }}>{c.status || '—'}</span>
+            <span style={{ width: 36, color: c.status >= 400 ? '#e08a8a' : c.status === 0 ? 'var(--fg-muted)' : 'var(--fg)' }}>{c.status || '—'}</span>
             <span style={{ width: 50, opacity: 0.6 }}>{c.durationMs}ms</span>
             <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.path}</span>
           </div>
@@ -86,7 +87,7 @@ export function DebugPanel({ project, onClose }: DebugPanelProps) {
       </section>
 
       <section style={{ marginBottom: 10 }}>
-        <div style={{ color: 'var(--paper-3)', marginBottom: 4 }}>last {sseEvents.length} sse events</div>
+        <div style={{ color: 'var(--fg-muted)', marginBottom: 6, fontSize: '0.55rem', letterSpacing: '0.14em', textTransform: 'uppercase' }}>last {sseEvents.length} sse events</div>
         {sseEvents.length === 0 && <div style={{ opacity: 0.5 }}>none yet</div>}
         {sseEvents.map((e, i) => (
           <div key={i} style={{ display: 'flex', gap: 8 }}>
@@ -97,7 +98,7 @@ export function DebugPanel({ project, onClose }: DebugPanelProps) {
       </section>
 
       <section>
-        <div style={{ color: 'var(--paper-3)', marginBottom: 4 }}>heartbeats</div>
+        <div style={{ color: 'var(--fg-muted)', marginBottom: 6, fontSize: '0.55rem', letterSpacing: '0.14em', textTransform: 'uppercase' }}>heartbeats</div>
         {heartbeats.length === 0 && <div style={{ opacity: 0.5 }}>none yet</div>}
         {heartbeats.map((h, i) => (
           <div key={i} style={{ display: 'flex', gap: 8 }}>

--- a/packages/web/app/components/GraphCanvas.tsx
+++ b/packages/web/app/components/GraphCanvas.tsx
@@ -1,12 +1,16 @@
 'use client'
 
-import { useEffect, useRef, useCallback } from 'react'
+import { useEffect, useRef, useCallback, useState } from 'react'
 import type { GraphNode, GraphEdge } from '@neat.is/types'
 import type { GraphData } from './AppShell'
 import { authedFetch, authedEventSourceUrl } from '../../lib/authed-fetch'
+import { buildModel, visibleGraph, type FileFirstModel } from './graph-model'
+import { GLYPH_LEGEND } from './glyphs'
 
-// Map NEAT node types to design visual types
+// Map NEAT node types to design visual types. FileNode is the primary node of
+// the file-first graph and gets its own square shape.
 function visualType(node: GraphNode): string {
+  if (node.type === 'FileNode') return 'file'
   if (node.type === 'ServiceNode') return 'service'
   if (node.type === 'DatabaseNode') return 'db'
   if (node.type === 'ConfigNode') return 'storage'
@@ -34,7 +38,16 @@ function edgeVerb(type: string): string {
   return type.toLowerCase().replace(/_/g, ' ')
 }
 
-const COMPOUND_TYPES = new Set(['cloud', 'env', 'vpc', 'cluster', 'namespace'])
+// A FileNode's display label is its basename — the full service-relative path
+// lives in the Inspector. Keeps the canvas legible when a service expands.
+function nodeLabel(node: GraphNode): string {
+  if (node.type === 'FileNode') {
+    const p = (node as { path?: string }).path ?? node.id
+    const parts = p.split('/')
+    return parts[parts.length - 1] || p
+  }
+  return (node as { name?: string }).name ?? node.id
+}
 
 interface GraphCanvasProps {
   project: string
@@ -42,17 +55,40 @@ interface GraphCanvasProps {
   onNodeSelect: (id: string) => void
   onGraphLoaded: (data: GraphData) => void
   onCyReady?: (cy: unknown) => void
+  // file-awareness §2/§3 drill state, owned by AppShell
+  expanded: Set<string>
+  onExpandService: (id: string) => void
+  onCollapseService: (id: string) => void
+  onCollapseAll: () => void
 }
 
-export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoaded, onCyReady }: GraphCanvasProps) {
+export function GraphCanvas({
+  project,
+  selectedNodeId,
+  onNodeSelect,
+  onGraphLoaded,
+  onCyReady,
+  expanded,
+  onExpandService,
+  onCollapseService,
+  onCollapseAll,
+}: GraphCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const minimapCanvasRef = useRef<HTMLCanvasElement>(null)
   const minimapFrameRef = useRef<HTMLDivElement>(null)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const cyRef = useRef<any>(null)
   const provFilterRef = useRef<Set<string>>(new Set())
-  const metaRef = useRef({ nodeCount: 0, edgeCount: 0 })
   const sseRef = useRef<EventSource | null>(null)
+  // the full file-first graph as last loaded — drill state recomputes the
+  // visible subset off this without re-fetching.
+  const fullRef = useRef<GraphData>({ nodes: [], edges: [] })
+  const modelRef = useRef<FileFirstModel | null>(null)
+  const expandedRef = useRef(expanded)
+  expandedRef.current = expanded
+
+  // breadcrumb of expanded services, in insertion order (for the in-canvas nav)
+  const [crumbs, setCrumbs] = useState<{ id: string; name: string }[]>([])
 
   const drawMinimap = useCallback(() => {
     const cy = cyRef.current
@@ -83,14 +119,13 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
     cy.edges().forEach((e: { source: () => { position: () => { x: number; y: number } }; target: () => { position: () => { x: number; y: number } }; data: (k: string) => string }) => {
       const a = e.source().position()
       const b = e.target().position()
-      ctx.strokeStyle = e.data('_color') + '55'
+      ctx.strokeStyle = (e.data('_color') || '#888') + '55'
       ctx.beginPath()
       ctx.moveTo(a.x * s + ox, a.y * s + oy)
       ctx.lineTo(b.x * s + ox, b.y * s + oy)
       ctx.stroke()
     })
     cy.nodes().forEach((n: { data: (k: string) => string | boolean; position: () => { x: number; y: number } }) => {
-      if (n.data('_isCompound')) return
       const p = n.position()
       ctx.fillStyle = (n.data('_color') as string) || '#888'
       ctx.beginPath()
@@ -109,6 +144,209 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
     mmFrame.style.height = Math.min(rect.height - Math.max(0, fy), fh) + 'px'
   }, [])
 
+  // Cytoscape style — shapes carry node kind, line treatment carries
+  // provenance. Monochrome on black; the glyph shape, not hue, draws kinds
+  // apart, matching the marketing legend.
+  const buildStyle = useCallback(() => {
+    const cssVar = (name: string) =>
+      getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+    const fg = cssVar('--fg') || '#fff'
+    const muted = cssVar('--fg-muted') || '#888'
+    const rule = cssVar('--rule') || '#333'
+    const observed = cssVar('--prov-observed') || '#5fcf9e'
+    return [
+      {
+        selector: 'node',
+        style: {
+          'background-color': 'data(_color)',
+          'background-opacity': 1,
+          shape: 'data(_shape)',
+          width: 'data(_size)',
+          height: 'data(_size)',
+          label: 'data(label)',
+          'text-valign': 'bottom',
+          'text-halign': 'center',
+          'text-margin-y': 7,
+          'font-family': 'DM Mono, monospace',
+          'font-size': 9,
+          color: muted,
+          'text-outline-width': 2,
+          'text-outline-color': '#000',
+          'border-width': 1,
+          'border-color': '#000',
+          'min-zoomed-font-size': 7,
+        },
+      },
+      // service container — outline hexagon-ish rounded rect, drawn as a
+      // collapsed grouping the operator opens. Larger, hollow, labelled above.
+      {
+        selector: 'node.t-service',
+        style: {
+          'background-color': '#000',
+          'background-opacity': 1,
+          'border-color': muted,
+          'border-width': 1.4,
+          shape: 'round-rectangle',
+          width: 46,
+          height: 46,
+          color: fg,
+          'font-size': 10,
+        },
+      },
+      { selector: 'node.t-service.expanded', style: { 'border-color': fg, 'border-style': 'dashed' } },
+      // file — the primary node, filled white square
+      {
+        selector: 'node.t-file',
+        style: { 'background-color': fg, shape: 'rectangle', width: 16, height: 16, color: fg },
+      },
+      { selector: 'node.t-db',       style: { 'background-color': muted, shape: 'ellipse', width: 26, height: 26 } },
+      { selector: 'node.t-storage',  style: { 'background-color': '#000', 'border-color': muted, 'border-width': 1.2, shape: 'rectangle', width: 22, height: 16 } },
+      { selector: 'node.t-external', style: { 'background-color': '#000', 'border-color': muted, 'border-width': 1, 'border-style': 'dashed', shape: 'pentagon', width: 26, height: 26 } },
+      { selector: 'node.t-compute',  style: { 'background-color': muted, shape: 'diamond', width: 24, height: 24 } },
+      { selector: 'node.t-cluster, node.t-namespace, node.t-vpc', style: { 'background-color': '#000', 'border-color': rule, 'border-width': 1, shape: 'triangle', width: 26, height: 26 } },
+      {
+        selector: 'node:selected',
+        style: {
+          'border-color': fg,
+          'border-width': 2,
+          color: fg,
+          'z-index': 999,
+        },
+      },
+      { selector: '.dim', style: { opacity: 0.16 } },
+      { selector: 'edge.dim', style: { opacity: 0.06 } },
+      { selector: 'node.hl, edge.hl', style: { opacity: 1 } },
+      { selector: 'edge.hl', style: { width: 1.8, opacity: 1 } },
+      {
+        selector: 'edge',
+        style: {
+          'curve-style': 'bezier',
+          'control-point-step-size': 32,
+          'line-color': 'data(_color)',
+          'line-style': 'data(_style)',
+          width: 'data(_width)',
+          opacity: 'data(_opacity)',
+          'target-arrow-shape': 'triangle',
+          'target-arrow-color': 'data(_color)',
+          'arrow-scale': 0.7,
+          'font-family': 'DM Mono, monospace',
+          'font-size': 7,
+          color: muted,
+          'text-rotation': 'autorotate',
+          'text-background-color': '#000',
+          'text-background-opacity': 1,
+          'text-background-padding': 2,
+        },
+      },
+      { selector: 'edge[type]', style: { label: 'data(type)', 'min-zoomed-font-size': 13 } },
+      // observed gets the live accent on its arrow
+      { selector: 'edge.p-OBSERVED', style: { 'line-color': observed, 'target-arrow-color': observed } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any
+  }, [])
+
+  // Translate a node/edge into a cytoscape element. Shapes + colors come from
+  // the marketing palette via CSS vars resolved in buildStyle's selectors;
+  // here we only need the per-element data the style binds to.
+  const nodeElement = useCallback((n: GraphNode) => {
+    const vt = visualType(n)
+    const cssVar = (name: string) => getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+    const colorVar = vt === 'file' ? '--n-file' : vt === 'service' ? '--n-service' : `--n-${vt}`
+    const color = cssVar(colorVar) || cssVar('--fg-muted') || '#888'
+    return {
+      data: {
+        id: n.id,
+        label: nodeLabel(n),
+        type: vt,
+        _color: color,
+        _shape: 'ellipse',
+        _size: 24,
+        _nodeType: n.type,
+        _raw: n,
+      },
+      classes: `t-${vt}`,
+    }
+  }, [])
+
+  const edgeElement = useCallback((e: GraphEdge & { _origSource?: string; _origTarget?: string }) => {
+    const vp = visualProv(e.provenance)
+    const cssVar = (name: string) => getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+    const color = vp === 'OBSERVED' ? (cssVar('--prov-observed') || '#5fcf9e') : (cssVar('--fg-muted') || '#888')
+    return {
+      data: {
+        id: e.id,
+        source: e.source,
+        target: e.target,
+        type: edgeVerb(e.type),
+        provenance: vp,
+        confidence: e.confidence,
+        _color: color,
+        _width: vp === 'OBSERVED' ? 1.4 : vp === 'INFERRED' ? 1 : 1.2,
+        _style: vp === 'INFERRED' ? 'dotted' : vp === 'OBSERVED' ? 'dashed' : 'solid',
+        _opacity: vp === 'INFERRED' ? 0.5 : vp === 'OBSERVED' ? 0.9 : 0.7,
+      },
+      classes: `p-${vp}`,
+    }
+  }, [])
+
+  // Recompute the visible cytoscape elements from the full graph + drill
+  // state. Called on load, on drill in/out, and on SSE updates. Never rolls
+  // file edges into service edges (file-awareness §3) — visibleGraph keeps
+  // every rendered edge file-grained, re-anchoring a hidden file's endpoint
+  // onto its collapsed-service container without summarizing.
+  const rerender = useCallback((animate: boolean) => {
+    const cy = cyRef.current
+    const model = modelRef.current
+    if (!cy || !model) return
+    const full = fullRef.current
+    const vis = visibleGraph(full.nodes, full.edges, model, expandedRef.current)
+
+    cy.elements().remove()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const els: any[] = []
+    for (const n of vis.nodes) {
+      const el = nodeElement(n)
+      if (n.type === 'ServiceNode' && expandedRef.current.has(n.id)) {
+        el.classes += ' expanded'
+      }
+      els.push(el)
+    }
+    for (const e of vis.edges) els.push(edgeElement(e))
+    cy.add(els)
+
+    cy.layout({
+      name: 'cose',
+      animate,
+      randomize: !animate,
+      idealEdgeLength: 90,
+      nodeRepulsion: 9000,
+      edgeElasticity: 80,
+      gravity: 0.4,
+      numIter: animate ? 1000 : 2000,
+      componentSpacing: 110,
+      padding: 40,
+      fit: true,
+    }).run()
+
+    // refresh canvas meta tag
+    const metaEl = document.querySelector('.canvas-tag .meta')
+    if (metaEl) {
+      const fileCount = vis.nodes.filter((n) => n.type === 'FileNode').length
+      const svcCount = vis.nodes.filter((n) => n.type === 'ServiceNode').length
+      metaEl.textContent = `${svcCount} services · ${fileCount} files · ${vis.edges.length} edges`
+    }
+    // refresh provenance counts (off the full graph so they don't jump while drilling)
+    const counts: Record<string, number> = { STATIC: 0, OBSERVED: 0, INFERRED: 0 }
+    full.edges.forEach((e) => {
+      if (e.type === 'CONTAINS') return
+      counts[visualProv(e.provenance)] += 1
+    })
+    const set = (id: string, v: number) => { const el = document.getElementById(id); if (el) el.textContent = String(v) }
+    set('ct-static', counts.STATIC)
+    set('ct-observed', counts.OBSERVED)
+    set('ct-inferred', counts.INFERRED)
+  }, [nodeElement, edgeElement])
+
   // Pan + select node when selectedNodeId is set from outside (search, URL, incidents link)
   useEffect(() => {
     const cy = cyRef.current
@@ -121,11 +359,23 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
     }
   }, [selectedNodeId])
 
+  // React to drill-state changes by recomputing the visible subset.
+  useEffect(() => {
+    const model = modelRef.current
+    if (!model) return
+    rerender(true)
+    setCrumbs(
+      [...expanded].map((id) => {
+        const n = model.byId.get(id) as { name?: string } | undefined
+        return { id, name: n?.name ?? id.replace(/^service:/, '') }
+      }),
+    )
+  }, [expanded, rerender])
+
   useEffect(() => {
     let destroyed = false
 
     async function init() {
-      // Dynamic import avoids SSR issues
       const cytoscape = (await import('cytoscape')).default
 
       // ADR-057 #5 — every API call carries the active project.
@@ -134,220 +384,36 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
       const data: GraphData = await res.json()
       if (destroyed) return
 
+      fullRef.current = data
+      modelRef.current = buildModel(data.nodes, data.edges)
+      // Inspector consumes the full file-first graph so file→target detail and
+      // service→files are both available regardless of what the canvas shows.
       onGraphLoaded(data)
-      metaRef.current = { nodeCount: data.nodes.length, edgeCount: data.edges.length }
-
-      const cssVar = (name: string) =>
-        getComputedStyle(document.documentElement).getPropertyValue(name).trim()
-
-      const TYPE_STYLE: Record<string, { color: string; shape: string; size?: number }> = {
-        service:   { color: cssVar('--n-service'),   shape: 'round-rectangle', size: 32 },
-        db:        { color: cssVar('--n-db'),         shape: 'barrel',          size: 34 },
-        cache:     { color: cssVar('--n-cache'),      shape: 'barrel',          size: 28 },
-        stream:    { color: cssVar('--n-stream'),     shape: 'cut-rectangle',   size: 32 },
-        queue:     { color: cssVar('--n-queue'),      shape: 'cut-rectangle',   size: 28 },
-        lambda:    { color: cssVar('--n-lambda'),     shape: 'diamond',         size: 30 },
-        cron:      { color: cssVar('--n-cron'),       shape: 'tag',             size: 26 },
-        api:       { color: cssVar('--n-api'),        shape: 'round-rectangle', size: 22 },
-        apigw:     { color: cssVar('--n-apigw'),      shape: 'round-rectangle', size: 36 },
-        compute:   { color: cssVar('--n-compute'),    shape: 'round-rectangle', size: 32 },
-        storage:   { color: cssVar('--n-storage'),    shape: 'round-tag',       size: 28 },
-        external:  { color: cssVar('--n-external'),   shape: 'round-octagon',   size: 30 },
-        search:    { color: cssVar('--n-search'),     shape: 'barrel',          size: 28 },
-        cluster:   { color: cssVar('--n-cluster'),    shape: 'round-rectangle' },
-        namespace: { color: cssVar('--n-namespace'),  shape: 'round-rectangle' },
-        vpc:       { color: cssVar('--n-vpc'),        shape: 'round-rectangle' },
-        env:       { color: cssVar('--n-env'),        shape: 'round-rectangle' },
-        cloud:     { color: cssVar('--ink-3'),        shape: 'round-rectangle' },
-      }
-
-      const provColor: Record<string, string> = {
-        STATIC:   cssVar('--prov-static'),
-        OBSERVED: cssVar('--prov-observed'),
-        INFERRED: cssVar('--prov-inferred'),
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const elements: any[] = []
-      data.nodes.forEach((n: GraphNode) => {
-        const vt = visualType(n)
-        const ts = TYPE_STYLE[vt] ?? { color: '#888', shape: 'ellipse', size: 24 }
-        elements.push({
-          data: {
-            id: n.id,
-            label: (n as { name?: string }).name ?? n.id,
-            type: vt,
-            _color: ts.color,
-            _shape: ts.shape,
-            _size: ts.size ?? 28,
-            _isCompound: COMPOUND_TYPES.has(vt),
-            _nodeType: n.type,
-            _raw: n,
-          },
-          classes: `t-${vt} ${COMPOUND_TYPES.has(vt) ? 'compound' : 'leaf'}`,
-        })
-      })
-
-      data.edges.forEach((e: GraphEdge) => {
-        const vp = visualProv(e.provenance)
-        const color = provColor[vp] ?? '#888'
-        elements.push({
-          data: {
-            id: e.id,
-            source: e.source,
-            target: e.target,
-            type: edgeVerb(e.type),
-            provenance: vp,
-            confidence: e.confidence,
-            _color: color,
-            _width: vp === 'INFERRED' ? 1 : vp === 'OBSERVED' ? 1.4 : 1.2,
-            _style: vp === 'INFERRED' ? 'dotted' : vp === 'OBSERVED' ? 'dashed' : 'solid',
-            _opacity: vp === 'INFERRED' ? 0.55 : vp === 'OBSERVED' ? 0.85 : 0.75,
-          },
-        })
-      })
 
       const cy = cytoscape({
         container: containerRef.current,
-        elements,
+        elements: [],
         minZoom: 0.001,
         maxZoom: 50,
         wheelSensitivity: 0.25,
         autoungrabify: true,
         autounselectify: false,
         boxSelectionEnabled: false,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        style: ([
-          {
-            selector: 'node.compound',
-            style: {
-              'background-color': 'data(_color)',
-              'background-opacity': 0.35,
-              'border-width': 1,
-              'border-color': '#2a2a30',
-              'border-style': 'solid',
-              shape: 'round-rectangle',
-              'corner-radius': '4',
-              label: 'data(label)',
-              'text-valign': 'top',
-              'text-halign': 'left',
-              'text-margin-x': 8,
-              'text-margin-y': 4,
-              'font-family': 'JetBrains Mono, monospace',
-              'font-size': 10.5,
-              color: '#9b968c',
-              padding: '24px',
-              'text-transform': 'lowercase',
-            },
-          },
-          { selector: 'node.t-cloud',     style: { 'background-opacity': 0.18, padding: '32px', 'font-size': 11.5, color: '#d8d3c9' } },
-          { selector: 'node.t-env',       style: { 'background-opacity': 0.3,  padding: '28px', 'font-size': 11,   color: '#d8d3c9' } },
-          { selector: 'node.t-vpc',       style: { 'background-opacity': 0.4,  padding: '22px', 'font-size': 10.5 } },
-          { selector: 'node.t-cluster',   style: { 'background-opacity': 0.55, padding: '20px' } },
-          { selector: 'node.t-namespace', style: { 'background-opacity': 0.65, padding: '16px' } },
-          {
-            selector: 'node.leaf',
-            style: {
-              'background-color': 'data(_color)',
-              'background-opacity': 0.92,
-              shape: 'data(_shape)',
-              width: 'data(_size)',
-              height: 'data(_size)',
-              label: 'data(label)',
-              'text-valign': 'bottom',
-              'text-halign': 'center',
-              'text-margin-y': 5,
-              'font-family': 'JetBrains Mono, monospace',
-              'font-size': 9.5,
-              color: '#d8d3c9',
-              'text-outline-width': 2,
-              'text-outline-color': '#0a0a0b',
-              'border-width': 1,
-              'border-color': '#0a0a0b',
-              'min-zoomed-font-size': 7,
-            },
-          },
-          { selector: 'node.t-api',      style: { width: 8,  height: 8,  'font-size': 8.5, color: '#9b968c' } },
-          { selector: 'node.t-cron',     style: { width: 18, height: 14 } },
-          { selector: 'node.t-external', style: { 'background-opacity': 0.7, 'border-color': '#46443f', 'border-width': 1, 'border-style': 'dashed', color: '#9b968c' } },
-          { selector: 'node.t-lambda',   style: { width: 22, height: 22 } },
-          { selector: 'node.t-queue',    style: { width: 20, height: 20 } },
-          {
-            selector: 'node:selected',
-            style: {
-              'border-color': cssVar('--accent'),
-              'border-width': 2,
-              'background-opacity': 1,
-              color: '#f4efe6',
-              'font-weight': 600,
-              'z-index': 999,
-            },
-          },
-          { selector: '.dim',      style: { opacity: 0.18 } },
-          { selector: 'edge.dim', style: { opacity: 0.08 } },
-          { selector: 'node.hl, edge.hl', style: { opacity: 1 } },
-          { selector: 'edge.hl',  style: { width: 'mapData(_width, 0, 2, 1.6, 2.4)', opacity: 1 } },
-          {
-            selector: 'edge',
-            style: {
-              'curve-style': 'bezier',
-              'control-point-step-size': 30,
-              'line-color': 'data(_color)',
-              'line-style': 'data(_style)',
-              width: 'data(_width)',
-              opacity: 'data(_opacity)',
-              'target-arrow-shape': 'triangle-backcurve',
-              'target-arrow-color': 'data(_color)',
-              'arrow-scale': 0.85,
-              'font-family': 'JetBrains Mono, monospace',
-              'font-size': 8,
-              color: '#6a675f',
-              'text-rotation': 'autorotate',
-              'text-background-color': '#0a0a0b',
-              'text-background-opacity': 1,
-              'text-background-padding': 2,
-            },
-          },
-          { selector: 'edge[type]', style: { label: 'data(type)', 'min-zoomed-font-size': 11 } },
-          { selector: 'node.t-apigw', style: { shape: 'round-rectangle', width: 36, height: 22, 'font-size': 9 } },
-        ] as any),
-        layout: {
-          name: 'cose',
-          animate: false,
-          randomize: true,
-          idealEdgeLength: 90,
-          nodeRepulsion: 9000,
-          edgeElasticity: 80,
-          gravity: 0.4,
-          numIter: 2200,
-          nestingFactor: 1.4,
-          componentSpacing: 100,
-          padding: 30,
-          fit: true,
-        },
+        style: buildStyle(),
       })
 
       cyRef.current = cy
       onCyReady?.(cy)
 
-      // Update legend counts
-      const counts: Record<string, number> = { STATIC: 0, OBSERVED: 0, INFERRED: 0 }
-      data.edges.forEach((e) => {
-        const vp = visualProv(e.provenance)
-        counts[vp] = (counts[vp] ?? 0) + 1
-      })
-      const ctStatic = document.getElementById('ct-static')
-      const ctObserved = document.getElementById('ct-observed')
-      const ctInferred = document.getElementById('ct-inferred')
-      if (ctStatic) ctStatic.textContent = String(counts.STATIC)
-      if (ctObserved) ctObserved.textContent = String(counts.OBSERVED)
-      if (ctInferred) ctInferred.textContent = String(counts.INFERRED)
+      // Render the initial (collapsed) view.
+      rerender(false)
+      setCrumbs(
+        [...expandedRef.current].map((id) => {
+          const n = modelRef.current?.byId.get(id) as { name?: string } | undefined
+          return { id, name: n?.name ?? id.replace(/^service:/, '') }
+        }),
+      )
 
-      // Update canvas tag
-      const metaEl = document.querySelector('.canvas-tag .meta')
-      if (metaEl) metaEl.textContent = `live · ${data.nodes.length} nodes · ${data.edges.length} edges · cose layout`
-
-      // Selection handler
       function focusNode(id: string) {
         cy.elements().removeClass('hl dim')
         const n = cy.getElementById(id)
@@ -358,10 +424,20 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
         onNodeSelect(id)
       }
 
+      // Single tap selects + inspects.
       cy.on('tap', 'node', (evt: { target: { id: () => string; select: () => void } }) => {
         cy.$(':selected').unselect()
         evt.target.select()
         focusNode(evt.target.id())
+      })
+      // Double tap on a service drills in (or out if already expanded) —
+      // navigation by the grouping. Non-service nodes ignore the gesture.
+      cy.on('dbltap', 'node', (evt: { target: { id: () => string; data: (k: string) => string } }) => {
+        const id = evt.target.id()
+        const nodeType = evt.target.data('_nodeType')
+        if (nodeType !== 'ServiceNode') return
+        if (expandedRef.current.has(id)) onCollapseService(id)
+        else onExpandService(id)
       })
       cy.on('tap', (evt: { target: unknown }) => {
         if (evt.target === cy) {
@@ -370,18 +446,11 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
         }
       })
 
-      // Initial layout + selection
       cy.ready(() => {
         setTimeout(() => {
-          cy.fit(undefined, 40)
+          cy.fit(undefined, 50)
           if (cy.zoom() < 0.25) {
             cy.zoom({ level: 0.45, renderedPosition: { x: cy.width() / 2, y: cy.height() / 2 } })
-          }
-          // Select first service node if available
-          const first = cy.nodes('.leaf').first()
-          if (first && first.length) {
-            first.select()
-            focusNode(first.id())
           }
           drawMinimap()
         }, 80)
@@ -407,7 +476,6 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
         cyEl.addEventListener('wheel', wheelHandler, { passive: false, capture: true })
       }
 
-      // Minimap updates
       cy.on('viewport zoom pan render', () => requestAnimationFrame(drawMinimap))
       window.addEventListener('resize', () => requestAnimationFrame(drawMinimap))
 
@@ -428,7 +496,6 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
         })
       })
 
-      // Zoom controls
       const zIn = document.getElementById('z-in')
       const zOut = document.getElementById('z-out')
       const zFit = document.getElementById('z-fit')
@@ -437,73 +504,41 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
       if (zFit) zFit.onclick = () => cy.fit(undefined, 60)
 
       // SSE live updates, scoped to the active project (ADR-051 dual-mount).
-      // Without the project param the daemon streams the default-project bus
-      // and every other registered project's events land on the same canvas,
-      // which reads as one merged graph across projects.
       const sse = new EventSource(
         authedEventSourceUrl(`/api/events?project=${encodeURIComponent(project)}`),
       )
       sseRef.current = sse
 
-      function pushGraphUpdate() {
-        onGraphLoaded({
-          nodes: cy.nodes(':visible').map((n: { data: (k: string) => unknown }) => n.data('_raw') as GraphNode),
-          edges: cy.edges(':visible').map((e: { data: (k: string) => unknown }) => ({ id: e.data('id'), source: e.data('source'), target: e.data('target'), type: e.data('type'), provenance: e.data('provenance'), confidence: e.data('confidence') }) as GraphEdge),
-        })
+      function applyDelta(mutate: (full: GraphData) => void) {
+        const full = fullRef.current
+        mutate(full)
+        modelRef.current = buildModel(full.nodes, full.edges)
+        onGraphLoaded({ nodes: [...full.nodes], edges: [...full.edges] })
+        rerender(false)
       }
 
       sse.addEventListener('node-added', (e) => {
         const { node } = JSON.parse(e.data) as { node: GraphNode }
-        const vt = visualType(node)
-        const ts = TYPE_STYLE[vt] ?? { color: '#888', shape: 'ellipse', size: 24 }
-        cy.add({
-          data: {
-            id: node.id,
-            label: (node as { name?: string }).name ?? node.id,
-            type: vt,
-            _color: ts.color,
-            _shape: ts.shape,
-            _size: ts.size ?? 28,
-            _isCompound: COMPOUND_TYPES.has(vt),
-            _raw: node,
-          },
-          classes: `t-${vt} ${COMPOUND_TYPES.has(vt) ? 'compound' : 'leaf'}`,
+        applyDelta((full) => {
+          if (!full.nodes.some((n) => n.id === node.id)) full.nodes.push(node)
         })
-        pushGraphUpdate()
       })
       sse.addEventListener('edge-added', (e) => {
         const { edge } = JSON.parse(e.data) as { edge: GraphEdge }
-        const vp = visualProv(edge.provenance)
-        const color = provColor[vp] ?? '#888'
-        cy.add({
-          data: {
-            id: edge.id,
-            source: edge.source,
-            target: edge.target,
-            type: edgeVerb(edge.type),
-            provenance: vp,
-            _color: color,
-            _width: vp === 'INFERRED' ? 1 : vp === 'OBSERVED' ? 1.4 : 1.2,
-            _style: vp === 'INFERRED' ? 'dotted' : vp === 'OBSERVED' ? 'dashed' : 'solid',
-            _opacity: vp === 'INFERRED' ? 0.55 : vp === 'OBSERVED' ? 0.85 : 0.75,
-          },
+        applyDelta((full) => {
+          if (!full.edges.some((x) => x.id === edge.id)) full.edges.push(edge)
         })
-        pushGraphUpdate()
       })
       sse.addEventListener('node-removed', (e) => {
         const { id } = JSON.parse(e.data) as { id: string }
-        const el = cy.getElementById(id)
-        if (el && el.length) el.remove()
-        pushGraphUpdate()
+        applyDelta((full) => { full.nodes = full.nodes.filter((n) => n.id !== id) })
       })
       sse.addEventListener('edge-removed', (e) => {
         const { id } = JSON.parse(e.data) as { id: string }
-        const el = cy.getElementById(id)
-        if (el && el.length) el.remove()
-        pushGraphUpdate()
+        applyDelta((full) => { full.edges = full.edges.filter((x) => x.id !== id) })
       })
       sse.addEventListener('error', () => {
-        // pre-v0.2.8 or connection drop — ignore silently
+        // pre-v0.2.8 or connection drop — handled by StatusBar's SSE state.
       })
 
       window.__cy = cy
@@ -522,16 +557,47 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
         cyRef.current = null
       }
     }
+    // Re-init only when the project changes; drill state is handled by the
+    // separate [expanded] effect above so we don't tear down cytoscape on
+    // every open/close.
   }, [project])
 
   return (
     <main className="canvas-wrap">
-      <div id="cy" ref={containerRef} aria-label="Service dependency graph" role="img" />
+      <div id="cy" ref={containerRef} aria-label="File-first dependency graph" role="img" />
 
       <div className="canvas-tag">
         <span className="title">NEAT</span>
         <span className="meta">loading…</span>
       </div>
+
+      {/* Drill breadcrumb — navigation by the grouping. Top → service → … */}
+      <nav className="drill-crumbs" aria-label="Drill-down navigation">
+        <button
+          className={`drill-crumb${crumbs.length === 0 ? ' current' : ''}`}
+          onClick={onCollapseAll}
+          disabled={crumbs.length === 0}
+          aria-label="Top view — all services collapsed"
+        >
+          all services
+        </button>
+        {crumbs.map((c) => (
+          <span key={c.id} style={{ display: 'inline-flex', alignItems: 'center', gap: 10 }}>
+            <span className="drill-crumb-sep">›</span>
+            <button
+              className="drill-crumb current"
+              onClick={() => onCollapseService(c.id)}
+              title={`Collapse ${c.name}`}
+              aria-label={`${c.name} expanded — click to collapse`}
+            >
+              {c.name}
+            </button>
+          </span>
+        ))}
+        <span className="drill-hint">
+          {crumbs.length === 0 ? 'double-click a service to open its files' : 'double-click to collapse'}
+        </span>
+      </nav>
 
       <div className="canvas-toolbar">
         <button
@@ -548,7 +614,7 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
           Locked
         </button>
         <span className="div" />
-        <button onClick={() => cyRef.current?.fit(undefined, 40)}>Fit</button>
+        <button onClick={() => cyRef.current?.fit(undefined, 50)}>Fit</button>
         <button onClick={() => cyRef.current?.center()}>Center</button>
         <span className="div" />
         <button onClick={() => cyRef.current?.layout({ name: 'cose', animate: true, randomize: false, idealEdgeLength: 90, nodeRepulsion: 9000, edgeElasticity: 80, gravity: 0.4, numIter: 1200 }).run()}>
@@ -565,8 +631,8 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
       <aside className="legend" id="legend">
         <h4>Edge provenance</h4>
         <div className="legend-row" data-prov="STATIC">
-          <span className="swatch" style={{ background: 'var(--prov-static)' }} />
-          <span className="name">Static</span>
+          <span className="swatch" />
+          <span className="name">Extracted</span>
           <span className="ct mono" id="ct-static">—</span>
         </div>
         <div className="legend-row" data-prov="OBSERVED">
@@ -584,14 +650,9 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
 
         <h4 style={{ marginTop: 0 }}>Node kind</h4>
         <div className="nodes-grid">
-          {[
-            ['service', '--n-service'], ['db', '--n-db'], ['cache', '--n-cache'],
-            ['stream', '--n-stream'], ['lambda', '--n-lambda'], ['cron', '--n-cron'],
-            ['api', '--n-api'], ['compute', '--n-compute'], ['storage', '--n-storage'],
-            ['external', '--n-external'],
-          ].map(([label, v]) => (
-            <div key={label} className="nrow">
-              <span className="nsq" style={{ background: `var(${v})` }} />
+          {GLYPH_LEGEND.map(({ kind, label }) => (
+            <div key={kind} className="nrow">
+              <KindGlyph kind={kind} />
               {label}
             </div>
           ))}
@@ -604,6 +665,27 @@ export function GraphCanvas({ project, selectedNodeId, onNodeSelect, onGraphLoad
         <div className="frame" id="minimap-frame" ref={minimapFrameRef} />
       </div>
     </main>
+  )
+}
+
+// Inline glyph for the legend — kept local so the legend's shape vocabulary
+// matches the canvas exactly. Filled square = file (primary node).
+function KindGlyph({ kind }: { kind: string }) {
+  const filled = kind === 'file'
+  let inner: React.ReactNode
+  switch (kind) {
+    case 'file': inner = <rect x="1.5" y="1.5" width="9" height="9" />; break
+    case 'service': inner = <polygon points="6,0.5 11,3.25 11,8.75 6,11.5 1,8.75 1,3.25" strokeLinejoin="round" />; break
+    case 'db': inner = <circle cx="6" cy="6" r="5" />; break
+    case 'storage': inner = <rect x="1" y="2.5" width="10" height="7" />; break
+    case 'external': inner = <polygon points="6,0.5 11.5,4.3 9.4,11 2.6,11 0.5,4.3" strokeLinejoin="round" />; break
+    case 'compute': inner = <polygon points="6,0.5 11.5,6 6,11.5 0.5,6" strokeLinejoin="round" />; break
+    default: inner = <circle cx="6" cy="6" r="5" />
+  }
+  return (
+    <svg className={`glyph${filled ? ' filled' : ''}`} viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      {inner}
+    </svg>
   )
 }
 

--- a/packages/web/app/components/Inspector.tsx
+++ b/packages/web/app/components/Inspector.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { GraphNode, GraphEdge } from '@neat.is/types'
 import type { GraphData } from './AppShell'
 import { authedFetch } from '../../lib/authed-fetch'
+import { buildModel, callsFrom, filesOf } from './graph-model'
 
 interface RootCauseResult {
   origin: string
@@ -25,6 +26,7 @@ function visualProv(provenance: string): 'STATIC' | 'OBSERVED' | 'INFERRED' {
 }
 
 function nodeName(node: GraphNode): string {
+  if (node.type === 'FileNode') return (node as { path?: string }).path ?? node.id
   return (node as unknown as { name?: string }).name ?? node.id
 }
 
@@ -41,7 +43,6 @@ function nodeProps(node: GraphNode): [string, string][] {
   if (n.host) props.push(['host', String(n.host)])
   if (n.port) props.push(['port', String(n.port)])
   if (n.fileType) props.push(['file type', String(n.fileType)])
-  if (n.path) props.push(['path', String(n.path)])
   if (n.firstObserved) props.push(['first seen', String(n.firstObserved)])
   if (n.lastObserved) props.push(['last seen', String(n.lastObserved)])
   return props
@@ -58,18 +59,14 @@ interface InspectorProps {
   project: string
   selectedNodeId: string | null
   graphData: GraphData | null
+  onNodeSelect: (id: string) => void
+  onExpandService: (id: string) => void
 }
 
-export function Inspector({ project, selectedNodeId, graphData }: InspectorProps) {
+export function Inspector({ project, selectedNodeId, graphData, onNodeSelect, onExpandService }: InspectorProps) {
   const [node, setNode] = useState<GraphNode | null>(null)
   const [rootCause, setRootCause] = useState<RootCauseResult | null>(null)
   const [activeTab, setActiveTab] = useState<'inspect' | 'edges' | 'owners' | 'history'>('inspect')
-
-  // Metric values come from the OBSERVED signal block on incident edges
-  // when present, or render as "—" when the selected node has no observed
-  // signal (#357). p99 stays "—" until the OBSERVED edge schema carries a
-  // span-duration histogram — that's its own schema-growth concern.
-  // Deltas are similarly absent until per-edge history lands.
 
   // ADR-057 #3 — re-fetch when project or selection changes.
   useEffect(() => {
@@ -90,6 +87,13 @@ export function Inspector({ project, selectedNodeId, graphData }: InspectorProps
       .catch(() => {})
   }, [selectedNodeId, project])
 
+  // file-first model off the full graph, for file→target detail and the
+  // service→files view. Memoized so it's not rebuilt on every render.
+  const model = useMemo(
+    () => (graphData ? buildModel(graphData.nodes, graphData.edges) : null),
+    [graphData],
+  )
+
   if (!selectedNodeId || !node) {
     return (
       <aside className="inspect" id="inspect">
@@ -101,8 +105,8 @@ export function Inspector({ project, selectedNodeId, graphData }: InspectorProps
           {/* ADR-056 — History deferred: explicit disabled affordance. */}
           <div className="inspect-tab disabled" role="tab" aria-selected={false} aria-disabled={true} title="History — coming in v0.3.x" style={{ opacity: 0.4, cursor: 'not-allowed' }}>History</div>
         </div>
-        <div className="insp-section" style={{ paddingTop: 32 }}>
-          <div style={{ fontFamily: 'Spectral, serif', fontStyle: 'italic', color: 'var(--paper-3)', textAlign: 'center' }}>
+        <div className="insp-section" style={{ paddingTop: 40 }}>
+          <div style={{ fontFamily: 'var(--font-body)', fontStyle: 'italic', color: 'var(--fg-muted)', textAlign: 'center', fontSize: '1rem' }}>
             select a node to inspect
           </div>
         </div>
@@ -110,55 +114,54 @@ export function Inspector({ project, selectedNodeId, graphData }: InspectorProps
     )
   }
 
-  // Derive edges from graphData (avoids extra fetch)
+  const isFile = node.type === 'FileNode'
+  const isService = node.type === 'ServiceNode'
+
+  // FileNode: the calls originating from it, file-grained, with evidence.
+  const originating = isFile && graphData && model
+    ? callsFrom(node.id, graphData.edges, model.byId)
+    : []
+  // FileNode: its owning service via the inbound CONTAINS edge.
+  const owningServiceId = isFile && model ? model.serviceByFile.get(node.id) : undefined
+  const owningService = owningServiceId && model ? model.byId.get(owningServiceId) : undefined
+  // ServiceNode: the files it CONTAINS.
+  const serviceFiles = isService && model ? filesOf(node.id, model) : []
+
+  // Generic edge rows (for the Edges tab + the incoming list).
   const outEdges: EdgeRow[] = graphData
     ? graphData.edges
-        .filter((e: GraphEdge) => e.source === node.id)
+        .filter((e: GraphEdge) => e.source === node.id && e.type !== 'CONTAINS')
         .map((e: GraphEdge) => {
           const targetNode = graphData.nodes.find((n: GraphNode) => n.id === e.target)
-          return {
-            verb: e.type.toLowerCase().replace(/_/g, ' '),
-            target: targetNode ? nodeName(targetNode) : e.target,
-            prov: visualProv(e.provenance),
-            conf: e.confidence,
-          }
+          return { verb: e.type.toLowerCase().replace(/_/g, ' '), target: targetNode ? nodeName(targetNode) : e.target, prov: visualProv(e.provenance), conf: e.confidence }
         })
     : []
-
   const inEdges: EdgeRow[] = graphData
     ? graphData.edges
-        .filter((e: GraphEdge) => e.target === node.id)
+        .filter((e: GraphEdge) => e.target === node.id && e.type !== 'CONTAINS')
         .map((e: GraphEdge) => {
           const srcNode = graphData.nodes.find((n: GraphNode) => n.id === e.source)
-          return {
-            verb: e.type.toLowerCase().replace(/_/g, ' '),
-            target: srcNode ? nodeName(srcNode) : e.source,
-            prov: visualProv(e.provenance),
-            conf: e.confidence,
-          }
+          return { verb: e.type.toLowerCase().replace(/_/g, ' '), target: srcNode ? nodeName(srcNode) : e.source, prov: visualProv(e.provenance), conf: e.confidence }
         })
     : []
-
   const allEdges = [...outEdges, ...inEdges]
   const edgeCount = allEdges.length
+
   const props = nodeProps(node)
   const name = nodeName(node)
   const labelParts = name.split('/')
-  const stem = labelParts.length > 1 ? labelParts[0] + '/' : ''
-  const rest = labelParts.length > 1 ? labelParts.slice(1).join('/') : name
+  const stem = labelParts.length > 1 ? labelParts.slice(0, -1).join('/') + '/' : ''
+  const rest = labelParts.length > 1 ? labelParts[labelParts.length - 1] : name
 
   const provCounts: Record<string, number> = { STATIC: 0, OBSERVED: 0, INFERRED: 0 }
   allEdges.forEach((e) => { provCounts[e.prov] = (provCounts[e.prov] ?? 0) + 1 })
   const total = allEdges.length || 1
 
   const typeLabel = node.type.replace('Node', '').toUpperCase()
-  const showMetrics = !['ConfigNode', 'FrontierNode'].includes(node.type)
+  const showMetrics = !['ConfigNode', 'FrontierNode', 'FileNode'].includes(node.type)
   const owner = (node as unknown as { owner?: string }).owner
 
-  // Derive metrics from incident OBSERVED edges (#357). When the node has
-  // no OBSERVED signal, every metric renders as "—" — the panel reports
-  // absence honestly rather than rolling Math.random() noise. p99 stays
-  // "—" until the OBSERVED edge schema carries a span-duration histogram.
+  // Metrics derived from incident OBSERVED edges (#357), honest "—" otherwise.
   let observedSpans = 0
   let observedErrors = 0
   if (graphData) {
@@ -178,42 +181,12 @@ export function Inspector({ project, selectedNodeId, graphData }: InspectorProps
   return (
     <aside className="inspect" id="inspect">
       <div className="inspect-tabs" role="tablist">
-        <div
-          className={`inspect-tab${activeTab === 'inspect' ? ' on' : ''}`}
-          role="tab"
-          aria-selected={activeTab === 'inspect'}
-          onClick={() => setActiveTab('inspect')}
-        >
-          Inspect
-        </div>
-        <div
-          className={`inspect-tab${activeTab === 'edges' ? ' on' : ''}`}
-          role="tab"
-          aria-selected={activeTab === 'edges'}
-          onClick={() => setActiveTab('edges')}
-        >
-          Edges<span className="ct">{edgeCount}</span>
-        </div>
+        <div className={`inspect-tab${activeTab === 'inspect' ? ' on' : ''}`} role="tab" aria-selected={activeTab === 'inspect'} onClick={() => setActiveTab('inspect')}>Inspect</div>
+        <div className={`inspect-tab${activeTab === 'edges' ? ' on' : ''}`} role="tab" aria-selected={activeTab === 'edges'} onClick={() => setActiveTab('edges')}>Edges<span className="ct">{edgeCount}</span></div>
         {/* ADR-056 — Owners wired: shows ServiceNode.owner when available (ADR-054). */}
-        <div
-          className={`inspect-tab${activeTab === 'owners' ? ' on' : ''}`}
-          role="tab"
-          aria-selected={activeTab === 'owners'}
-          onClick={() => setActiveTab('owners')}
-        >
-          Owners
-        </div>
+        <div className={`inspect-tab${activeTab === 'owners' ? ' on' : ''}`} role="tab" aria-selected={activeTab === 'owners'} onClick={() => setActiveTab('owners')}>Owners</div>
         {/* ADR-056 — History deferred: explicit disabled affordance. */}
-        <div
-          className="inspect-tab disabled"
-          role="tab"
-          aria-selected={false}
-          aria-disabled={true}
-          title="History — coming in v0.3.x"
-          style={{ opacity: 0.4, cursor: 'not-allowed' }}
-        >
-          History
-        </div>
+        <div className="inspect-tab disabled" role="tab" aria-selected={false} aria-disabled={true} title="History — coming in v0.3.x" style={{ opacity: 0.4, cursor: 'not-allowed' }}>History</div>
       </div>
 
       <div id="inspect-body">
@@ -227,38 +200,94 @@ export function Inspector({ project, selectedNodeId, graphData }: InspectorProps
               </div>
               <div className="insp-sub">{escapeHtml(node.id)}</div>
               <div className="insp-tags">
-                {(node as { language?: string }).language && (
-                  <span className="tag">{escapeHtml((node as { language: string }).language)}</span>
-                )}
-                {(node as { engine?: string }).engine && (
-                  <span className="tag">{escapeHtml((node as { engine: string }).engine)}</span>
-                )}
-                {(node as { kind?: string }).kind && (
-                  <span className="tag">{escapeHtml((node as { kind: string }).kind)}</span>
-                )}
-                {props.length === 0 && <span className="tag">{escapeHtml(typeLabel.toLowerCase())}</span>}
+                {(node as { language?: string }).language && <span className="tag">{escapeHtml((node as { language: string }).language)}</span>}
+                {(node as { engine?: string }).engine && <span className="tag">{escapeHtml((node as { engine: string }).engine)}</span>}
+                {(node as { kind?: string }).kind && <span className="tag">{escapeHtml((node as { kind: string }).kind)}</span>}
+                {!isFile && props.length === 0 && <span className="tag">{escapeHtml(typeLabel.toLowerCase())}</span>}
               </div>
             </section>
+
+            {/* FileNode — owning service (file-awareness §2). Clickable: drills
+                into the service so the file's siblings come into view. */}
+            {isFile && owningService && (
+              <section className="insp-section">
+                <div className="insp-h">Owning service</div>
+                <button
+                  className="owning-service"
+                  onClick={() => { onExpandService(owningService.id); onNodeSelect(owningService.id) }}
+                  title="Open this service's files"
+                >
+                  <svg className="glyph" viewBox="0 0 12 12" aria-hidden="true">
+                    <polygon points="6,0.5 11,3.25 11,8.75 6,11.5 1,8.75 1,3.25" strokeLinejoin="round" />
+                  </svg>
+                  <span className="svc-name">{escapeHtml((owningService as { name?: string }).name ?? owningService.id)}</span>
+                </button>
+              </section>
+            )}
+
+            {/* FileNode — the calls originating from this file, file-grained,
+                each with provenance + evidence file:line (file-awareness §1/§6). */}
+            {isFile && (
+              <section className="insp-section">
+                <div className="insp-h">Calls from this file <span className="ct">{originating.length}</span></div>
+                <ul className="edge-list">
+                  {originating.length ? originating.map((c) => (
+                    <li key={c.edgeId} style={{ flexWrap: 'wrap', borderBottom: 'none' }}>
+                      <span style={{ display: 'flex', alignItems: 'center', gap: 10, width: '100%' }}>
+                        <span className={`pdot ${visualProv(c.provenance)}`} />
+                        <span className="verb">{visualProv(c.provenance).toLowerCase()}</span>
+                        <span
+                          className="target clickable"
+                          onClick={() => onNodeSelect(c.targetId)}
+                          title={`Select ${c.targetName}`}
+                        >{escapeHtml(c.targetName)}</span>
+                        <span className="conf">{typeof c.confidence === 'number' ? c.confidence.toFixed(2) : '—'}</span>
+                      </span>
+                      {c.evidenceFile && (
+                        <span className="edge-evidence" style={{ width: '100%' }}>
+                          {escapeHtml(c.evidenceFile)}{typeof c.evidenceLine === 'number' ? `:${c.evidenceLine}` : ''}
+                        </span>
+                      )}
+                    </li>
+                  )) : (
+                    <li style={{ borderBottom: 'none' }}><span style={{ color: 'var(--fg-muted)', fontStyle: 'italic', fontFamily: 'var(--font-body)' }}>no calls originate from this file</span></li>
+                  )}
+                </ul>
+              </section>
+            )}
+
+            {/* ServiceNode — the files it CONTAINS (file-awareness §2).
+                Clicking a file drills the canvas open and selects it. */}
+            {isService && (
+              <section className="insp-section">
+                <div className="insp-h">Files <span className="ct">{serviceFiles.length}</span></div>
+                <ul className="file-list">
+                  {serviceFiles.length ? serviceFiles.map((f) => (
+                    <li
+                      key={f.id}
+                      onClick={() => { onExpandService(node.id); onNodeSelect(f.id) }}
+                      title={(f as { path?: string }).path}
+                    >
+                      <svg className="fglyph" viewBox="0 0 12 12" aria-hidden="true"><rect x="1.5" y="1.5" width="9" height="9" /></svg>
+                      <span className="fpath">{escapeHtml((f as { path?: string }).path ?? f.id)}</span>
+                    </li>
+                  )) : (
+                    <li style={{ cursor: 'default' }}><span className="fpath" style={{ color: 'var(--fg-muted)', fontStyle: 'italic', fontFamily: 'var(--font-body)' }}>no files attributed to this service</span></li>
+                  )}
+                </ul>
+              </section>
+            )}
 
             {showMetrics && (
               <section className="insp-section">
                 <div className="metrics">
-                  <div className="metric">
-                    <div className="lbl">spans</div>
-                    <div className="val">{rpsDisplay}</div>
-                  </div>
-                  <div className="metric">
-                    <div className="lbl">p99 ms</div>
-                    <div className="val">—</div>
-                  </div>
-                  <div className="metric">
-                    <div className="lbl">err %</div>
-                    <div className={`val${errBad ? ' bad' : ''}`}>{errDisplay}</div>
-                  </div>
+                  <div className="metric"><div className="lbl">spans</div><div className="val">{rpsDisplay}</div></div>
+                  <div className="metric"><div className="lbl">p99 ms</div><div className="val">—</div></div>
+                  <div className="metric"><div className="lbl">err %</div><div className={`val${errBad ? ' bad' : ''}`}>{errDisplay}</div></div>
                 </div>
                 {!hasObservedSignal && (
-                  <div className="insp-sub" style={{ marginTop: 8, fontStyle: 'italic' }}>
-                    no observed signal — drive traffic to this service to populate
+                  <div className="insp-sub" style={{ marginTop: 12, fontStyle: 'italic', fontFamily: 'var(--font-body)' }}>
+                    no observed signal — drive traffic to populate
                   </div>
                 )}
               </section>
@@ -271,9 +300,7 @@ export function Inspector({ project, selectedNodeId, graphData }: InspectorProps
                   <div className="rc-label">divergence detected</div>
                   <div className="rc-node">{escapeHtml(rootCause.rootCauseNode ?? '')}</div>
                   <div className="rc-reason">{escapeHtml(rootCause.reason)}</div>
-                  {rootCause.fixRecommendation && (
-                    <div className="rc-fix">{escapeHtml(rootCause.fixRecommendation)}</div>
-                  )}
+                  {rootCause.fixRecommendation && <div className="rc-fix">{escapeHtml(rootCause.fixRecommendation)}</div>}
                 </div>
               </section>
             )}
@@ -283,59 +310,47 @@ export function Inspector({ project, selectedNodeId, graphData }: InspectorProps
                 <div className="insp-h">Properties <span className="ct">{props.length}</span></div>
                 <dl className="kv">
                   {props.map(([k, v]) => (
-                    <>
-                      <dt key={`k-${k}`}>{escapeHtml(k)}</dt>
-                      <dd key={`v-${k}`}>{escapeHtml(v)}</dd>
-                    </>
+                    <div key={k} style={{ display: 'contents' }}>
+                      <dt>{escapeHtml(k)}</dt>
+                      <dd>{escapeHtml(v)}</dd>
+                    </div>
                   ))}
                 </dl>
               </section>
             )}
 
-            <section className="insp-section">
-              <div className="insp-h">Outgoing <span className="ct">{outEdges.length}</span></div>
-              <ul className="edge-list">
-                {outEdges.length ? outEdges.map((e, i) => (
-                  <li key={i}>
-                    <span className={`pdot ${e.prov}`} />
-                    <span className="verb">{escapeHtml(e.verb)}</span>
-                    <span className="target">{escapeHtml(e.target)}</span>
-                    <span className="conf">{typeof e.conf === 'number' ? e.conf.toFixed(2) : '—'}</span>
-                  </li>
-                )) : (
-                  <li><span className="verb">—</span><span className="target" style={{ color: 'var(--paper-3)' }}>no outgoing edges</span></li>
-                )}
-              </ul>
-            </section>
-
-            <section className="insp-section">
-              <div className="insp-h">Incoming <span className="ct">{inEdges.length}</span></div>
-              <ul className="edge-list">
-                {inEdges.length ? inEdges.map((e, i) => (
-                  <li key={i}>
-                    <span className={`pdot ${e.prov}`} />
-                    <span className="verb">{escapeHtml(e.verb)}</span>
-                    <span className="target">{escapeHtml(e.target)}</span>
-                    <span className="conf">{typeof e.conf === 'number' ? e.conf.toFixed(2) : '—'}</span>
-                  </li>
-                )) : (
-                  <li><span className="verb">—</span><span className="target" style={{ color: 'var(--paper-3)' }}>no incoming edges</span></li>
-                )}
-              </ul>
-            </section>
+            {/* Incoming relationships — kept for non-file nodes; for files the
+                originating-calls block above is the file-grained surface. */}
+            {!isFile && (
+              <section className="insp-section">
+                <div className="insp-h">Incoming <span className="ct">{inEdges.length}</span></div>
+                <ul className="edge-list">
+                  {inEdges.length ? inEdges.map((e, i) => (
+                    <li key={i}>
+                      <span className={`pdot ${e.prov}`} />
+                      <span className="verb">{escapeHtml(e.verb)}</span>
+                      <span className="target">{escapeHtml(e.target)}</span>
+                      <span className="conf">{typeof e.conf === 'number' ? e.conf.toFixed(2) : '—'}</span>
+                    </li>
+                  )) : (
+                    <li><span className="verb">—</span><span className="target" style={{ color: 'var(--fg-muted)' }}>no incoming edges</span></li>
+                  )}
+                </ul>
+              </section>
+            )}
 
             <section className="insp-section">
               <div className="insp-h">Provenance <span className="ct">{edgeCount}</span></div>
               {(['STATIC', 'OBSERVED', 'INFERRED'] as const).map((k) => {
                 const pct = (provCounts[k] / total) * 100
                 return (
-                  <div key={k} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: '11.5px', margin: '5px 0' }}>
+                  <div key={k} style={{ display: 'flex', alignItems: 'center', gap: 10, margin: '7px 0' }}>
                     <span className={`pdot ${k}`} style={{ width: 7, height: 7, borderRadius: '50%', background: `var(--prov-${k.toLowerCase()})`, flexShrink: 0 }} />
-                    <span style={{ fontStyle: 'italic', width: 70, color: 'var(--paper-2)', fontFamily: 'Spectral, serif' }}>{k.toLowerCase()}</span>
-                    <div style={{ flex: 1, height: 4, background: 'var(--ink-3)', borderRadius: 2, overflow: 'hidden' }}>
-                      <div style={{ width: `${pct}%`, height: '100%', background: `var(--prov-${k.toLowerCase()})` }} />
+                    <span style={{ width: 76, color: 'var(--fg-muted)', fontFamily: 'var(--font-mono)', fontSize: '0.55rem', letterSpacing: '0.08em', textTransform: 'uppercase' }}>{k.toLowerCase()}</span>
+                    <div style={{ flex: 1, height: 1, background: 'var(--rule)', position: 'relative' }}>
+                      <div style={{ position: 'absolute', left: 0, top: 0, bottom: 0, width: `${pct}%`, background: `var(--prov-${k.toLowerCase()})` }} />
                     </div>
-                    <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '10.5px', color: 'var(--paper-3)', width: 34, textAlign: 'right' }}>{provCounts[k]}</span>
+                    <span style={{ fontFamily: 'var(--font-mono)', fontSize: '0.6rem', color: 'var(--fg-muted)', width: 28, textAlign: 'right' }}>{provCounts[k]}</span>
                   </div>
                 )
               })}
@@ -355,7 +370,7 @@ export function Inspector({ project, selectedNodeId, graphData }: InspectorProps
                   <span className="conf">{typeof e.conf === 'number' ? e.conf.toFixed(2) : '—'}</span>
                 </li>
               )) : (
-                <li><span style={{ color: 'var(--paper-3)', fontStyle: 'italic', fontFamily: 'Spectral, serif' }}>no edges</span></li>
+                <li><span style={{ color: 'var(--fg-muted)', fontStyle: 'italic', fontFamily: 'var(--font-body)' }}>no edges</span></li>
               )}
             </ul>
           </section>
@@ -365,12 +380,9 @@ export function Inspector({ project, selectedNodeId, graphData }: InspectorProps
           <section className="insp-section">
             <div className="insp-h">Owners</div>
             {owner ? (
-              <dl className="kv">
-                <dt>owner</dt>
-                <dd>{escapeHtml(owner)}</dd>
-              </dl>
+              <dl className="kv"><dt>owner</dt><dd>{escapeHtml(owner)}</dd></dl>
             ) : (
-              <div style={{ color: 'var(--paper-3)', fontStyle: 'italic', fontFamily: 'Spectral, serif', fontSize: 12 }}>
+              <div style={{ color: 'var(--fg-muted)', fontStyle: 'italic', fontFamily: 'var(--font-body)', fontSize: '0.92rem' }}>
                 no owner declared in package.json or pyproject.toml (ADR-054)
               </div>
             )}

--- a/packages/web/app/components/StatusBar.tsx
+++ b/packages/web/app/components/StatusBar.tsx
@@ -63,9 +63,11 @@ export function EnvironmentIndicator() {
 
   const local = isLocalHost(hostname)
   const label = local ? 'local' : `remote · ${hostname}`
-  const bg = local ? 'rgba(95,207,158,0.18)' : 'rgba(216,165,84,0.20)'
-  const fg = local ? 'var(--prov-observed)' : '#d8a554'
-  const border = local ? 'rgba(95,207,158,0.35)' : 'rgba(216,165,84,0.45)'
+  // Local is the one live accent (green); remote stays monochrome on the
+  // black surface — a hollow white-ruled chip rather than amber-gold.
+  const bg = local ? 'rgba(95,207,158,0.16)' : 'transparent'
+  const fg = local ? 'var(--prov-observed)' : 'var(--fg)'
+  const border = local ? 'rgba(95,207,158,0.4)' : 'var(--rule)'
 
   return (
     <div className="st-item" data-env-state={local ? 'local' : 'remote'}>
@@ -146,7 +148,7 @@ export function SignOutButton() {
         title="Clear the bearer token and return to the login screen"
         style={{
           background: 'rgba(255,255,255,0.04)',
-          color: 'var(--paper-3)',
+          color: 'var(--fg-muted)',
           border: '1px solid var(--rule)',
           borderRadius: 999,
           padding: '1px 8px',

--- a/packages/web/app/components/Toaster.tsx
+++ b/packages/web/app/components/Toaster.tsx
@@ -36,23 +36,24 @@ export function Toaster() {
       }}
     >
       {toasts.map((t) => {
-        const color = t.level === 'error' ? '#e87a7a' : t.level === 'warn' ? '#d3a847' : 'var(--prov-observed)'
+        const color = t.level === 'error' ? '#e08a8a' : t.level === 'warn' ? 'var(--fg)' : 'var(--prov-observed)'
         return (
           <div
             key={t.id}
             className="toast"
             onClick={() => setToasts((prev) => prev.filter((p) => p.id !== t.id))}
             style={{
-              background: 'var(--ink-2, #14141a)',
-              border: `1px solid ${color}`,
-              borderLeft: `3px solid ${color}`,
-              padding: '8px 12px',
-              fontFamily: 'JetBrains Mono, monospace',
+              background: 'var(--bg, #000)',
+              border: `1px solid var(--rule)`,
+              borderLeft: `2px solid ${color}`,
+              padding: '10px 14px',
+              fontFamily: 'var(--font-mono, monospace)',
               fontSize: 11,
-              color: 'var(--paper-1, #d8d3c9)',
+              letterSpacing: '0.02em',
+              color: 'var(--fg, #fff)',
               maxWidth: 360,
               cursor: 'pointer',
-              boxShadow: '0 8px 16px rgba(0,0,0,0.35)',
+              boxShadow: '0 8px 24px rgba(0,0,0,0.6)',
             }}
           >
             <div style={{ display: 'flex', gap: 8, alignItems: 'baseline' }}>

--- a/packages/web/app/components/glyphs.tsx
+++ b/packages/web/app/components/glyphs.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+// The glyph vocabulary, ported from the marketing site (neat-web-v1/v2).
+// Shapes encode node kind; fill/stroke encodes provenance. Triangle fires,
+// circle runs, rectangle stores, hexagon coordinates, diamond is fast/
+// transient, pentagon is security/edge. FileNode — the primary node of the
+// file-first graph — gets the filled square so it reads as "the thing that
+// holds the code".
+
+export type GlyphKind =
+  | 'file'
+  | 'service'
+  | 'db'
+  | 'storage'
+  | 'external'
+  | 'compute'
+  | 'cluster'
+  | 'namespace'
+  | 'vpc'
+
+const VIEWBOX = '0 0 12 12'
+
+interface GlyphProps {
+  kind: GlyphKind
+  className?: string
+  filled?: boolean
+}
+
+// Map a node kind to its glyph shape SVG inner markup.
+function shapeFor(kind: GlyphKind): React.ReactNode {
+  switch (kind) {
+    case 'file':
+      // filled square — the primary node
+      return <rect x="1.5" y="1.5" width="9" height="9" />
+    case 'service':
+      // hexagon — a service coordinates its files
+      return <polygon points="6,0.5 11,3.25 11,8.75 6,11.5 1,8.75 1,3.25" strokeLinejoin="round" />
+    case 'db':
+      // circle — a datastore runs
+      return <circle cx="6" cy="6" r="5" />
+    case 'storage':
+      // rectangle — stores
+      return <rect x="1" y="2.5" width="10" height="7" />
+    case 'external':
+      // pentagon — frontier / edge
+      return <polygon points="6,0.5 11.5,4.3 9.4,11 2.6,11 0.5,4.3" strokeLinejoin="round" />
+    case 'compute':
+      // diamond — transient compute
+      return <polygon points="6,0.5 11.5,6 6,11.5 0.5,6" strokeLinejoin="round" />
+    case 'cluster':
+    case 'namespace':
+    case 'vpc':
+      // triangle — infra container
+      return <polygon points="6,1 11.5,11 0.5,11" strokeLinejoin="round" />
+    default:
+      return <circle cx="6" cy="6" r="5" />
+  }
+}
+
+export function Glyph({ kind, className, filled }: GlyphProps) {
+  const isFilled = filled ?? kind === 'file'
+  return (
+    <svg
+      className={`glyph${isFilled ? ' filled' : ''}${className ? ` ${className}` : ''}`}
+      viewBox={VIEWBOX}
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      {shapeFor(kind)}
+    </svg>
+  )
+}
+
+// The kind label used in the legend, in the order they appear in the graph.
+export const GLYPH_LEGEND: { kind: GlyphKind; label: string }[] = [
+  { kind: 'file', label: 'file' },
+  { kind: 'service', label: 'service' },
+  { kind: 'db', label: 'database' },
+  { kind: 'storage', label: 'config' },
+  { kind: 'compute', label: 'compute' },
+  { kind: 'external', label: 'frontier' },
+]

--- a/packages/web/app/components/graph-model.ts
+++ b/packages/web/app/components/graph-model.ts
@@ -1,0 +1,189 @@
+// File-first graph model for the dashboard's level-of-detail drill-down.
+//
+// The graph is file-first (file-awareness.md §1-§3): FileNodes are primary,
+// CALLS edges originate from files, and `service ──CONTAINS──▶ file` is the
+// only place a service appears in relation to its files. Drill-down navigates
+// *by the grouping* — it never rolls file edges up into service edges and
+// never shows a service-level edge view (§3). A service is a container you
+// open, not an aggregation.
+//
+// Level-of-detail:
+//   - collapsed (default): each service shows as one collapsed container;
+//     its files are hidden so the canvas isn't a flat file hairball.
+//   - expanded (drilled): the focused service's FileNodes are revealed via
+//     its CONTAINS edges; files outside the focus stay collapsed under their
+//     own service container.
+//
+// Rendered edges are always file-grained. When a file is hidden inside a
+// collapsed service, an edge that originates from (or lands on) that file is
+// re-anchored onto the visible service *container* so the relationship still
+// reads — but it stays the same file-grained edge with its own provenance and
+// evidence; we never synthesize a service→service summary edge.
+
+import type { GraphNode, GraphEdge } from '@neat.is/types'
+
+export const CONTAINS = 'CONTAINS'
+
+export interface FileFirstModel {
+  /** every node by id */
+  byId: Map<string, GraphNode>
+  /** service id → file node ids it CONTAINS */
+  filesByService: Map<string, string[]>
+  /** file id → owning service id (from the inbound CONTAINS edge) */
+  serviceByFile: Map<string, string>
+  /** service ids present in the graph */
+  serviceIds: string[]
+  /** file ids present in the graph */
+  fileIds: string[]
+}
+
+export function isFileNode(node: GraphNode | undefined): boolean {
+  return node?.type === 'FileNode'
+}
+
+export function isServiceNode(node: GraphNode | undefined): boolean {
+  return node?.type === 'ServiceNode'
+}
+
+// Build the service↔file containment index from CONTAINS edges. CONTAINS is
+// the structural ownership edge (service → file); we read it rather than the
+// FileNode.service string so the model matches the graph the daemon actually
+// shipped.
+export function buildModel(nodes: GraphNode[], edges: GraphEdge[]): FileFirstModel {
+  const byId = new Map<string, GraphNode>()
+  for (const n of nodes) byId.set(n.id, n)
+
+  const filesByService = new Map<string, string[]>()
+  const serviceByFile = new Map<string, string>()
+
+  for (const e of edges) {
+    if (e.type !== CONTAINS) continue
+    const svc = byId.get(e.source)
+    const file = byId.get(e.target)
+    if (!isServiceNode(svc) || !isFileNode(file)) continue
+    const list = filesByService.get(e.source) ?? []
+    list.push(e.target)
+    filesByService.set(e.source, list)
+    serviceByFile.set(e.target, e.source)
+  }
+
+  const serviceIds: string[] = []
+  const fileIds: string[] = []
+  for (const n of nodes) {
+    if (n.type === 'ServiceNode') serviceIds.push(n.id)
+    else if (n.type === 'FileNode') fileIds.push(n.id)
+  }
+
+  return { byId, filesByService, serviceByFile, serviceIds, fileIds }
+}
+
+export interface VisibleGraph {
+  nodes: GraphNode[]
+  // edges re-anchored onto whatever node currently represents each endpoint,
+  // carrying the original edge id so selection + evidence still resolve.
+  edges: (GraphEdge & { _origSource: string; _origTarget: string })[]
+}
+
+// Given the model and the set of *expanded* service ids, resolve which node id
+// currently represents a given node: a file inside a collapsed service is
+// represented by that service container; everything else is itself.
+function representativeOf(id: string, model: FileFirstModel, expanded: Set<string>): string {
+  const svc = model.serviceByFile.get(id)
+  if (svc && !expanded.has(svc)) return svc
+  return id
+}
+
+// Compute the visible node + edge set for the current drill state.
+//
+//   expanded — service ids the user has drilled into. Empty = top view
+//   (all services collapsed). A service container is always shown; its files
+//   appear only when it's expanded.
+//
+// CONTAINS edges are never rendered as graph edges — containment is expressed
+// by visibility (open the container to see its files), not by an arrow.
+export function visibleGraph(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  model: FileFirstModel,
+  expanded: Set<string>,
+): VisibleGraph {
+  const visibleNodes: GraphNode[] = []
+  const shown = new Set<string>()
+
+  for (const n of nodes) {
+    if (n.type === 'FileNode') {
+      // file is visible only inside an expanded service
+      const svc = model.serviceByFile.get(n.id)
+      if (svc && !expanded.has(svc)) continue
+      // an orphan file (no CONTAINS) is always shown — honest fallback
+    }
+    visibleNodes.push(n)
+    shown.add(n.id)
+  }
+
+  const out: VisibleGraph['edges'] = []
+  const seen = new Set<string>()
+
+  for (const e of edges) {
+    if (e.type === CONTAINS) continue // containment is visibility, not an arrow
+
+    const src = representativeOf(e.source, model, expanded)
+    const tgt = representativeOf(e.target, model, expanded)
+
+    // both endpoints must resolve to a currently-visible node
+    if (!shown.has(src) || !shown.has(tgt)) continue
+    // drop self-loops produced when both endpoints collapse to the same
+    // service container — that would read as a service→service edge, which
+    // §3 forbids. The relationship stays a file-grained edge; it's simply not
+    // drawn while both its files are hidden in the same container.
+    if (src === tgt) continue
+
+    // de-dup edges that re-anchor onto the same visible pair (multiple files
+    // in one collapsed service calling the same target). Keep the first;
+    // the file-grained detail stays available in the Inspector.
+    const key = `${e.type}:${src}->${tgt}:${e.provenance}`
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    out.push({ ...e, source: src, target: tgt, _origSource: e.source, _origTarget: e.target })
+  }
+
+  return { nodes: visibleNodes, edges: out }
+}
+
+// Files a service CONTAINS, resolved to nodes (for the Inspector's service view).
+export function filesOf(serviceId: string, model: FileFirstModel): GraphNode[] {
+  const ids = model.filesByService.get(serviceId) ?? []
+  return ids.map((id) => model.byId.get(id)).filter((n): n is GraphNode => !!n)
+}
+
+// The calls originating from a file (file-grained CALLS edges), with evidence.
+export interface OriginatingCall {
+  edgeId: string
+  targetId: string
+  targetName: string
+  provenance: string
+  confidence?: number
+  evidenceFile?: string
+  evidenceLine?: number
+}
+
+export function callsFrom(fileId: string, edges: GraphEdge[], byId: Map<string, GraphNode>): OriginatingCall[] {
+  const calls: OriginatingCall[] = []
+  for (const e of edges) {
+    if (e.source !== fileId) continue
+    if (e.type === CONTAINS) continue
+    const target = byId.get(e.target)
+    const name = target ? ((target as { name?: string; path?: string }).name ?? (target as { path?: string }).path ?? e.target) : e.target
+    calls.push({
+      edgeId: e.id,
+      targetId: e.target,
+      targetName: name,
+      provenance: e.provenance,
+      confidence: e.confidence,
+      evidenceFile: e.evidence?.file,
+      evidenceLine: e.evidence?.line,
+    })
+  }
+  return calls
+}

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -2,31 +2,52 @@
 @tailwind components;
 @tailwind utilities;
 
-/* ------------------------------------------------------------------
-   PALETTE — "ink and paper, in the dark"
-   ------------------------------------------------------------------ */
+/* ==================================================================
+   NEAT dashboard — marketing identity (matches neat-web-v1/v2)
+   Black canvas, Cormorant Garamond display, EB Garamond body,
+   DM Mono labels. 1px #333 rules, generous whitespace, glyph
+   vocabulary for node kind + provenance.
+   ------------------------------------------------------------------
+   The structural class names (.app, .topbar, .rail, .canvas-wrap,
+   .inspect, .status, .legend …) are preserved so the wired shell
+   keeps working; only the skin changes. The --ink-* / --paper-*
+   token names survive because GraphCanvas reads node colors off
+   them via getComputedStyle — they are remapped onto the marketing
+   palette so the cytoscape canvas reads the same as the chrome.
+   ================================================================== */
 :root {
-  --ink-0: #0a0a0b;
-  --ink-1: #111114;
-  --ink-2: #16161a;
-  --ink-3: #1d1d22;
-  --ink-4: #26262d;
-  --rule:  #232328;
-  --rule-soft: #1a1a1f;
+  /* marketing tokens */
+  --bg:        #000000;
+  --fg:        #ffffff;
+  --fg-muted:  #888888;
+  --rule:      #333333;
+  --rule-soft: #1c1c1c;
 
-  --paper-0: #f4efe6;
-  --paper-1: #d8d3c9;
-  --paper-2: #9b968c;
-  --paper-3: #6a675f;
-  --paper-4: #46443f;
+  /* provenance — kept distinct but muted to sit on black without shouting */
+  --prov-static:    #ffffff;  /* EXTRACTED — solid white */
+  --prov-observed:  #5fcf9e;  /* OBSERVED — the one live accent */
+  --prov-inferred:  #888888;  /* INFERRED — muted grey */
 
-  --accent: #c8a25a;
+  /* surface ramp mapped onto the monochrome scale so existing
+     getComputedStyle('--ink-N') lookups in GraphCanvas resolve */
+  --ink-0: #000000;
+  --ink-1: #000000;
+  --ink-2: #0a0a0a;
+  --ink-3: #161616;
+  --ink-4: #222222;
 
-  --prov-static:    #6ea8ff;
-  --prov-observed:  #5fcf9e;
-  --prov-inferred:  #d27ad8;
+  --paper-0: #ffffff;
+  --paper-1: #e6e6e6;
+  --paper-2: #888888;
+  --paper-3: #666666;
+  --paper-4: #444444;
 
-  --n-service:   #d8d3c9;
+  --accent: #ffffff;
+
+  /* node kinds — monochrome by default, drawn apart by glyph shape
+     in the canvas + legend, not by hue. FileNode is the primary. */
+  --n-file:      #ffffff;
+  --n-service:   #888888;
   --n-db:        #b8c7c2;
   --n-cache:     #c2b8a8;
   --n-stream:    #b8b0c8;
@@ -37,36 +58,61 @@
   --n-apigw:     #98a8b8;
   --n-compute:   #c8b098;
   --n-storage:   #a8a89c;
-  --n-external:  #888278;
+  --n-external:  #777777;
   --n-search:    #c4b6a0;
-  --n-cluster:   #5a5750;
-  --n-namespace: #45433d;
-  --n-vpc:       #38362f;
-  --n-env:       #2a2823;
+  --n-cluster:   #3a3a3a;
+  --n-namespace: #2e2e2e;
+  --n-vpc:       #242424;
+  --n-env:       #1a1a1a;
+
+  /* type primitives */
+  --font-display: 'Cormorant Garamond', Georgia, serif;
+  --font-body:    'EB Garamond', Georgia, serif;
+  --font-mono:    'DM Mono', ui-monospace, monospace;
+
+  /* DM-Mono label recipe — uppercase, wide tracking, small */
+  --label-size: 0.62rem;
+  --label-track: 0.14em;
 }
 
 * { box-sizing: border-box; }
 html, body {
   margin: 0; padding: 0;
   height: 100%; width: 100%;
-  background: var(--ink-0);
-  color: var(--paper-1);
-  font-family: 'Spectral', 'Iowan Old Style', Georgia, serif;
-  font-feature-settings: "ss01", "kern", "liga";
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   overflow: hidden;
 }
-.mono   { font-family: 'JetBrains Mono', ui-monospace, monospace; font-feature-settings: "ss02", "calt", "zero"; }
-.sans   { font-family: 'Inter', -apple-system, system-ui, sans-serif; }
-.serif  { font-family: 'Spectral', Georgia, serif; }
+.mono   { font-family: var(--font-mono); }
+.sans   { font-family: var(--font-body); }
+.serif  { font-family: var(--font-display); }
+
+/* a reusable DM-Mono label */
+.label {
+  font-family: var(--font-mono);
+  font-size: var(--label-size);
+  letter-spacing: var(--label-track);
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+/* the quiet live pulse, ported verbatim from the marketing site */
+@keyframes livePulse {
+  0%, 100% { opacity: 0.4; transform: scale(0.85); }
+  50%      { opacity: 1;   transform: scale(1); }
+}
 
 /* ------------------------------------------------------------------
    APP SHELL
    ------------------------------------------------------------------ */
 .app {
   display: grid;
-  grid-template-columns: 56px 1fr 360px;
-  grid-template-rows: 44px 1fr 28px;
+  grid-template-columns: 56px 1fr 380px;
+  grid-template-rows: 56px 1fr 30px;
   grid-template-areas:
     "topbar topbar topbar"
     "rail   canvas inspect"
@@ -81,8 +127,8 @@ html, body {
   display: flex;
   align-items: center;
   border-bottom: 1px solid var(--rule);
-  background: var(--ink-1);
-  padding-right: 8px;
+  background: var(--bg);
+  padding-right: 16px;
   user-select: none;
 }
 .brand {
@@ -92,226 +138,257 @@ html, body {
   align-items: center;
   justify-content: center;
   border-right: 1px solid var(--rule);
-  font-family: 'Spectral', Georgia, serif;
-  font-weight: 500;
-  font-style: italic;
-  font-size: 22px;
-  color: var(--paper-0);
-  letter-spacing: 0.01em;
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: 26px;
+  color: var(--fg);
+  letter-spacing: -0.02em;
   position: relative;
-}
-.brand::after {
-  content: "";
-  width: 4px; height: 4px;
-  background: var(--accent);
-  border-radius: 50%;
-  margin-left: 2px;
-  margin-bottom: -10px;
 }
 .crumbs {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 0 14px;
-  color: var(--paper-2);
-  font-size: 13px;
-  letter-spacing: 0.01em;
+  gap: 12px;
+  padding: 0 20px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
 }
-.crumbs .sep { color: var(--paper-4); }
-.crumbs .here { color: var(--paper-0); font-style: italic; }
+.crumbs .sep { color: var(--rule); }
+.crumbs .here {
+  font-family: var(--font-mono);
+  font-size: var(--label-size);
+  letter-spacing: var(--label-track);
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
 .crumbs .repo {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
-  color: var(--paper-1);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--fg);
+  letter-spacing: 0.04em;
 }
 
 .topbar-spacer { flex: 1; }
 
+/* project switcher */
+.project-switcher {
+  display: inline-flex;
+  align-items: center;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  padding: 4px 6px;
+  transition: color 0.18s ease;
+}
+.project-switcher:hover { color: var(--fg); }
+.project-switcher .project-name { border-bottom: 1px solid var(--rule); padding-bottom: 1px; }
+.project-switcher:hover .project-name { border-color: var(--fg); }
+.project-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 16px;
+  background: var(--bg);
+  border: 1px solid var(--rule);
+  z-index: 100;
+  min-width: 200px;
+}
+.project-menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--rule);
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  padding: 9px 14px;
+  cursor: pointer;
+  transition: color 0.16s ease, background 0.16s ease;
+}
+.project-menu-item:last-child { border-bottom: none; }
+.project-menu-item:hover { color: var(--fg); background: rgba(255,255,255,0.03); }
+.project-menu-item.active { color: var(--fg); }
+.project-menu-empty {
+  padding: 12px 14px;
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--fg-muted);
+}
+
 .top-search {
   display: flex;
   align-items: center;
-  gap: 8px;
-  background: var(--ink-2);
+  gap: 10px;
+  background: transparent;
   border: 1px solid var(--rule);
-  border-radius: 4px;
-  padding: 4px 10px;
+  padding: 6px 12px;
   width: 320px;
-  color: var(--paper-2);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
   position: relative;
+  transition: border-color 0.18s ease;
 }
+.top-search:focus-within { border-color: var(--fg-muted); }
+.top-search svg { stroke: var(--fg-muted); }
 .top-search input {
   background: transparent;
   border: 0; outline: 0;
-  color: var(--paper-0);
-  font: inherit;
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.02em;
   flex: 1;
 }
+.top-search input::placeholder { color: var(--rule); }
 .top-search .kbd {
-  color: var(--paper-3);
-  font-size: 10.5px;
-  border: 1px solid var(--rule-soft);
-  padding: 1px 5px;
-  border-radius: 3px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.1em;
+  border: 1px solid var(--rule);
+  padding: 1px 6px;
 }
 .search-results {
   position: absolute;
-  top: calc(100% + 4px);
+  top: calc(100% + 6px);
   left: 0; right: 0;
-  background: var(--ink-2);
+  background: var(--bg);
   border: 1px solid var(--rule);
-  border-radius: 4px;
   z-index: 100;
-  max-height: 320px;
+  max-height: 340px;
   overflow-y: auto;
 }
 .search-result-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 7px 10px;
+  gap: 10px;
+  padding: 9px 12px;
   cursor: pointer;
-  font-size: 12px;
+  border-bottom: 1px solid var(--rule);
 }
-.search-result-item:hover { background: var(--ink-3); }
+.search-result-item:last-child { border-bottom: none; }
+.search-result-item:hover { background: rgba(255,255,255,0.03); }
 .search-result-item .sr-name {
-  font-family: 'JetBrains Mono', monospace;
-  color: var(--paper-1);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--fg);
   flex: 1;
 }
 .search-result-item .sr-type {
-  font-family: 'Spectral', serif;
-  font-style: italic;
-  font-size: 11px;
-  color: var(--paper-3);
+  font-family: var(--font-mono);
+  font-size: var(--label-size);
+  letter-spacing: var(--label-track);
+  text-transform: uppercase;
+  color: var(--fg-muted);
 }
 .search-result-item .sr-score {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
-  color: var(--paper-4);
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  color: var(--rule);
 }
 
-.top-actions { display: flex; align-items: center; gap: 4px; margin-left: 10px; }
+.top-actions { display: flex; align-items: center; gap: 18px; margin-left: 18px; }
+.top-actions .daemon-url {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  color: var(--rule);
+}
 .top-btn {
   height: 28px;
-  padding: 0 10px;
+  padding: 0;
   background: transparent;
-  color: var(--paper-1);
-  border: 1px solid transparent;
-  border-radius: 4px;
-  font-family: 'Spectral', Georgia, serif;
-  font-size: 13px;
+  color: var(--fg-muted);
+  border: none;
+  font-family: var(--font-mono);
+  font-size: var(--label-size);
+  letter-spacing: 0.1em;
+  text-transform: lowercase;
   cursor: pointer;
-  display: flex; align-items: center; gap: 6px;
+  display: flex; align-items: center; gap: 7px;
+  transition: color 0.18s ease;
 }
-.top-btn:hover { background: var(--ink-2); border-color: var(--rule); }
-.top-btn.primary {
-  background: var(--paper-0);
-  color: var(--ink-0);
-  font-weight: 500;
+.top-btn:hover:not(:disabled) { color: var(--fg); }
+.top-btn svg { stroke: currentColor; }
+.top-btn .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--rule); flex-shrink: 0; }
+.top-btn .dot.live {
+  background: var(--fg);
+  animation: livePulse 2.6s ease-in-out infinite;
 }
-.top-btn.primary:hover { background: #fff; }
-.top-btn .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--paper-4); }
-.top-btn .dot.live { background: var(--prov-observed); }
-
-.env-pill {
-  display: inline-flex; align-items: center; gap: 6px;
-  padding: 3px 8px 3px 7px;
-  background: var(--ink-2);
-  border: 1px solid var(--rule);
-  border-radius: 3px;
-  color: var(--paper-1);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11.5px;
-}
-.env-pill .dot {
-  width: 6px; height: 6px; border-radius: 50%;
-  background: var(--prov-observed);
-  box-shadow: 0 0 0 2px rgba(95, 207, 158, 0.18);
-}
-
-/* project switcher in topbar */
-.project-select {
-  background: var(--ink-2);
-  border: 1px solid var(--rule);
-  border-radius: 3px;
-  color: var(--paper-1);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
-  padding: 2px 6px;
-  outline: none;
-  cursor: pointer;
-}
-.project-select:focus { border-color: var(--accent); }
 
 /* ---- LEFT RAIL ---------------------------------------------------- */
 .rail {
   grid-area: rail;
-  background: var(--ink-1);
+  background: var(--bg);
   border-right: 1px solid var(--rule);
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 6px 0;
+  padding: 14px 0;
   gap: 2px;
 }
 .rail-group {
   display: flex; flex-direction: column; align-items: center;
-  gap: 2px;
-  padding: 4px 0;
+  gap: 4px;
+  padding: 10px 0;
 }
-.rail-group + .rail-group { border-top: 1px solid var(--rule); margin-top: 4px; }
+.rail-group + .rail-group { border-top: 1px solid var(--rule); }
 .rail-btn {
-  width: 36px; height: 36px;
-  border-radius: 4px;
+  width: 38px; height: 38px;
   display: flex; align-items: center; justify-content: center;
-  color: var(--paper-2);
+  color: var(--fg-muted);
   cursor: pointer;
   position: relative;
   background: transparent;
   border: none;
+  transition: color 0.16s ease;
 }
-.rail-btn:hover { background: var(--ink-2); color: var(--paper-0); }
-.rail-btn.active {
-  background: var(--ink-3);
-  color: var(--paper-0);
-}
+.rail-btn:hover:not(:disabled) { color: var(--fg); }
+.rail-btn.active { color: var(--fg); }
 .rail-btn.active::before {
   content: "";
-  position: absolute; left: -1px; top: 8px; bottom: 8px;
-  width: 2px; background: var(--accent);
-  border-radius: 0 2px 2px 0;
+  position: absolute; left: 0; top: 9px; bottom: 9px;
+  width: 1px; background: var(--fg);
 }
-.rail-btn svg { width: 18px; height: 18px; stroke-width: 1.4; }
+.rail-btn svg { width: 18px; height: 18px; stroke-width: 1.3; stroke: currentColor; }
 .rail-btn .badge {
-  position: absolute; top: 4px; right: 4px;
+  position: absolute; top: 2px; right: 2px;
   min-width: 14px; height: 14px;
-  background: var(--prov-inferred);
-  color: var(--ink-0);
+  background: var(--fg);
+  color: var(--bg);
   border-radius: 7px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 9px;
-  font-weight: 600;
+  font-family: var(--font-mono);
+  font-size: 0.5rem;
   display: flex; align-items: center; justify-content: center;
   padding: 0 3px;
 }
 .rail-tip {
-  position: absolute; left: 44px; top: 50%; transform: translateY(-50%);
-  background: var(--ink-3);
+  position: absolute; left: 46px; top: 50%; transform: translateY(-50%);
+  background: var(--bg);
   border: 1px solid var(--rule);
-  color: var(--paper-0);
-  padding: 4px 8px;
-  border-radius: 3px;
-  font-size: 11.5px;
-  font-family: 'Spectral', serif;
+  color: var(--fg);
+  padding: 5px 10px;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   white-space: nowrap;
   pointer-events: none;
   opacity: 0;
   transition: opacity 0.12s;
   z-index: 50;
 }
-.rail-tip .k { color: var(--paper-3); margin-left: 8px; font-family: 'JetBrains Mono', monospace; font-size: 10.5px; }
+.rail-tip .k { color: var(--fg-muted); margin-left: 10px; }
 .rail-btn:hover .rail-tip { opacity: 1; }
 .rail-spacer { flex: 1; }
 
@@ -320,18 +397,16 @@ html, body {
   grid-area: canvas;
   position: relative;
   overflow: hidden;
-  background:
-    radial-gradient(circle at 20% 0%, rgba(110, 168, 255, 0.04) 0%, transparent 40%),
-    radial-gradient(circle at 80% 100%, rgba(210, 122, 216, 0.03) 0%, transparent 45%),
-    var(--ink-0);
+  background: var(--bg);
 }
+/* baseline grid — faint rule lines, in keeping with the marketing grid */
 .canvas-wrap::before {
   content: "";
   position: absolute; inset: 0;
   background-image:
-    linear-gradient(to right, rgba(244, 239, 230, 0.018) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(244, 239, 230, 0.018) 1px, transparent 1px);
-  background-size: 24px 24px;
+    linear-gradient(to right, rgba(255,255,255,0.016) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(255,255,255,0.016) 1px, transparent 1px);
+  background-size: 32px 32px;
   pointer-events: none;
 }
 #cy {
@@ -340,178 +415,212 @@ html, body {
 }
 
 .canvas-tag {
-  position: absolute; top: 12px; left: 14px;
-  display: flex; align-items: baseline; gap: 10px;
-  color: var(--paper-2);
+  position: absolute; top: 18px; left: 20px;
+  display: flex; flex-direction: column; gap: 4px;
   pointer-events: none;
   z-index: 5;
 }
 .canvas-tag .title {
-  font-family: 'Spectral', serif;
-  font-style: italic;
-  font-size: 18px;
-  color: var(--paper-0);
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: 22px;
+  color: var(--fg);
+  letter-spacing: -0.01em;
 }
 .canvas-tag .meta {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  color: var(--paper-3);
-  letter-spacing: 0.02em;
+  font-family: var(--font-mono);
+  font-size: var(--label-size);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+/* drill-down breadcrumb — the navigation-by-grouping affordance */
+.drill-crumbs {
+  position: absolute; top: 18px; left: 50%; transform: translateX(-50%);
+  display: flex; align-items: center; gap: 10px;
+  z-index: 6;
+  background: var(--bg);
+  border: 1px solid var(--rule);
+  padding: 7px 14px;
+}
+.drill-crumb {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--label-size);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  padding: 0;
+  transition: color 0.16s ease;
+}
+.drill-crumb:hover:not(:disabled) { color: var(--fg); }
+.drill-crumb.current { color: var(--fg); cursor: default; }
+.drill-crumb-sep {
+  color: var(--rule);
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+}
+.drill-hint {
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 0.78rem;
+  color: var(--fg-muted);
+  border-left: 1px solid var(--rule);
+  padding-left: 12px;
+  margin-left: 2px;
 }
 
 .canvas-toolbar {
-  position: absolute; top: 12px; right: 14px;
-  display: flex; gap: 4px;
-  background: var(--ink-1);
+  position: absolute; top: 18px; right: 20px;
+  display: flex; gap: 0;
+  background: var(--bg);
   border: 1px solid var(--rule);
-  border-radius: 4px;
-  padding: 3px;
   z-index: 5;
 }
 .canvas-toolbar button {
-  height: 26px;
-  padding: 0 9px;
+  height: 28px;
+  padding: 0 12px;
   background: transparent;
   border: 0;
-  color: var(--paper-1);
-  font-family: 'Spectral', serif;
-  font-size: 12.5px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--label-size);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   cursor: pointer;
-  border-radius: 3px;
-  display: flex; align-items: center; gap: 6px;
+  display: flex; align-items: center; gap: 7px;
+  transition: color 0.16s ease;
 }
-.canvas-toolbar button:hover { background: var(--ink-3); color: var(--paper-0); }
-.canvas-toolbar button.on {
-  background: var(--ink-3);
-  color: var(--paper-0);
-}
-.canvas-toolbar .div { width: 1px; background: var(--rule); margin: 4px 2px; }
-.canvas-toolbar .mono { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--paper-2); }
+.canvas-toolbar button:hover { color: var(--fg); }
+.canvas-toolbar button.on { color: var(--fg); }
+.canvas-toolbar button svg { stroke: currentColor; }
+.canvas-toolbar .div { width: 1px; background: var(--rule); }
+.canvas-toolbar .mono { font-family: var(--font-mono); color: var(--fg); }
 
-/* PROVENANCE LEGEND */
+/* PROVENANCE + KIND LEGEND */
 .legend {
   position: absolute;
-  left: 14px; bottom: 14px;
-  background: var(--ink-1);
+  left: 20px; bottom: 20px;
+  background: var(--bg);
   border: 1px solid var(--rule);
-  border-radius: 4px;
-  padding: 10px 12px 11px;
+  padding: 16px 18px 17px;
   z-index: 6;
-  min-width: 220px;
+  min-width: 232px;
 }
 .legend h4 {
-  margin: 0 0 8px;
-  font-family: 'Spectral', serif;
-  font-style: italic;
-  font-weight: 500;
-  font-size: 12px;
-  color: var(--paper-2);
-  letter-spacing: 0.04em;
+  margin: 0 0 12px;
+  font-family: var(--font-mono);
+  font-weight: 400;
+  font-size: var(--label-size);
+  letter-spacing: var(--label-track);
   text-transform: uppercase;
+  color: var(--fg-muted);
 }
 .legend-row {
-  display: flex; align-items: center; gap: 9px;
-  padding: 4px 0;
-  font-size: 12.5px;
-  color: var(--paper-1);
+  display: flex; align-items: center; gap: 11px;
+  padding: 5px 0;
+  font-family: var(--font-body);
+  font-size: 0.86rem;
+  color: var(--fg);
   cursor: pointer;
+  transition: opacity 0.16s ease;
 }
 .legend-row .swatch {
-  width: 18px; height: 2px; border-radius: 1px;
+  width: 20px; height: 0;
+  border-top: 1.4px solid var(--fg);
   flex-shrink: 0;
 }
-.legend-row .swatch.dashed {
-  background: transparent;
-  border-top: 1.5px dashed var(--prov-observed);
-  height: 0;
-}
-.legend-row .swatch.dotted {
-  background: transparent;
-  border-top: 2px dotted var(--prov-inferred);
-  height: 0;
-}
-.legend-row .name {
-  font-family: 'Spectral', serif;
-  font-style: italic;
-  flex: 1;
-}
+.legend-row .swatch.dashed { border-top-style: dashed; border-top-color: var(--prov-observed); }
+.legend-row .swatch.dotted { border-top-style: dotted; border-top-color: var(--prov-inferred); }
+.legend-row .name { flex: 1; }
 .legend-row .ct {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  color: var(--paper-3);
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+  color: var(--fg-muted);
 }
 .legend-rule {
   height: 1px;
   background: var(--rule);
-  margin: 8px -12px 8px;
+  margin: 12px -18px 12px;
 }
 .legend .nodes-grid {
-  display: grid; grid-template-columns: 1fr 1fr; column-gap: 12px; row-gap: 4px;
-  font-size: 11px;
+  display: grid; grid-template-columns: 1fr 1fr; column-gap: 16px; row-gap: 7px;
 }
 .legend .nodes-grid .nrow {
-  display: flex; align-items: center; gap: 7px;
-  color: var(--paper-2);
+  display: flex; align-items: center; gap: 9px;
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
 }
-.legend .nodes-grid .nrow .nsq {
-  width: 9px; height: 9px; border-radius: 2px;
+.legend .nodes-grid .nrow .glyph {
+  width: 10px; height: 10px;
   flex-shrink: 0;
+  stroke: var(--fg-muted);
+  fill: none;
+  stroke-width: 1.2;
 }
+.legend .nodes-grid .nrow .glyph.filled { fill: var(--fg); stroke: var(--fg); }
 
 /* MINIMAP */
 .minimap {
   position: absolute;
-  right: 14px; bottom: 14px;
-  width: 220px; height: 150px;
-  background: var(--ink-1);
+  right: 20px; bottom: 20px;
+  width: 224px; height: 150px;
+  background: var(--bg);
   border: 1px solid var(--rule);
-  border-radius: 4px;
   z-index: 6;
   overflow: hidden;
 }
 .minimap canvas { width: 100%; height: 100%; display: block; }
 .minimap .frame {
   position: absolute;
-  border: 1px solid var(--accent);
-  background: rgba(200, 162, 90, 0.08);
+  border: 1px solid var(--fg);
+  background: rgba(255,255,255,0.05);
   pointer-events: none;
 }
 .minimap-label {
-  position: absolute; top: 4px; left: 6px;
-  font-family: 'Spectral', serif;
-  font-style: italic;
-  font-size: 11px;
-  color: var(--paper-3);
+  position: absolute; top: 6px; left: 8px;
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  letter-spacing: var(--label-track);
+  text-transform: uppercase;
+  color: var(--fg-muted);
   pointer-events: none;
 }
 
 /* ZOOM CONTROLS */
 .zoomctl {
   position: absolute;
-  right: 14px; top: 56px;
+  right: 20px; top: 62px;
   display: flex; flex-direction: column;
-  background: var(--ink-1);
+  background: var(--bg);
   border: 1px solid var(--rule);
-  border-radius: 4px;
   z-index: 5;
-  overflow: hidden;
 }
 .zoomctl button {
   width: 30px; height: 28px;
   background: transparent;
   border: 0;
-  color: var(--paper-1);
+  color: var(--fg-muted);
   cursor: pointer;
   display: flex; align-items: center; justify-content: center;
-  font-size: 14px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  transition: color 0.16s ease;
 }
-.zoomctl button:hover { background: var(--ink-3); color: var(--paper-0); }
+.zoomctl button:hover { color: var(--fg); }
 .zoomctl button + button { border-top: 1px solid var(--rule); }
 
 /* ---- INSPECTOR --------------------------------------------------- */
 .inspect {
   grid-area: inspect;
-  background: var(--ink-1);
+  background: var(--bg);
   border-left: 1px solid var(--rule);
   overflow-y: auto;
   overflow-x: hidden;
@@ -519,175 +628,240 @@ html, body {
 .inspect-tabs {
   display: flex;
   border-bottom: 1px solid var(--rule);
-  padding: 0 10px;
-  gap: 4px;
+  padding: 0 18px;
+  gap: 20px;
 }
 .inspect-tab {
-  padding: 10px 8px 9px;
-  font-family: 'Spectral', serif;
-  font-size: 13px;
-  color: var(--paper-2);
+  padding: 16px 0 14px;
+  font-family: var(--font-mono);
+  font-size: var(--label-size);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
   cursor: pointer;
   border-bottom: 1px solid transparent;
   margin-bottom: -1px;
+  transition: color 0.16s ease;
 }
+.inspect-tab:hover { color: var(--fg); }
 .inspect-tab.on {
-  color: var(--paper-0);
-  border-bottom-color: var(--accent);
-  font-style: italic;
+  color: var(--fg);
+  border-bottom-color: var(--fg);
 }
 .inspect-tab .ct {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
-  color: var(--paper-3);
-  margin-left: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  color: var(--fg-muted);
+  margin-left: 5px;
 }
 
-.insp-section { padding: 14px 16px 18px; }
+.insp-section { padding: 22px 20px; }
 .insp-section + .insp-section { border-top: 1px solid var(--rule); }
 
 .insp-eyebrow {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
-  color: var(--paper-3);
+  font-family: var(--font-mono);
+  font-size: var(--label-size);
+  letter-spacing: var(--label-track);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  margin-bottom: 6px;
+  color: var(--fg-muted);
+  margin-bottom: 12px;
 }
 .insp-title {
-  font-family: 'Spectral', serif;
-  font-size: 22px;
-  line-height: 1.2;
-  color: var(--paper-0);
-  font-weight: 400;
+  font-family: var(--font-display);
+  font-size: 1.9rem;
+  font-weight: 300;
+  line-height: 1.12;
+  color: var(--fg);
   word-break: break-word;
+  letter-spacing: -0.01em;
 }
-.insp-title .stem { font-style: italic; color: var(--paper-2); margin-right: 4px; }
+.insp-title .stem { font-style: italic; color: var(--fg-muted); margin-right: 2px; }
 .insp-sub {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  color: var(--paper-2);
-  margin-top: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.04em;
+  color: var(--fg-muted);
+  margin-top: 10px;
   word-break: break-all;
 }
 .insp-tags {
-  display: flex; flex-wrap: wrap; gap: 5px;
-  margin-top: 10px;
+  display: flex; flex-wrap: wrap; gap: 7px;
+  margin-top: 16px;
 }
 .tag {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
-  padding: 2px 6px;
-  border-radius: 2px;
-  background: var(--ink-3);
-  color: var(--paper-1);
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  background: transparent;
+  color: var(--fg-muted);
   border: 1px solid var(--rule);
 }
-.tag.alive { color: var(--prov-observed); border-color: rgba(95,207,158,0.25); }
-.tag.warn  { color: var(--prov-inferred); border-color: rgba(210,122,216,0.25); }
+.tag.alive { color: var(--prov-observed); border-color: rgba(95,207,158,0.4); }
+.tag.warn  { color: var(--fg); border-color: var(--fg-muted); }
 
 .kv {
   display: grid;
-  grid-template-columns: 110px 1fr;
-  column-gap: 12px;
-  row-gap: 4px;
-  font-size: 12px;
+  grid-template-columns: 120px 1fr;
+  column-gap: 16px;
+  row-gap: 0;
 }
 .kv dt {
-  font-family: 'Spectral', serif;
-  font-style: italic;
-  color: var(--paper-3);
+  font-family: var(--font-mono);
+  font-size: var(--label-size);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  padding: 8px 0;
+  border-top: 1px solid var(--rule);
+  align-self: baseline;
 }
 .kv dd {
   margin: 0;
-  font-family: 'JetBrains Mono', monospace;
-  color: var(--paper-1);
+  font-family: var(--font-body);
+  font-size: 0.92rem;
+  color: var(--fg);
   word-break: break-all;
+  padding: 8px 0;
+  border-top: 1px solid var(--rule);
+  align-self: baseline;
 }
 
 .insp-h {
-  font-family: 'Spectral', serif;
-  font-style: italic;
-  font-weight: 500;
-  color: var(--paper-0);
-  font-size: 13px;
-  margin: 0 0 8px;
+  font-family: var(--font-mono);
+  font-size: var(--label-size);
+  letter-spacing: var(--label-track);
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin: 0 0 14px;
   display: flex; align-items: baseline; justify-content: space-between;
 }
 .insp-h .ct {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
-  font-style: normal;
-  color: var(--paper-3);
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  color: var(--fg-muted);
 }
 
 .edge-list { list-style: none; margin: 0; padding: 0; }
 .edge-list li {
-  display: flex; align-items: center; gap: 8px;
-  padding: 5px 0;
-  font-size: 12px;
-  border-bottom: 1px dashed var(--rule-soft);
+  display: flex; align-items: center; gap: 10px;
+  padding: 9px 0;
+  border-top: 1px solid var(--rule);
 }
-.edge-list li:last-child { border-bottom: 0; }
+.edge-list li:first-child { border-top: none; }
 .edge-list .verb {
-  font-family: 'Spectral', serif;
-  font-style: italic;
-  color: var(--paper-2);
-  width: 70px;
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  width: 76px;
   flex-shrink: 0;
 }
 .edge-list .target {
-  font-family: 'JetBrains Mono', monospace;
-  color: var(--paper-1);
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  color: var(--fg);
   flex: 1;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
+.edge-list .target.clickable { cursor: pointer; transition: color 0.14s ease; }
+.edge-list .target.clickable:hover { color: var(--fg-muted); }
 .edge-list .pdot {
-  width: 6px; height: 6px; border-radius: 50%;
+  width: 7px; height: 7px; border-radius: 50%;
   flex-shrink: 0;
 }
 .edge-list .pdot.STATIC   { background: var(--prov-static); }
 .edge-list .pdot.OBSERVED { background: var(--prov-observed); }
 .edge-list .pdot.INFERRED { background: var(--prov-inferred); }
 .edge-list .conf {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
-  color: var(--paper-3);
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  color: var(--fg-muted);
   width: 32px;
   text-align: right;
 }
+/* file:line evidence under a call row */
+.edge-evidence {
+  font-family: var(--font-mono);
+  font-size: 0.56rem;
+  letter-spacing: 0.02em;
+  color: var(--fg-muted);
+  padding: 0 0 9px 86px;
+  margin-top: -4px;
+  border-bottom: 1px solid var(--rule);
+  word-break: break-all;
+}
+.edge-evidence:last-child { border-bottom: none; }
+
+/* file list when a service is selected */
+.file-list { list-style: none; margin: 0; padding: 0; }
+.file-list li {
+  display: flex; align-items: center; gap: 10px;
+  padding: 9px 0;
+  border-top: 1px solid var(--rule);
+  cursor: pointer;
+  transition: color 0.14s ease;
+}
+.file-list li:first-child { border-top: none; }
+.file-list li:hover .fpath { color: var(--fg-muted); }
+.file-list .fglyph { width: 9px; height: 9px; flex-shrink: 0; fill: var(--fg); }
+.file-list .fpath {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.01em;
+  color: var(--fg);
+  flex: 1;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  transition: color 0.14s ease;
+}
+
+/* owning service link */
+.owning-service {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--font-body);
+  font-size: 0.92rem;
+  color: var(--fg);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+.owning-service .svc-name { border-bottom: 1px solid var(--rule); transition: border-color 0.16s ease; }
+.owning-service:hover .svc-name { border-color: var(--fg); }
+.owning-service .glyph { width: 9px; height: 9px; stroke: var(--fg-muted); fill: none; stroke-width: 1.2; }
 
 /* root cause block */
 .root-cause-block {
-  background: var(--ink-2);
   border: 1px solid var(--rule);
-  border-radius: 3px;
-  padding: 10px 12px;
+  padding: 14px 16px;
 }
 .root-cause-block .rc-label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
-  color: var(--prov-inferred);
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  letter-spacing: var(--label-track);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  margin-bottom: 5px;
+  color: var(--fg-muted);
+  margin-bottom: 8px;
 }
 .root-cause-block .rc-node {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
-  color: var(--paper-0);
-  margin-bottom: 5px;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--fg);
+  margin-bottom: 8px;
 }
 .root-cause-block .rc-reason {
-  font-family: 'Spectral', serif;
+  font-family: var(--font-body);
   font-style: italic;
-  font-size: 12.5px;
-  color: var(--paper-1);
-  margin-bottom: 5px;
+  font-size: 0.92rem;
+  line-height: 1.6;
+  color: var(--fg);
+  margin-bottom: 8px;
 }
 .root-cause-block .rc-fix {
-  font-family: 'Spectral', serif;
-  font-size: 12px;
+  font-family: var(--font-body);
+  font-size: 0.9rem;
   color: var(--prov-observed);
 }
 
@@ -695,224 +869,217 @@ html, body {
 .metrics {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
-  gap: 10px;
+  border: 1px solid var(--rule);
 }
 .metric {
-  background: var(--ink-2);
-  border: 1px solid var(--rule);
-  border-radius: 3px;
-  padding: 8px 10px;
+  padding: 14px 14px;
+  border-left: 1px solid var(--rule);
 }
+.metric:first-child { border-left: none; }
 .metric .lbl {
-  font-family: 'Spectral', serif;
-  font-style: italic;
-  font-size: 11px;
-  color: var(--paper-3);
+  font-family: var(--font-mono);
+  font-size: 0.52rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
 }
 .metric .val {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 16px;
-  color: var(--paper-0);
-  margin-top: 2px;
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  font-weight: 300;
+  color: var(--fg);
+  margin-top: 6px;
+  font-variant-numeric: tabular-nums;
 }
-.metric .delta {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
-  color: var(--prov-observed);
-  margin-top: 1px;
-}
-.metric .delta.bad { color: #e87a7a; }
+.metric .val.bad { color: #e08a8a; }
 
 /* ---- STATUS BAR -------------------------------------------------- */
 .status {
   grid-area: status;
   border-top: 1px solid var(--rule);
-  background: var(--ink-1);
+  background: var(--bg);
   display: flex;
   align-items: center;
-  padding: 0 10px;
-  gap: 14px;
-  color: var(--paper-2);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+  padding: 0 16px;
+  gap: 20px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
 }
-.status .st-item { display: flex; align-items: center; gap: 6px; }
-.status .st-item .k { color: var(--paper-3); }
-.status .st-item .v { color: var(--paper-1); }
+.status .st-item { display: flex; align-items: center; gap: 8px; }
+.status .st-item .dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.status .st-item .k { color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.1em; }
+.status .st-item .v { color: var(--fg); }
 .status .st-spacer { flex: 1; }
-.status .live::before {
-  content: ""; display: inline-block;
-  width: 6px; height: 6px; border-radius: 50%;
-  background: var(--prov-observed);
-  margin-right: 6px;
-  box-shadow: 0 0 0 0 rgba(95,207,158,0.5);
-  animation: pulse 1.8s infinite;
-}
-.status .live-dead::before {
-  content: ""; display: inline-block;
-  width: 6px; height: 6px; border-radius: 50%;
-  background: var(--paper-4);
-  margin-right: 6px;
-}
-@keyframes pulse {
-  0% { box-shadow: 0 0 0 0 rgba(95,207,158,0.45); }
-  70% { box-shadow: 0 0 0 6px rgba(95,207,158,0); }
-  100% { box-shadow: 0 0 0 0 rgba(95,207,158,0); }
-}
 
 /* time scrubber */
 .scrub {
-  display: flex; align-items: center; gap: 8px;
-  background: var(--ink-2);
-  border: 1px solid var(--rule);
-  border-radius: 3px;
-  padding: 2px 8px;
-  height: 20px;
+  display: flex; align-items: center; gap: 10px;
 }
+.scrub .k { color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.1em; }
 .scrub .bar {
-  width: 220px; height: 4px;
-  background: var(--ink-3);
-  border-radius: 2px;
+  width: 200px; height: 1px;
+  background: var(--rule);
   position: relative;
 }
 .scrub .bar .fill {
   position: absolute; left: 0; top: 0; bottom: 0;
   width: 100%;
-  background: linear-gradient(to right, rgba(110,168,255,0.4), rgba(95,207,158,0.6));
-  border-radius: 2px;
+  background: var(--fg-muted);
 }
 .scrub .bar .head {
   position: absolute; right: 0; top: -3px;
-  width: 2px; height: 10px; background: var(--accent);
+  width: 1px; height: 7px; background: var(--fg);
 }
-.scrub .now { color: var(--paper-1); }
+.scrub .now { color: var(--fg); font-variant-numeric: tabular-nums; }
 
 /* ---- INCIDENTS PAGE ----------------------------------------------- */
 .incidents-page {
-  padding: 24px 32px;
-  max-width: 1000px;
+  padding: 48px 64px;
+  max-width: 1100px;
   overflow-y: auto;
-  height: calc(100vh - 44px);
+  height: 100vh;
 }
 .incidents-page h1 {
-  font-family: 'Spectral', serif;
-  font-style: italic;
-  font-weight: 400;
-  font-size: 28px;
-  color: var(--paper-0);
-  margin: 0 0 4px;
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: 2.6rem;
+  line-height: 1.05;
+  color: var(--fg);
+  margin: 0 0 8px;
+  letter-spacing: -0.01em;
 }
 .incidents-page .subtitle {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11.5px;
-  color: var(--paper-3);
-  margin-bottom: 24px;
+  font-family: var(--font-mono);
+  font-size: var(--label-size);
+  letter-spacing: var(--label-track);
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin-bottom: 40px;
 }
 .incidents-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 12.5px;
 }
 .incidents-table th {
-  font-family: 'Spectral', serif;
-  font-style: italic;
-  font-weight: 500;
-  font-size: 11.5px;
-  color: var(--paper-2);
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  letter-spacing: var(--label-track);
+  text-transform: uppercase;
+  font-weight: 400;
+  color: var(--fg-muted);
   text-align: left;
-  padding: 6px 12px;
+  padding: 10px 16px;
   border-bottom: 1px solid var(--rule);
 }
 .incidents-table td {
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--rule-soft);
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--rule);
   vertical-align: top;
 }
-.incidents-table tr:hover td { background: var(--ink-2); }
+.incidents-table tr:hover td { background: rgba(255,255,255,0.02); }
 .incidents-table .td-node {
-  font-family: 'JetBrains Mono', monospace;
-  color: var(--paper-1);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--fg);
   white-space: nowrap;
 }
 .incidents-table .td-time {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  color: var(--paper-3);
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  color: var(--fg-muted);
   white-space: nowrap;
 }
 .incidents-table .td-type {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  color: var(--prov-inferred);
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+  color: var(--fg-muted);
 }
 .incidents-table .td-msg {
-  font-family: 'Spectral', serif;
+  font-family: var(--font-body);
   font-style: italic;
-  color: var(--paper-1);
-  max-width: 400px;
+  font-size: 0.95rem;
+  color: var(--fg);
+  max-width: 440px;
 }
 .incidents-empty {
-  font-family: 'Spectral', serif;
+  font-family: var(--font-body);
   font-style: italic;
-  color: var(--paper-3);
-  padding: 32px 0;
+  font-size: 1rem;
+  color: var(--fg-muted);
+  padding: 48px 0;
   text-align: center;
 }
 .incidents-nav-link {
-  color: var(--paper-2);
+  color: var(--fg-muted);
   text-decoration: none;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
+  font-family: var(--font-mono);
+  font-size: var(--label-size);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  transition: color 0.16s ease;
 }
+.incidents-nav-link:hover { color: var(--fg); }
 .incidents-node-link {
-  color: var(--paper-1);
+  color: var(--fg);
   text-decoration: none;
-  font-family: 'JetBrains Mono', monospace;
+  border-bottom: 1px solid var(--rule);
+  font-family: var(--font-mono);
+  transition: border-color 0.16s ease;
 }
-.incidents-node-link:hover { color: var(--paper-0); text-decoration: underline; }
-.td-stacktrace { padding: 0 !important; background: var(--ink-2); }
+.incidents-node-link:hover { border-color: var(--fg); }
+.td-stacktrace { padding: 0 !important; }
 .stacktrace-pre {
   margin: 0;
-  padding: 12px 16px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10.5px;
-  color: var(--paper-3);
+  padding: 16px 20px;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  line-height: 1.7;
+  color: var(--fg-muted);
   white-space: pre-wrap;
   word-break: break-all;
-  background: var(--ink-2);
-  border-bottom: 1px solid var(--rule-soft);
+  border-bottom: 1px solid var(--rule);
 }
-.stack-toggle { color: var(--paper-3); font-style: normal; font-size: 10px; }
+.stack-toggle { color: var(--fg-muted); font-size: 0.55rem; }
+
+/* status chips (env / public-read / sign-out) inherit mono via .status */
+.env-chip, .public-read-chip { font-family: var(--font-mono); }
 
 /* scrollbars */
 ::-webkit-scrollbar { width: 8px; height: 8px; }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--ink-3); border-radius: 4px; }
-::-webkit-scrollbar-thumb:hover { background: var(--ink-4); }
+::-webkit-scrollbar-thumb { background: var(--rule); }
+::-webkit-scrollbar-thumb:hover { background: var(--fg-muted); }
+
+a:focus-visible, button:focus-visible {
+  outline: 1px solid var(--fg);
+  outline-offset: 2px;
+}
 
 /* ------------------------------------------------------------------
-   shadcn primitive tokens — single dark theme. The login surface
-   uses these via `bg-background`, `text-foreground`, etc. The app
-   shell ignores them; its palette is defined above.
+   shadcn primitive tokens — the /login surface uses these via
+   `bg-background`, `text-foreground`, etc. Remapped onto the
+   marketing palette so login reads as the same product.
    ------------------------------------------------------------------ */
 :root {
-  --background: var(--ink-0);
-  --foreground: var(--paper-1);
-  --card: var(--ink-1);
-  --card-foreground: var(--paper-1);
-  --popover: var(--ink-1);
-  --popover-foreground: var(--paper-1);
-  --primary: var(--paper-0);
-  --primary-foreground: var(--ink-0);
-  --secondary: var(--ink-2);
-  --secondary-foreground: var(--paper-1);
-  --muted: var(--ink-2);
-  --muted-foreground: var(--paper-3);
-  --accent: var(--accent);
-  --accent-foreground: var(--ink-0);
-  --destructive: #e87a7a;
+  --background: var(--bg);
+  --foreground: var(--fg);
+  --card: var(--bg);
+  --card-foreground: var(--fg);
+  --popover: var(--bg);
+  --popover-foreground: var(--fg);
+  --primary: var(--fg);
+  --primary-foreground: var(--bg);
+  --secondary: #0a0a0a;
+  --secondary-foreground: var(--fg);
+  --muted: #0a0a0a;
+  --muted-foreground: var(--fg-muted);
+  --accent-foreground: var(--bg);
+  --destructive: #e08a8a;
   --border: var(--rule);
   --input: var(--rule);
-  --ring: var(--accent);
-  --radius: 0.5rem;
+  --ring: var(--fg);
+  --radius: 0;
 }

--- a/packages/web/app/incidents/IncidentsClient.tsx
+++ b/packages/web/app/incidents/IncidentsClient.tsx
@@ -69,7 +69,7 @@ export function IncidentsClient() {
   }, [project])
 
   return (
-    <div style={{ background: 'var(--ink-0)', minHeight: '100vh' }}>
+    <div style={{ background: 'var(--bg)', minHeight: '100vh' }}>
       <header className="topbar">
         <div className="brand" title="NEAT">N</div>
         <div className="crumbs">

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
-          href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Cormorant+Garamond:wght@300;400;600&family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@400;500;600&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400;1,500;1,600&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=DM+Mono:ital,wght@0,300;0,400;0,500;1,400&display=swap"
           rel="stylesheet"
         />
       </head>

--- a/packages/web/audit/09-gaps-and-stubs.md
+++ b/packages/web/audit/09-gaps-and-stubs.md
@@ -50,10 +50,25 @@ When code state changes, this file changes in lockstep.
 
 | Tab | Status | Notes |
 |-----|--------|-------|
-| Inspect | wired | Default tab — node detail. |
+| Inspect | wired | Default tab — node detail. For a FileNode: path, calls originating from it (provenance + `file:line` evidence), owning service. For a service: the files it CONTAINS. |
 | Edges | wired | All in/out edges with provenance. |
 | Owners | wired | Renders `ServiceNode.owner` per ADR-054, or "no owner declared" hint. |
 | History | disabled | Tooltip: "History — coming in v0.3.x". |
+
+### GraphCanvas drill-down (#397, file-awareness §2/§3)
+
+Every drill affordance is wired — it produces an observable change (the canvas
+expands/collapses a service to its files, or selects a node). The first-column
+label below is a verbatim source string so the ADR-056 #4 scan resolves it.
+
+| Element | Status | Notes |
+|---------|--------|-------|
+| all services | wired | Breadcrumb root button — collapses every expanded service back to the top view (`onCollapseAll`). Disabled when already at top. |
+| drill-crumb | wired | One breadcrumb button per expanded service — collapses just that service (`onCollapseService`). |
+| Drill breadcrumb | wired | The breadcrumb nav itself; double-click a service node to expand (`onExpandService`), double-click again to collapse. |
+| owning service | wired | Inspector, FileNode view — opens the file's service and selects it. |
+| file-list | wired | Inspector, service view — each file row drills the canvas open and selects the file. |
+| target clickable | wired | Inspector, "calls from this file" — selects the called node. |
 
 ---
 

--- a/packages/web/lib/fixtures.ts
+++ b/packages/web/lib/fixtures.ts
@@ -1,26 +1,50 @@
 // Fixture data returned when NEAT_DEMO=1 and core is unreachable.
-// Represents a realistic microservices graph for standalone frontend dev.
+// File-first graph (file-awareness.md §1-§3): FileNodes are the primary
+// nodes, CALLS edges originate from files, and `service ──CONTAINS──▶ file`
+// expresses ownership. CONNECTS_TO to databases/infra also originates from
+// the file that opens the connection. The dashboard collapses services by
+// default and expands to these files on drill-down.
 
 export const FIXTURE_GRAPH = {
   nodes: [
+    // services — collapsed containers in the top view
     { id: 'service:checkout', type: 'ServiceNode', name: 'checkout', language: 'TypeScript', version: '2.4.1' },
-    { id: 'service:payments', type: 'ServiceNode', name: 'payments', language: 'Go', version: '1.2.0' },
+    { id: 'service:payments', type: 'ServiceNode', name: 'payments', language: 'TypeScript', version: '1.2.0' },
     { id: 'service:auth', type: 'ServiceNode', name: 'auth', language: 'TypeScript', version: '3.0.0' },
-    { id: 'service:api-gateway', type: 'ServiceNode', name: 'api/gateway', language: 'TypeScript', version: '1.0.5' },
+    { id: 'service:api-gateway', type: 'ServiceNode', name: 'api-gateway', language: 'TypeScript', version: '1.0.5' },
     { id: 'service:notifications', type: 'ServiceNode', name: 'notifications', language: 'Python', version: '1.1.0' },
-    { id: 'database:payments-db.internal', type: 'DatabaseNode', name: 'payments-db', host: 'payments-db.internal', port: '5432', engine: 'postgresql', engineVersion: '15.2' },
-    { id: 'database:auth-db.internal', type: 'DatabaseNode', name: 'auth-db', host: 'auth-db.internal', port: '5432', engine: 'postgresql', engineVersion: '14.8' },
-    { id: 'infra:redis:cache.internal', type: 'InfraNode', name: 'cache', kind: 'cache', host: 'cache.internal', port: '6379' },
+    // files — revealed when a service is opened
+    { id: 'file:checkout:src/routes/charge.ts', type: 'FileNode', service: 'checkout', path: 'src/routes/charge.ts', language: 'ts' },
+    { id: 'file:checkout:src/lib/cache.ts', type: 'FileNode', service: 'checkout', path: 'src/lib/cache.ts', language: 'ts' },
+    { id: 'file:checkout:src/notify.ts', type: 'FileNode', service: 'checkout', path: 'src/notify.ts', language: 'ts' },
+    { id: 'file:payments:src/db.ts', type: 'FileNode', service: 'payments', path: 'src/db.ts', language: 'ts' },
+    { id: 'file:auth:src/token.ts', type: 'FileNode', service: 'auth', path: 'src/token.ts', language: 'ts' },
+    { id: 'file:auth:src/db.ts', type: 'FileNode', service: 'auth', path: 'src/db.ts', language: 'ts' },
+    { id: 'file:api-gateway:src/proxy.ts', type: 'FileNode', service: 'api-gateway', path: 'src/proxy.ts', language: 'ts' },
+    // datastores + infra
+    { id: 'database:payments-db.internal', type: 'DatabaseNode', name: 'payments-db', host: 'payments-db.internal', port: 5432, engine: 'postgresql', engineVersion: '15.2', compatibleDrivers: [] },
+    { id: 'database:auth-db.internal', type: 'DatabaseNode', name: 'auth-db', host: 'auth-db.internal', port: 5432, engine: 'postgresql', engineVersion: '14.8', compatibleDrivers: [] },
+    { id: 'infra:redis:cache.internal', type: 'InfraNode', name: 'cache', kind: 'cache', provider: 'redis' },
   ],
   edges: [
-    { id: 'CALLS:OBSERVED:service:api-gateway->service:checkout', source: 'service:api-gateway', target: 'service:checkout', type: 'CALLS', provenance: 'OBSERVED', confidence: 1.0, callCount: 42891 },
-    { id: 'CALLS:OBSERVED:service:api-gateway->service:auth', source: 'service:api-gateway', target: 'service:auth', type: 'CALLS', provenance: 'OBSERVED', confidence: 1.0, callCount: 18204 },
-    { id: 'CALLS:OBSERVED:service:checkout->service:payments', source: 'service:checkout', target: 'service:payments', type: 'CALLS', provenance: 'OBSERVED', confidence: 1.0, callCount: 9341 },
-    { id: 'CALLS:EXTRACTED:service:checkout->service:notifications', source: 'service:checkout', target: 'service:notifications', type: 'CALLS', provenance: 'EXTRACTED', confidence: 0.9 },
-    { id: 'CONNECTS_TO:OBSERVED:service:payments->database:payments-db.internal', source: 'service:payments', target: 'database:payments-db.internal', type: 'CONNECTS_TO', provenance: 'OBSERVED', confidence: 1.0 },
-    { id: 'CONNECTS_TO:EXTRACTED:service:auth->database:auth-db.internal', source: 'service:auth', target: 'database:auth-db.internal', type: 'CONNECTS_TO', provenance: 'EXTRACTED', confidence: 0.95 },
-    { id: 'CONNECTS_TO:INFERRED:service:checkout->infra:redis:cache.internal', source: 'service:checkout', target: 'infra:redis:cache.internal', type: 'CONNECTS_TO', provenance: 'INFERRED', confidence: 0.6 },
-    { id: 'CONNECTS_TO:INFERRED:service:auth->infra:redis:cache.internal', source: 'service:auth', target: 'infra:redis:cache.internal', type: 'CONNECTS_TO', provenance: 'INFERRED', confidence: 0.6 },
+    // service ──CONTAINS──▶ file (structural ownership, not traffic)
+    { id: 'CONTAINS:checkout->charge', source: 'service:checkout', target: 'file:checkout:src/routes/charge.ts', type: 'CONTAINS', provenance: 'EXTRACTED', confidence: 1.0 },
+    { id: 'CONTAINS:checkout->cache', source: 'service:checkout', target: 'file:checkout:src/lib/cache.ts', type: 'CONTAINS', provenance: 'EXTRACTED', confidence: 1.0 },
+    { id: 'CONTAINS:checkout->notify', source: 'service:checkout', target: 'file:checkout:src/notify.ts', type: 'CONTAINS', provenance: 'EXTRACTED', confidence: 1.0 },
+    { id: 'CONTAINS:payments->db', source: 'service:payments', target: 'file:payments:src/db.ts', type: 'CONTAINS', provenance: 'EXTRACTED', confidence: 1.0 },
+    { id: 'CONTAINS:auth->token', source: 'service:auth', target: 'file:auth:src/token.ts', type: 'CONTAINS', provenance: 'EXTRACTED', confidence: 1.0 },
+    { id: 'CONTAINS:auth->db', source: 'service:auth', target: 'file:auth:src/db.ts', type: 'CONTAINS', provenance: 'EXTRACTED', confidence: 1.0 },
+    { id: 'CONTAINS:gw->proxy', source: 'service:api-gateway', target: 'file:api-gateway:src/proxy.ts', type: 'CONTAINS', provenance: 'EXTRACTED', confidence: 1.0 },
+    // CALLS originate from files, with file:line evidence
+    { id: 'CALLS:OBSERVED:gw-proxy->charge', source: 'file:api-gateway:src/proxy.ts', target: 'file:checkout:src/routes/charge.ts', type: 'CALLS', provenance: 'OBSERVED', confidence: 0.98, callCount: 42891, evidence: { file: 'src/proxy.ts', line: 64 }, signal: { spanCount: 42891, errorCount: 12 } },
+    { id: 'CALLS:OBSERVED:gw-proxy->token', source: 'file:api-gateway:src/proxy.ts', target: 'file:auth:src/token.ts', type: 'CALLS', provenance: 'OBSERVED', confidence: 0.97, callCount: 18204, evidence: { file: 'src/proxy.ts', line: 81 }, signal: { spanCount: 18204, errorCount: 3 } },
+    { id: 'CALLS:OBSERVED:charge->payments-db', source: 'file:checkout:src/routes/charge.ts', target: 'file:payments:src/db.ts', type: 'CALLS', provenance: 'OBSERVED', confidence: 0.95, callCount: 9341, evidence: { file: 'src/routes/charge.ts', line: 118 }, signal: { spanCount: 9341, errorCount: 421 } },
+    { id: 'CALLS:EXTRACTED:notify->notifications', source: 'file:checkout:src/notify.ts', target: 'service:notifications', type: 'CALLS', provenance: 'EXTRACTED', confidence: 0.9, evidence: { file: 'src/notify.ts', line: 22 } },
+    // connections to datastores + infra, file-grained
+    { id: 'CONNECTS_TO:OBSERVED:payments-db->pg', source: 'file:payments:src/db.ts', target: 'database:payments-db.internal', type: 'CONNECTS_TO', provenance: 'OBSERVED', confidence: 1.0, evidence: { file: 'src/db.ts', line: 9 } },
+    { id: 'CONNECTS_TO:EXTRACTED:auth-db->pg', source: 'file:auth:src/db.ts', target: 'database:auth-db.internal', type: 'CONNECTS_TO', provenance: 'EXTRACTED', confidence: 0.95, evidence: { file: 'src/db.ts', line: 11 } },
+    { id: 'CONNECTS_TO:INFERRED:checkout-cache->redis', source: 'file:checkout:src/lib/cache.ts', target: 'infra:redis:cache.internal', type: 'CONNECTS_TO', provenance: 'INFERRED', confidence: 0.6 },
+    { id: 'CONNECTS_TO:INFERRED:auth-token->redis', source: 'file:auth:src/token.ts', target: 'infra:redis:cache.internal', type: 'CONNECTS_TO', provenance: 'INFERRED', confidence: 0.6 },
   ],
 }
 
@@ -58,11 +82,17 @@ export const FIXTURE_PROJECTS = [
 
 export const FIXTURE_VIOLATIONS = { violations: [] }
 
+// A node's searchable / display name. FileNodes carry `path` rather than
+// `name`, so fall back to it (then to the id) — keeps search file-aware.
+function fixtureNodeLabel(n: { name?: string; path?: string; id: string }): string {
+  return n.name ?? n.path ?? n.id
+}
+
 export function fixtureSearch(q: string) {
   const lower = q.toLowerCase()
   const results = FIXTURE_GRAPH.nodes
-    .filter((n) => n.name.toLowerCase().includes(lower) || n.id.toLowerCase().includes(lower))
-    .map((n) => ({ node: { id: n.id, type: n.type, name: n.name }, score: 0.95 }))
+    .filter((n) => fixtureNodeLabel(n).toLowerCase().includes(lower) || n.id.toLowerCase().includes(lower))
+    .map((n) => ({ node: { id: n.id, type: n.type, name: fixtureNodeLabel(n) }, score: 0.95 }))
   return { results }
 }
 

--- a/packages/web/test/drilldown-model.test.ts
+++ b/packages/web/test/drilldown-model.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import type { GraphNode, GraphEdge } from '@neat.is/types'
+import {
+  buildModel,
+  visibleGraph,
+  filesOf,
+  callsFrom,
+} from '../app/components/graph-model'
+
+// A small file-first graph (file-awareness.md §1-§3):
+//   service:a CONTAINS file:a/x, file:a/y
+//   service:b CONTAINS file:b/z
+//   file:a/x CALLS file:b/z   (file-grained, with evidence)
+//   file:a/y CONNECTS_TO database:d
+const nodes: GraphNode[] = [
+  { id: 'service:a', type: 'ServiceNode', name: 'a', language: 'ts' } as GraphNode,
+  { id: 'service:b', type: 'ServiceNode', name: 'b', language: 'ts' } as GraphNode,
+  { id: 'file:a:x.ts', type: 'FileNode', service: 'a', path: 'src/x.ts' } as GraphNode,
+  { id: 'file:a:y.ts', type: 'FileNode', service: 'a', path: 'src/y.ts' } as GraphNode,
+  { id: 'file:b:z.ts', type: 'FileNode', service: 'b', path: 'src/z.ts' } as GraphNode,
+  { id: 'database:d', type: 'DatabaseNode', name: 'd', engine: 'pg', engineVersion: '15', compatibleDrivers: [] } as GraphNode,
+]
+const edges: GraphEdge[] = [
+  { id: 'c1', source: 'service:a', target: 'file:a:x.ts', type: 'CONTAINS', provenance: 'EXTRACTED' } as GraphEdge,
+  { id: 'c2', source: 'service:a', target: 'file:a:y.ts', type: 'CONTAINS', provenance: 'EXTRACTED' } as GraphEdge,
+  { id: 'c3', source: 'service:b', target: 'file:b:z.ts', type: 'CONTAINS', provenance: 'EXTRACTED' } as GraphEdge,
+  { id: 'call1', source: 'file:a:x.ts', target: 'file:b:z.ts', type: 'CALLS', provenance: 'OBSERVED', confidence: 0.9, evidence: { file: 'src/x.ts', line: 42 } } as GraphEdge,
+  { id: 'conn1', source: 'file:a:y.ts', target: 'database:d', type: 'CONNECTS_TO', provenance: 'EXTRACTED', confidence: 0.8, evidence: { file: 'src/y.ts', line: 7 } } as GraphEdge,
+]
+
+describe('file-first drill-down model (file-awareness §2/§3)', () => {
+  const model = buildModel(nodes, edges)
+
+  it('indexes service↔file containment from CONTAINS edges (§2)', () => {
+    expect(model.filesByService.get('service:a')).toEqual(['file:a:x.ts', 'file:a:y.ts'])
+    expect(model.filesByService.get('service:b')).toEqual(['file:b:z.ts'])
+    expect(model.serviceByFile.get('file:a:x.ts')).toBe('service:a')
+    expect(model.serviceByFile.get('file:b:z.ts')).toBe('service:b')
+  })
+
+  it('top view (no expansion) hides files and shows services as containers', () => {
+    const vis = visibleGraph(nodes, edges, model, new Set())
+    const ids = vis.nodes.map((n) => n.id)
+    expect(ids).toContain('service:a')
+    expect(ids).toContain('service:b')
+    expect(ids).toContain('database:d')
+    // files are hidden until their service is opened
+    expect(ids).not.toContain('file:a:x.ts')
+    expect(ids).not.toContain('file:b:z.ts')
+  })
+
+  it('never renders CONTAINS as a graph edge — containment is visibility, not an arrow', () => {
+    const vis = visibleGraph(nodes, edges, model, new Set(['service:a', 'service:b']))
+    expect(vis.edges.some((e) => e.type === 'CONTAINS')).toBe(false)
+  })
+
+  it('a hidden file re-anchors its edge onto its collapsed-service container, never a service→service summary', () => {
+    // expand only service:a; file:b:z.ts stays hidden under collapsed service:b.
+    const vis = visibleGraph(nodes, edges, model, new Set(['service:a']))
+    const ids = vis.nodes.map((n) => n.id)
+    expect(ids).toContain('file:a:x.ts') // a's files revealed
+    expect(ids).not.toContain('file:b:z.ts') // b still collapsed
+
+    // the file:a:x.ts → file:b:z.ts CALLS edge renders file-grained on the
+    // source side and re-anchors the hidden target onto service:b — but it is
+    // still the same CALLS edge with its provenance, not a new service edge.
+    const call = vis.edges.find((e) => e.id === 'call1')
+    expect(call).toBeTruthy()
+    expect(call!.source).toBe('file:a:x.ts')
+    expect(call!.target).toBe('service:b')
+    expect(call!.type).toBe('CALLS')
+    expect(call!.provenance).toBe('OBSERVED')
+    // provenance proof that we didn't fabricate a service→service rollup
+    expect(call!._origSource).toBe('file:a:x.ts')
+    expect(call!._origTarget).toBe('file:b:z.ts')
+  })
+
+  it('drops an edge that would collapse to a self-loop between two files in the same collapsed service (no service→service edge)', () => {
+    // an intra-service call: file:a:x → file:a:y, both under service:a.
+    const intra: GraphEdge[] = [
+      ...edges,
+      { id: 'call2', source: 'file:a:x.ts', target: 'file:a:y.ts', type: 'CALLS', provenance: 'OBSERVED' } as GraphEdge,
+    ]
+    const m = buildModel(nodes, intra)
+    // collapsed: both endpoints → service:a → would be a self-loop, dropped.
+    const collapsed = visibleGraph(nodes, intra, m, new Set())
+    expect(collapsed.edges.some((e) => e.id === 'call2')).toBe(false)
+    // expanded: the file-grained edge is drawn between the two files.
+    const expanded = visibleGraph(nodes, intra, m, new Set(['service:a']))
+    const e = expanded.edges.find((x) => x.id === 'call2')
+    expect(e?.source).toBe('file:a:x.ts')
+    expect(e?.target).toBe('file:a:y.ts')
+  })
+
+  it('filesOf returns the files a service CONTAINS (for the Inspector service view)', () => {
+    const files = filesOf('service:a', model).map((f) => f.id)
+    expect(files).toEqual(['file:a:x.ts', 'file:a:y.ts'])
+  })
+
+  it('callsFrom returns file-grained originating calls with provenance + file:line evidence (§1/§6)', () => {
+    const calls = callsFrom('file:a:x.ts', edges, model.byId)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      targetId: 'file:b:z.ts',
+      provenance: 'OBSERVED',
+      confidence: 0.9,
+      evidenceFile: 'src/x.ts',
+      evidenceLine: 42,
+    })
+    // CONTAINS is structural ownership, not a call — excluded.
+    const svcCalls = callsFrom('service:a', edges, model.byId)
+    expect(svcCalls).toHaveLength(0)
+  })
+})

--- a/packages/web/test/inspector-file-first.test.tsx
+++ b/packages/web/test/inspector-file-first.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import type { GraphNode, GraphEdge } from '@neat.is/types'
+import type { GraphData } from '../app/components/AppShell'
+import { Inspector } from '../app/components/Inspector'
+
+// file-first sample: service:a CONTAINS file:a/x; file:a/x CALLS database:d
+const nodes: GraphNode[] = [
+  { id: 'service:a', type: 'ServiceNode', name: 'a', language: 'ts' } as GraphNode,
+  { id: 'file:a:x.ts', type: 'FileNode', service: 'a', path: 'src/x.ts', language: 'ts' } as GraphNode,
+  { id: 'database:d', type: 'DatabaseNode', name: 'orders-db', engine: 'pg', engineVersion: '15', compatibleDrivers: [] } as GraphNode,
+]
+const edges: GraphEdge[] = [
+  { id: 'c1', source: 'service:a', target: 'file:a:x.ts', type: 'CONTAINS', provenance: 'EXTRACTED' } as GraphEdge,
+  { id: 'call1', source: 'file:a:x.ts', target: 'database:d', type: 'CONNECTS_TO', provenance: 'OBSERVED', confidence: 0.91, evidence: { file: 'src/x.ts', line: 128 } } as GraphEdge,
+]
+const graphData: GraphData = { nodes, edges }
+
+function stubNodeFetch(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const m = url.match(/\/api\/graph\/node\/([^?]+)/)
+      if (m) {
+        const id = decodeURIComponent(m[1])
+        const node = nodes.find((n) => n.id === id)
+        return new Response(JSON.stringify({ node }), { status: 200, headers: { 'content-type': 'application/json' } })
+      }
+      // root-cause + anything else: empty
+      return new Response(JSON.stringify({ rootCauseNode: null }), { status: 200, headers: { 'content-type': 'application/json' } })
+    }),
+  )
+}
+
+beforeEach(() => stubNodeFetch())
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks() })
+
+describe('Inspector file-grained detail (#397, file-awareness §1/§2)', () => {
+  it('a FileNode shows its path, owning service, and the calls originating from it with file:line evidence', async () => {
+    render(
+      <Inspector
+        project="default"
+        selectedNodeId="file:a:x.ts"
+        graphData={graphData}
+        onNodeSelect={vi.fn()}
+        onExpandService={vi.fn()}
+      />,
+    )
+
+    // path is the title surface
+    await waitFor(() => expect(screen.getByText('x.ts')).toBeInTheDocument())
+    // owning service is named and clickable
+    expect(screen.getByText('Owning service')).toBeInTheDocument()
+    expect(screen.getByText('a')).toBeInTheDocument()
+    // calls-from-file block with the target and its file:line evidence
+    expect(screen.getByText(/Calls from this file/i)).toBeInTheDocument()
+    expect(screen.getByText('orders-db')).toBeInTheDocument()
+    expect(screen.getByText('src/x.ts:128')).toBeInTheDocument()
+  })
+
+  it('clicking the owning service drills into it (onExpandService) and selects it', async () => {
+    const onExpandService = vi.fn()
+    const onNodeSelect = vi.fn()
+    render(
+      <Inspector
+        project="default"
+        selectedNodeId="file:a:x.ts"
+        graphData={graphData}
+        onNodeSelect={onNodeSelect}
+        onExpandService={onExpandService}
+      />,
+    )
+    const svcBtn = await screen.findByTitle("Open this service's files")
+    fireEvent.click(svcBtn)
+    expect(onExpandService).toHaveBeenCalledWith('service:a')
+    expect(onNodeSelect).toHaveBeenCalledWith('service:a')
+  })
+
+  it('a service shows the files it CONTAINS; clicking a file drills in and selects it', async () => {
+    const onExpandService = vi.fn()
+    const onNodeSelect = vi.fn()
+    render(
+      <Inspector
+        project="default"
+        selectedNodeId="service:a"
+        graphData={graphData}
+        onNodeSelect={onNodeSelect}
+        onExpandService={onExpandService}
+      />,
+    )
+    await waitFor(() => expect(screen.getByText(/^Files$/i)).toBeInTheDocument())
+    const fileRow = screen.getByText('src/x.ts')
+    fireEvent.click(fileRow)
+    expect(onExpandService).toHaveBeenCalledWith('service:a')
+    expect(onNodeSelect).toHaveBeenCalledWith('file:a:x.ts')
+  })
+})


### PR DESCRIPTION
Refs #397

Two pieces, both off `main` (which already has the #414/#415 read-path auth): the dashboard now wears the v2 marketing identity, and the file-first graph drills from services down to their files.

## Restyle

The shell — AppShell, GraphCanvas, Inspector, TopBar, StatusBar, Rail, DebugPanel — is reskinned to match the marketing site, not rebuilt. Black canvas, Cormorant Garamond display, EB Garamond body, DM Mono labels (uppercase, wide tracking), 1px `#333` rule-line dividers, generous whitespace. The connection dot uses the quiet `livePulse`. The cytoscape canvas reads off the same tokens so the graph matches the chrome, and node kinds are drawn apart by the glyph vocabulary (filled square = file, hexagon = service, circle = db, pentagon = frontier, diamond = compute, triangle = infra) rather than by hue. The structural class names and the `--ink/--paper` token aliases the canvas reads survive, so every wire (auth, SSE, multi-project, search) keeps working.

## Drill-down (file-awareness §2/§3)

The graph is file-first, so the dashboard navigates *by the grouping* and never rolls up:

- **Top view** shows services as collapsed containers; files are hidden so it isn't a flat file hairball (level-of-detail default).
- **Double-clicking a service** expands it to the `FileNode`s it `CONTAINS`; double-click again collapses. A breadcrumb in the canvas (`all services › svc › …`) tracks what's open and walks back out.
- **Rendered edges stay file-grained.** A hidden file's endpoint re-anchors onto its collapsed-service container so the relationship still reads, but it's the same `CALLS`/`CONNECTS_TO` edge with its own provenance and evidence — never collapsed into a service→service summary, and there is no service-level edge view. An edge that would become a self-loop between two files in one collapsed service is dropped, not drawn as a service edge. `CONTAINS` is expressed by visibility (open the container), never as an arrow.
- **Inspector** is file-grained: a `FileNode` shows its path, the calls originating from it (provenance + `file:line` evidence), and its owning service (click to open it); a service shows the files it contains (click a file to drill in and select it).

The demo fixture is now file-first (FileNodes, CONTAINS, file-grained CALLS with evidence) so standalone dev exercises the drill-down.

## Governance

- **web-completeness (#26):** every new drill affordance is wired (observable change); the gaps-and-stubs audit records them, and the ADR-056 scan passes.
- **web-multi-project (#27):** AppShell still owns project state; drill state is project-orthogonal UI state. All consumers re-fetch on `[project]`.
- **web-debugging (#28):** StatusBar's daemon/SSE state attributes and `Ctrl+Shift+D` are intact.
- **file-awareness (#42 §2/§3):** group-not-rollup, no service-edge view — enforced in `graph-model.ts` and covered by tests.

## Tests

`npx turbo build test lint` green across the monorepo. New: `drilldown-model.test.ts` (7) covers the file-first model rules; `inspector-file-first.test.tsx` (3) covers the Inspector's file-grained surfaces. Existing 19 web tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)