### PR TITLE
Fix Inspector IMPORTS/CALLS mislabeling and multi-dot Python relative imports

### DIFF
--- a/packages/core/src/extract/imports.ts
+++ b/packages/core/src/extract/imports.ts
@@ -141,8 +141,16 @@ function collectPyImports(node: Parser.SyntaxNode, out: RawPyImport[]): void {
         for (let j = 0; j < child.childCount; j++) {
           const rc = child.child(j)
           if (!rc) continue
-          if (rc.type === 'import_prefix') level++
-          else if (rc.type === 'dotted_name') modulePath = rc.text
+          // tree-sitter-python groups every leading dot into a single
+          // import_prefix node — `..` parses as one import_prefix with two
+          // `.` children, not two import_prefix nodes. Count the `.` tokens,
+          // not the prefix nodes, or multi-dot imports under-count `level`
+          // and resolve onto the wrong (sometimes self) target (#457).
+          if (rc.type === 'import_prefix') {
+            for (let k = 0; k < rc.childCount; k++) {
+              if (rc.child(k)?.type === '.') level++
+            }
+          } else if (rc.type === 'dotted_name') modulePath = rc.text
         }
         break
       }

--- a/packages/core/test/fixtures/imports/py-service/app/api/jobs.py
+++ b/packages/core/test/fixtures/imports/py-service/app/api/jobs.py
@@ -1,0 +1,5 @@
+from ..jobs import get_job
+
+
+def list_jobs():
+    return [get_job(1)]

--- a/packages/core/test/fixtures/imports/py-service/app/jobs.py
+++ b/packages/core/test/fixtures/imports/py-service/app/jobs.py
@@ -1,0 +1,2 @@
+def get_job(job_id):
+    return {"id": job_id}

--- a/packages/core/test/imports.test.ts
+++ b/packages/core/test/imports.test.ts
@@ -69,6 +69,27 @@ describe('import graph extraction (ADR-092, file-awareness.md §10)', () => {
     expect(edge.evidence?.snippet).toContain('format_total')
   })
 
