### PR TITLE
Bump to 0.4.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10550,7 +10550,7 @@
     },
     "packages/claude-skill": {
       "name": "@neat.is/claude-skill",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "license": "BUSL-1.1",
       "engines": {
         "node": ">=20"
@@ -10558,13 +10558,13 @@
     },
     "packages/core": {
       "name": "@neat.is/core",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "license": "BUSL-1.1",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
         "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
-        "@neat.is/types": "^0.4.8",
+        "@neat.is/types": "^0.4.9",
         "chokidar": "^4.0.3",
         "fastify": "^5.0.0",
         "graphology": "^0.25.4",
@@ -10603,11 +10603,11 @@
     },
     "packages/mcp": {
       "name": "@neat.is/mcp",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "license": "BUSL-1.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@neat.is/types": "^0.4.8",
+        "@neat.is/types": "^0.4.9",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -10625,13 +10625,13 @@
       }
     },
     "packages/neat.is": {
-      "version": "0.4.8",
+      "version": "0.4.9",
       "license": "BUSL-1.1",
       "dependencies": {
-        "@neat.is/claude-skill": "^0.4.8",
-        "@neat.is/core": "^0.4.8",
-        "@neat.is/mcp": "^0.4.8",
-        "@neat.is/web": "^0.4.8"
+        "@neat.is/claude-skill": "^0.4.9",
+        "@neat.is/core": "^0.4.9",
+        "@neat.is/mcp": "^0.4.9",
+        "@neat.is/web": "^0.4.9"
       },
       "bin": {
         "neat": "bin/neat",
@@ -10645,7 +10645,7 @@
     },
     "packages/types": {
       "name": "@neat.is/types",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "license": "BUSL-1.1",
       "dependencies": {
         "zod": "^3.23.8"
@@ -10661,11 +10661,11 @@
     },
     "packages/web": {
       "name": "@neat.is/web",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "license": "BUSL-1.1",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
-        "@neat.is/types": "^0.4.8",
+        "@neat.is/types": "^0.4.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cytoscape": "^3.33.3",

--- a/packages/claude-skill/package.json
+++ b/packages/claude-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/claude-skill",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Claude Code skill drop-in for NEAT — wires the @neat.is/mcp server into Claude's MCP config",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/core",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "NEAT graph engine: tree-sitter extraction, OTel ingest, REST API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -50,7 +50,7 @@
     "@fastify/cors": "^10.0.0",
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
-    "@neat.is/types": "^0.4.8",
+    "@neat.is/types": "^0.4.9",
     "chokidar": "^4.0.3",
     "fastify": "^5.0.0",
     "graphology": "^0.25.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/mcp",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "NEAT MCP server: exposes graph queries to AI agents over stdio",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@neat.is/types": "^0.4.8",
+    "@neat.is/types": "^0.4.9",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/neat.is/package.json
+++ b/packages/neat.is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neat.is",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "NEAT — live semantic graph of a software system, queryable from AI agents over MCP. Install once, get the neat / neatd / neat-mcp CLIs.",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -26,9 +26,9 @@
     "README.md"
   ],
   "dependencies": {
-    "@neat.is/core": "^0.4.8",
-    "@neat.is/mcp": "^0.4.8",
-    "@neat.is/claude-skill": "^0.4.8",
-    "@neat.is/web": "^0.4.8"
+    "@neat.is/core": "^0.4.9",
+    "@neat.is/mcp": "^0.4.9",
+    "@neat.is/claude-skill": "^0.4.9",
+    "@neat.is/web": "^0.4.9"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/types",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Shared Zod schemas, types, and runtime constants for NEAT",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/web",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "NEAT web shell — minimal Next.js app fronting the core API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "@neat.is/types": "^0.4.8",
+    "@neat.is/types": "^0.4.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cytoscape": "^3.33.3",


### PR DESCRIPTION
Lockstep bump to 0.4.9 across all six packages, internal dep ranges, and the lockfile. Ships the dashboard restyle with service→file drill-down and the read-client bearer wiring to npm.

Refs #414 #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)