### PR TITLE
Fix registry resolve() returning null for non-coercible version strings

### DIFF
--- a/packages/instrumentation-registry/src/index.ts
+++ b/packages/instrumentation-registry/src/index.ts
@@ -40,9 +40,8 @@ export function resolve(library: string, installedVersion?: string): RegistryEnt
   const entry = (registryJson as Record<string, { versions: Array<Record<string, string>> }>)[library]
   if (!entry) return null
   for (const v of entry.versions) {
-    const matches =
-      !installedVersion ||
-      semver.satisfies(semver.coerce(installedVersion)?.version ?? installedVersion, v['range'] as string)
+    const coerced = installedVersion ? semver.coerce(installedVersion)?.version : undefined
+    const matches = !installedVersion || !coerced || semver.satisfies(coerced, v['range'] as string)
     if (matches) {
       return {
         library,


### PR DESCRIPTION
## What and why

The pre-publish smoke for v0.4.12 called `resolve('stripe', '*')` and `resolve('hono', '*')` and got `null` back for both — even though both libraries are in the registry. This PR fixes that.

## Root cause

`resolve()` determines whether an installed version matches a registry range entry using this logic:

```ts
// before
const matches =
  !installedVersion ||
  semver.satisfies(semver.coerce(installedVersion)?.version ?? installedVersion, v['range'] as string)
```

Step by step with `installedVersion = '*'`:

1. `semver.coerce('*')` returns `null`. The `*` character is a valid semver **range** expression but not a valid semver **version** — `coerce` only accepts version strings (`'1.0.0'`, `'^1.2.3'`, `'v2'`, etc.), so it returns null for `'*'`.
2. The `?? installedVersion` fallback kicks in, passing the raw string `'*'` as the first argument to `semver.satisfies`.
3. `semver.satisfies('*', someRange)` returns `false` — the first argument to `satisfies` must be a concrete version, not a range. `'*'` in position one is invalid.
4. The loop finds no matching entry and falls through to `return null`, even though the library exists in the registry.

## The fix

```ts
// after
const coerced = installedVersion ? semver.coerce(installedVersion)?.version : undefined
const matches = !installedVersion || !coerced || semver.satisfies(coerced, v['range'] as string)
```

When `coerced` is `undefined` (semver.coerce could not parse the installed version string), `!coerced` is `true` so `matches` is `true` — the entry matches regardless of range. This is the correct semantic: if a package.json carries `"stripe": "*"`, any version of Stripe is installed, so any instrumentation range entry is compatible.

The old `?? installedVersion` fallback was passing the raw un-parseable string as a concrete version to `semver.satisfies`, which silently returns false instead of throwing.

## When does this matter in practice?

Rarely — `'*'` as a package.json dep version is unusual. Real projects pin to `'^X.Y.Z'` or `'X.Y.Z'`, and for those `semver.coerce` works fine. The v0.4.12 installer reconciliation (#391) reads real `package.json` deps and was unaffected.

The case this closes: a project with a bare `'*'` pin for any library in the registry gets `null` from `resolve()` instead of the correct entry, causing the installer to skip version reconciliation for that dep and causing `neat_list_uninstrumented` (#387, wave 2) to miss it.

## Verification

`npm run test --workspace @neat.is/instrumentation-registry` passes (9 tests). The existing tests cover Prisma 5/6 range-matching; a follow-up can add an explicit `'*'` case if desired.

Refs #386