### PR TITLE
Rewrite docker-compose.yml as a one-shot install template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
 
 COPY package.json package-lock.json turbo.json tsconfig.base.json ./
 COPY packages/types/package.json packages/types/
+COPY packages/instrumentation-registry/package.json packages/instrumentation-registry/
 COPY packages/core/package.json packages/core/
 COPY packages/mcp/package.json packages/mcp/
 COPY packages/web/package.json packages/web/
@@ -52,6 +53,11 @@ ENV NEAT_WEB_DISABLED=1
 COPY --from=builder /repo/node_modules ./node_modules
 COPY --from=builder /repo/packages/types/dist ./packages/types/dist
 COPY --from=builder /repo/packages/types/package.json ./packages/types/package.json
+# neatd requires @neat.is/instrumentation-registry at runtime; the node_modules
+# symlink from the builder points here, so the dist has to ride along like
+# types' does.
+COPY --from=builder /repo/packages/instrumentation-registry/dist ./packages/instrumentation-registry/dist
+COPY --from=builder /repo/packages/instrumentation-registry/package.json ./packages/instrumentation-registry/package.json
 COPY --from=builder /repo/packages/core/dist ./packages/core/dist
 COPY --from=builder /repo/packages/core/compat.json ./packages/core/compat.json
 COPY --from=builder /repo/packages/core/proto ./packages/core/proto

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,97 @@
+# M2 demo stack — the pg-mismatch showcase, not an install template. To point
+# NEAT at your own codebase, use docker-compose.yml in this directory instead.
+#
+# `docker compose -f docker-compose.demo.yml up` boots:
+#   - payments-db: postgres:15 — the database service-b talks to (badly).
+#   - service-a / service-b: instrumented Node services. Hit `localhost:3000/data`
+#     and watch service-b 500 from the pg 7.4.0 / PG 15 SCRAM mismatch.
+#   - otel-collector: receives spans on 4318, fans out to neat-core + a logging
+#     exporter so you can `docker compose logs otel-collector` and see traces.
+#   - neat-core: REST graph on 8080, OTLP receiver on 4318.
+
+services:
+  payments-db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: neatdemo
+      POSTGRES_USER: neat
+      POSTGRES_PASSWORD: neat
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U neat -d neatdemo']
+      interval: 2s
+      timeout: 3s
+      retries: 15
+    networks: [neat]
+
+  neat-core:
+    build:
+      context: .
+      dockerfile: packages/core/Dockerfile
+    environment:
+      NEAT_SCAN_PATH: /demo
+      NEAT_OUT_PATH: /neat-out/graph.json
+      HOST: 0.0.0.0
+      PORT: '8080'
+    ports:
+      - '8080:8080'
+    volumes:
+      - ./demo:/demo:ro
+      - neat-out:/neat-out
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://127.0.0.1:8080/health || exit 1']
+      interval: 3s
+      timeout: 3s
+      retries: 10
+    networks: [neat]
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.96.0
+    command: ['--config=/etc/otel-collector-config.yaml']
+    volumes:
+      - ./demo/collector/config.yaml:/etc/otel-collector-config.yaml:ro
+    depends_on:
+      neat-core:
+        condition: service_started
+    networks: [neat]
+
+  service-b:
+    build:
+      context: ./demo/service-b
+    environment:
+      PORT: '3001'
+      PGHOST: payments-db
+      PGPORT: '5432'
+      PGUSER: neat
+      PGPASSWORD: neat
+      PGDATABASE: neatdemo
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318/v1/traces
+      OTEL_SERVICE_NAME: service-b
+    depends_on:
+      payments-db:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+    networks: [neat]
+
+  service-a:
+    build:
+      context: ./demo/service-a
+    environment:
+      PORT: '3000'
+      SERVICE_B_URL: http://service-b:3001
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318/v1/traces
+      OTEL_SERVICE_NAME: service-a
+    ports:
+      - '3000:3000'
+    depends_on:
+      service-b:
+        condition: service_started
+      otel-collector:
+        condition: service_started
+    networks: [neat]
+
+volumes:
+  neat-out:
+
+networks:
+  neat:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,94 +1,59 @@
-# M2 demo stack. `docker compose up` boots:
-#   - payments-db: postgres:15 — the database service-b talks to (badly).
-#   - service-a / service-b: instrumented Node services. Hit `localhost:3000/data`
-#     and watch service-b 500 from the pg 7.4.0 / PG 15 SCRAM mismatch.
-#   - otel-collector: receives spans on 4318, fans out to neat-core + a logging
-#     exporter so you can `docker compose logs otel-collector` and see traces.
-#   - neat-core: REST graph on 8080, OTLP receiver on 4318.
+# Run NEAT against your own codebase.
+#
+# Two things to edit before `docker compose up`:
+#
+#   1. The volume mount below. The left side of `./:/workspace` is the
+#      directory NEAT scans — as shipped it scans the directory this file
+#      sits in. Point it at your repo instead, e.g.
+#        - /path/to/your/repo:/workspace
+#   2. NEAT_AUTH_TOKEN. Replace the placeholder with a real secret
+#      (`openssl rand -hex 32`). REST/SSE callers and OTel exporters send it
+#      as `Authorization: Bearer <token>`.
+#
+# Then: `docker compose up -d`
+#
+#   REST API   http://localhost:8080   (try /health, then /graph)
+#   OTLP       http://localhost:4318   (point your OTel SDK exporters here)
+#   Web UI     http://localhost:6328   (serves once @neat.is/web is layered
+#                                       into the image; see the Dockerfile
+#                                       note on NEAT_WEB_DISABLED)
+#
+# Snapshots and the embeddings cache persist in the `neat-out` volume across
+# restarts. To watch the pg-mismatch demo showcase instead, use
+# `docker compose -f docker-compose.demo.yml up`.
 
 services:
