### PR TITLE
Out-of-scope runtime detection + BYO-OTel escape hatch

### DIFF
--- a/docs/installer-scope.md
+++ b/docs/installer-scope.md
@@ -1,0 +1,55 @@
+# Installer scope
+
+`neat init` installs OTel deterministically for the following runtimes and frameworks:
+
+**Node.js** — Express, Fastify, Koa, raw HTTP  
+**Next.js** — Pages + App Router, Webpack + Turbopack, flat and src/ layouts  
+**Remix** — v2+  
+**SvelteKit** — adapter-node  
+**Nuxt** — Nuxt 3  
+**Astro** — @astrojs/node adapter  
+**Python** — Flask, FastAPI, Django
+
+## Manual setup for out-of-scope runtimes
+
+For runtimes NEAT can't instrument deterministically, configure your OTel exporter to point at the NEAT receiver and it will pick up spans automatically.
+
+### Bun
+
+Install `@opentelemetry/sdk-bun` (or the standard Node SDK with `--bun` flag) and configure:
+
+```env
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/projects/<your-project>/v1/traces
+OTEL_SERVICE_NAME=<your-service>
+```
+
+### Deno
+
+Use `@opentelemetry/sdk-node` via npm compatibility or `npm:@opentelemetry/sdk-node`. Set:
+
+```env
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/projects/<your-project>/v1/traces
+OTEL_SERVICE_NAME=<your-service>
+```
+
+### Cloudflare Workers
+
+Use the Cloudflare OTel binding or `@microlabs/otel-cf-workers`. Export to:
+
+```
+http://localhost:4318/projects/<your-project>/v1/traces
+```
+
+Workers can't reach localhost in production — use NEAT's hosted receiver URL there.
+
+### AWS Lambda (ADOT)
+
+Use the AWS Distro for OpenTelemetry (ADOT) Lambda layer. Configure `OTEL_EXPORTER_OTLP_ENDPOINT` to point at NEAT's receiver.
+
+### Vercel Edge Functions / React Native / Electron
+
+Bring your own OTel SDK and export spans to NEAT's receiver as above.
+
+## Promoting a runtime to in-scope
+
+A runtime moves to in-scope when: (a) 10+ users requesting it or top-20 npm framework rank; (b) a stable OTel pattern across two minor versions; (c) a fixture + contract assertions + CI smoke land alongside. Open an issue to start the conversation.

