### PR TITLE
Add IMPORTS edges between FileNodes (Phase 2 of file-span extraction)

### DIFF
--- a/packages/core/src/extract/imports.ts
+++ b/packages/core/src/extract/imports.ts
@@ -1,0 +1,449 @@
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import Parser from 'tree-sitter'
+import JavaScript from 'tree-sitter-javascript'
+import Python from 'tree-sitter-python'
+import type { GraphEdge } from '@neat.is/types'
+import {
+  EdgeType,
+  Provenance,
+  confidenceForExtracted,
+  extractedEdgeId,
+  fileId,
+} from '@neat.is/types'
+import type { NeatGraph } from '../graph.js'
+import { isTestPath, type DiscoveredService } from './shared.js'
+import { recordExtractionError } from './errors.js'
+import { loadSourceFiles, toPosix } from './calls/shared.js'
+
+// Phase 2 — import graph extraction (ADR-092, file-awareness.md §10). Walks
+// every source file's AST for import / require statements and emits IMPORTS
+// edges between FileNodes within the same service. Cross-service and
+// unresolvable specifiers are silent skips — Phase 3's CALLS producers cover
+// the cross-service case where an external-call pattern matches.
+
+// Same chunked-parse approach as calls/shared.ts — tree-sitter's bare string
+// path throws "Invalid argument" once the source clears ~32K code units. The
+// callback form streams the source in bounded slices instead.
+const PARSE_CHUNK = 16384
+
+function parseSource(parser: Parser, source: string): Parser.Tree {
+  return parser.parse((index: number) =>
+    index >= source.length ? '' : source.slice(index, index + PARSE_CHUNK),
+  )
+}
+
+function makeJsParser(): Parser {
+  const p = new Parser()
+  p.setLanguage(JavaScript)
+  return p
+}
+
+function makePyParser(): Parser {
+  const p = new Parser()
+  p.setLanguage(Python)
+  return p
+}
+
+// ── string-literal text ────────────────────────────────────────────────────
+
+// The interior text of a string literal node, stripped of quote characters.
+// tree-sitter-javascript wraps the content in a `string_fragment` child;
+// fall back to slicing the raw text when that shape isn't present (e.g. an
+// empty string literal has no fragment child at all).
+function stringLiteralText(node: Parser.SyntaxNode): string | null {
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i)
+    if (child?.type === 'string_fragment') return child.text
+  }
+  const raw = node.text
+  if (raw.length >= 2) return raw.slice(1, -1)
+  return raw.length === 0 ? null : ''
+}
+
+function clipSnippet(text: string): string {
+  const oneLine = text.split('\n')[0] ?? text
+  return oneLine.length > 120 ? oneLine.slice(0, 120) : oneLine
+}
+
+// ── JS / TS import collection ──────────────────────────────────────────────
+
+interface RawImport {
+  specifier: string
+  line: number // 1-indexed
+  snippet: string
+}
+
+// Walks the AST for `import ... from 'spec'` / `import 'spec'` (ES modules)
+// and `require('spec')` (CommonJS). Doesn't recurse into import_statement —
+// its only string child is the source specifier, never a nested import.
+function collectJsImports(node: Parser.SyntaxNode, out: RawImport[]): void {
+  if (node.type === 'import_statement') {
+    const source = node.childForFieldName('source')
+    if (source) {
+      const specifier = stringLiteralText(source)
+      if (specifier) {
+        out.push({ specifier, line: node.startPosition.row + 1, snippet: clipSnippet(node.text) })
+      }
+    }
+    return
+  }
+
+  if (node.type === 'call_expression') {
+    const fn = node.childForFieldName('function')
+    if (fn?.type === 'identifier' && fn.text === 'require') {
+      const args = node.childForFieldName('arguments')
+      const firstArg = args?.namedChild(0)
+      if (firstArg?.type === 'string') {
+        const specifier = stringLiteralText(firstArg)
+        if (specifier) {
+          out.push({ specifier, line: node.startPosition.row + 1, snippet: clipSnippet(node.text) })
+        }
+      }
+    }
+  }
+
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i)
+    if (child) collectJsImports(child, out)
+  }
+}
+
+// ── Python import collection ───────────────────────────────────────────────
+
+interface RawPyImport {
+  modulePath: string // dotted path with the leading dots stripped, e.g. 'utils.auth'
+  level: number // count of leading dots; 0 = absolute import
+  line: number
+  snippet: string
+}
+
+// Walks the AST for `from X import ...` / `from .X import ...`. Bare `import
+// X` statements name modules without resolving to a single file (`import
+// os.path` doesn't tell us which file in `os` got used), so Phase 2 limits
+// itself to the `from`-form per the resolution rules in the contract.
+function collectPyImports(node: Parser.SyntaxNode, out: RawPyImport[]): void {
+  if (node.type === 'import_from_statement') {
+    let level = 0
+    let modulePath = ''
+    let pastFrom = false
+
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i)
+      if (!child) continue
+      if (!pastFrom) {
+        if (child.type === 'from') pastFrom = true
+        continue
+      }
+      if (child.type === 'import') break
+
+      if (child.type === 'relative_import') {
+        for (let j = 0; j < child.childCount; j++) {
+          const rc = child.child(j)
+          if (!rc) continue
+          if (rc.type === 'import_prefix') level++
+          else if (rc.type === 'dotted_name') modulePath = rc.text
+        }
+        break
+      }
+      if (child.type === 'dotted_name') {
+        modulePath = child.text
+        break
+      }
+    }
+
+    if (level > 0 || modulePath) {
+      out.push({ modulePath, level, line: node.startPosition.row + 1, snippet: clipSnippet(node.text) })
+    }
+  }
+
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i)
+    if (child) collectPyImports(child, out)
+  }
+}
+
+// ── filesystem resolution helpers ──────────────────────────────────────────
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// An import that escapes the service directory (`../../other-service/x`)
+// isn't an intra-service edge — Phase 2 is scoped to within-service module
+// dependencies (file-awareness.md §10).
+function isWithinServiceDir(candidate: string, serviceDir: string): boolean {
+  const rel = path.relative(serviceDir, candidate)
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel)
+}
+
+const JS_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']
+const JS_INDEX_FILES = JS_EXTENSIONS.map((ext) => `index${ext}`)
+
+// Try `base`, `base.<ext>`, and `base/index.<ext>` in TypeScript-resolution
+// order. Returns the service-relative posix path of the first hit.
+async function firstExistingCandidate(
+  base: string,
+  serviceDir: string,
+): Promise<string | null> {
+  for (const ext of JS_EXTENSIONS) {
+    const candidate = base + ext
+    if (isWithinServiceDir(candidate, serviceDir) && (await fileExists(candidate))) {
+      return toPosix(path.relative(serviceDir, candidate))
+    }
+  }
+  for (const indexFile of JS_INDEX_FILES) {
+    const candidate = path.join(base, indexFile)
+    if (isWithinServiceDir(candidate, serviceDir) && (await fileExists(candidate))) {
+      return toPosix(path.relative(serviceDir, candidate))
+    }
+  }
+  return null
+}
+
+interface TsPathConfig {
+  paths: Record<string, string[]>
+  baseDir: string // absolute directory compilerOptions.baseUrl resolves against
+}
+
+// `tsconfig.json` at the service root. The contract names scanPath as a
+// fallback location too, but every discovered service already carries its own
+// root — the scanPath fallback only matters for configs that live above the
+// service tree, which the resolver doesn't have a path back to from here.
+async function loadTsPathConfig(serviceDir: string): Promise<TsPathConfig | null> {
+  const tsconfigPath = path.join(serviceDir, 'tsconfig.json')
+  let raw: string
+  try {
+    raw = await fs.readFile(tsconfigPath, 'utf8')
+  } catch {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(raw) as {
+      compilerOptions?: { paths?: Record<string, string[]>; baseUrl?: string }
+    }
+    const paths = parsed.compilerOptions?.paths
+    if (!paths || Object.keys(paths).length === 0) return null
+    const baseUrl = parsed.compilerOptions?.baseUrl
+    return { paths, baseDir: baseUrl ? path.resolve(serviceDir, baseUrl) : serviceDir }
+  } catch (err) {
+    recordExtractionError('import alias resolution', tsconfigPath, err)
+    return null
+  }
+}
+
+// Resolve a bare specifier against `compilerOptions.paths`. Matches the first
+// alias whose pattern fits — exact (`@db`) or wildcard (`@db/*`) — and tries
+// each mapped target in declaration order. No match anywhere → null, the
+// silent-skip the contract calls for.
+async function resolveTsAlias(
+  specifier: string,
+  config: TsPathConfig,
+  serviceDir: string,
+): Promise<string | null> {
+  for (const [pattern, targets] of Object.entries(config.paths)) {
+    let suffix: string | null = null
+    if (pattern === specifier) {
+      suffix = ''
+    } else if (pattern.endsWith('/*')) {
+      const prefix = pattern.slice(0, -1) // keep the trailing '/'
+      if (specifier.startsWith(prefix)) suffix = specifier.slice(prefix.length)
+    }
+    if (suffix === null) continue
+
+    for (const target of targets) {
+      const targetBase = target.endsWith('/*') ? target.slice(0, -2) : target.replace(/\*$/, '')
+      const resolvedBase = path.resolve(config.baseDir, targetBase, suffix)
+      const hit = await firstExistingCandidate(resolvedBase, serviceDir)
+      if (hit) return hit
+      // The candidate may already carry its own extension (`@db/mongo.ts`).
+      if (isWithinServiceDir(resolvedBase, serviceDir) && (await fileExists(resolvedBase))) {
+        return toPosix(path.relative(serviceDir, resolvedBase))
+      }
+    }
+  }
+  return null
+}
+
+// Resolves a JS/TS module specifier to a service-relative posix path, or
+// null when it names something outside the service (node_modules, Node
+// builtins, an alias with no tsconfig match, an escaping relative path).
+async function resolveJsImport(
+  specifier: string,
+  importerDir: string,
+  serviceDir: string,
+  tsPaths: TsPathConfig | null,
+): Promise<string | null> {
+  if (!specifier) return null
+
+  if (specifier.startsWith('./') || specifier.startsWith('../')) {
+    const base = path.resolve(importerDir, specifier)
+    const ext = path.extname(specifier)
+
+    if (ext) {
+      // `./foo.js` written against a `.ts` source — the TypeScript ESM
+      // convention of naming the post-build extension in source. Try the
+      // TS sibling before the literal path.
+      if (ext === '.js' || ext === '.jsx') {
+        const tsExt = ext === '.jsx' ? '.tsx' : '.ts'
+        const tsSibling = base.slice(0, -ext.length) + tsExt
+        if (isWithinServiceDir(tsSibling, serviceDir) && (await fileExists(tsSibling))) {
+          return toPosix(path.relative(serviceDir, tsSibling))
+        }
+      }
+      if (isWithinServiceDir(base, serviceDir) && (await fileExists(base))) {
+        return toPosix(path.relative(serviceDir, base))
+      }
+      return null
+    }
+
+    return firstExistingCandidate(base, serviceDir)
+  }
+
+  // Bare specifier — only a registered TS path alias can make this
+  // intra-service. Anything else is node_modules / a Node builtin.
+  if (tsPaths) return resolveTsAlias(specifier, tsPaths, serviceDir)
+  return null
+}
+
+// Resolves a Python `from`-import to a service-relative posix path.
+// Relative imports (level > 0) walk up from the importing module's directory;
+// absolute imports match against the service source tree directly.
+async function resolvePyImport(
+  imp: RawPyImport,
+  importerPath: string,
+  serviceDir: string,
+): Promise<string | null> {
+  if (!imp.modulePath) return null // bare `from . import x` names a package, not a file
+
+  const relPath = imp.modulePath.split('.').join('/')
+  let baseDir: string
+  if (imp.level > 0) {
+    baseDir = path.dirname(importerPath)
+    for (let i = 1; i < imp.level; i++) baseDir = path.dirname(baseDir)
+  } else {
+    baseDir = serviceDir
+  }
+
+  const candidates = [path.join(baseDir, `${relPath}.py`), path.join(baseDir, relPath, '__init__.py')]
+  for (const candidate of candidates) {
+    if (isWithinServiceDir(candidate, serviceDir) && (await fileExists(candidate))) {
+      return toPosix(path.relative(serviceDir, candidate))
+    }
+  }
+  return null
+}
+
+// ── edge emission ──────────────────────────────────────────────────────────
+
+function emitImportEdge(
+  graph: NeatGraph,
+  serviceName: string,
+  importerFileId: string,
+  importerRelPath: string,
+  importeeRelPath: string,
+  line: number,
+  snippet: string,
+): number {
+  const importeeFileId = fileId(serviceName, importeeRelPath)
+  // Phase 1 enumerates every source file unconditionally; a resolved path
+  // that isn't a FileNode is outside SERVICE_FILE_EXTENSIONS or otherwise
+  // wasn't walked — not an intra-service module edge.
+  if (!graph.hasNode(importeeFileId)) return 0
+
+  const edgeId = extractedEdgeId(importerFileId, importeeFileId, EdgeType.IMPORTS)
+  if (graph.hasEdge(edgeId)) return 0
+
+  const edge: GraphEdge = {
+    id: edgeId,
+    source: importerFileId,
+    target: importeeFileId,
+    type: EdgeType.IMPORTS,
+    provenance: Provenance.EXTRACTED,
+    confidence: confidenceForExtracted('structural'),
+    evidence: { file: importerRelPath, line, snippet },
+  }
+  graph.addEdgeWithKey(edgeId, importerFileId, importeeFileId, edge)
+  return 1
+}
+
+// ── producer ───────────────────────────────────────────────────────────────
+
+export async function addImports(
+  graph: NeatGraph,
+  services: DiscoveredService[],
+  scanPath: string,
+): Promise<{ nodesAdded: number; edgesAdded: number }> {
+  const jsParser = makeJsParser()
+  const pyParser = makePyParser()
+  let edgesAdded = 0
+
+  for (const service of services) {
+    const tsPaths = await loadTsPathConfig(service.dir)
+    const files = await loadSourceFiles(service.dir)
+
+    for (const file of files) {
+      // ADR-065 §1 — test-scope exclusion. The file stays a FileNode (Phase 1);
+      // only its outbound module edges are filtered (file-awareness.md §10).
+      if (isTestPath(file.path)) continue
+
+      const relFile = toPosix(path.relative(service.dir, file.path))
+      const importerFileId = fileId(service.pkg.name, relFile)
+      const isPython = path.extname(file.path) === '.py'
+
+      if (isPython) {
+        let pyImports: RawPyImport[] = []
+        try {
+          const tree = parseSource(pyParser, file.content)
+          collectPyImports(tree.rootNode, pyImports)
+        } catch (err) {
+          recordExtractionError('import extraction', file.path, err)
+          continue
+        }
+        for (const imp of pyImports) {
+          const resolved = await resolvePyImport(imp, file.path, service.dir)
+          if (!resolved) continue
+          edgesAdded += emitImportEdge(
+            graph,
+            service.pkg.name,
+            importerFileId,
+            relFile,
+            resolved,
+            imp.line,
+            imp.snippet,
+          )
+        }
+        continue
+      }
+
+      let jsImports: RawImport[] = []
+      try {
+        const tree = parseSource(jsParser, file.content)
+        collectJsImports(tree.rootNode, jsImports)
+      } catch (err) {
+        recordExtractionError('import extraction', file.path, err)
+        continue
+      }
+      for (const imp of jsImports) {
+        const resolved = await resolveJsImport(imp.specifier, path.dirname(file.path), service.dir, tsPaths)
+        if (!resolved) continue
+        edgesAdded += emitImportEdge(
+          graph,
+          service.pkg.name,
+          importerFileId,
+          relFile,
+          resolved,
+          imp.line,
+          imp.snippet,
+        )
+      }
+    }
+  }
+
+  return { nodesAdded: 0, edgesAdded }
+}

