### PR TITLE
Add @neat.is/instrumentation-registry package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,7 @@ jobs:
             echo "  published"
           }
 
+          publish_one "packages/instrumentation-registry"
           publish_one "packages/types"
           publish_one "packages/core"
           publish_one "packages/mcp"
@@ -122,7 +123,7 @@ jobs:
           # because the retry loop only checked the umbrella. Every package in
           # the lockstep set must be visible at the target version before we
           # install.
-          for pkg in "@neat.is/types" "@neat.is/core" "@neat.is/mcp" "@neat.is/claude-skill" "@neat.is/web" "neat.is"; do
+          for pkg in "@neat.is/instrumentation-registry" "@neat.is/types" "@neat.is/core" "@neat.is/mcp" "@neat.is/claude-skill" "@neat.is/web" "neat.is"; do
             for i in 1 2 3 4 5 6 7 8 9 10; do
               if npm view "${pkg}@${version}" version > /dev/null 2>&1; then
                 echo "  ${pkg}@${version} visible"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2008,6 +2008,10 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@neat.is/instrumentation-registry": {
+      "resolved": "packages/instrumentation-registry",
+      "link": true
+    },
     "node_modules/@neat.is/mcp": {
       "resolved": "packages/mcp",
       "link": true
@@ -10550,7 +10554,7 @@
     },
     "packages/claude-skill": {
       "name": "@neat.is/claude-skill",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "license": "BUSL-1.1",
       "engines": {
         "node": ">=20"
@@ -10558,13 +10562,14 @@
     },
     "packages/core": {
       "name": "@neat.is/core",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "license": "BUSL-1.1",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
         "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
-        "@neat.is/types": "^0.4.10",
+        "@neat.is/instrumentation-registry": "*",
+        "@neat.is/types": "^0.4.11",
         "chokidar": "^4.0.3",
         "fastify": "^5.0.0",
         "graphology": "^0.25.4",
@@ -10602,13 +10607,31 @@
         "@xenova/transformers": "^2.17.2"
       }
     },
