### PR TITLE
Parse the large core files and tell init who really holds the lock

### DIFF
--- a/packages/core/src/extract/calls/http.ts
+++ b/packages/core/src/extract/calls/http.ts
@@ -82,12 +82,29 @@ export interface HttpCallSite {
   line: number
 }
 
+// tree-sitter's node binding copies a string handed to `parser.parse` into a
+// fixed scratch buffer of ~32K code units and throws a bare "Invalid argument"
+// once the source is larger — it never names the size as the cause. NEAT's own
+// `cli.ts`, `ingest.ts`, and `installers/javascript.ts` all clear 40K, so the
+// http-call extractor was quietly skipping the three most interesting files in
+// the repo while dogfooding NEAT-on-NEAT. The callback form sidesteps the
+// buffer entirely: tree-sitter pulls the text in chunks we keep well under the
+// limit, so a file of any length parses. Chunking is by `.length` (UTF-16 code
+// units), which is exactly what the buffer counts.
+const PARSE_CHUNK = 16384
+
+function parseSource(parser: Parser, source: string): Parser.Tree {
+  return parser.parse((index: number) =>
+    index >= source.length ? '' : source.slice(index, index + PARSE_CHUNK),
+  )
+}
+
 export function callsFromSource(
   source: string,
   parser: Parser,
   knownHosts: Set<string>,
 ): HttpCallSite[] {
-  const tree = parser.parse(source)
+  const tree = parseSource(parser, source)
   const literals: { text: string; node: Parser.SyntaxNode }[] = []
   collectStringLiterals(tree.rootNode, literals)
   const out: HttpCallSite[] = []

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -46,6 +46,139 @@ export function registryLockPath(): string {
   return path.join(neatHome(), 'projects.json.lock')
 }
 
+// The daemon writes its PID here on startup (daemon.ts). It's the authoritative
+// "is a neat daemon running" signal — more reliable than matching the lock's
+// own PID, since the daemon holds the registry lock only for brief read-modify-
+// write windows and an init that contends usually catches an orphaned lock
+// rather than the daemon mid-write.
+function daemonPidPath(): string {
+  return path.join(neatHome(), 'neatd.pid')
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// #432 — distinguish a live daemon from a genuinely stale lock.
+//
+// `neat init` used to hang the full timeout on any contended lock and then
+// print one remediation: "remove the file by hand." That advice is actively
+// dangerous when a neat daemon is alive — the daemon grabs the lock for its
+// own registry writes, so hand-removing it races the daemon and corrupts the
+// registry for the live process. The lock now carries the holder PID, and the
+// timeout (or first contention with a live daemon) resolves to a message that
+// names who holds it and what's safe to do.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type LockHolder =
+  | { kind: 'daemon'; pid: number }
+  | { kind: 'command'; pid: number }
+  | { kind: 'stale' }
+
+// Probes the holder-resolution logic depends on, broken out so tests can drive
+// each branch without a real daemon or live PIDs.
+export interface LockHolderProbe {
+  // POSIX liveness via `process.kill(pid, 0)`: true if the process exists
+  // (including EPERM — alive but owned by another user), false if it's gone.
+  isPidAlive(pid: number): boolean
+  // PID recorded in `~/.neat/neatd.pid`, or undefined if there's no pidfile.
+  daemonPidFromFile(): Promise<number | undefined>
+  // Whether the daemon's always-open `/health` endpoint answers. Confirms a
+  // live neatd.pid is actually our daemon and not a reused PID.
+  daemonResponds(): Promise<boolean>
+}
+
+function isPidAliveDefault(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    // ESRCH → no such process (dead). EPERM → exists but owned by another user
+    // (alive). Treat anything else as not-alive: we'd rather under-claim a live
+    // holder than wrongly block on a lock we can't verify.
+    return (err as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+async function readPidFile(file: string): Promise<number | undefined> {
+  try {
+    const raw = await fs.readFile(file, 'utf8')
+    const pid = Number.parseInt(raw.trim(), 10)
+    return Number.isInteger(pid) && pid > 0 ? pid : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const defaultLockHolderProbe: LockHolderProbe = {
+  isPidAlive: isPidAliveDefault,
+  daemonPidFromFile: () => readPidFile(daemonPidPath()),
+  async daemonResponds(): Promise<boolean> {
+    const base = process.env.NEAT_API_URL ?? 'http://localhost:8080'
+    try {
+      // `/health` stays unauthenticated in every mode (auth.ts), so a reachable
+      // daemon answers it even with a bearer token set. Any HTTP response — not
+      // just 2xx — means a daemon owns the port. A short timeout keeps the
+      // fail-fast path well under a second.
+      await fetch(`${base}/health`, { signal: AbortSignal.timeout(750) })
+      return true
+    } catch {
+      return false
+    }
+  },
+}
+
+// Read the PID a lock holder recorded when it created the lock. Undefined for a
+// legacy empty lock, an unreadable file, or a lock unlinked out from under us.
+async function readLockPid(lockPath: string): Promise<number | undefined> {
+  return readPidFile(lockPath)
+}
+
+// Decide who holds (or orphaned) the lock. A live daemon dominates: while neatd
+// is alive, hand-removing the lock is never safe, so we surface the daemon
+// message even when the lock itself is an empty orphan. We never classify our
+// own process as the blocking daemon — a daemon serializing two of its own
+// registry writes contends with itself briefly and should just retry.
+export async function classifyLockHolder(
+  lockPath: string,
+  probe: LockHolderProbe = defaultLockHolderProbe,
+): Promise<LockHolder> {
+  const lockPid = await readLockPid(lockPath)
+  const daemonPid = await probe.daemonPidFromFile()
+  if (
+    daemonPid !== undefined &&
+    daemonPid !== process.pid &&
+    probe.isPidAlive(daemonPid) &&
+    // The lock already names the daemon, or the daemon answers on its port.
+    // Either confirms a live daemon is in the picture (the second guards
+    // against a stale pidfile whose PID got reused).
+    (daemonPid === lockPid || (await probe.daemonResponds()))
+  ) {
+    return { kind: 'daemon', pid: daemonPid }
+  }
+  if (lockPid !== undefined && lockPid !== process.pid && probe.isPidAlive(lockPid)) {
+    return { kind: 'command', pid: lockPid }
+  }
+  return { kind: 'stale' }
+}
+
+export function lockHolderMessage(holder: LockHolder, lockPath: string, timeoutMs: number): string {
+  switch (holder.kind) {
+    case 'daemon':
+      return (
+        `The neat daemon (pid ${holder.pid}) is holding the registry lock. ` +
+        'Register this project through the daemon, or stop neatd and re-run `neat init`.'
+      )
+    case 'command':
+      return (
+        `Another neat command (pid ${holder.pid}) is holding the registry lock. ` +
+        "Wait for it to finish, or check `ps` if you're not sure what's running."
+      )
+    case 'stale':
+      return (
+        `neat registry: timed out after ${timeoutMs}ms waiting for ${lockPath}. ` +
+        'Another neat process is holding the lock; if no such process exists, remove the file by hand.'
+      )
+  }
+}
+
 /**
  * Path normalisation per ADR-048 #7. Two `init` calls from different relative
  * paths to the same dir must collapse to one entry. `path.resolve` handles
@@ -80,22 +213,41 @@ export async function writeAtomically(target: string, contents: string): Promise
   await fs.rename(tmp, target)
 }
 
-async function acquireLock(lockPath: string, timeoutMs: number = LOCK_TIMEOUT_MS): Promise<void> {
+async function acquireLock(
+  lockPath: string,
+  timeoutMs: number = LOCK_TIMEOUT_MS,
+  probe: LockHolderProbe = defaultLockHolderProbe,
+): Promise<void> {
   const deadline = Date.now() + timeoutMs
   await fs.mkdir(path.dirname(lockPath), { recursive: true })
+  let probedHolder = false
   while (true) {
     try {
       const fd = await fs.open(lockPath, 'wx')
-      await fd.close()
+      try {
+        // Stamp the lock with our PID so a contender can name who holds it and
+        // tell a live holder apart from a stale file. Best-effort: an empty
+        // lock still excludes correctly, it just can't be diagnosed.
+        await fd.writeFile(`${process.pid}\n`, 'utf8')
+      } finally {
+        await fd.close()
+      }
       return
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code
       if (code !== 'EEXIST') throw err
+      // A live daemon holds the registry continuously enough that spinning the
+      // full timeout is pointless — surface the routed remediation on the first
+      // contention. Peer commands and stale locks fall through to the retry:
+      // peers clear on their own, and a stale lock wants the timeout's guidance.
+      if (!probedHolder) {
+        probedHolder = true
+        const holder = await classifyLockHolder(lockPath, probe)
+        if (holder.kind === 'daemon') throw new Error(lockHolderMessage(holder, lockPath, timeoutMs))
+      }
       if (Date.now() >= deadline) {
-        throw new Error(
-          `neat registry: timed out after ${timeoutMs}ms waiting for ${lockPath}. ` +
-            `Another neat process is holding the lock; if no such process exists, remove the file by hand.`,
-        )
+        const holder = await classifyLockHolder(lockPath, probe)
+        throw new Error(lockHolderMessage(holder, lockPath, timeoutMs))
       }
       await new Promise((r) => setTimeout(r, LOCK_RETRY_MS))
     }

--- a/packages/core/test/calls-largefile.test.ts
+++ b/packages/core/test/calls-largefile.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import Parser from 'tree-sitter'
+import JavaScript from 'tree-sitter-javascript'
+import { callsFromSource } from '../src/extract/calls/http.js'
+
+// #431 — tree-sitter's node binding copies a string passed to `parser.parse`
+// into a ~32K-code-unit scratch buffer and throws a bare "Invalid argument"
+// once the source is larger. NEAT's own cli.ts / ingest.ts /
+// installers/javascript.ts all clear 40K, so the http-call extractor silently
+// skipped them while dogfooding. callsFromSource feeds the source through the
+// callback form, which sidesteps the buffer, so files of any size parse.
+describe('callsFromSource on files past the tree-sitter string limit', () => {
+  function makeJsParser(): Parser {
+    const p = new Parser()
+    p.setLanguage(JavaScript)
+    return p
+  }
+
+  it('parses a source larger than the 32K buffer and still finds the host', () => {
+    const parser = makeJsParser()
+    // Pad past the limit with filler statements, then name a known host on a
+    // line that only the parser (not a substring scan) can place correctly.
+    const filler = 'const noise = 1\n'.repeat(4000) // ~64K, well past 32768
+    const source = `${filler}const url = 'https://payments.example/charge'\n`
+    const hosts = new Set(['payments.example'])
+
+    const sites = callsFromSource(source, parser, hosts)
+
+    expect(sites).toHaveLength(1)
+    expect(sites[0].host).toBe('payments.example')
+    // The line is recovered from the AST, not guessed — it sits just after the
+    // 4000 filler lines.
+    expect(sites[0].line).toBe(4001)
+  })
+
+  it('handles multibyte content past the limit (buffer counts code units)', () => {
+    const parser = makeJsParser()
+    const comment = '// 😀 ünïcödé padding\n'.repeat(3000) // multibyte, > 32K units
+    const source = `${comment}const u = 'https://billing.example/x'\n`
+    const sites = callsFromSource(source, parser, new Set(['billing.example']))
+    expect(sites.map((s) => s.host)).toEqual(['billing.example'])
+  })
+})

--- a/packages/core/test/registry-lock.test.ts
+++ b/packages/core/test/registry-lock.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { classifyLockHolder, lockHolderMessage, type LockHolderProbe } from '../src/registry.js'
+
+// #432 — `neat init` used to hang the full lock timeout and then tell the user
+// to "remove the file by hand" regardless of who held the lock. Following that
+// while neatd is alive corrupts the registry for the live daemon. The holder
+// resolution now names the holder and gates the remove-by-hand advice on there
+// being no live daemon.
+
+// Fake PIDs the probe treats as alive — distinct from our own process.pid so
+// the self-contention guard doesn't swallow them. DEAD_PID is never reported
+// alive.
+const COMMAND_PID = 424242
+const DAEMON_PID = 525252
+const DEAD_PID = 2 ** 30
+
+function probe(over: Partial<LockHolderProbe> = {}): LockHolderProbe {
+  const alive = new Set([COMMAND_PID, DAEMON_PID])
+  return {
+    isPidAlive: (pid) => alive.has(pid),
+    daemonPidFromFile: async () => undefined,
+    daemonResponds: async () => false,
+    ...over,
+  }
+}
+
+describe('classifyLockHolder', () => {
+  let tmpDir: string
+  let lockPath: string
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-lock-'))
+    lockPath = path.join(tmpDir, 'projects.json.lock')
+  })
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('reports the daemon when a live daemon answers /health, even for an empty orphan lock', async () => {
+    // The real-world trigger: a 0-byte orphan lock left on disk while neatd
+    // runs. No PID in the lock, but the daemon is alive and answering.
+    await fs.writeFile(lockPath, '', 'utf8')
+    const holder = await classifyLockHolder(
+      lockPath,
+      probe({
+        daemonPidFromFile: async () => DAEMON_PID,
+        daemonResponds: async () => true,
+      }),
+    )
+    expect(holder).toEqual({ kind: 'daemon', pid: DAEMON_PID })
+
+    const msg = lockHolderMessage(holder, lockPath, 5000)
+    expect(msg).toContain('neat daemon')
+    expect(msg).toContain(`pid ${DAEMON_PID}`)
+    expect(msg).not.toContain('remove the file by hand')
+  })
+
+  it('reports the daemon without an HTTP probe when the lock PID is the daemon PID', async () => {
+    await fs.writeFile(lockPath, `${DAEMON_PID}\n`, 'utf8')
+    let probed = false
+    const holder = await classifyLockHolder(
+      lockPath,
+      probe({
+        daemonPidFromFile: async () => DAEMON_PID,
+        daemonResponds: async () => {
+          probed = true
+          return false
+        },
+      }),
+    )
+    expect(holder).toEqual({ kind: 'daemon', pid: DAEMON_PID })
+    // The lock already named the daemon, so we don't need the network probe.
+    expect(probed).toBe(false)
+  })
+
+  it('reports another neat command for a live non-daemon holder', async () => {
+    await fs.writeFile(lockPath, `${COMMAND_PID}\n`, 'utf8')
+    const holder = await classifyLockHolder(
+      lockPath,
+      // No daemon running, and the port does not answer.
+      probe({ daemonPidFromFile: async () => undefined, daemonResponds: async () => false }),
+    )
+    expect(holder).toEqual({ kind: 'command', pid: COMMAND_PID })
+
+    const msg = lockHolderMessage(holder, lockPath, 5000)
+    expect(msg).toContain('Another neat command')
+    expect(msg).toContain(`pid ${COMMAND_PID}`)
+    expect(msg).not.toContain('remove the file by hand')
+  })
+
+  it('falls back to the stale remediation for a dead PID and no daemon', async () => {
+    await fs.writeFile(lockPath, `${DEAD_PID}\n`, 'utf8')
+    const holder = await classifyLockHolder(lockPath, probe())
+    expect(holder).toEqual({ kind: 'stale' })
+
+    const msg = lockHolderMessage(holder, lockPath, 5000)
+    expect(msg).toContain('remove the file by hand')
+    expect(msg).toContain(lockPath)
+  })
+
+  it('does not classify our own process as the blocking daemon', async () => {
+    // A daemon serializing two of its own registry writes contends with itself.
+    // Its own PID in both the lock and the pidfile must not fast-fail it.
+    await fs.writeFile(lockPath, `${process.pid}\n`, 'utf8')
+    const holder = await classifyLockHolder(
+      lockPath,
+      probe({
+        isPidAlive: () => true,
+        daemonPidFromFile: async () => process.pid,
+        daemonResponds: async () => true,
+      }),
+    )
+    expect(holder.kind).toBe('stale')
+  })
+})


### PR DESCRIPTION
Two small, unrelated papercuts that both surfaced dogfooding NEAT against its own repo with the daemon running. Different layers (extractor parser path; registry lock), so they ride one PR.

## #431 — extractor refused the three largest core files

The http-call extractor handed whole files to tree-sitter's string `parse`, which copies the source into a fixed ~32K scratch buffer and throws a bare `Invalid argument` once it's larger. `cli.ts`, `ingest.ts`, and `installers/javascript.ts` all clear 40K, so they were the only files in the package logging `http call extraction skipped … Invalid argument` while the other ~80 extracted fine.

The fix feeds the source through tree-sitter's callback form, which pulls the text in chunks kept under the buffer limit — so a file of any length parses. No broadening of the catch: a file that genuinely can't parse still records its real error.

## #432 — init mistook a live daemon's lock for a stale one

`neat init` hung the full 5s lock timeout on any contended registry lock and then printed one remediation: "remove the file by hand." Following that while `neatd` is alive corrupts the registry for the live daemon, which grabs the lock for its own writes.

The lock now carries the holder PID. On contention, init checks PID liveness and the daemon pidfile (`~/.neat/neatd.pid`, confirmed via the always-open `/health` probe) to resolve who holds it:

- **live daemon** → "register through the daemon, or stop neatd" — and it short-circuits the wait instead of spinning 5s
- **another live neat command** → "wait for it to finish"
- **dead/absent PID, no daemon** → the original "remove the file by hand" remediation (the only case where that's safe)

## Verification

- New unit tests: `calls-largefile.test.ts` (parses a >32K file and still finds the host; fails before the fix) and `registry-lock.test.ts` (each holder-resolution branch).
- `npx turbo build test lint` green. No new `tsc` errors (the three pre-existing ones in `cli-client.ts` / `installers/javascript.ts` are untouched and out of scope).
- Dogfood rerun (`init . --no-install` against this repo with neatd up): zero parse-skip lines, and a fast, accurate "daemon holds the lock" message.

No tag, no publish, no version bump.

Refs #431 #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)