--- a/packages/core/src/extract/index.ts
+++ b/packages/core/src/extract/index.ts
@@ -17,6 +17,7 @@ import { ensureCompatLoaded } from '../compat.js'
 import { emitNeatEvent } from '../events.js'
 import { addServiceNodes, discoverServices } from './services.js'
 import { addServiceAliases } from './aliases.js'
+import { addImports } from './imports.js'
 import { addDatabasesAndCompat } from './databases/index.js'
 import { addConfigNodes } from './configs.js'
 import { addCallEdges } from './calls/index.js'
@@ -87,6 +88,7 @@ export async function extractFromDirectory(
 
   const phase1Nodes = addServiceNodes(graph, services)
   await addServiceAliases(graph, scanPath, services)
+  const importGraph = await addImports(graph, services, scanPath)
   const phase2 = await addDatabasesAndCompat(graph, services, scanPath)
   const phase3 = await addConfigNodes(graph, services, scanPath)
   const phase4 = await addCallEdges(graph, services)
@@ -147,11 +149,13 @@ export async function extractFromDirectory(
   const result: ExtractResult = {
     nodesAdded:
       phase1Nodes +
+      importGraph.nodesAdded +
       phase2.nodesAdded +
       phase3.nodesAdded +
       phase4.nodesAdded +
       phase5.nodesAdded,
     edgesAdded:
+      importGraph.edgesAdded +
       phase2.edgesAdded + phase3.edgesAdded + phase4.edgesAdded + phase5.edgesAdded,
     frontiersPromoted,
     extractionErrors: errorEntries.length,

--- a/packages/core/src/watch.ts
+++ b/packages/core/src/watch.ts
@@ -8,6 +8,7 @@ import { assertBindAuthority, readAuthEnv } from './auth.js'
 import { ensureCompatLoaded } from './compat.js'
 import { discoverServices, addServiceNodes } from './extract/services.js'
 import { addServiceAliases } from './extract/aliases.js'
+import { addImports } from './extract/imports.js'
 import { addDatabasesAndCompat } from './extract/databases/index.js'
 import { addConfigNodes } from './extract/configs.js'
 import { addCallEdges } from './extract/calls/index.js'
@@ -36,6 +37,7 @@ import { attachGraphToEventBus, emitNeatEvent } from './events.js'
 export type ExtractPhase =
   | 'services'
   | 'aliases'
+  | 'imports'
   | 'databases'
   | 'configs'
   | 'calls'
@@ -44,6 +46,7 @@ export type ExtractPhase =
 const ALL_PHASES: ExtractPhase[] = [
   'services',
   'aliases',
+  'imports',
   'databases',
   'configs',
   'calls',
@@ -60,7 +63,10 @@ const ALL_PHASES: ExtractPhase[] = [
 //   .env / *.env.* / prisma / knex / ormconfig → databases + configs
 //   docker-compose / Dockerfile / *.tf / k8s yaml → infra + aliases
 //     (compose labels and Dockerfile labels feed alias discovery)
-//   *.js / *.ts / *.tsx / *.py / *.jsx / *.mjs / *.cjs → calls
+//   *.js / *.ts / *.tsx / *.py / *.jsx / *.mjs / *.cjs → imports + calls
+//     (a source edit can shift both its IMPORTS and CALLS edges; the shared
+//     evidence.file retirement mechanism — static-extraction.md §Ghost-edge
+//     cleanup — drops the stale ones from either producer before re-running)
 //   *.yaml / *.yml that isn't compose → databases + configs (ORM yaml fallbacks)
 export function classifyChange(relPath: string): Set<ExtractPhase> {
   const phases = new Set<ExtractPhase>()
@@ -102,6 +108,7 @@ export function classifyChange(relPath: string): Set<ExtractPhase> {
   }
 
   if (/\.(?:js|jsx|mjs|cjs|ts|tsx|py)$/.test(base)) {
+    phases.add('imports')
     phases.add('calls')
   }
 
@@ -149,6 +156,11 @@ export async function runExtractPhases(
   }
   if (phases.has('aliases')) {
     await addServiceAliases(graph, scanPath, services)
+  }
+  if (phases.has('imports')) {
+    const r = await addImports(graph, services, scanPath)
+    nodesAdded += r.nodesAdded
+    edgesAdded += r.edgesAdded
   }
   if (phases.has('databases')) {
     const r = await addDatabasesAndCompat(graph, services, scanPath)

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -68,6 +68,7 @@
                       "CONSUMES_FROM",
                       "CONTAINS",
                       "DEPENDS_ON",
+                      "IMPORTS",
                       "PUBLISHES_TO",
                       "RUNS_ON"
                     ]
@@ -159,6 +160,7 @@
                           "CONSUMES_FROM",
                           "CONTAINS",
                           "DEPENDS_ON",
+                          "IMPORTS",
                           "PUBLISHES_TO",
                           "RUNS_ON"
                         ]
@@ -190,6 +192,7 @@
                       "CONSUMES_FROM",
                       "CONTAINS",
                       "DEPENDS_ON",
+                      "IMPORTS",
                       "PUBLISHES_TO",
                       "RUNS_ON"
                     ]
@@ -281,6 +284,7 @@
                           "CONSUMES_FROM",
                           "CONTAINS",
                           "DEPENDS_ON",
+                          "IMPORTS",
                           "PUBLISHES_TO",
                           "RUNS_ON"
                         ]
@@ -436,6 +440,7 @@
                           "CONSUMES_FROM",
                           "CONTAINS",
                           "DEPENDS_ON",
+                          "IMPORTS",
                           "PUBLISHES_TO",
                           "RUNS_ON"
                         ]
@@ -498,6 +503,7 @@
                 "CONSUMES_FROM",
                 "CONTAINS",
                 "DEPENDS_ON",
+                "IMPORTS",
                 "PUBLISHES_TO",
                 "RUNS_ON"
               ]
@@ -589,6 +595,7 @@
                     "CONSUMES_FROM",
                     "CONTAINS",
                     "DEPENDS_ON",
+                    "IMPORTS",
                     "PUBLISHES_TO",
                     "RUNS_ON"
                   ]