--- a/packages/core/src/installers/javascript.ts
+++ b/packages/core/src/installers/javascript.ts
@@ -174,7 +174,7 @@ function projectToken(
 // can't execute. Detection runs after framework dispatch (Next / Remix /
 // SvelteKit / Nuxt / Astro all render server-side, so they classify as
 // `node`); only the framework-less packages reach the bucket here.
-type RuntimeKind = 'node' | 'browser-bundle' | 'react-native'
+type RuntimeKind = 'node' | 'browser-bundle' | 'react-native' | 'bun' | 'deno' | 'cloudflare-workers' | 'electron'
 
 async function readJsonFile(p: string): Promise<unknown> {
   try {
@@ -206,6 +206,19 @@ async function detectRuntimeKind(
   ) {
     return 'browser-bundle'
   }
+  // Issues #389 #390 — out-of-scope runtime detection for BYO-OTel escape hatch.
+  // Order: wrangler.toml first (Workers projects may also carry package.json),
+  // then bun.lockb (Bun projects often have package.json too), then Deno signals.
+  if (await exists(path.join(pkgRoot, 'wrangler.toml'))) return 'cloudflare-workers'
+  if (await exists(path.join(pkgRoot, 'bun.lockb'))) return 'bun'
+  if (
+    (await exists(path.join(pkgRoot, 'deno.json'))) ||
+    (await exists(path.join(pkgRoot, 'deno.lock')))
+  ) {
+    return 'deno'
+  }
+  const engines = (pkg as { engines?: Record<string, unknown> }).engines ?? {}
+  if ('electron' in engines) return 'electron'
   return 'node'
 }
 
@@ -1405,6 +1418,28 @@ async function apply(installPlan: InstallPlan): Promise<ApplyResult> {
       serviceDir,
       outcome: 'react-native',
       reason: 'React Native / Expo target; Node OTel SDK cannot run here',
+      writtenFiles: [],
+    }
+  }
+  if (installPlan.runtimeKind === 'bun') {
+    return { serviceDir, outcome: 'bun', reason: 'Bun runtime; use BYO-OTel', writtenFiles: [] }
+  }
+  if (installPlan.runtimeKind === 'deno') {
+    return { serviceDir, outcome: 'deno', reason: 'Deno runtime; use BYO-OTel', writtenFiles: [] }
+  }
+  if (installPlan.runtimeKind === 'cloudflare-workers') {
+    return {
+      serviceDir,
+      outcome: 'cloudflare-workers',
+      reason: 'Cloudflare Workers runtime; use BYO-OTel',
+      writtenFiles: [],
+    }
+  }
+  if (installPlan.runtimeKind === 'electron') {
+    return {
+      serviceDir,
+      outcome: 'electron',
+      reason: 'Electron; use BYO-OTel',
       writtenFiles: [],
     }
   }

--- a/packages/core/src/installers/shared.ts
+++ b/packages/core/src/installers/shared.ts
@@ -79,7 +79,7 @@ export interface InstallPlan {
   // and writes nothing. Absent → vanilla Node default (the existing apply
   // path). Browser-side OTel support (`@opentelemetry/sdk-trace-web`) lands
   // in a future release.
-  runtimeKind?: 'browser-bundle' | 'react-native'
+  runtimeKind?: 'browser-bundle' | 'react-native' | 'bun' | 'deno' | 'cloudflare-workers' | 'electron'
   // ADR-073 §1 — Next.js' `next.config.{js,ts,mjs}` may need the
   // `experimental.instrumentationHook: true` flag set when the major
   // version is < 15. The apply phase mutates the file in place when this
@@ -105,6 +105,10 @@ export type ApplyOutcome =
   | 'failed'
   | 'browser-bundle'
   | 'react-native'
+  | 'bun'
+  | 'deno'
+  | 'cloudflare-workers'
+  | 'electron'
 
 export interface ApplyResult {
   serviceDir: string

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -77,6 +77,10 @@ export interface OrchestratorResult {
       alreadyInstrumented: number
       libOnly: number
       skipped: boolean
+      bun?: number
+      deno?: number
+      cloudflareWorkers?: number
+      electron?: number
       // Issue #381 — package-manager invocations the orchestrator ran
       // after apply() mutated package.json. Absent for `--no-instrument`
       // runs and runs where every plan was empty.
@@ -149,6 +153,11 @@ export interface ApplyInstallersTally {
   libOnly: number
   browserBundle: number
   reactNative: number
+  // Issues #389 #390 — BYO-OTel out-of-scope runtime counters.
+  bun: number
+  deno: number
+  cloudflareWorkers: number
+  electron: number
   // Issue #381 — package-manager invocations the orchestrator ran after
   // apply() mutated package.json. One entry per distinct lockfile-owning
   // directory (monorepos share a single install run regardless of how
@@ -177,6 +186,10 @@ export async function applyInstallersOver(
   let libOnly = 0
   let browserBundle = 0
   let reactNative = 0
+  let bun = 0
+  let deno = 0
+  let cloudflareWorkers = 0
+  let electron = 0
   // Distinct install commands keyed by `<pm>:<cwd>` so a monorepo with
   // multiple instrumented sub-packages still runs install exactly once at
   // its workspace root. The first plan that landed a dep edit for a given
@@ -211,7 +224,59 @@ export async function applyInstallersOver(
       console.log(`skipping ${svc.dir}: browser bundle; browser-OTel support lands in a future release.`)
     } else if (outcome.outcome === 'react-native') {
       reactNative++
-      console.log(`skipping ${svc.dir}: React Native target; browser-OTel support lands in a future release.`)
+      const svcName = path.basename(svc.dir)
+      console.log(
+        `neat: ${svc.dir} detected as React Native / Expo\n` +
+          `  The installer doesn't cover this runtime deterministically.\n` +
+          `  Configure your OTel binding to send spans to:\n` +
+          `    http://localhost:4318/projects/${project}/v1/traces\n` +
+          `  Set OTEL_SERVICE_NAME=${svcName}\n` +
+          `  See docs/installer-scope.md → "Manual setup for out-of-scope runtimes"`,
+      )
+    } else if (outcome.outcome === 'bun') {
+      bun++
+      const svcName = path.basename(svc.dir)
+      console.log(
+        `neat: ${svc.dir} detected as Bun\n` +
+          `  The installer doesn't cover this runtime deterministically.\n` +
+          `  Configure your OTel binding to send spans to:\n` +
+          `    http://localhost:4318/projects/${project}/v1/traces\n` +
+          `  Set OTEL_SERVICE_NAME=${svcName}\n` +
+          `  See docs/installer-scope.md → "Manual setup for out-of-scope runtimes"`,
+      )
+    } else if (outcome.outcome === 'deno') {
+      deno++
+      const svcName = path.basename(svc.dir)
+      console.log(
+        `neat: ${svc.dir} detected as Deno\n` +
+          `  The installer doesn't cover this runtime deterministically.\n` +
+          `  Configure your OTel binding to send spans to:\n` +
+          `    http://localhost:4318/projects/${project}/v1/traces\n` +
+          `  Set OTEL_SERVICE_NAME=${svcName}\n` +
+          `  See docs/installer-scope.md → "Manual setup for out-of-scope runtimes"`,
+      )
+    } else if (outcome.outcome === 'cloudflare-workers') {
+      cloudflareWorkers++
+      const svcName = path.basename(svc.dir)
+      console.log(
+        `neat: ${svc.dir} detected as Cloudflare Workers\n` +
+          `  The installer doesn't cover this runtime deterministically.\n` +
+          `  Configure your OTel binding to send spans to:\n` +
+          `    http://localhost:4318/projects/${project}/v1/traces\n` +
+          `  Set OTEL_SERVICE_NAME=${svcName}\n` +
+          `  See docs/installer-scope.md → "Manual setup for out-of-scope runtimes"`,
+      )
+    } else if (outcome.outcome === 'electron') {
+      electron++
+      const svcName = path.basename(svc.dir)
+      console.log(
+        `neat: ${svc.dir} detected as Electron\n` +
+          `  The installer doesn't cover this runtime deterministically.\n` +
+          `  Configure your OTel binding to send spans to:\n` +
+          `    http://localhost:4318/projects/${project}/v1/traces\n` +
+          `  Set OTEL_SERVICE_NAME=${svcName}\n` +
+          `  See docs/installer-scope.md → "Manual setup for out-of-scope runtimes"`,
+      )
     }
   }
 
@@ -242,6 +307,10 @@ export async function applyInstallersOver(
     libOnly,
     browserBundle,
     reactNative,
+    bun,
+    deno,
+    cloudflareWorkers,
+    electron,
     packageManagerInstalls,
   }
 }

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -11940,6 +11940,91 @@ describe('v0.4.4 substrate — project-scoped OTLP routing + runtime-kind + hook
     })
   })
 
+  // Issues #389 #390 — installer-scope contract: out-of-scope runtimes (Bun,
+  // Deno, Cloudflare Workers) produce zero writes + zero dep edits and the
+  // orchestrator emits the BYO-OTel escape-hatch message.
+  describe('#389 #390 — installer-scope: out-of-scope runtimes write nothing', () => {
+    it('cloudflare-workers-baseline: detects as cloudflare-workers, writes nothing', async () => {
+      const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+      const plan = await javascriptInstaller.plan(
+        join(__dirname, '../fixtures/cloudflare-workers-baseline'),
+        { project: 'demo' },
+      )
+      expect(plan.runtimeKind).toBe('cloudflare-workers')
+      expect(plan.dependencyEdits).toEqual([])
+      expect(plan.generatedFiles ?? []).toEqual([])
+      const result = await javascriptInstaller.apply(plan)
+      expect(result.outcome).toBe('cloudflare-workers')
+      expect(result.writtenFiles).toEqual([])
+    })
+
+    it('bun-baseline: detects as bun, writes nothing', async () => {
+      const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+      const plan = await javascriptInstaller.plan(
+        join(__dirname, '../fixtures/bun-baseline'),
+        { project: 'demo' },
+      )
+      expect(plan.runtimeKind).toBe('bun')
+      expect(plan.dependencyEdits).toEqual([])
+      expect(plan.generatedFiles ?? []).toEqual([])
+      const result = await javascriptInstaller.apply(plan)
+      expect(result.outcome).toBe('bun')
+      expect(result.writtenFiles).toEqual([])
+    })
+
+    it('deno-baseline: detects as deno, writes nothing', async () => {
+      const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+      const plan = await javascriptInstaller.plan(
+        join(__dirname, '../fixtures/deno-baseline'),
+        { project: 'demo' },
+      )
+      expect(plan.runtimeKind).toBe('deno')
+      expect(plan.dependencyEdits).toEqual([])
+      expect(plan.generatedFiles ?? []).toEqual([])
+      const result = await javascriptInstaller.apply(plan)
+      expect(result.outcome).toBe('deno')
+      expect(result.writtenFiles).toEqual([])
+    })
+
+    it('prisma-baseline: runtimeKind is node, dep edit includes @prisma/instrumentation@^6.0.0', async () => {
+      const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+      const plan = await javascriptInstaller.plan(
+        join(__dirname, '../fixtures/prisma-baseline'),
+        { project: 'demo' },
+      )
+      expect(plan.runtimeKind).toBeUndefined()
+      const prismaEdit = plan.dependencyEdits.find((e) => e.name === '@prisma/instrumentation')
+      expect(prismaEdit).toBeDefined()
+      expect(prismaEdit?.version).toBe('^6.0.0')
+    })
+
+    it('orchestrator emits BYO-OTel escape-hatch URL for cloudflare-workers', async () => {
+      const { applyInstallersOver } = await import('../../src/orchestrator.js')
+      const { discoverServices } = await import('../../src/extract/services.js')
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      try {
+        const services = await discoverServices(
+          join(__dirname, '../fixtures/cloudflare-workers-baseline'),
+        )
+        await applyInstallersOver(services, 'demo', {
+          runInstall: async (cmd) => ({
+            pm: cmd.pm,
+            cwd: cmd.cwd,
+            args: cmd.args,
+            exitCode: 0,
+            stdout: '',
+            stderr: '',
+          }),
+        })
+        const logged = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+        expect(logged).toContain('http://localhost:4318/projects/')
+        expect(logged).toContain('installer-scope.md')
+      } finally {
+        logSpy.mockRestore()
+      }
+    })
+  })
+
   // Issue #375 — classification pipeline reorders: lib-only takes precedence
   // over a stray Vite config or Expo deps when no runtime entry resolves.
   // Vite/Expo on a library package (no main, no scripts, no src entry) means

--- a/packages/core/test/fixtures/bun-baseline/package.json
+++ b/packages/core/test/fixtures/bun-baseline/package.json
@@ -1,0 +1,1 @@
+{ "name": "my-bun-app", "version": "1.0.0", "scripts": { "start": "bun run src/index.ts" } }

--- a/packages/core/test/fixtures/bun-baseline/src/index.ts
+++ b/packages/core/test/fixtures/bun-baseline/src/index.ts
@@ -1,0 +1,1 @@
+console.log('hello from bun')

--- a/packages/core/test/fixtures/cloudflare-workers-baseline/package.json
+++ b/packages/core/test/fixtures/cloudflare-workers-baseline/package.json
@@ -1,0 +1,1 @@
+{ "name": "my-worker", "version": "1.0.0" }

--- a/packages/core/test/fixtures/cloudflare-workers-baseline/src/index.ts
+++ b/packages/core/test/fixtures/cloudflare-workers-baseline/src/index.ts
@@ -1,0 +1,1 @@
+export default { async fetch(request: Request): Promise<Response> { return new Response('ok') } }

--- a/packages/core/test/fixtures/cloudflare-workers-baseline/wrangler.toml
+++ b/packages/core/test/fixtures/cloudflare-workers-baseline/wrangler.toml
@@ -1,0 +1,4 @@
+[name]
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"

--- a/packages/core/test/fixtures/deno-baseline/deno.json
+++ b/packages/core/test/fixtures/deno-baseline/deno.json
@@ -1,0 +1,1 @@
+{ "tasks": { "start": "deno run src/main.ts" } }

--- a/packages/core/test/fixtures/deno-baseline/deno.lock
+++ b/packages/core/test/fixtures/deno-baseline/deno.lock
@@ -1,0 +1,1 @@
+{ "version": "3", "packages": {}, "remote": {} }

--- a/packages/core/test/fixtures/deno-baseline/package.json
+++ b/packages/core/test/fixtures/deno-baseline/package.json
@@ -1,0 +1,1 @@
+{ "name": "my-deno-app", "version": "1.0.0" }

--- a/packages/core/test/fixtures/deno-baseline/src/main.ts
+++ b/packages/core/test/fixtures/deno-baseline/src/main.ts
@@ -1,0 +1,1 @@
+console.log('hello from deno')

--- a/packages/core/test/fixtures/prisma-baseline/package.json
+++ b/packages/core/test/fixtures/prisma-baseline/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "prisma-app",
+  "version": "1.0.0",
+  "main": "src/index.js",
+  "dependencies": {
+    "@prisma/client": "^6.1.0",
+    "express": "^4.18.0"
+  }
+}

