### PR TITLE
Bump to 0.4.12

### DIFF
--- a/packages/claude-skill/package.json
+++ b/packages/claude-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/claude-skill",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Claude Code skill drop-in for NEAT — wires the @neat.is/mcp server into Claude's MCP config",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/core",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "NEAT graph engine: tree-sitter extraction, OTel ingest, REST API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -52,7 +52,7 @@
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
     "@neat.is/instrumentation-registry": "*",
-    "@neat.is/types": "^0.4.11",
+    "@neat.is/types": "^0.4.12",
     "chokidar": "^4.0.3",
     "fastify": "^5.0.0",
     "graphology": "^0.25.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/mcp",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "NEAT MCP server: exposes graph queries to AI agents over stdio",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@neat.is/types": "^0.4.11",
+    "@neat.is/types": "^0.4.12",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/neat.is/package.json
+++ b/packages/neat.is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neat.is",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "NEAT — live semantic graph of a software system, queryable from AI agents over MCP. Install once, get the neat / neatd / neat-mcp CLIs.",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -26,9 +26,9 @@
     "README.md"
   ],
   "dependencies": {
-    "@neat.is/core": "^0.4.11",
-    "@neat.is/mcp": "^0.4.11",
-    "@neat.is/claude-skill": "^0.4.11",
-    "@neat.is/web": "^0.4.11"
+    "@neat.is/core": "^0.4.12",
+    "@neat.is/mcp": "^0.4.12",
+    "@neat.is/claude-skill": "^0.4.12",
+    "@neat.is/web": "^0.4.12"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/types",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Shared Zod schemas, types, and runtime constants for NEAT",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/web",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "NEAT web shell — minimal Next.js app fronting the core API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "@neat.is/types": "^0.4.11",
+    "@neat.is/types": "^0.4.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cytoscape": "^3.33.3",


### PR DESCRIPTION
Version bump following the file-first canvas batch:

- #445 Route CONNECTS_TO, RUNS_ON, CONFIGURED_BY through FileNodes
- #446 File-first canvas: drop service nodes, fix dashboard bugs
- #447 Attach code.* call-site evidence to OBSERVED edges
- #448 Call-site span processor acceptance criteria

Refs #396 #395 #394 #393