### PR TITLE
v0.4.10 dashboard fixes: healthy-project resolution + daemon URL alignment

### DIFF
--- a/docs/contracts/web-multi-project.md
+++ b/docs/contracts/web-multi-project.md
@@ -37,10 +37,20 @@ In order, first non-empty wins:
 
 1. URL query param: `?project=X`
 2. `localStorage.getItem('neat:lastProject')` — survives reload
-3. First entry from `GET /projects` if registry is non-empty
+3. First **active** entry from `GET /projects` (rule 2.3 below)
 4. `'default'` fallback (only allowed value of `'default'` in branching logic)
 
 Steps 1-2 run synchronously inside the `useState` lazy initializer; step 3 is async and runs from a `useEffect` after mount only when steps 1-2 produced no value. AppShell is rendered client-only (see rule 2a below), so the synchronous reads are safe — no server-side execution to disagree with.
+
+### 2.3 Step 3 is health-aware
+
+The `/projects` payload carries a `status` per ADR-051 (`'active' | 'paused' | 'broken'`). Step 3 must not blindly take `list[0]` — a `broken` (dead path) or `paused` project resolves to an empty/erroring graph and blanks the dashboard (#419). Resolution within step 3:
+
+1. First project whose `status` is `'active'`.
+2. If none are active, the first project with a name (so a single non-active registered project still beats `'default'`).
+3. Only if the list is empty (or the registry is unreachable), `'default'`.
+
+The selector is a pure function (`resolveProjectFromList` in `AppShell.tsx`) so it can be unit-tested directly without rendering.
 
 ### 2a. Client-only render boundaries (ADR-062 + 2026-05-11 amendment, supersedes the SSR-safety amendment to ADR-057)
 

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -7214,12 +7214,15 @@ describe('Web shell multi-project routing (ADR-057)', () => {
     expect(src).toMatch(/localStorage[\s\S]*?neat:lastProject/)
   })
 
-  it('AppShell.tsx falls back to first entry from GET /projects when registry is non-empty (ADR-057 #2.3)', () => {
+  it('AppShell.tsx resolves to the first active project from GET /projects, skipping broken/paused (ADR-057 #2.3, web-multi-project §2.3)', () => {
     const src = readSrc(APP_SHELL)
     // `authedFetch` from ADR-073 §3 is also acceptable — it's a thin wrapper
     // around `fetch` that attaches the bearer when one is in storage.
     expect(src).toMatch(/(authed)?[Ff]etch\(['"]\/api\/projects['"]\)/)
-    expect(src).toMatch(/list\[0\]/)
+    // Resolution is a pure, unit-testable selector that prefers an active
+    // project so the dashboard never opens onto a broken/paused one (#419).
+    expect(src).toMatch(/resolveProjectFromList/)
+    expect(src).toMatch(/status\s*===\s*['"]active['"]/)
   })
 
   it('AppShell.tsx falls back to "default" when registry is empty (ADR-057 #2.4)', () => {

--- a/packages/web/app/components/AppShell.tsx
+++ b/packages/web/app/components/AppShell.tsx
@@ -17,7 +17,21 @@ export interface GraphData {
   edges: GraphEdge[]
 }
 
-interface ProjectEntry { name: string }
+// The /projects payload carries a status per ADR-051. 'active' is the healthy
+// state; 'broken' (dead path) and 'paused' both yield an empty/erroring graph.
+interface ProjectEntry { name: string; status?: 'active' | 'paused' | 'broken' }
+
+// web-multi-project §2.3 — pick the project to land on when neither the URL
+// nor localStorage named one. Prefer the first *active* project so we never
+// open onto a broken/paused one and blank the dashboard (#419). If none are
+// active, fall back to the first available project, then to 'default' (§2.4).
+export function resolveProjectFromList(list: ProjectEntry[]): string {
+  const active = list.find((p) => p?.name && p.status === 'active')
+  if (active?.name) return active.name
+  const firstNamed = list.find((p) => p?.name)
+  if (firstNamed?.name) return firstNamed.name
+  return 'default'
+}
 
 // ADR-057 #2 — resolution chain. URL → localStorage → first /projects → 'default'.
 function readUrlProject(): string | null {
@@ -72,8 +86,10 @@ export function AppShell() {
     window.history.replaceState({}, '', url)
   }
 
-  // ADR-057 #2.3, #2.4 — if neither URL nor localStorage gave us a project,
-  // fetch /projects and use the first entry; fall back to 'default' if empty.
+  // ADR-057 #2.3, #2.4 / web-multi-project §2.3 — if neither URL nor
+  // localStorage gave us a project, fetch /projects and resolve to the first
+  // *active* one (skip broken/paused so we don't open onto an empty graph,
+  // #419); fall back to the first available, then to 'default' if empty.
   useEffect(() => {
     if (resolvedRef.current) return
     resolvedRef.current = true
@@ -81,11 +97,7 @@ export function AppShell() {
       .then((r) => (r.ok ? r.json() : []))
       .then((data: ProjectEntry[] | { projects?: ProjectEntry[] }) => {
         const list = Array.isArray(data) ? data : Array.isArray(data?.projects) ? data.projects : []
-        if (list.length > 0 && list[0]?.name) {
-          setProject(list[0].name)
-        } else {
-          setProject('default')
-        }
+        setProject(resolveProjectFromList(list))
       })
       .catch(() => {
         /* registry unreachable — keep 'default' fallback */

--- a/packages/web/lib/proxy.ts
+++ b/packages/web/lib/proxy.ts
@@ -1,4 +1,10 @@
-export const CORE_URL = process.env.NEAT_CORE_URL ?? 'http://localhost:8080'
+// web-bootstrap §6 — neatd's spawnWebUI sets NEAT_API_URL in the child's env,
+// pointing at the daemon that launched it. The proxy routes must read the same
+// name, or a non-default PORT lands us back on :8080 (the old NEAT_CORE_URL
+// mismatch, #418). NEAT_CORE_URL stays as a deprecated fallback so operators
+// who set it by hand don't break on upgrade.
+export const CORE_URL =
+  process.env.NEAT_API_URL ?? process.env.NEAT_CORE_URL ?? 'http://localhost:8080'
 export const DEMO = process.env.NEAT_DEMO === '1'
 
 // Forward the operator's bearer (ADR-073 §3) and the SSE caller's Last-Event-ID

--- a/packages/web/test/project-resolution.test.tsx
+++ b/packages/web/test/project-resolution.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+
+// #419 — when neither the URL nor localStorage names a project, AppShell
+// resolves against GET /projects. Taking list[0] blindly lands on a broken
+// (dead path) or paused project, which graphs to nothing and blanks the
+// dashboard. The resolver must skip non-active projects.
+
+import { AppShell, resolveProjectFromList } from '../app/components/AppShell'
+
+describe('#419 — resolveProjectFromList (the resolution selector, tested directly)', () => {
+  it('skips a broken project ordered first and picks the active one', () => {
+    expect(
+      resolveProjectFromList([
+        { name: 'dead', status: 'broken' },
+        { name: 'live', status: 'active' },
+      ]),
+    ).toBe('live')
+  })
+
+  it('skips a paused project ordered first and picks the active one', () => {
+    expect(
+      resolveProjectFromList([
+        { name: 'snoozed', status: 'paused' },
+        { name: 'live', status: 'active' },
+      ]),
+    ).toBe('live')
+  })
+
+  it('resolves a single registered project to it, not to default', () => {
+    expect(resolveProjectFromList([{ name: 'medusa', status: 'active' }])).toBe('medusa')
+  })
+
+  it('falls back to the first available when none are active', () => {
+    expect(
+      resolveProjectFromList([
+        { name: 'dead', status: 'broken' },
+        { name: 'snoozed', status: 'paused' },
+      ]),
+    ).toBe('dead')
+  })
+
+  it('treats a missing status as non-active but still beats default', () => {
+    // A registered project with no status string shouldn't be preferred over an
+    // explicitly active one...
+    expect(
+      resolveProjectFromList([{ name: 'unknown' }, { name: 'live', status: 'active' }]),
+    ).toBe('live')
+    // ...but on its own it still beats the literal 'default'.
+    expect(resolveProjectFromList([{ name: 'unknown' }])).toBe('unknown')
+  })
+
+  it('falls back to default on an empty list', () => {
+    expect(resolveProjectFromList([])).toBe('default')
+  })
+})
+
+// Stub the heavy data-fetching children so AppShell renders under jsdom; each
+// echoes the project it was handed onto a /api fetch so we can read resolution.
+vi.mock('../app/components/GraphCanvas', () => ({
+  GraphCanvas: ({ project }: { project: string }) => {
+    fetch(`/api/graph?project=${encodeURIComponent(project)}`)
+    return <div data-testid="graph-canvas" data-project={project} />
+  },
+}))
+vi.mock('../app/components/Inspector', () => ({ Inspector: () => null }))
+vi.mock('../app/components/StatusBar', () => ({ StatusBar: () => null }))
+vi.mock('../app/components/Rail', () => ({ Rail: () => null }))
+vi.mock('../app/components/TopBar', () => ({ TopBar: () => null }))
+vi.mock('../app/components/Toaster', () => ({ Toaster: () => null }))
+vi.mock('../app/components/DebugPanel', () => ({ DebugPanel: () => null }))
+
+// jsdom 25's built-in localStorage is flaky under this setup, so we install a
+// fresh in-memory shim per test (same pattern as login-surface.test.tsx).
+function makeStorage(): Storage {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v))
+    },
+    removeItem: (k: string) => {
+      store.delete(k)
+    },
+    clear: () => store.clear(),
+  } as Storage
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('#419 — AppShell resolves to a healthy project end to end', () => {
+  const fetchCalls: string[] = []
+
+  beforeEach(() => {
+    fetchCalls.length = 0
+    // No URL or localStorage project, so resolution falls to GET /projects.
+    window.history.replaceState({}, '', '/')
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: makeStorage(),
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        fetchCalls.push(url)
+        if (url.includes('/api/projects')) {
+          return jsonResponse([
+            { name: 'broken-one', status: 'broken' },
+            { name: 'healthy-one', status: 'active' },
+          ])
+        }
+        return jsonResponse({})
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('lands the graph on the active project, never the broken one ordered first', async () => {
+    render(<AppShell />)
+    await waitFor(() => {
+      expect(fetchCalls.some((u) => u.includes('project=healthy-one'))).toBe(true)
+    })
+    expect(fetchCalls.some((u) => u.includes('project=broken-one'))).toBe(false)
+    // And localStorage now remembers the healthy resolution, not 'default'.
+    expect(window.localStorage.getItem('neat:lastProject')).toBe('healthy-one')
+  })
+})

--- a/packages/web/test/proxy-core-url.test.ts
+++ b/packages/web/test/proxy-core-url.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+// #418 — neatd's spawnWebUI sets NEAT_API_URL on the spawned web process
+// (web-bootstrap §6). The proxy routes must read that same name. Before the
+// fix they read only NEAT_CORE_URL, so on a non-default PORT the daemon set
+// NEAT_API_URL=http://localhost:<restPort> while the proxy fell through to
+// the :8080 default — and the dashboard talked to the wrong daemon.
+//
+// CORE_URL is resolved at module load, so each case resets the module
+// registry and re-imports with the env it wants.
+
+const ORIGINAL_API = process.env.NEAT_API_URL
+const ORIGINAL_CORE = process.env.NEAT_CORE_URL
+
+afterEach(() => {
+  if (ORIGINAL_API === undefined) delete process.env.NEAT_API_URL
+  else process.env.NEAT_API_URL = ORIGINAL_API
+  if (ORIGINAL_CORE === undefined) delete process.env.NEAT_CORE_URL
+  else process.env.NEAT_CORE_URL = ORIGINAL_CORE
+  vi.resetModules()
+})
+
+async function loadCoreUrl(): Promise<string> {
+  vi.resetModules()
+  const mod = await import('../lib/proxy')
+  return mod.CORE_URL
+}
+
+describe('#418 — proxy reads the daemon URL from NEAT_API_URL', () => {
+  it('uses NEAT_API_URL when neatd spawned us on a non-default port', async () => {
+    delete process.env.NEAT_CORE_URL
+    process.env.NEAT_API_URL = 'http://localhost:9090'
+    expect(await loadCoreUrl()).toBe('http://localhost:9090')
+  })
+
+  it('does not fall back to :8080 when NEAT_API_URL is set to a non-default port', async () => {
+    delete process.env.NEAT_CORE_URL
+    process.env.NEAT_API_URL = 'http://localhost:9090'
+    expect(await loadCoreUrl()).not.toBe('http://localhost:8080')
+  })
+
+  it('keeps the :8080 default when nothing is set', async () => {
+    delete process.env.NEAT_API_URL
+    delete process.env.NEAT_CORE_URL
+    expect(await loadCoreUrl()).toBe('http://localhost:8080')
+  })
+
+  it('still honors a hand-set NEAT_CORE_URL as a deprecated fallback', async () => {
+    delete process.env.NEAT_API_URL
+    process.env.NEAT_CORE_URL = 'http://localhost:7070'
+    expect(await loadCoreUrl()).toBe('http://localhost:7070')
+  })
+
+  it('prefers NEAT_API_URL over NEAT_CORE_URL when both are set', async () => {
+    process.env.NEAT_API_URL = 'http://localhost:9090'
+    process.env.NEAT_CORE_URL = 'http://localhost:7070'
+    expect(await loadCoreUrl()).toBe('http://localhost:9090')
+  })
+})


### PR DESCRIPTION
Two web↔daemon-boundary fixes from the v0.4.9 dashboard, one PR.

## #419 — dashboard resolves to a healthy project

When neither the URL nor localStorage named a project, `AppShell` resolved the `/projects` list by taking `list[0]` outright. A `broken` (dead path) or `paused` project ordered first meant an empty graph and a blank dashboard. The `'default'` fallback also landed on a literal `'default'` that the orchestrator usually hasn't registered (it registers the repo basename).

Resolution now lives in a pure `resolveProjectFromList` selector: first project whose `status` is `active`, else the first available, else `'default'`. URL → localStorage precedence (ADR-057 §2) is untouched — this only refines step 3. A single registered project now resolves to itself, not `'default'`.

Contract `web-multi-project.md` §2.3 records the health-aware resolution; the ADR-057 enforcement test moves off the old `list[0]` check onto the selector.

## #418 — proxy reaches the daemon on non-default ports

`neatd`'s `spawnWebUI` hands the spawned web process `NEAT_API_URL=http://localhost:<restPort>`, but the proxy routes read only `NEAT_CORE_URL ?? 'http://localhost:8080'`. The names never met, so on a non-default `PORT` the proxy fell through to `:8080` and the dashboard talked to the wrong daemon.

`packages/web/lib/proxy.ts` now reads `NEAT_API_URL` first (the name `web-bootstrap` §6 and `web-debugging` §1 already name for the web side), keeping `NEAT_CORE_URL` as a deprecated fallback and the `:8080` default. The daemon side is unchanged.

## Tests

- `packages/web/test/project-resolution.test.tsx` — the `resolveProjectFromList` selector directly (broken/paused skipped, single project, no-status, empty → `'default'`) plus an AppShell end-to-end check that the graph lands on the active project. Fails on the old `list[0]` resolution, passes now.
- `packages/web/test/proxy-core-url.test.ts` — `CORE_URL` resolves from `NEAT_API_URL`, doesn't fall to `:8080` on a non-default port, keeps the default when unset, honors the `NEAT_CORE_URL` fallback. Fails on the old name mismatch, passes now.

`npx turbo build test lint` green (the one core lint warning is pre-existing in `orchestrator.ts`, outside this diff).

## Out of scope

Registry/extend (v0.4.11), static-extraction breadth, browser instrumentation.

Refs #419 #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)