-  payments-db:
-    image: postgres:15-alpine
-    environment:
-      POSTGRES_DB: neatdemo
-      POSTGRES_USER: neat
-      POSTGRES_PASSWORD: neat
-    healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U neat -d neatdemo']
-      interval: 2s
-      timeout: 3s
-      retries: 15
-    networks: [neat]
-
   neat-core:
+    # Builds the generic NEAT image from this repo's root Dockerfile. To use
+    # a pre-built image instead, replace the `build:` block with
+    # `image: ghcr.io/neat-technologies/neat:latest`.
     build:
       context: .
-      dockerfile: packages/core/Dockerfile
+    restart: unless-stopped
     environment:
-      NEAT_SCAN_PATH: /demo
-      NEAT_OUT_PATH: /neat-out/graph.json
-      HOST: 0.0.0.0
-      PORT: '8080'
+      # CHANGE ME — placeholder token, not a secret. Generate a real one
+      # with `openssl rand -hex 32`.
+      NEAT_AUTH_TOKEN: change-me-generate-a-real-token
     ports:
-      - '8080:8080'
+      - '8080:8080' # REST graph API
+      - '4318:4318' # OTLP receiver
+      - '6328:6328' # web UI (when @neat.is/web is layered in)
     volumes:
-      - ./demo:/demo:ro
+      # EDIT THIS — left side is the codebase NEAT extracts from.
+      - ./:/workspace
       - neat-out:/neat-out
     healthcheck:
-      test: ['CMD-SHELL', 'wget -qO- http://127.0.0.1:8080/health || exit 1']
-      interval: 3s
+      # The runtime image is node:*-slim with no wget/curl; probe with node.
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "require('http').get('http://127.0.0.1:8080/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))",
+        ]
+      interval: 5s
       timeout: 3s