+  it('resolves a two-dot Python relative import to its parent-package target, not a self-loop (#457)', async () => {
+    const graph = getGraph()
+    const result = await extractFromDirectory(graph, FIXTURES)
+
+    // app/api/jobs.py: `from ..jobs import get_job` walks up past the `api`
+    // package to app/jobs.py. tree-sitter-python groups `..` into a single
+    // import_prefix node with two `.` children — counting nodes instead of
+    // dots under-resolves to level=1 and lands back on the importer itself,
+    // which addImports rejects as a self-loop (UsageGraphError).
+    const edgeId =
+      'IMPORTS:file:fixture-imports-py-service:app/api/jobs.py->file:fixture-imports-py-service:app/jobs.py'
+    expect(graph.hasEdge(edgeId)).toBe(true)
+
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.source).not.toBe(edge.target)
+    expect(edge.provenance).toBe('EXTRACTED')
+    expect(edge.evidence?.file).toBe('app/api/jobs.py')
+    expect(edge.evidence?.snippet).toContain('get_job')
+    expect(result.extractionErrors).toBe(0)
+  })
+
   it('is idempotent across repeated passes', async () => {
     const graph = getGraph()
     const first = await extractFromDirectory(graph, FIXTURES)

--- a/packages/web/app/components/Inspector.tsx
+++ b/packages/web/app/components/Inspector.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import type { GraphNode, GraphEdge } from '@neat.is/types'
 import type { GraphData } from './AppShell'
 import { authedFetch } from '../../lib/authed-fetch'
-import { buildModel, callsFrom, filesOf } from './graph-model'
+import { buildModel, callsFrom, importsFrom, filesOf } from './graph-model'
 
 interface RootCauseResult {
   origin: string
@@ -116,9 +116,14 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: 
   const isFile = node.type === 'FileNode'
   const isService = node.type === 'ServiceNode'
 
-  // FileNode: the calls originating from it, file-grained, with evidence.
+  // FileNode: the runtime calls originating from it, file-grained, with evidence.
   const originating = isFile && graphData && model
     ? callsFrom(node.id, graphData.edges, model.byId)
+    : []
+  // FileNode: the static module imports originating from it (file-awareness §10
+  // — IMPORTS is distinct from CALLS, surfaced in its own section).
+  const imports = isFile && graphData && model
+    ? importsFrom(node.id, graphData.edges, model.byId)
     : []
   // FileNode: its owning service via the inbound CONTAINS edge.
   const owningServiceId = isFile && model ? model.serviceByFile.get(node.id) : undefined
@@ -250,6 +255,39 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: 
                     </li>
                   )) : (
                     <li style={{ borderBottom: 'none' }}><span style={{ color: 'var(--fg-muted)', fontStyle: 'italic', fontFamily: 'var(--font-body)' }}>no calls originate from this file</span></li>
+                  )}
+                </ul>
+              </section>
+            )}
+
+            {/* FileNode — the static module imports originating from this file,
+                file-grained, each with provenance + evidence file:line. Kept
+                separate from "Calls from this file": IMPORTS is a compile-time
+                module dependency, not a runtime invocation (file-awareness §10). */}
+            {isFile && (
+              <section className="insp-section">
+                <div className="insp-h">Imports <span className="ct">{imports.length}</span></div>
+                <ul className="edge-list">
+                  {imports.length ? imports.map((c) => (
+                    <li key={c.edgeId} style={{ flexWrap: 'wrap', borderBottom: 'none' }}>
+                      <span style={{ display: 'flex', alignItems: 'center', gap: 10, width: '100%' }}>
+                        <span className={`pdot ${visualProv(c.provenance)}`} />
+                        <span className="verb">{visualProv(c.provenance).toLowerCase()}</span>
+                        <span
+                          className="target clickable"
+                          onClick={() => onNodeSelect(c.targetId)}
+                          title={`Select ${c.targetName}`}
+                        >{escapeHtml(c.targetName)}</span>
+                        <span className="conf">{typeof c.confidence === 'number' ? c.confidence.toFixed(2) : '—'}</span>
+                      </span>
+                      {c.evidenceFile && (
+                        <span className="edge-evidence" style={{ width: '100%' }}>
+                          {escapeHtml(c.evidenceFile)}{typeof c.evidenceLine === 'number' ? `:${c.evidenceLine}` : ''}
+                        </span>
+                      )}
+                    </li>
+                  )) : (
+                    <li style={{ borderBottom: 'none' }}><span style={{ color: 'var(--fg-muted)', fontStyle: 'italic', fontFamily: 'var(--font-body)' }}>no imports originate from this file</span></li>
                   )}
                 </ul>
               </section>

--- a/packages/web/app/components/graph-model.ts
+++ b/packages/web/app/components/graph-model.ts
@@ -20,7 +20,7 @@
 // reads — but it stays the same file-grained edge with its own provenance and
 // evidence; we never synthesize a service→service summary edge.
 
-import type { GraphNode, GraphEdge } from '@neat.is/types'
+import { EdgeType, type GraphNode, type GraphEdge } from '@neat.is/types'
 
 export const CONTAINS = 'CONTAINS'
 
@@ -135,8 +135,10 @@ export function filesOf(serviceId: string, model: FileFirstModel): GraphNode[] {
   return ids.map((id) => model.byId.get(id)).filter((n): n is GraphNode => !!n)
 }
 
-// The calls originating from a file (file-grained CALLS edges), with evidence.
-export interface OriginatingCall {
+// A file-grained outbound edge, resolved to its target's display name, with
+// evidence. Shared shape for the Inspector's "Calls from this file" and
+// "Imports" sections (file-awareness.md §10 — IMPORTS is distinct from CALLS).
+export interface OriginatingEdge {
   edgeId: string
   targetId: string
   targetName: string
@@ -146,14 +148,19 @@ export interface OriginatingCall {
   evidenceLine?: number
 }
 
-export function callsFrom(fileId: string, edges: GraphEdge[], byId: Map<string, GraphNode>): OriginatingCall[] {
-  const calls: OriginatingCall[] = []
+function originatingEdges(
+  fileId: string,
+  edges: GraphEdge[],
+  byId: Map<string, GraphNode>,
+  matchesType: (type: string) => boolean,
+): OriginatingEdge[] {
+  const out: OriginatingEdge[] = []
   for (const e of edges) {
     if (e.source !== fileId) continue
-    if (e.type === CONTAINS) continue
+    if (!matchesType(e.type)) continue
     const target = byId.get(e.target)
     const name = target ? ((target as { name?: string; path?: string }).name ?? (target as { path?: string }).path ?? e.target) : e.target
-    calls.push({
+    out.push({
       edgeId: e.id,
       targetId: e.target,
       targetName: name,
@@ -163,5 +170,27 @@ export function callsFrom(fileId: string, edges: GraphEdge[], byId: Map<string, 
       evidenceLine: e.evidence?.line,
     })
   }
-  return calls
+  return out
+}
+
+// The runtime calls originating from a file — HTTP requests, queue
+// publish/consume, and other live invocations (file-grained CALLS /
+// PUBLISHES_TO / CONSUMES_FROM edges), with evidence. CONNECTS_TO and
+// CONFIGURED_BY are declared/static relationships, not runtime calls, and
+// IMPORTS is a compile-time module dependency — see importsFrom — so none of
+// the three belong in this list (file-awareness.md §10).
+export function callsFrom(fileId: string, edges: GraphEdge[], byId: Map<string, GraphNode>): OriginatingEdge[] {
+  return originatingEdges(
+    fileId,
+    edges,
+    byId,
+    (t) => t === EdgeType.CALLS || t === EdgeType.PUBLISHES_TO || t === EdgeType.CONSUMES_FROM,
+  )
+}
+
+// The static module imports originating from a file (file-grained IMPORTS
+// edges), with evidence. Compile-time module dependencies, distinct from
+// runtime calls (file-awareness.md §10).
+export function importsFrom(fileId: string, edges: GraphEdge[], byId: Map<string, GraphNode>): OriginatingEdge[] {
+  return originatingEdges(fileId, edges, byId, (t) => t === EdgeType.IMPORTS)
 }

--- a/packages/web/test/drilldown-model.test.ts
+++ b/packages/web/test/drilldown-model.test.ts
@@ -5,13 +5,15 @@ import {
   visibleGraph,
   filesOf,
   callsFrom,
+  importsFrom,
 } from '../app/components/graph-model'
 
 // A small file-first graph (file-awareness.md §1-§3):
 //   service:a CONTAINS file:a/x, file:a/y
 //   service:b CONTAINS file:b/z
-//   file:a/x CALLS file:b/z   (file-grained, with evidence)
-//   file:a/y CONNECTS_TO database:d
+//   file:a/x CALLS file:b/z       (runtime — file-grained, with evidence)
+//   file:a/x IMPORTS file:a/y     (static module dependency, ADR-092 §10)
+//   file:a/y CONNECTS_TO database:d (declared, not a runtime call)
 const nodes: GraphNode[] = [
   { id: 'service:a', type: 'ServiceNode', name: 'a', language: 'ts' } as GraphNode,
   { id: 'service:b', type: 'ServiceNode', name: 'b', language: 'ts' } as GraphNode,
@@ -25,6 +27,7 @@ const edges: GraphEdge[] = [
   { id: 'c2', source: 'service:a', target: 'file:a:y.ts', type: 'CONTAINS', provenance: 'EXTRACTED' } as GraphEdge,
   { id: 'c3', source: 'service:b', target: 'file:b:z.ts', type: 'CONTAINS', provenance: 'EXTRACTED' } as GraphEdge,
   { id: 'call1', source: 'file:a:x.ts', target: 'file:b:z.ts', type: 'CALLS', provenance: 'OBSERVED', confidence: 0.9, evidence: { file: 'src/x.ts', line: 42 } } as GraphEdge,
+  { id: 'imp1', source: 'file:a:x.ts', target: 'file:a:y.ts', type: 'IMPORTS', provenance: 'EXTRACTED', confidence: 1, evidence: { file: 'src/x.ts', line: 1, snippet: "import { y } from './y'" } } as GraphEdge,
   { id: 'conn1', source: 'file:a:y.ts', target: 'database:d', type: 'CONNECTS_TO', provenance: 'EXTRACTED', confidence: 0.8, evidence: { file: 'src/y.ts', line: 7 } } as GraphEdge,
 ]
 
@@ -89,7 +92,7 @@ describe('file-first drill-down model (file-awareness §2/§3)', () => {
     expect(files).toEqual(['file:a:x.ts', 'file:a:y.ts'])
   })
 
-  it('callsFrom returns file-grained originating calls with provenance + file:line evidence (§1/§6)', () => {
+  it('callsFrom returns only runtime-call edges, never IMPORTS or CONNECTS_TO (file-awareness §10)', () => {
     const calls = callsFrom('file:a:x.ts', edges, model.byId)
     expect(calls).toHaveLength(1)
     expect(calls[0]).toMatchObject({
@@ -99,8 +102,28 @@ describe('file-first drill-down model (file-awareness §2/§3)', () => {
       evidenceFile: 'src/x.ts',
       evidenceLine: 42,
     })
+    // The IMPORTS edge from the same file must never surface as a "call" —
+    // that's the #456 bug (static module imports mislabeled as runtime calls).
+    expect(calls.some((c) => c.targetId === 'file:a:y.ts')).toBe(false)
+    // CONNECTS_TO is a declared relationship, not a runtime call — excluded.
+    expect(callsFrom('file:a:y.ts', edges, model.byId)).toHaveLength(0)
     // CONTAINS is structural ownership, not a call — excluded.
-    const svcCalls = callsFrom('service:a', edges, model.byId)
-    expect(svcCalls).toHaveLength(0)
+    expect(callsFrom('service:a', edges, model.byId)).toHaveLength(0)
+  })
+
+  it('importsFrom returns file-grained IMPORTS edges with provenance + file:line evidence, never CALLS (file-awareness §10)', () => {
+    const imports = importsFrom('file:a:x.ts', edges, model.byId)
+    expect(imports).toHaveLength(1)
+    expect(imports[0]).toMatchObject({
+      targetId: 'file:a:y.ts',
+      provenance: 'EXTRACTED',
+      confidence: 1,
+      evidenceFile: 'src/x.ts',
+      evidenceLine: 1,
+    })
+    // The CALLS edge from the same file must never surface as an "import".
+    expect(imports.some((i) => i.targetId === 'file:b:z.ts')).toBe(false)
+    // No outbound IMPORTS edge from file:a:y.ts — empty, not absent.
+    expect(importsFrom('file:a:y.ts', edges, model.byId)).toHaveLength(0)
   })
 })

--- a/packages/web/test/inspector-file-first.test.tsx
+++ b/packages/web/test/inspector-file-first.test.tsx
@@ -5,6 +5,8 @@ import type { GraphData } from '../app/components/AppShell'
 import { Inspector } from '../app/components/Inspector'
 
 // file-first sample: service:a CONTAINS file:a/x; file:a/x CALLS database:d
+// (a runtime database query — CONNECTS_TO is a declared relationship, not a
+// call, and stays out of "Calls from this file" per file-awareness §10.)
 const nodes: GraphNode[] = [
   { id: 'service:a', type: 'ServiceNode', name: 'a', language: 'ts' } as GraphNode,
   { id: 'file:a:x.ts', type: 'FileNode', service: 'a', path: 'src/x.ts', language: 'ts' } as GraphNode,
@@ -12,7 +14,7 @@ const nodes: GraphNode[] = [
 ]
 const edges: GraphEdge[] = [
   { id: 'c1', source: 'service:a', target: 'file:a:x.ts', type: 'CONTAINS', provenance: 'EXTRACTED' } as GraphEdge,
-  { id: 'call1', source: 'file:a:x.ts', target: 'database:d', type: 'CONNECTS_TO', provenance: 'OBSERVED', confidence: 0.91, evidence: { file: 'src/x.ts', line: 128 } } as GraphEdge,
+  { id: 'call1', source: 'file:a:x.ts', target: 'database:d', type: 'CALLS', provenance: 'OBSERVED', confidence: 0.91, evidence: { file: 'src/x.ts', line: 128 } } as GraphEdge,
 ]
 const graphData: GraphData = { nodes, edges }
 


### PR DESCRIPTION
## Summary
- Inspector's "Calls from this file" was folding every non-CONTAINS outbound edge into the calls list — including IMPORTS, CONNECTS_TO, CONFIGURED_BY. `callsFrom()` now scopes to actual runtime-call edge types (CALLS/PUBLISHES_TO/CONSUMES_FROM), and a new "Imports" section surfaces IMPORTS edges separately, per file-awareness.md §10.
- `collectPyImports` counted `import_prefix` nodes instead of the `.` tokens inside them, so multi-dot relative imports (`from ..jobs import get_job`) under-counted `level`, resolved onto the importer's own path, and crashed `addImports` with a self-loop `UsageGraphError`. Now counts dots directly.

## Test plan
- [x] `npx turbo test --filter=@neat.is/web --filter=@neat.is/core` — all green (42 web tests, 887 core tests)
- [x] New `drilldown-model.test.ts` cases assert `callsFrom`/`importsFrom` never cross-leak IMPORTS/CALLS/CONNECTS_TO
- [x] New `imports.test.ts` case adds a two-dot relative import fixture (`app/api/jobs.py` → `app/jobs.py`) and confirms it resolves correctly with no self-loop or crash — verified it reproduces the exact `UsageGraphError` from #457 without the fix

Refs #456, Refs #457