@@ -620,6 +627,7 @@
                 "CONSUMES_FROM",
                 "CONTAINS",
                 "DEPENDS_ON",
+                "IMPORTS",
                 "PUBLISHES_TO",
                 "RUNS_ON"
               ]
@@ -711,6 +719,7 @@
                     "CONSUMES_FROM",
                     "CONTAINS",
                     "DEPENDS_ON",
+                    "IMPORTS",
                     "PUBLISHES_TO",
                     "RUNS_ON"
                   ]
@@ -866,6 +875,7 @@
                     "CONSUMES_FROM",
                     "CONTAINS",
                     "DEPENDS_ON",
+                    "IMPORTS",
                     "PUBLISHES_TO",
                     "RUNS_ON"
                   ]
@@ -907,6 +917,7 @@
       "CONSUMES_FROM",
       "CONTAINS",
       "DEPENDS_ON",
+      "IMPORTS",
       "PUBLISHES_TO",
       "RUNS_ON"
     ]
@@ -1045,6 +1056,7 @@
           "CONSUMES_FROM",
           "CONTAINS",
           "DEPENDS_ON",
+          "IMPORTS",
           "PUBLISHES_TO",
           "RUNS_ON"
         ]
@@ -1341,6 +1353,7 @@
                             "CONSUMES_FROM",
                             "CONTAINS",
                             "DEPENDS_ON",
