### PR TITLE
Phase 1 — unconditional file enumeration

### DIFF
--- a/packages/core/src/extract/files.ts
+++ b/packages/core/src/extract/files.ts
@@ -1,0 +1,34 @@
+import type { NeatGraph } from '../graph.js'
+import type { DiscoveredService } from './shared.js'
+import { ensureFileNode, walkSourceFiles, toPosix } from './calls/shared.js'
+import path from 'node:path'
+
+// Phase 1 — unconditional file enumeration (ADR-092, file-awareness.md §1).
+// Walks every source file matching SERVICE_FILE_EXTENSIONS within each service
+// and emits a FileNode + service ──CONTAINS──▶ file edge, regardless of whether
+// any call pattern fires from the file later.
+export async function addFiles(
+  graph: NeatGraph,
+  services: DiscoveredService[],
+  scanPath: string,
+): Promise<{ nodesAdded: number; edgesAdded: number }> {
+  let nodesAdded = 0
+  let edgesAdded = 0
+
+  for (const service of services) {
+    const filePaths = await walkSourceFiles(service.dir)
+    for (const filePath of filePaths) {
+      const relPath = toPosix(path.relative(service.dir, filePath))
+      const { nodesAdded: n, edgesAdded: e } = ensureFileNode(
+        graph,
+        service.pkg.name,
+        service.node.id,
+        relPath,
+      )
+      nodesAdded += n
+      edgesAdded += e
+    }
+  }
+
+  return { nodesAdded, edgesAdded }
+}

--- a/packages/core/src/extract/index.ts
+++ b/packages/core/src/extract/index.ts
@@ -17,6 +17,7 @@ import { ensureCompatLoaded } from '../compat.js'
 import { emitNeatEvent } from '../events.js'
 import { addServiceNodes, discoverServices } from './services.js'
 import { addServiceAliases } from './aliases.js'
+import { addFiles } from './files.js'
 import { addDatabasesAndCompat } from './databases/index.js'
 import { addConfigNodes } from './configs.js'
 import { addCallEdges } from './calls/index.js'