+    "packages/instrumentation-registry": {
+      "name": "@neat.is/instrumentation-registry",
+      "version": "1.0.0",
+      "license": "BUSL-1.1",
+      "dependencies": {
+        "semver": "^7.6.0",
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "@types/semver": "^7.5.8",
+        "tsup": "^8.3.0",
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "packages/mcp": {
       "name": "@neat.is/mcp",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "license": "BUSL-1.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@neat.is/types": "^0.4.10",
+        "@neat.is/types": "^0.4.11",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -10626,13 +10649,13 @@
       }
     },
     "packages/neat.is": {
-      "version": "0.4.10",
+      "version": "0.4.11",
       "license": "BUSL-1.1",
       "dependencies": {
-        "@neat.is/claude-skill": "^0.4.10",
-        "@neat.is/core": "^0.4.10",
-        "@neat.is/mcp": "^0.4.10",
-        "@neat.is/web": "^0.4.10"
+        "@neat.is/claude-skill": "^0.4.11",
+        "@neat.is/core": "^0.4.11",
+        "@neat.is/mcp": "^0.4.11",
+        "@neat.is/web": "^0.4.11"
       },
       "bin": {
         "neat": "bin/neat",
@@ -10646,7 +10669,7 @@
     },
     "packages/types": {
       "name": "@neat.is/types",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "license": "BUSL-1.1",
       "dependencies": {
         "zod": "^3.23.8"
@@ -10662,11 +10685,11 @@
     },
     "packages/web": {
       "name": "@neat.is/web",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "license": "BUSL-1.1",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
-        "@neat.is/types": "^0.4.10",
+        "@neat.is/types": "^0.4.11",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cytoscape": "^3.33.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,6 +47,7 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
+    "@neat.is/instrumentation-registry": "*",
     "@fastify/cors": "^10.0.0",
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",

--- a/packages/core/src/installers/javascript.ts
+++ b/packages/core/src/installers/javascript.ts
@@ -64,6 +64,7 @@ import {
   renderNextInstrumentationNode,
   renderNodeOtelInit,
 } from './templates.js'
+import { resolve as _resolveRegistry } from '@neat.is/instrumentation-registry' // #391 uses _resolveRegistry for version-reconciled instrumentation advice
 
 // ADR-069 §5 — three OTel packages land in `dependencies`. `dotenv` was a
 // fourth from v0.3.6 through v0.4.3; the generated `otel-init` templates

--- a/packages/instrumentation-registry/package.json
+++ b/packages/instrumentation-registry/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@neat.is/instrumentation-registry",
+  "version": "1.0.0",
+  "description": "Curated OTel instrumentation coverage dataset for the NEAT installer",
+  "license": "BUSL-1.1",
+  "homepage": "https://neat.is",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NEAT-Technologies/Neat.git",
+    "directory": "packages/instrumentation-registry"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "prepublishOnly": "npm run build",
+    "test": "vitest run",
+    "lint": "eslint src",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "semver": "^7.6.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/semver": "^7.5.8",
+    "tsup": "^8.3.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/instrumentation-registry/src/index.test.ts
+++ b/packages/instrumentation-registry/src/index.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { list, resolve } from './index.js'
+
+describe('schema validation', () => {
+  it('seed JSON validates against the Zod schema without throwing', () => {
+    expect(() => list()).not.toThrow()
+  })
+})
+
+describe('resolve()', () => {
+  it('resolves @prisma/client@5.3.0 to the Prisma 5 entry', () => {
+    const entry = resolve('@prisma/client', '5.3.0')
+    expect(entry).not.toBeNull()
+    expect(entry!.coverage).toBe('first-party')
+    expect(entry!.instrumentation_package).toBe('@prisma/instrumentation')
+    expect(entry!.package_version).toBe('^5.0.0')
+  })
+
+  it('resolves @prisma/client@6.1.0 to the Prisma 6 entry', () => {
+    const entry = resolve('@prisma/client', '6.1.0')
+    expect(entry).not.toBeNull()
+    expect(entry!.coverage).toBe('first-party')
+    expect(entry!.instrumentation_package).toBe('@prisma/instrumentation')
+    expect(entry!.package_version).toBe('^6.0.0')
+  })
+
+  it('returns null for an unknown library', () => {
+    expect(resolve('not-a-real-library')).toBeNull()
+  })
+
+  it('resolves express to bundled', () => {
+    const entry = resolve('express')
+    expect(entry).not.toBeNull()
+    expect(entry!.coverage).toBe('bundled')
+  })
+
+  it('resolves hono to gap', () => {
+    const entry = resolve('hono')
+    expect(entry).not.toBeNull()
+    expect(entry!.coverage).toBe('gap')
+  })
+
+  it('resolves stripe to http-only', () => {
+    const entry = resolve('stripe')
+    expect(entry).not.toBeNull()
+    expect(entry!.coverage).toBe('http-only')
+  })
+})
+
+describe('list()', () => {
+  it('returns at least 80 entries', () => {
+    expect(list().length).toBeGreaterThanOrEqual(80)
+  })
+
+  it('every entry has library and coverage', () => {
+    for (const entry of list()) {
+      expect(entry.library).toBeTruthy()
+      expect(entry.coverage).toBeTruthy()
+    }
+  })
+})

--- a/packages/instrumentation-registry/src/index.ts
+++ b/packages/instrumentation-registry/src/index.ts
@@ -1,0 +1,74 @@
+import semver from 'semver'
+import { z } from 'zod'
+import registryJson from './registry.json' with { type: 'json' }
+
+const VersionEntryBaseSchema = z.object({
+  range: z.string(),
+  coverage: z.enum(['bundled', 'first-party', 'third-party', 'http-only', 'gap']),
+  notes: z.string(),
+})
+
+const VersionEntryInstallSchema = VersionEntryBaseSchema.extend({
+  coverage: z.enum(['first-party', 'third-party']),
+  instrumentation_package: z.string(),
+  package_version: z.string(),
+  registration: z.string(),
+})
+
+const VersionEntrySchema = z.discriminatedUnion('coverage', [
+  VersionEntryInstallSchema,
+  VersionEntryBaseSchema.extend({ coverage: z.enum(['bundled', 'http-only', 'gap']) }),
+])
+
+export type Coverage = 'bundled' | 'first-party' | 'third-party' | 'http-only' | 'gap'
+
+export interface RegistryEntry {
+  library: string
+  coverage: Coverage
+  instrumentation_package?: string
+  package_version?: string
+  registration?: string
+  notes?: string
+}
+
+const RegistrySchema = z.record(z.object({ versions: z.array(VersionEntrySchema) }))
+
+// Validate the seed JSON at module load time — catches malformed entries fast.
+const _validated = RegistrySchema.parse(registryJson)
+
+export function resolve(library: string, installedVersion?: string): RegistryEntry | null {
+  const entry = (registryJson as Record<string, { versions: Array<Record<string, string>> }>)[library]
+  if (!entry) return null
+  for (const v of entry.versions) {
+    const matches =
+      !installedVersion ||
+      semver.satisfies(semver.coerce(installedVersion)?.version ?? installedVersion, v['range'] as string)
+    if (matches) {
+      return {
+        library,
+        coverage: v['coverage'] as Coverage,
+        instrumentation_package: v['instrumentation_package'],
+        package_version: v['package_version'],
+        registration: v['registration'],
+        notes: v['notes'],
+      }
+    }
+  }
+  return null
+}
+
+export function list(): RegistryEntry[] {
+  return Object.entries(
+    registryJson as Record<string, { versions: Array<Record<string, string>> }>,
+  ).map(([library, { versions }]) => {
+    const first = versions[0]!
+    return {
+      library,
+      coverage: first['coverage'] as Coverage,
+      instrumentation_package: first['instrumentation_package'],
+      package_version: first['package_version'],
+      registration: first['registration'],
+      notes: first['notes'],
+    }
+  })
+}

--- a/packages/instrumentation-registry/src/registry.json
+++ b/packages/instrumentation-registry/src/registry.json
@@ -1,0 +1,459 @@
+{
+  "express": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/auto-instrumentations-node/register via opentelemetry-instrumentation-express." }
+    ]
+  },
+  "fastify": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/auto-instrumentations-node/register via @opentelemetry/instrumentation-fastify." }
+    ]
+  },
+  "koa": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/auto-instrumentations-node/register via @opentelemetry/instrumentation-koa." }
+    ]
+  },
+  "http": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Node built-in http module; covered by @opentelemetry/instrumentation-http shipped inside auto-instrumentations-node." }
+    ]
+  },
+  "https": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Node built-in https module; same instrumentation as http." }
+    ]
+  },
+  "fetch": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Global fetch (Node 18+); covered by @opentelemetry/instrumentation-undici via auto-instrumentations-node." }
+    ]
+  },
+  "undici": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-undici via auto-instrumentations-node." }
+    ]
+  },
+  "pg": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-pg via auto-instrumentations-node." }
+    ]
+  },
+  "mysql": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-mysql via auto-instrumentations-node." }
+    ]
+  },
+  "mysql2": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-mysql2 via auto-instrumentations-node." }
+    ]
+  },
+  "mongodb": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-mongodb via auto-instrumentations-node." }
+    ]
+  },
+  "redis": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-redis via auto-instrumentations-node. Use ioredis entry for the ioredis client." }
+    ]
+  },
+  "ioredis": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-ioredis via auto-instrumentations-node." }
+    ]
+  },
+  "graphql": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-graphql via auto-instrumentations-node." }
+    ]
+  },
+  "@grpc/grpc-js": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-grpc via auto-instrumentations-node." }
+    ]
+  },
+  "aws-sdk": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "AWS SDK v2; covered by @opentelemetry/instrumentation-aws-sdk via auto-instrumentations-node." }
+    ]
+  },
+  "@aws-sdk/client-s3": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "AWS SDK v3 client; covered by @opentelemetry/instrumentation-aws-sdk via auto-instrumentations-node." }
+    ]
+  },
+  "@nestjs/core": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-nestjs-core via auto-instrumentations-node." }
+    ]
+  },
+  "@hapi/hapi": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-hapi via auto-instrumentations-node." }
+    ]
+  },
+  "hapi": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Legacy hapi package; see @hapi/hapi for the current scope. Covered by @opentelemetry/instrumentation-hapi." }
+    ]
+  },
+  "restify": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-restify via auto-instrumentations-node." }
+    ]
+  },
+  "connect": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-connect via auto-instrumentations-node." }
+    ]
+  },
+  "dns": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Node built-in dns module; covered by @opentelemetry/instrumentation-dns via auto-instrumentations-node." }
+    ]
+  },
+  "net": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Node built-in net module; covered by @opentelemetry/instrumentation-net via auto-instrumentations-node." }
+    ]
+  },
+  "knex": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-knex via auto-instrumentations-node." }
+    ]
+  },
+  "sequelize": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-sequelize via auto-instrumentations-node. The bundled coverage requires sequelize as a peer dep of the instrumentation package; if it is absent the instrumentation silently no-ops." }
+    ]
+  },
+  "mongoose": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-mongoose via auto-instrumentations-node." }
+    ]
+  },
+  "socket.io": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-socket.io via auto-instrumentations-node." }
+    ]
+  },
+  "pino": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-pino via auto-instrumentations-node; injects trace context into log records." }
+    ]
+  },
+  "winston": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-winston via auto-instrumentations-node; injects trace context into log records." }
+    ]
+  },
+  "bunyan": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-bunyan via auto-instrumentations-node; injects trace context into log records." }
+    ]
+  },
+  "@prisma/client": {
+    "versions": [
+      {
+        "range": ">=6.0.0",
+        "coverage": "first-party",
+        "instrumentation_package": "@prisma/instrumentation",
+        "package_version": "^6.0.0",
+        "registration": "new PrismaInstrumentation()",
+        "notes": "Prisma 6 ships its own OTel instrumentation. Add @prisma/instrumentation@^6.0.0 and register PrismaInstrumentation() in the OTel setup."
+      },
+      {
+        "range": ">=5.0.0 <6.0.0",
+        "coverage": "first-party",
+        "instrumentation_package": "@prisma/instrumentation",
+        "package_version": "^5.0.0",
+        "registration": "new PrismaInstrumentation()",
+        "notes": "Prisma 5 ships its own OTel instrumentation. Add @prisma/instrumentation@^5.0.0 and register PrismaInstrumentation() in the OTel setup."
+      }
+    ]
+  },
+  "@vercel/otel": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "@vercel/otel ships its own OTel setup and wraps auto-instrumentations internally. NEAT defers to it; do not add a second SDK init alongside it." }
+    ]
+  },
+  "@langchain/core": {
+    "versions": [
+      {
+        "range": "*",
+        "coverage": "third-party",
+        "instrumentation_package": "@traceloop/node-server-sdk",
+        "package_version": "*",
+        "registration": "new LangChainInstrumentation()",
+        "notes": "LangChain instrumentation is provided by @traceloop/node-server-sdk. Import LangChainInstrumentation from the SDK and register it."
+      }
+    ]
+  },
+  "openai": {
+    "versions": [
+      {
+        "range": "*",
+        "coverage": "third-party",
+        "instrumentation_package": "@traceloop/node-server-sdk",
+        "package_version": "*",
+        "registration": "new OpenAIInstrumentation()",
+        "notes": "Wraps OpenAI API calls via @traceloop/node-server-sdk. Import OpenAIInstrumentation from the SDK and register it."
+      }
+    ]
+  },
+  "@anthropic-ai/sdk": {
+    "versions": [
+      {
+        "range": "*",
+        "coverage": "third-party",
+        "instrumentation_package": "@traceloop/node-server-sdk",
+        "package_version": "*",
+        "registration": "new AnthropicInstrumentation()",
+        "notes": "Anthropic SDK instrumentation via @traceloop/node-server-sdk. Import AnthropicInstrumentation from the SDK and register it."
+      }
+    ]
+  },
+  "llamaindex": {
+    "versions": [
+      {
+        "range": "*",
+        "coverage": "third-party",
+        "instrumentation_package": "@arizeai/openinference-instrumentation-llamaindex",
+        "package_version": "*",
+        "registration": "new LlamaIndexInstrumentation()",
+        "notes": "LlamaIndex instrumentation via @arizeai/openinference-instrumentation-llamaindex from the Arize AI OpenInference project."
+      }
+    ]
+  },
+  "typeorm": {
+    "versions": [
+      {
+        "range": "*",
+        "coverage": "third-party",
+        "instrumentation_package": "@opentelemetry/instrumentation-typeorm",
+        "package_version": "*",
+        "registration": "new TypeormInstrumentation()",
+        "notes": "TypeORM is not in the auto-instrumentations-node bundle. Install @opentelemetry/instrumentation-typeorm separately and register TypeormInstrumentation()."
+      }
+    ]
+  },
+  "stripe": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Stripe SDK makes HTTPS calls to api.stripe.com; the HTTP auto-instrumentation covers outbound spans. No SDK-level instrumentation package exists." }
+    ]
+  },
+  "twilio": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Twilio SDK makes HTTPS calls to api.twilio.com; captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "@sendgrid/mail": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "SendGrid SDK makes HTTPS calls to api.sendgrid.com; captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "resend": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Resend SDK calls api.resend.com over HTTPS; captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "plaid": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Plaid Node client calls sandbox.plaid.com or production.plaid.com over HTTPS; captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "braintree": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Braintree SDK calls the Braintree API over HTTPS; captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "chargebee": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Chargebee Node client calls your-site.chargebee.com over HTTPS; captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "shopify-api-node": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Shopify API Node client calls your-store.myshopify.com over HTTPS; captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "@shopify/shopify-api": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Official Shopify API library; REST and GraphQL calls go over HTTPS and are captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "clerk": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Clerk SDK calls api.clerk.dev over HTTPS; captured by HTTP auto-instrumentation. The @clerk/nextjs / @clerk/express SDK wrappers share the same transport." }
+    ]
+  },
+  "@clerk/nextjs": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Clerk Next.js SDK; API calls go to api.clerk.dev over HTTPS and are captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "auth0": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Auth0 Node SDK calls your tenant at *.auth0.com over HTTPS; captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "launchdarkly-node-server-sdk": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "LaunchDarkly SDK calls app.launchdarkly.com over HTTPS; captured by HTTP auto-instrumentation. Native OTel support is experimental in LD's SDK." }
+    ]
+  },
+  "split-node-suite": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Split.io SDK calls sdk.split.io over HTTPS; captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "posthog-node": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "PostHog Node SDK calls app.posthog.com or your instance over HTTPS; captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "mixpanel": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Mixpanel Node client calls api.mixpanel.com over HTTPS; captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "@segment/analytics-node": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Segment Node.js client calls api.segment.io over HTTPS; captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "@amplitude/analytics-node": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Amplitude Node SDK calls api2.amplitude.com over HTTPS; captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "hono": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "No OTel instrumentation package for Hono exists. Hono's middleware system supports manual span wrapping; see https://hono.dev/guides/opentelemetry for the manual approach." }
+    ]
+  },
+  "elysia": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "No OTel instrumentation package for Elysia exists. Elysia runs on Bun; instrument via manual span creation or the http-fallback for outbound calls." }
+    ]
+  },
+  "bun-serve": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "Bun's built-in HTTP server has no OTel instrumentation package. Instrument request handlers manually using the OTel API." }
+    ]
+  },
+  "better-auth": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "No OTel instrumentation package for better-auth. Auth flows can be traced manually; HTTP calls to external identity providers are covered by HTTP auto-instrumentation." }
+    ]
+  },
+  "lucia": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "No OTel instrumentation package for Lucia. Instrument session-management paths manually." }
+    ]
+  },
+  "kysely": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "No dedicated OTel instrumentation package for Kysely. A plugin approach is possible manually; no published package covers it yet." }
+    ]
+  },
+  "mastra": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "Mastra is a new AI orchestration framework; no OTel instrumentation package exists yet. Instrument agent steps manually." }
+    ]
+  },
+  "drizzle-orm": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "No published OTel instrumentation package for Drizzle ORM. The underlying database driver (pg, mysql2, etc.) is covered by its own bundled instrumentation; Drizzle's ORM layer is not." }
+    ]
+  },
+  "@tanstack/start": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "TanStack Start is in early access; no OTel instrumentation package exists. HTTP calls from server functions are captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "solid-start": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "SolidStart has no OTel instrumentation package. Server-side calls go through the Fetch/HTTP layer captured by auto-instrumentation." }
+    ]
+  },
+  "qwik": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "Qwik City server-side rendering has no OTel instrumentation package. Outbound HTTP from server actions is captured by HTTP auto-instrumentation." }
+    ]
+  },
+  "fresh": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "Fresh is a Deno framework; Deno is out of scope for NEAT's Node.js runtime target. Noted here for completeness; no Node-compatible instrumentation applies." }
+    ]
+  },
+  "vike": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "Vike (formerly vite-plugin-ssr) has no OTel instrumentation package. Server-side data-fetching calls are captured by HTTP auto-instrumentation where applicable." }
+    ]
+  },
+  "axios": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Axios uses Node's http/https modules internally; covered by @opentelemetry/instrumentation-http via auto-instrumentations-node." }
+    ]
+  },
+  "node-fetch": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "node-fetch routes through Node's http/https; covered by @opentelemetry/instrumentation-http via auto-instrumentations-node." }
+    ]
+  },
+  "@elastic/elasticsearch": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-elasticsearch via auto-instrumentations-node." }
+    ]
+  },
+  "cassandra-driver": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "Covered by @opentelemetry/instrumentation-cassandra-driver via auto-instrumentations-node." }
+    ]
+  },
+  "@redis/client": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "The modern @redis/client package is covered by @opentelemetry/instrumentation-redis-4 via auto-instrumentations-node." }
+    ]
+  },
+  "bullmq": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "No published OTel instrumentation package for BullMQ. Queue jobs can be traced manually by propagating context into job data and creating spans in processors." }
+    ]
+  },
+  "kafkajs": {
+    "versions": [
+      {
+        "range": "*",
+        "coverage": "third-party",
+        "instrumentation_package": "opentelemetry-instrumentation-kafkajs",
+        "package_version": "*",
+        "registration": "new KafkaJsInstrumentation()",
+        "notes": "KafkaJS instrumentation via the community opentelemetry-instrumentation-kafkajs package. Not in the auto-instrumentations-node bundle; register separately."
+      }
+    ]
+  },
+  "nats": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "No published OTel instrumentation package for nats.js. Instrument publish/subscribe calls manually using the OTel API." }
+    ]
+  },
+  "firebase-admin": {
+    "versions": [
+      { "range": "*", "coverage": "http-only", "notes": "Firebase Admin SDK calls Firebase REST APIs over HTTPS; captured by HTTP auto-instrumentation. Firestore and RTDB calls are not individually distinguished at the span level." }
+    ]
+  },
+  "got": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "got v12+ uses Node's built-in fetch; earlier versions use http/https. Both paths are covered by @opentelemetry/instrumentation-http or instrumentation-undici via auto-instrumentations-node." }
+    ]
+  },
+  "superagent": {
+    "versions": [
+      { "range": "*", "coverage": "bundled", "notes": "superagent uses Node's http/https internally; covered by @opentelemetry/instrumentation-http via auto-instrumentations-node." }
+    ]
+  }
+}

