### PR TITLE
Attach code.* call-site evidence to OBSERVED edges

### DIFF
--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -653,6 +653,7 @@ function upsertObservedEdge(
   target: string,
   ts: string,
   isError = false,
+  evidence?: { file: string; line?: number },
 ): UpsertResult | null {
   if (!graph.hasNode(source) || !graph.hasNode(target)) return null
 
@@ -696,6 +697,9 @@ function upsertObservedEdge(
     lastObserved: ts,
     callCount: 1,
     signal,
+    // Call-site evidence from span code.* semconv (file-awareness.md §4 + §6).
+    // Only set when code.filepath was present on the span — never fabricated.
+    ...(evidence ? { evidence } : {}),
   }
   graph.addEdgeWithKey(id, source, target, edge)
   return { edge, created: true }
@@ -872,6 +876,12 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
   const callSite = callSiteFromSpan(span, sourceServiceNode, ctx.scanPath)
   const observedSource = (): string =>
     callSite ? ensureObservedFileNode(ctx.graph, span.service, sourceId, callSite) : sourceId
+  // Evidence for the OBSERVED edge — populated from the span's code.* semconv
+  // when the call site resolved (file-awareness.md §4 + §6). Never fabricated:
+  // absent call site → undefined evidence.
+  const callSiteEvidence: { file: string; line?: number } | undefined = callSite
+    ? { file: callSite.relPath, ...(callSite.line !== undefined ? { line: callSite.line } : {}) }
+    : undefined
 
   let affectedNode = sourceId
 
@@ -898,6 +908,7 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
         targetId,
         ts,
         isError,
+        callSiteEvidence,
       )
       if (result) affectedNode = targetId
     }
@@ -924,6 +935,7 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
           targetId,
           ts,
           isError,
+          callSiteEvidence,
         )
         affectedNode = targetId
         resolvedViaAddress = true
@@ -936,6 +948,7 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
           frontierNodeId,
           ts,
           isError,
+          callSiteEvidence,
         )
         affectedNode = frontierNodeId
         resolvedViaAddress = true

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -873,3 +873,116 @@ describe('handleSpan kind-gate (issue #429)', () => {
     expect(connects).toBe(0)
   })
 })
+
+// Issue #395 — OBSERVED edges carry evidence and originate from a FileNode when
+// a span carries code.* semconv (file-awareness.md §4 + §6).
+describe('handleSpan code.* evidence (issue #395)', () => {
+  let tmpDir: string
+  let ctx: IngestContext
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-code-star-'))
+    ctx = { graph: newGraph(), errorsPath: path.join(tmpDir, 'errors.ndjson') }
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('sets evidence.file and evidence.line on the OBSERVED edge when code.* attrs are present', async () => {
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        attributes: {
+          'server.address': 'service-b',
+          'code.filepath': 'src/client.ts',
+          'code.lineno': 42,
+          'code.function': 'callServiceB',
+        },
+      }),
+    )
+    // The edge source is now a FileNode id, not the service id.
+    const fileNodeId = 'file:service-a:src/client.ts'
+    expect(ctx.graph.hasNode(fileNodeId)).toBe(true)
+    const fileNode = ctx.graph.getNodeAttributes(fileNodeId) as { type: string; path: string }
+    expect(fileNode.type).toBe(NodeType.FileNode)
+    expect(fileNode.path).toBe('src/client.ts')
+
+    // The OBSERVED edge originates from the FileNode.
+    const edgeId = `${EdgeType.CALLS}:OBSERVED:${fileNodeId}->service:service-b`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.source).toBe(fileNodeId)
+    expect(edge.evidence).toBeDefined()
+    expect(edge.evidence!.file).toBe('src/client.ts')
+    expect(edge.evidence!.line).toBe(42)
+  })
+
+  it('creates a CONTAINS edge from the service to the FileNode', async () => {
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        attributes: {
+          'server.address': 'service-b',
+          'code.filepath': 'src/client.ts',
+          'code.lineno': 42,
+        },
+      }),
+    )
+    const fileNodeId = 'file:service-a:src/client.ts'
+    // A CONTAINS edge connects service:service-a → file:service-a:src/client.ts
+    let containsFound = false
+    ctx.graph.forEachEdge((_id, attrs) => {
+      const e = attrs as GraphEdge
+      if (
+        e.type === EdgeType.CONTAINS &&
+        e.source === 'service:service-a' &&
+        e.target === fileNodeId
+      ) {
+        containsFound = true
+      }
+    })
+    expect(containsFound).toBe(true)
+  })
+
+  it('sets no evidence and source stays as the service node when code.* is absent', async () => {
+    await handleSpan(ctx, clientHttpSpan())
+    const edgeId = `${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.source).toBe('service:service-a')
+    expect(edge.evidence).toBeUndefined()
+    // No FileNode was created.
+    let fileNodeCount = 0
+    ctx.graph.forEachNode((_id, attrs) => {
+      if ((attrs as { type: string }).type === NodeType.FileNode) fileNodeCount++
+    })
+    expect(fileNodeCount).toBe(0)
+  })
+
+  it('sets evidence on CONNECTS_TO edges for db spans carrying code.*', async () => {
+    await handleSpan(
+      ctx,
+      dbSpan({
+        attributes: {
+          'db.system': 'postgresql',
+          'db.name': 'neatdemo',
+          'server.address': 'payments-db',
+          'code.filepath': 'src/repo.ts',
+          'code.lineno': 88,
+          'code.function': 'findUser',
+        },
+      }),
+    )
+    const fileNodeId = 'file:service-b:src/repo.ts'
+    expect(ctx.graph.hasNode(fileNodeId)).toBe(true)
+
+    const edgeId = `${EdgeType.CONNECTS_TO}:OBSERVED:${fileNodeId}->database:payments-db`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.evidence).toBeDefined()
+    expect(edge.evidence!.file).toBe('src/repo.ts')
+    expect(edge.evidence!.line).toBe(88)
+  })
+})


### PR DESCRIPTION
## Summary

Ingest now promotes file-grained OBSERVED edges when spans carry `code.*` semconv. When a span includes `code.filepath` / `code.lineno` / `code.function`, the OBSERVED edge gets `evidence: { file, line }` set on creation — so consumers (traversal, divergence, the MCP surface) can read the exact call site without re-parsing the span.

- `upsertObservedEdge` accepts an optional `evidence` arg; it lands on the edge at creation time, never on updates (the first observation is the attribution, subsequent spans just increment the signal)
- The `observedSource()` thunk already ensured the edge source is a FileNode when `code.*` is present; evidence is now wired alongside it
- Spans without `code.*` produce no evidence — contract §6 (never fabricate)

## Test plan

- New `describe('handleSpan code.* evidence (issue #395)')` in `packages/core/test/ingest.test.ts`
  - [ ] Edge carries `evidence.file` + `evidence.line` and sources from a FileNode when code.* present (CALLS + CONNECTS_TO)
  - [ ] A service→file CONTAINS edge is created
  - [ ] No evidence set and source is the service node when code.* absent
  - [ ] No FileNode created when code.* absent
- `npx turbo test --filter @neat.is/core` — 873 passed, 0 failures

Refs #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)