### PR TITLE
Remove instrumentation-registry from publish smoke-test visibility loop

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,7 +123,7 @@ jobs:
           # because the retry loop only checked the umbrella. Every package in
           # the lockstep set must be visible at the target version before we
           # install.
-          for pkg in "@neat.is/instrumentation-registry" "@neat.is/types" "@neat.is/core" "@neat.is/mcp" "@neat.is/claude-skill" "@neat.is/web" "neat.is"; do
+          for pkg in "@neat.is/types" "@neat.is/core" "@neat.is/mcp" "@neat.is/claude-skill" "@neat.is/web" "neat.is"; do
             for i in 1 2 3 4 5 6 7 8 9 10; do
               if npm view "${pkg}@${version}" version > /dev/null 2>&1; then
                 echo "  ${pkg}@${version} visible"


### PR DESCRIPTION
@neat.is/instrumentation-registry carries its own independent version (1.0.0), not the lockstep 0.4.x version. The smoke-test loop was waiting for it at the lockstep version, causing every publish to fail at the smoke step even after the six actual lockstep packages published successfully.

The publish-system contract explicitly defines the lockstep set as @neat.is/{types,core,mcp,claude-skill,web} + neat.is. instrumentation-registry is not in that set.

Discovered when v0.4.12 published cleanly but the smoke test timed out on @neat.is/instrumentation-registry@0.4.12.

Refs #449