--- a/packages/instrumentation-registry/tsconfig.json
+++ b/packages/instrumentation-registry/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/instrumentation-registry/tsup.config.ts
+++ b/packages/instrumentation-registry/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  target: 'node20',
+})

--- a/packages/instrumentation-registry/vitest.config.ts
+++ b/packages/instrumentation-registry/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -22,7 +22,21 @@ fi
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# Six packages that must share the same version on every release.
+LOCKSTEP_PACKAGES=(
+  "packages/types"
+  "packages/core"
+  "packages/mcp"
+  "packages/claude-skill"
+  "packages/web"
+  "packages/neat.is"
+)
+
+# All packages to publish, in dependency order.
+# @neat.is/instrumentation-registry is independently versioned (v1.x) but
+# ships before core since core depends on it.
 PACKAGES=(
+  "packages/instrumentation-registry"
   "packages/types"
   "packages/core"
   "packages/mcp"
@@ -67,7 +81,7 @@ fi
 echo
 echo "── versions ──"
 VERSIONS=()
-for pkg_dir in "${PACKAGES[@]}"; do
+for pkg_dir in "${LOCKSTEP_PACKAGES[@]}"; do
   v=$(node -p "require('./${pkg_dir}/package.json').version")
   name=$(node -p "require('./${pkg_dir}/package.json').name")
   echo "  ${name}: ${v}"
@@ -82,8 +96,6 @@ if [ "$UNIQUE_COUNT" != "1" ]; then
   exit 1
 fi
 
-TARGET_VERSION="${VERSIONS[0]}"
-
 # ── Build + test gate ───────────────────────────────────────────────────
 echo
 echo "── build / test / lint ──"
@@ -97,11 +109,12 @@ SKIPPED=()
 
 for pkg_dir in "${PACKAGES[@]}"; do
   pkg_name=$(node -p "require('./${pkg_dir}/package.json').name")
+  pkg_version=$(node -p "require('./${pkg_dir}/package.json').version")
 
   echo
-  echo "${pkg_name}@${TARGET_VERSION}"
+  echo "${pkg_name}@${pkg_version}"
 
-  if npm view "${pkg_name}@${TARGET_VERSION}" version > /dev/null 2>&1; then
+  if npm view "${pkg_name}@${pkg_version}" version > /dev/null 2>&1; then
     echo "  already on registry, skipping"
     SKIPPED+=("$pkg_name")
     continue


### PR DESCRIPTION
## Summary

- New `packages/instrumentation-registry/` package at `1.0.0` — 80-entry curated OTel coverage dataset (bundled / first-party / third-party / http-only / gap) with Zod schema validation, range-matched `resolve()` loader, and `list()`
- `@neat.is/core` gains a workspace dependency and imports the loader in `javascript.ts` ahead of #391 consuming it
- Publish workflow and `scripts/publish.sh` include the registry in dependency order before `types` (since core depends on it); lockstep version check stays scoped to the six existing lockstep packages

## Test plan

- [ ] `npx turbo build test lint` clean (9/9 registry tests, all core contracts pass)
- [ ] `resolve('@prisma/client', '5.3.0')` → Prisma 5 `first-party` entry
- [ ] `resolve('@prisma/client', '6.1.0')` → Prisma 6 `first-party` entry with `^6.0.0`
- [ ] `resolve('hono')` → `gap`; `resolve('stripe')` → `http-only`; `resolve('express')` → `bundled`
- [ ] `list().length >= 80`
- [ ] Seed JSON validates against Zod schema on module load

Refs #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)