+                            "IMPORTS",
                             "PUBLISHES_TO",
                             "RUNS_ON"
                           ]
@@ -1397,6 +1410,7 @@
                             "CONSUMES_FROM",
                             "CONTAINS",
                             "DEPENDS_ON",
+                            "IMPORTS",
                             "PUBLISHES_TO",
                             "RUNS_ON"
                           ]
@@ -1627,6 +1641,7 @@
                 "CONSUMES_FROM",
                 "CONTAINS",
                 "DEPENDS_ON",
+                "IMPORTS",
                 "PUBLISHES_TO",
                 "RUNS_ON"
               ]

--- a/packages/core/test/fixtures/imports/py-service/app/main.py
+++ b/packages/core/test/fixtures/imports/py-service/app/main.py
@@ -1,0 +1,5 @@
+from .utils import format_total
+
+
+def run():
+    return format_total(10)

--- a/packages/core/test/fixtures/imports/py-service/app/utils.py
+++ b/packages/core/test/fixtures/imports/py-service/app/utils.py
@@ -1,0 +1,2 @@
+def format_total(amount):
+    return f"${amount:.2f}"

--- a/packages/core/test/fixtures/imports/py-service/pyproject.toml
+++ b/packages/core/test/fixtures/imports/py-service/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.poetry]
+name = "fixture-imports-py-service"
+version = "0.1.0"
+
+[tool.poetry.dependencies]
+python = "^3.11"

