### PR TITLE
Gate OBSERVED edges to the caller side and normalize observed file paths

### DIFF
--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -53,6 +53,13 @@ import { emitNeatEvent } from './events.js'
 export interface IngestContext {
   graph: NeatGraph
   errorsPath: string
+  // Absolute scan root the daemon is watching for this project. When set, a
+  // runtime `code.filepath` is made service-root-relative against it before the
+  // FileNode is keyed (file-awareness.md §4) — the service's absolute root is
+  // `scanPath/<repoPath>`, which recovers `dist/foo.js` even for a single-
+  // package service whose `repoPath` is empty (issue #430). Omitted by ad-hoc
+  // callers and most tests, which rely on the repoPath-segment anchor instead.
+  scanPath?: string
   // Project name for event-bus routing (ADR-051). Defaults to DEFAULT_PROJECT
   // when omitted — keeps single-project tests / scripts wire-compatible.
   project?: string
@@ -142,6 +149,28 @@ export function resetUnidentifiedSpanWarnings(): void {
   unidentifiedWarnedProjects.clear()
 }
 
+// One-time-per-session-per-service audit for a compiled `dist/...js` call site
+// that carried no adjacent source map (file-awareness.md §4 + §6). Without a
+// map, ingest can't reconcile the observed dist file to the static `src/...ts`
+// the extractor parsed — the dist path is the honest answer, never a fabricated
+// src path. The leak this surfaces (issue #430) was hiding behind an absolute
+// path prefix; once the path is service-root-relative the mismatch is legible,
+// and this line tells the operator how to close it.
+const noSourceMapWarnedServices = new Set<string>()
+function warnNoSourceMaps(serviceName: string): void {
+  if (noSourceMapWarnedServices.has(serviceName)) return
+  noSourceMapWarnedServices.add(serviceName)
+  console.warn(
+    `[neat] ${serviceName}: no .map files found under dist/; observed file edges will land on dist paths, not src. Set sourceMap: true in tsconfig to enable file-level reconciliation.`,
+  )
+}
+
+// Test seam — mirrors resetUnidentifiedSpanWarnings for the once-per-service
+// audit above.
+export function resetNoSourceMapWarnings(): void {
+  noSourceMapWarnedServices.clear()
+}
+
 function pickAttr(span: ParsedSpan, ...keys: string[]): string | undefined {
   for (const k of keys) {
     const v = span.attributes[k]
@@ -213,8 +242,22 @@ function languageForExt(relPath: string): string | undefined {
 // the package-relative tail. With no usable anchor, the real runtime path is
 // returned in a relative-looking form — honest, even if it doesn't align with a
 // static src path. Never fabricated.
-function relPathForRuntimeFile(filepath: string, serviceNode?: ServiceNode): string | null {
+function relPathForRuntimeFile(
+  filepath: string,
+  serviceNode?: ServiceNode,
+  scanPath?: string,
+): string | null {
   let p = toPosix(filepath).replace(/^file:\/\//, '')
+  // When ingest knows the absolute scan root, the service's absolute root is
+  // `scanPath/<repoPath>`. Stripping it directly recovers the service-relative
+  // tail (`dist/foo.js`) even for a single-package service whose `repoPath` is
+  // empty — the segment anchor below has nothing to grab in that case, so the
+  // absolute path used to leak into the FileNode key (issue #430).
+  if (scanPath && scanPath.length > 0) {
+    const absRoot = toPosix(path.resolve(scanPath, serviceNode?.repoPath ?? ''))
+    const anchor = absRoot.endsWith('/') ? absRoot : `${absRoot}/`
+    if (p.startsWith(anchor)) return p.slice(anchor.length)
+  }
   const root = serviceNode?.repoPath
   if (root && root !== '.' && root.length > 0) {
     const rootPosix = toPosix(root)
@@ -296,7 +339,11 @@ function resolveDistToSrc(absFilepath: string, line?: number): ResolvedSrc | nul
 // Read the call-site attributes off a span. Returns null when the span carries
 // no `code.filepath` (SERVER spans, un-instrumented peers, callee side) so the
 // caller falls back to a service-level edge.
-function callSiteFromSpan(span: ParsedSpan, serviceNode?: ServiceNode): CallSite | null {
+function callSiteFromSpan(
+  span: ParsedSpan,
+  serviceNode?: ServiceNode,
+  scanPath?: string,
+): CallSite | null {
   const filepath = span.attributes[CODE_FILEPATH_ATTR]
   if (typeof filepath !== 'string' || filepath.length === 0) return null
   const linenoRaw = span.attributes[CODE_LINENO_ATTR]
@@ -309,12 +356,19 @@ function callSiteFromSpan(span: ParsedSpan, serviceNode?: ServiceNode): CallSite
   let effectivePath = filepath
   let originalRelPath: string | undefined
   if (resolved) {
-    originalRelPath = relPathForRuntimeFile(filepath, serviceNode) ?? undefined
+    originalRelPath = relPathForRuntimeFile(filepath, serviceNode, scanPath) ?? undefined
     effectivePath = resolved.filepath
     if (resolved.line !== undefined) line = resolved.line
   }
-  const relPath = relPathForRuntimeFile(effectivePath, serviceNode)
+  const relPath = relPathForRuntimeFile(effectivePath, serviceNode, scanPath)
   if (!relPath) return null
+  // A compiled `dist/...js` call site that didn't resolve through a map keeps
+  // the (honest) dist path. Surface the absence once per service so the
+  // operator can enable source maps and recover src-level reconciliation
+  // (file-awareness.md §4 + §6, issue #430).
+  if (!resolved && abs.endsWith('.js') && relPath.startsWith('dist/') && serviceNode?.name) {
+    warnNoSourceMaps(serviceNode.name)
+  }
   const fnRaw = span.attributes[CODE_FUNCTION_ATTR]
   const fn = typeof fnRaw === 'string' && fnRaw.length > 0 ? fnRaw : undefined
   return {
@@ -379,6 +433,35 @@ function makeInferredEdgeId(type: EdgeTypeValue, source: string, target: string)
 
 const INFERRED_CONFIDENCE = 0.6
 const STITCH_MAX_DEPTH = 2
+
+// OTLP-wire SpanKind values. The receiver decodes the raw wire integer onto
+// `ParsedSpan.kind` (otel.ts), and the wire enum is offset by one from the
+// `@opentelemetry/api` SpanKind the SDK uses in-process — UNSPECIFIED 0,
+// INTERNAL 1, SERVER 2, CLIENT 3, PRODUCER 4, CONSUMER 5. So we must NOT import
+// `@opentelemetry/api` here: its CLIENT is 2 (= wire SERVER) and PRODUCER is 3
+// (= wire CLIENT), which would gate the wrong kinds. Cross-referenced with the
+// wire fixtures in otel.test.ts (kind 2 = SERVER, kind 3 = CLIENT) and the
+// CLIENT call-site spans in ingest.test.ts (kind 3).
+const WIRE_SPAN_KIND_CLIENT = 3
+const WIRE_SPAN_KIND_PRODUCER = 4
+
+// An OBSERVED edge originates from the caller/producer side of a call. CLIENT
+// and PRODUCER spans are that side; INTERNAL / SERVER / CONSUMER are not — a
+// SERVER span is the callee, and its edge is minted from its parent CLIENT via
+// the parent-span fallback (the mirror image of CLIENT+SERVER, and of
+// PRODUCER+CONSUMER for queues). Without this gate every INTERNAL span that
+// happens to carry a peer address — e.g. a `tcp.connect` / `tls.connect` to an
+// AWS endpoint — mints a spurious service-level edge (issue #429), because no
+// §4 capture layer stamps `code.*` on INTERNAL spans.
+//
+// A span that reports no kind (undefined) or UNSPECIFIED (0) carries no
+// caller/callee signal, so it falls back to the historical unconditional
+// behavior — hand-built and legacy producers keep minting. The leak this gates
+// is always an explicitly-kinded INTERNAL span.
+function spanMintsObservedEdge(kind: number | undefined): boolean {
+  if (kind === undefined || kind === 0) return true
+  return kind === WIRE_SPAN_KIND_CLIENT || kind === WIRE_SPAN_KIND_PRODUCER
+}
 
 // Parent-span TTL cache (ADR-033). Address-based peer resolution (server.address /
 // net.peer.name / url.full) misses non-HTTP RPCs and any span with an opaque
@@ -786,16 +869,24 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
   // they only land when an edge actually does — and never for the inbound
   // (SERVER) parent-fallback side, which carries no call site.
   const sourceServiceNode = ctx.graph.getNodeAttributes(sourceId) as ServiceNode
-  const callSite = callSiteFromSpan(span, sourceServiceNode)
+  const callSite = callSiteFromSpan(span, sourceServiceNode, ctx.scanPath)
   const observedSource = (): string =>
     callSite ? ensureObservedFileNode(ctx.graph, span.service, sourceId, callSite) : sourceId
 
   let affectedNode = sourceId
 
+  // Only the caller/producer side of a call mints an OBSERVED edge directly
+  // (issue #429). INTERNAL / SERVER / CONSUMER spans don't: a SERVER/CONSUMER
+  // span is the callee, and its edge is minted from its parent via the
+  // parent-span fallback below (left ungated). Gating here keeps INTERNAL
+  // connection spans (`tcp.connect` / `tls.connect` with a peer address) from
+  // minting spurious service-level edges.
+  const mintsFromCallerSide = spanMintsObservedEdge(span.kind)
+
   if (span.dbSystem) {
     // Database span — try to resolve the DatabaseNode by host.
     const host = pickAddress(span)
-    if (host) {
+    if (mintsFromCallerSide && host) {
       // Auto-create a minimal DatabaseNode when this host hasn't been seen.
       // Engine comes off the OTel attribute as a string per Rule 8.
       ensureDatabaseNode(ctx.graph, host, span.dbSystem)
@@ -823,7 +914,7 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
     // stays OBSERVED across promotion.
     const host = pickAddress(span)
     let resolvedViaAddress = false
-    if (host && host !== span.service) {
+    if (mintsFromCallerSide && host && host !== span.service) {
       const targetId = resolveServiceId(ctx.graph, host, env)
       if (targetId && targetId !== sourceId) {
         upsertObservedEdge(

--- a/packages/core/src/watch.ts
+++ b/packages/core/src/watch.ts
@@ -438,6 +438,7 @@ export async function startWatch(
   const onSpan = makeSpanHandler({
     graph,
     errorsPath: opts.errorsPath,
+    scanPath: opts.scanPath,
     project: projectName,
     writeErrorEventInline: false,
     onPolicyTrigger,
@@ -457,6 +458,7 @@ export async function startWatch(
     const onSpanGrpc = makeSpanHandler({
       graph,
       errorsPath: opts.errorsPath,
+      scanPath: opts.scanPath,
       project: projectName,
       onPolicyTrigger,
     })

--- a/packages/core/test/ingest-sourcemap.test.ts
+++ b/packages/core/test/ingest-sourcemap.test.ts
@@ -6,13 +6,13 @@
 // When no map is on the daemon's disk the dist frame is kept verbatim — honest,
 // never fabricated (§6).
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import path from 'node:path'
 import { promises as fs } from 'node:fs'
 import os from 'node:os'
 import { MultiDirectedGraph } from 'graphology'
 import { type GraphEdge, type GraphNode, type FileNode, NodeType } from '@neat.is/types'
-import { handleSpan, type IngestContext } from '../src/ingest.js'
+import { handleSpan, resetNoSourceMapWarnings, type IngestContext } from '../src/ingest.js'
 import type { ParsedSpan } from '../src/otel.js'
 import type { NeatGraph } from '../src/graph.js'
 
@@ -34,7 +34,9 @@ function clientSpanAt(filepath: string, lineno: number): ParsedSpan {
     traceId: 'trace-1',
     spanId: 'span-1',
     name: 'GET /x',
-    kind: 2,
+    // OTLP-wire CLIENT (the SDK-side @opentelemetry/api CLIENT is 2; the wire
+    // value is 3). A CLIENT span is the caller side that carries the call site.
+    kind: 3,
     startTimeUnixNano: '0',
     endTimeUnixNano: '0',
     durationNanos: 0n,
@@ -124,5 +126,68 @@ describe('dist→src source-map resolution at ingest (file-awareness §4)', () =
     expect(files).toHaveLength(1)
     expect(files[0].path).toBe('src/route.ts')
     expect(files[0].originalPath).toBeUndefined()
+  })
+})
+
+// Issue #430 — a single-package service has an empty `repoPath`, so the runtime
+// `code.filepath` arrives absolute and there's no repo segment to anchor on.
+// With the scan root threaded through ctx, ingest joins the runtime path against
+// the service's absolute root (`scanPath/<repoPath>`) so the FileNode keys on
+// `dist/foo.js`, not the leaked absolute path. When dist ships no source maps,
+// the dist path is kept (never fabricated, §6) and surfaced once per service.
+describe('service-root normalization for single-package services (issue #430)', () => {
+  let tmpDir: string
+  let svcDir: string
+
+  beforeEach(async () => {
+    resetNoSourceMapWarnings()
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-430-'))
+    // Single-package layout: the service root IS the scan root, so repoPath is ''.
+    svcDir = tmpDir
+    await fs.mkdir(path.join(svcDir, 'dist'), { recursive: true })
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('keys the FileNode on dist/foo.js when repoPath is empty and ctx carries scanPath', async () => {
+    await fs.writeFile(path.join(svcDir, 'dist', 'foo.js'), 'const x = 1\n')
+    const graph = graphWithService('')
+    const ctx: IngestContext = {
+      graph,
+      errorsPath: path.join(tmpDir, 'errors.ndjson'),
+      scanPath: svcDir,
+    }
+    await handleSpan(ctx, clientSpanAt(path.join(svcDir, 'dist', 'foo.js'), 1))
+
+    const files = fileNodesOf(graph)
+    expect(files).toHaveLength(1)
+    expect(files[0].path).toBe('dist/foo.js')
+    expect(graph.hasNode('file:svc:dist/foo.js')).toBe(true)
+  })
+
+  it('audits a missing source map once per service (loud, never fabricated)', async () => {
+    await fs.writeFile(path.join(svcDir, 'dist', 'foo.js'), 'const x = 1\n')
+    await fs.writeFile(path.join(svcDir, 'dist', 'bar.js'), 'const y = 1\n')
+    const graph = graphWithService('')
+    const ctx: IngestContext = {
+      graph,
+      errorsPath: path.join(tmpDir, 'errors.ndjson'),
+      scanPath: svcDir,
+    }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      await handleSpan(ctx, clientSpanAt(path.join(svcDir, 'dist', 'foo.js'), 1))
+      await handleSpan(ctx, clientSpanAt(path.join(svcDir, 'dist', 'bar.js'), 1))
+      const noMapCalls = warn.mock.calls.filter((c) =>
+        String(c[0]).includes('no .map files found under dist/'),
+      )
+      expect(noMapCalls).toHaveLength(1)
+      expect(String(noMapCalls[0][0])).toContain('svc')
+      expect(String(noMapCalls[0][0])).toContain('Set sourceMap: true')
+    } finally {
+      warn.mockRestore()
+    }
   })
 })

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -797,3 +797,79 @@ describe('promoteFrontierNodes', () => {
     expect(graph.hasNode('frontier:unknown')).toBe(true)
   })
 })
+
+// Issue #429 — only CLIENT / PRODUCER spans mint an OBSERVED edge from the peer
+// address. INTERNAL spans (e.g. `tcp.connect` / `tls.connect` to a cloud
+// endpoint) carry a `peer.address` but are not a cross-service call, so they
+// must not mint a service-level edge. The kind here is the OTLP wire value
+// (INTERNAL 1, SERVER 2, CLIENT 3, PRODUCER 4, CONSUMER 5) — the value the
+// receiver puts on ParsedSpan.kind, offset by one from @opentelemetry/api.
+describe('handleSpan kind-gate (issue #429)', () => {
+  let tmpDir: string
+  let ctx: IngestContext
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-kind-'))
+    ctx = { graph: newGraph(), errorsPath: path.join(tmpDir, 'errors.ndjson') }
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  function callsEdgeCount(): number {
+    let n = 0
+    ctx.graph.forEachEdge((_id, attrs) => {
+      const e = attrs as GraphEdge
+      if (e.type === EdgeType.CALLS && e.provenance === Provenance.OBSERVED) n++
+    })
+    return n
+  }
+
+  // The SQS leak the smoke caught: an INTERNAL connection span to a resolvable
+  // cloud endpoint. No edge, no FrontierNode placeholder.
+  it('mints nothing for an INTERNAL span with a resolvable peer address', async () => {
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        kind: 1,
+        attributes: { 'net.peer.name': 'sqs.us-east-1.amazonaws.com' },
+      }),
+    )
+    expect(callsEdgeCount()).toBe(0)
+    expect(ctx.graph.hasNode('frontier:sqs.us-east-1.amazonaws.com')).toBe(false)
+  })
+
+  it('mints one CALLS edge for the same shape as a CLIENT span', async () => {
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        kind: 3,
+        attributes: { 'net.peer.name': 'sqs.us-east-1.amazonaws.com' },
+      }),
+    )
+    expect(callsEdgeCount()).toBe(1)
+    expect(ctx.graph.hasNode('frontier:sqs.us-east-1.amazonaws.com')).toBe(true)
+  })
+
+  it('mints one CALLS edge for a PRODUCER span (queue send)', async () => {
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        kind: 4,
+        attributes: { 'net.peer.name': 'sqs.us-east-1.amazonaws.com' },
+      }),
+    )
+    expect(callsEdgeCount()).toBe(1)
+  })
+
+  it('does not mint a CONNECTS_TO edge for an INTERNAL db span', async () => {
+    await handleSpan(ctx, dbSpan({ kind: 1 }))
+    let connects = 0
+    ctx.graph.forEachEdge((_id, attrs) => {
+      const e = attrs as GraphEdge
+      if (e.type === EdgeType.CONNECTS_TO && e.provenance === Provenance.OBSERVED) connects++
+    })
+    expect(connects).toBe(0)
+  })
+})


### PR DESCRIPTION
Refs #429 #430

Two ingest-side fixes that together make the v0.4.11 pre-publish smoke clean. §4 capture is unchanged — both are decisions about what to do with the spans it produces.

## #429 — Kind-gate OBSERVED edge minting

`ingest.ts` reached `upsertObservedEdge` unconditionally, so every INTERNAL `tcp.connect` / `tls.connect` span that happened to carry a peer address minted a service-level edge (the SQS branch leaked 24 of them). Now only CLIENT and PRODUCER spans mint directly from the peer address; the SERVER parent-span fallback is untouched, which is the correct path for a callee span to land as the far end of its parent CLIENT's edge.

One thing worth flagging: `ParsedSpan.kind` is the raw **OTLP wire** value (CLIENT 3, PRODUCER 4), which is offset by one from `@opentelemetry/api`'s `SpanKind` (CLIENT 2, PRODUCER 3). Importing that enum would gate the wrong kinds — it would treat wire SERVER as CLIENT and silently drop real PRODUCER (queue `send`) spans. So the gate uses local wire constants, cross-checked against the wire fixtures in `otel.test.ts` and the CLIENT call-site spans in `ingest.test.ts`. Spans that report no kind keep the historical unconditional behavior, so hand-built and legacy producers still mint.

## #430 — Normalize observed `code.filepath` to the service root

A single-package service has an empty `repoPath`, so a runtime `code.filepath` arrived absolute with no repo segment to anchor on, and the FileNode keyed on the leaked absolute path instead of `dist/index.js`. The daemon already knows the scan root, so `IngestContext` now carries `scanPath` and ingest joins the runtime path against the service's absolute root (`scanPath/<repoPath>`) before keying — which collapses the absolute/relative mismatch even when `repoPath` is empty.

When `dist/` ships no source maps the dist path is kept (never a fabricated src path, §6) and the absence is surfaced once per service:

```
[neat] <service>: no .map files found under dist/; observed file edges will land on dist paths, not src. Set sourceMap: true in tsconfig to enable file-level reconciliation.
```

## Tests

- #429: an INTERNAL span with a resolvable peer address mints nothing (no edge, no FrontierNode); the same shape as a CLIENT or PRODUCER span mints one CALLS edge; an INTERNAL db span mints no CONNECTS_TO.
- #430: a span under a single-package service (empty `repoPath`, `scanPath` in ctx) keys the FileNode on `dist/foo.js`; the missing-source-map audit fires once per service.

All four behavior-changing assertions fail before the fix and pass after. `npx turbo build test lint` is green. No tag, no publish, no version bump here — that's the separate publish→smoke step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)