--- a/packages/core/test/fixtures/prisma-baseline/src/index.js
+++ b/packages/core/test/fixtures/prisma-baseline/src/index.js
@@ -1,0 +1,11 @@
+const express = require('express')
+const { PrismaClient } = require('@prisma/client')
+
+const app = express()
+const prisma = new PrismaClient()
+
+app.get('/', async (req, res) => {
+  res.json({ ok: true })
+})
+
+app.listen(3000)


### PR DESCRIPTION
## Summary

- Extends `detectRuntimeKind` to cover Cloudflare Workers (`wrangler.toml`), Bun (`bun.lockb`), Deno (`deno.json`/`deno.lock`), and Electron (`package.json#engines.electron`)
- Each out-of-scope runtime writes nothing and emits a BYO-OTel escape-hatch message with the project-scoped OTLP URL and a pointer to `docs/installer-scope.md`
- Updates react-native message to the same escape-hatch format
- Adds four new fixtures and five contract assertions; 583 tests pass

## Test plan

- [x] `npx turbo build test lint` clean
- [x] `cloudflare-workers-baseline` → `runtimeKind: 'cloudflare-workers'`, zero writes, zero dep edits
- [x] `bun-baseline` → `runtimeKind: 'bun'`, zero writes, zero dep edits
- [x] `deno-baseline` → `runtimeKind: 'deno'`, zero writes, zero dep edits
- [x] `prisma-baseline` → `runtimeKind` undefined, `@prisma/instrumentation@^6.0.0` dep edit present
- [x] Orchestrator escape-hatch log contains `http://localhost:4318/projects/` and `installer-scope.md`

Refs #389 #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)