--- a/packages/core/test/fixtures/imports/ts-alias-service/package.json
+++ b/packages/core/test/fixtures/imports/ts-alias-service/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-imports-alias-service",
+  "version": "1.0.0"
+}

--- a/packages/core/test/fixtures/imports/ts-alias-service/src/index.ts
+++ b/packages/core/test/fixtures/imports/ts-alias-service/src/index.ts
@@ -1,0 +1,5 @@
+import { client } from '@db/mongo'
+
+export function getClient() {
+  return client
+}

--- a/packages/core/test/fixtures/imports/ts-alias-service/tsconfig.json
+++ b/packages/core/test/fixtures/imports/ts-alias-service/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@db/*": ["src/db/*"]
+    }
+  }
+}

--- a/packages/core/test/fixtures/imports/ts-service/index.ts
+++ b/packages/core/test/fixtures/imports/ts-service/index.ts
@@ -1,0 +1,7 @@
+import { connectToMongo } from './mongo'
+import express from 'express'
+
+export function start() {
+  connectToMongo()
+  return express()
+}

--- a/packages/core/test/fixtures/imports/ts-service/mongo.ts
+++ b/packages/core/test/fixtures/imports/ts-service/mongo.ts
@@ -1,0 +1,3 @@
+export function connectToMongo() {
+  return 'connected'
+}

--- a/packages/core/test/fixtures/imports/ts-service/package.json
+++ b/packages/core/test/fixtures/imports/ts-service/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fixture-imports-ts-service",
+  "version": "1.0.0",
+  "dependencies": {
+    "express": "^4.18.0"
+  }
+}

--- a/packages/core/test/imports.test.ts
+++ b/packages/core/test/imports.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import type { GraphEdge } from '@neat.is/types'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES = path.resolve(__dirname, 'fixtures', 'imports')
+
+describe('import graph extraction (ADR-092, file-awareness.md §10)', () => {
+  beforeEach(() => resetGraph())
+
+  it('emits an IMPORTS edge for a relative TS import, with evidence', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    const edgeId =
+      'IMPORTS:file:fixture-imports-ts-service:index.ts->file:fixture-imports-ts-service:mongo.ts'
+    expect(graph.hasEdge(edgeId)).toBe(true)
+
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe('EXTRACTED')
+    expect(edge.evidence?.file).toBe('index.ts')
+    expect(edge.evidence?.line).toBeGreaterThan(0)
+    expect(edge.evidence?.snippet).toContain('./mongo')
+  })
+
+  it('does not emit an edge for a node_modules import', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    expect(
+      graph.hasEdge(
+        'IMPORTS:file:fixture-imports-ts-service:index.ts->file:fixture-imports-ts-service:express.ts',
+      ),
+    ).toBe(false)
+    // express never resolves to an intra-service file, so no FileNode for it.
+    expect(graph.hasNode('file:fixture-imports-ts-service:express.ts')).toBe(false)
+
+    const ts = graph.getNodeAttributes(
+      'file:fixture-imports-ts-service:index.ts',
+    ) as Record<string, unknown>
+    expect(ts).toBeDefined()
+  })
+
+  it('does not emit an edge or raise an error for an unresolvable TS path alias', async () => {
+    const graph = getGraph()
+    const result = await extractFromDirectory(graph, FIXTURES)
+
+    expect(graph.hasNode('file:fixture-imports-alias-service:src/index.ts')).toBe(true)
+    // @db/mongo maps to src/db/mongo.ts, which doesn't exist on disk.
+    const edges = graph.edges().filter((id) => id.startsWith('IMPORTS:file:fixture-imports-alias-service:'))
+    expect(edges).toHaveLength(0)
+    expect(result.extractionErrors).toBe(0)
+  })
+
+  it('emits an IMPORTS edge for a Python relative import', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    const edgeId =
+      'IMPORTS:file:fixture-imports-py-service:app/main.py->file:fixture-imports-py-service:app/utils.py'
+    expect(graph.hasEdge(edgeId)).toBe(true)
+
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe('EXTRACTED')
+    expect(edge.evidence?.file).toBe('app/main.py')
+    expect(edge.evidence?.snippet).toContain('format_total')
+  })
+
+  it('is idempotent across repeated passes', async () => {
+    const graph = getGraph()
+    const first = await extractFromDirectory(graph, FIXTURES)
+    const before = graph.edges().filter((id) => id.startsWith('IMPORTS:')).length
+
+    const second = await extractFromDirectory(graph, FIXTURES)
+    const after = graph.edges().filter((id) => id.startsWith('IMPORTS:')).length
+
+    expect(after).toBe(before)
+    expect(first.edgesAdded).toBeGreaterThan(0)
+    expect(second.edgesAdded).toBe(0)
+  })
+})

--- a/packages/core/test/watch.test.ts
+++ b/packages/core/test/watch.test.ts
@@ -23,11 +23,11 @@ describe('classifyChange', () => {
     ])
   })
 
-  it('routes JS/TS/Python source to calls only', () => {
-    expect([...classifyChange(`src${sep}index.ts`)]).toEqual(['calls'])
-    expect([...classifyChange(`src${sep}index.js`)]).toEqual(['calls'])
-    expect([...classifyChange(`src${sep}page.tsx`)]).toEqual(['calls'])
-    expect([...classifyChange(`app${sep}main.py`)]).toEqual(['calls'])
+  it('routes JS/TS/Python source to imports + calls', () => {
+    expect([...classifyChange(`src${sep}index.ts`)].sort()).toEqual(['calls', 'imports'])
+    expect([...classifyChange(`src${sep}index.js`)].sort()).toEqual(['calls', 'imports'])
+    expect([...classifyChange(`src${sep}page.tsx`)].sort()).toEqual(['calls', 'imports'])
+    expect([...classifyChange(`app${sep}main.py`)].sort()).toEqual(['calls', 'imports'])
   })
 
   it('routes .env / prisma / knex / ormconfig to databases + configs', () => {
@@ -40,12 +40,13 @@ describe('classifyChange', () => {
       'configs',
       'databases',
     ])
-    // knexfile.ts also looks like JS source — its `calls` phase rerun is a
+    // knexfile.ts also looks like JS source — its imports/calls rerun is a
     // no-op for the file but cheap, so we accept the overlap.
     expect([...classifyChange(`knexfile.ts`)].sort()).toEqual([
       'calls',
       'configs',
       'databases',
+      'imports',
     ])
     expect([...classifyChange(`ormconfig.json`)].sort()).toEqual(['configs', 'databases'])
   })

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -20,6 +20,10 @@ export const EdgeType = {
   // grouping that lets file-grained relationships roll up to a service only
   // as the honest fallback, never as a summary view.
   CONTAINS: 'CONTAINS',
+  // Static module dependency between two FileNodes within a service (ADR-092,
+  // file-awareness.md §10). Compile-time, not runtime — represents one file
+  // importing another. Distinct from CALLS which records runtime invocations.
+  IMPORTS: 'IMPORTS',
 } as const
 
 export type EdgeTypeValue = (typeof EdgeType)[keyof typeof EdgeType]

--- a/packages/types/src/edges.ts
+++ b/packages/types/src/edges.ts
@@ -17,6 +17,7 @@ export const EdgeTypeSchema = z.enum([
   EdgeType.CONSUMES_FROM,
   EdgeType.RUNS_ON,
   EdgeType.CONTAINS,
+  EdgeType.IMPORTS,
 ])
 
 // Static-extraction evidence for an EXTRACTED edge (ADR-029, contract #5).


### PR DESCRIPTION
## Summary

Phase 2 of the file-span extraction work (ADR-092, file-awareness.md §10). Walks each service's source AST for import/require statements — TS/JS via tree-sitter, Python from-imports — and emits IMPORTS edges between FileNodes that resolve to a real file in the same service, including TS path-alias resolution via tsconfig.json. Cross-service imports, node_modules, and unresolvable specifiers are silent skips; edges that do land carry full evidence (file/line/snippet).

Wires `addImports` into both the init/orchestration pipeline (`extract/index.ts`) and the watch loop's `classifyChange` routing (`watch.ts`), so source edits re-run the import pass and the existing evidence.file ghost-edge retirement keeps stale IMPORTS edges from piling up.

## Note on test status

This PR's `addImports` only emits an edge when the target FileNode already exists in the graph (`emitImportEdge` checks `graph.hasNode`). FileNodes for files that don't match any CALLS pattern are created by Phase 1 (`addFiles`, #451 / branch `451-file-enumeration`), which is landing as a sibling PR. Until #451 merges, `imports.test.ts` fails standalone in this branch — that's expected and accounted for; the two PRs are intentionally kept as clean, non-overlapping diffs (no duplicate `files.ts`) and the suite goes green once both land.

## Test plan
- [x] `npx turbo build` — green
- [x] `imports.test.ts` (5 tests: TS relative import, node_modules skip, unresolvable TS alias, Python relative import, idempotency) — green against the combined working tree with #451's `addFiles`; expected to fail standalone until #451 merges
- [x] `watch.test.ts`, `contracts.test.ts`, `schema-snapshot.test.ts` — green standalone

Refs #452 Refs #453