-      retries: 10
-    networks: [neat]
-
-  otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.96.0
-    command: ['--config=/etc/otel-collector-config.yaml']
-    volumes:
-      - ./demo/collector/config.yaml:/etc/otel-collector-config.yaml:ro
-    depends_on:
-      neat-core:
-        condition: service_started
-    networks: [neat]
-
-  service-b:
-    build:
-      context: ./demo/service-b
-    environment:
-      PORT: '3001'
-      PGHOST: payments-db
-      PGPORT: '5432'
-      PGUSER: neat
-      PGPASSWORD: neat
-      PGDATABASE: neatdemo
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318/v1/traces
-      OTEL_SERVICE_NAME: service-b
-    depends_on:
-      payments-db:
-        condition: service_healthy
-      otel-collector:
-        condition: service_started
-    networks: [neat]
-
-  service-a:
-    build:
-      context: ./demo/service-a
-    environment:
-      PORT: '3000'
-      SERVICE_B_URL: http://service-b:3001
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318/v1/traces
-      OTEL_SERVICE_NAME: service-a
-    ports:
-      - '3000:3000'
-    depends_on:
-      service-b:
-        condition: service_started
-      otel-collector:
-        condition: service_started
-    networks: [neat]
+      retries: 12
 
 volumes:
   neat-out:
-
-networks:
-  neat:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ neat/
   CLAUDE.md    repo-level agent guide
 ```
 
-`demo/payments-db` exists only in `docker-compose.yml` (M2) — it's the `postgres:15-alpine` image, no source.
+`demo/payments-db` exists only in `docker-compose.demo.yml` (M2) — it's the `postgres:15-alpine` image, no source.
 
 ## Package boundaries
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -97,7 +97,7 @@ NEAT_SCAN_PATH=./demo \
 - **`tsup` build fails with `Cannot find module '.../packages/<pkg>/node_modules/tsup/dist/cli-default.js'`** — leftover per-package node_modules from a different package manager. Wipe and reinstall (see "First-time setup").
 - **`npx turbo build` says `Could not resolve workspaces. Missing packageManager field in package.json`** — the root `package.json` lost its `"packageManager": "npm@x.y.z"` line. Turbo 2.x requires it.
 - **README CI badge 404s** — the workflow path changed. The badge URL must match `/.github/workflows/<file>.yml`.
-- **`npm install` adds 80 packages out of nowhere** — someone added `demo/*` back into root `workspaces` before M2 is ready. Drop it again until docker-compose actually launches the services.
+- **`npm install` adds 80 packages out of nowhere** — someone added `demo/*` back into root `workspaces` before M2 is ready. Drop it again until `docker-compose.demo.yml` actually launches the services.
 
 ## Publishing to npm
 


### PR DESCRIPTION
Refs #460

`docker compose up` from the repo root now boots NEAT against the operator's own codebase instead of the demo showcase. The compose file matches the shape the root Dockerfile already documents: mount your repo at `/workspace`, set `NEAT_AUTH_TOKEN`, get REST on 8080, OTLP on 4318, and the web UI port on 6328. The header comment tells the operator exactly which two lines to edit before starting.

The M2 pg-mismatch demo stack lives on unchanged as `docker-compose.demo.yml` (`docker compose -f docker-compose.demo.yml up`), and the two doc references to it (`docs/architecture.md`, `docs/runbook.md`) point at the new name.

Boot-testing the template surfaced that the runtime image couldn't start `neatd` at all: `@neat.is/instrumentation-registry` is a runtime require of the daemon, the builder compiles it, but the runtime stage never copied its dist — the node_modules symlink dangled and the container crash-looped on `MODULE_NOT_FOUND`. The Dockerfile now ships the registry's dist and package.json alongside types'. The CI container smoke only runs in the publish workflow on tag push, which is why no PR check caught it.

## Verification

Exercised locally with Docker Desktop (Compose v2.40):

- `docker compose config` parses clean for both files
- `docker compose up -d --build` with a toy JS workspace mounted at `/workspace`:
  - `/health` → 200, container healthcheck reports healthy
  - `/graph` → 401 without bearer, 200 with the template token
  - OTLP `POST :4318/v1/traces` → 200
  - `:6328` has no listener, matching the image's `NEAT_WEB_DISABLED=1` default; the template comment says so
  - the toy workspace extracted for real: `service:toy-service` + its FileNode in `/graph`
- `npx turbo build test lint` — 17/17 green

One note for the launch checklist, outside this PR's scope: `ghcr.io/neat-technologies/neat:latest` is not anonymously pullable today (the registry token handshake 403s), so the template defaults to `build:` with the ghcr image as the commented alternative. Flipping the package to public visibility would make the `image:` path work for visitors — the README's `docker run ghcr...` snippet depends on that too.