@@ -87,6 +88,7 @@ export async function extractFromDirectory(
 
   const phase1Nodes = addServiceNodes(graph, services)
   await addServiceAliases(graph, scanPath, services)
+  const fileEnum = await addFiles(graph, services, scanPath)
   const phase2 = await addDatabasesAndCompat(graph, services, scanPath)
   const phase3 = await addConfigNodes(graph, services, scanPath)
   const phase4 = await addCallEdges(graph, services)
@@ -147,11 +149,13 @@ export async function extractFromDirectory(
   const result: ExtractResult = {
     nodesAdded:
       phase1Nodes +
+      fileEnum.nodesAdded +
       phase2.nodesAdded +
       phase3.nodesAdded +
       phase4.nodesAdded +
       phase5.nodesAdded,
     edgesAdded:
+      fileEnum.edgesAdded +
       phase2.edgesAdded + phase3.edgesAdded + phase4.edgesAdded + phase5.edgesAdded,
     frontiersPromoted,
     extractionErrors: errorEntries.length,

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -195,12 +195,16 @@ describe('REST API (fastify.inject)', () => {
     const body = res.json()
     expect(body.origin).toBe('service:service-a')
     // File-first — databases/dockerfile/configs extractors now all anchor edges
-    // on FileNodes. service-a CONTAINS three files at distance 1 (index.js,
-    // Dockerfile, .env.neat); infra:container-image is at distance 2 (via
-    // Dockerfile FileNode); service-b at distance 2 (via index.js); service-b's
-    // three config FileNodes at distance 3; their ConfigNodes and payments-db
-    // at distance 4.
-    expect(body.totalAffected).toBe(12)
+    // on FileNodes. Phase 1 file enumeration (ADR-092, file-awareness.md §1)
+    // now gives every source file a FileNode unconditionally, so service-a
+    // CONTAINS four files at distance 1 (index.js, Dockerfile, .env.neat, and
+    // otel.js — previously invisible because no call pattern fired from it);
+    // infra:container-image is at distance 2 (via Dockerfile FileNode);
+    // service-b at distance 2 (via index.js); service-b's five files
+    // (db-config.yaml, Dockerfile, .env.neat, index.js, and otel.js — the
+    // latter two previously invisible for the same reason) at distance 3;
+    // their ConfigNodes and payments-db at distance 4.
+    expect(body.totalAffected).toBe(15)
     // path + confidence land per ADR-038 §affectedNodes payload. Property-style
     // assertions so this test doesn't pin every BFS path detail — the contract
     // tests in contracts.test.ts pin the per-node invariants tightly.
@@ -220,9 +224,12 @@ describe('REST API (fastify.inject)', () => {
       'file:service-a:.env.neat',
       'file:service-a:Dockerfile',
       'file:service-a:index.js',
+      'file:service-a:otel.js',
       'file:service-b:.env.neat',
       'file:service-b:Dockerfile',
       'file:service-b:db-config.yaml',
+      'file:service-b:index.js',
+      'file:service-b:otel.js',
       'infra:container-image:node:20-bookworm-slim',
       'service:service-b',
     ])
@@ -257,15 +264,18 @@ describe('REST API (fastify.inject)', () => {
     })
     expect(res.statusCode).toBe(200)
     const body = res.json()
-    // File-first — at distance 1 service-a reaches all three of its own
-    // FileNodes via CONTAINS (.env.neat, Dockerfile, index.js). The
-    // container-image and service-b both sit at distance 2, so depth=1
+    // File-first — at distance 1 service-a reaches all four of its own
+    // FileNodes via CONTAINS (.env.neat, Dockerfile, index.js, and — newly
+    // visible since Phase 1 file enumeration gives every source file a
+    // FileNode unconditionally (ADR-092, file-awareness.md §1) — otel.js).
+    // The container-image and service-b both sit at distance 2, so depth=1
     // doesn't reach them.
-    expect(body.totalAffected).toBe(3)
+    expect(body.totalAffected).toBe(4)
     expect(body.affectedNodes.map((n: { nodeId: string }) => n.nodeId).sort()).toEqual([
       'file:service-a:.env.neat',
       'file:service-a:Dockerfile',
       'file:service-a:index.js',
+      'file:service-a:otel.js',
     ])
   })
 

--- a/packages/core/test/files.test.ts
+++ b/packages/core/test/files.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { NodeType } from '@neat.is/types'
+import { getGraph, resetGraph } from '../src/graph.js'
+import { addFiles } from '../src/extract/files.js'
+import type { DiscoveredService } from '../src/extract/shared.js'
+
+function makeService(name: string, dir: string): DiscoveredService {
+  return {
+    pkg: { name },
+    dir,
+    node: {
+      id: `service:${name}`,
+      type: NodeType.ServiceNode,
+      name,
+      language: 'typescript',
+      discoveredVia: 'static',
+    },
+  }
+}
+
+describe('addFiles — Phase 1 file enumeration', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    resetGraph()
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-files-test-'))
+  })
+
+  it('emits a FileNode and CONTAINS edge for every source file', async () => {
+    await fs.writeFile(path.join(tmpDir, 'index.ts'), 'export {}')
+    await fs.writeFile(path.join(tmpDir, 'utils.ts'), 'export {}')
+    await fs.writeFile(path.join(tmpDir, 'helper.ts'), 'export {}')
+
+    const graph = getGraph()
+    const service = makeService('my-svc', tmpDir)
+    graph.addNode(service.node.id, service.node)
+
+    const result = await addFiles(graph, [service], tmpDir)
+
+    expect(result.nodesAdded).toBe(3)
+    expect(result.edgesAdded).toBe(3)
+
+    expect(graph.hasNode('file:my-svc:index.ts')).toBe(true)
+    expect(graph.hasNode('file:my-svc:utils.ts')).toBe(true)
+    expect(graph.hasNode('file:my-svc:helper.ts')).toBe(true)
+
+    const node = graph.getNodeAttributes('file:my-svc:index.ts') as { type: string; service: string; path: string }
+    expect(node.type).toBe(NodeType.FileNode)
+    expect(node.service).toBe('my-svc')
+
+    expect(graph.hasEdge('CONTAINS:service:my-svc->file:my-svc:index.ts')).toBe(true)
+    expect(graph.hasEdge('CONTAINS:service:my-svc->file:my-svc:utils.ts')).toBe(true)
+    expect(graph.hasEdge('CONTAINS:service:my-svc->file:my-svc:helper.ts')).toBe(true)
+  })
+
+  it('includes files with no external call patterns (the unconditional guarantee)', async () => {
+    await fs.writeFile(path.join(tmpDir, 'plain.ts'), 'const x = 1')
+
+    const graph = getGraph()
+    const service = makeService('my-svc', tmpDir)
+    graph.addNode(service.node.id, service.node)
+
+    const result = await addFiles(graph, [service], tmpDir)
+
+    expect(result.nodesAdded).toBe(1)
+    expect(graph.hasNode('file:my-svc:plain.ts')).toBe(true)
+  })
+
+  it('is idempotent — running twice produces the same node count', async () => {
+    await fs.writeFile(path.join(tmpDir, 'a.ts'), '')
+    await fs.writeFile(path.join(tmpDir, 'b.ts'), '')
+
+    const graph = getGraph()
+    const service = makeService('my-svc', tmpDir)
+    graph.addNode(service.node.id, service.node)
+
+    const first = await addFiles(graph, [service], tmpDir)
+    const second = await addFiles(graph, [service], tmpDir)
+
+    expect(first.nodesAdded).toBe(2)
+    expect(second.nodesAdded).toBe(0)
+    expect(graph.order).toBe(3) // 1 service node + 2 file nodes
+  })
+})


### PR DESCRIPTION
Every source file in every service now gets a FileNode and a `service ──CONTAINS──▶ file` edge at extraction time, regardless of whether any CALLS/IMPORTS/CONNECTS_TO/CONFIGURED_BY edge ever fires from it. `addFiles` runs as the first producer in the static-extraction pipeline, ahead of databases/configs/calls/infra, per ADR-092 and file-awareness.md §1.

It reuses the existing `ensureFileNode`/`walkSourceFiles`/`toPosix` helpers so idempotency and id formatting match every other producer exactly.

Updated the demo blast-radius assertions in `api.test.ts` — `service-a/otel.js` and `service-b/index.js` and `service-b/otel.js` were previously invisible because no call pattern ever matched them. Phase 1 surfaces them honestly, which is the whole point of the contract.

Refs #451