### PR TITLE
Drop the dead settings gear, make the incidents page read the real payload

### DIFF
--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -7147,9 +7147,8 @@ describe('Web shell completeness (ADR-056)', () => {
   it('Rail: Agents button wired or disabled (ADR-056 #1)', () => {
     assertWiredOrDisabled(readComponent('Rail'), 'Agents', 'Rail.tsx')
   })
-  it('Rail: Settings button wired or disabled (ADR-056 #1)', () => {
-    assertWiredOrDisabled(readComponent('Rail'), 'Settings', 'Rail.tsx')
-  })
+  // Rail: Settings was removed for launch (#473) — no settings surface exists
+  // behind it, so there is nothing to assert wired-or-disabled anymore.
   it('GraphCanvas toolbar: Layout: cose toggle wired or disabled (ADR-056 #1)', () => {
     const src = readComponent('GraphCanvas')
     expect(src).toMatch(/Layout:/)

--- a/packages/web/app/components/Rail.tsx
+++ b/packages/web/app/components/Rail.tsx
@@ -39,9 +39,10 @@ export function Rail({ project }: RailProps) {
   }, [project])
 
   // ADR-056 — Find is wired: dispatches a custom event TopBar's search input listens for.
-  // ADR-056 — Layers / NeatScript / Time travel / Diff / Comments / Agents / Settings
-  // are deferred features; rendered with `disabled` + tooltip affordance so the user
-  // perceives them as unavailable, not broken.
+  // ADR-056 — Layers / NeatScript / Time travel / Diff / Comments / Agents are
+  // deferred features; rendered with `disabled` + tooltip affordance so the user
+  // perceives them as unavailable, not broken. Settings was removed outright (#473) —
+  // no surface exists behind it yet.
   function focusFind(): void {
     const input = document.querySelector<HTMLInputElement>('.top-search input')
     input?.focus()
@@ -129,16 +130,6 @@ export function Rail({ project }: RailProps) {
       </div>
 
       <div className="rail-spacer" />
-
-      <div className="rail-group" style={{ borderTop: '1px solid var(--rule)' }}>
-        <button className="rail-btn" aria-label="Settings (coming soon)" disabled title={disabledTip('Settings')} style={{ opacity: 0.35, cursor: 'not-allowed' }}>
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <circle cx="12" cy="12" r="3" />
-            <path d="M19 12a7 7 0 0 1-.4 2.3l2 1.5-2 3.4-2.3-1a7 7 0 0 1-4 2.3l-.4 2.5h-4l-.4-2.5a7 7 0 0 1-4-2.3l-2.3 1-2-3.4 2-1.5A7 7 0 0 1 5 12a7 7 0 0 1 .4-2.3l-2-1.5 2-3.4 2.3 1a7 7 0 0 1 4-2.3L12 1h4l.4 2.5a7 7 0 0 1 4 2.3l2.3-1 2 3.4-2 1.5" />
-          </svg>
-          <span className="rail-tip">Settings</span>
-        </button>
-      </div>
     </nav>
   )
 }

--- a/packages/web/app/incidents/IncidentsClient.tsx
+++ b/packages/web/app/incidents/IncidentsClient.tsx
@@ -1,17 +1,23 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 import Link from 'next/link'
 import { authedFetch } from '../../lib/authed-fetch'
 import { useAuthGate } from '../../lib/use-auth-gate'
 import { resolveProjectFromList, type ProjectEntry } from '../../lib/resolve-project'
 
+// Mirrors the canonical ErrorEvent shape from @neat.is/types — the daemon's
+// /api/incidents envelope (ADR-061) carries these fields, not the
+// nodeId/type/message trio this table once assumed (#474).
 interface Incident {
-  nodeId: string
+  id: string
   timestamp: string
-  type: string
-  message: string
-  stacktrace?: string
+  service: string
+  errorType?: string
+  errorMessage: string
+  exceptionType?: string
+  exceptionStacktrace?: string
+  affectedNode: string
 }
 
 interface IncidentsResponse {
@@ -136,38 +142,37 @@ export function IncidentsClient() {
             </thead>
             <tbody>
               {data.events.map((evt, i) => {
-                const rowKey = `${i}-${evt.nodeId}`
+                const rowKey = `${i}-${evt.id}`
                 const isOpen = openRow === rowKey
                 return (
-                  <>
+                  <Fragment key={rowKey}>
                     <tr
-                      key={rowKey}
-                      style={{ cursor: evt.stacktrace ? 'pointer' : undefined }}
-                      onClick={() => evt.stacktrace && setOpenRow(isOpen ? null : rowKey)}
-                      title={evt.stacktrace ? (isOpen ? 'Collapse stacktrace' : 'Expand stacktrace') : undefined}
+                      style={{ cursor: evt.exceptionStacktrace ? 'pointer' : undefined }}
+                      onClick={() => evt.exceptionStacktrace && setOpenRow(isOpen ? null : rowKey)}
+                      title={evt.exceptionStacktrace ? (isOpen ? 'Collapse stacktrace' : 'Expand stacktrace') : undefined}
                     >
                       <td className="td-node">
-                        <Link href={`/?node=${encodeURIComponent(evt.nodeId)}&project=${encodeURIComponent(project ?? '')}`} className="incidents-node-link">
-                          {evt.nodeId}
+                        <Link href={`/?node=${encodeURIComponent(evt.affectedNode)}&project=${encodeURIComponent(project ?? '')}`} className="incidents-node-link">
+                          {evt.affectedNode}
                         </Link>
                       </td>
                       <td className="td-time">{formatTs(evt.timestamp)}</td>
-                      <td className="td-type">{evt.type}</td>
+                      <td className="td-type">{evt.errorType ?? evt.exceptionType ?? '—'}</td>
                       <td className="td-msg">
-                        {evt.message}
-                        {evt.stacktrace && (
+                        {evt.errorMessage}
+                        {evt.exceptionStacktrace && (
                           <span className="stack-toggle">{isOpen ? ' ▲' : ' ▼'}</span>
                         )}
                       </td>
                     </tr>
-                    {isOpen && evt.stacktrace && (
-                      <tr key={`${rowKey}-stack`}>
+                    {isOpen && evt.exceptionStacktrace && (
+                      <tr>
                         <td colSpan={4} className="td-stacktrace">
-                          <pre className="stacktrace-pre">{evt.stacktrace}</pre>
+                          <pre className="stacktrace-pre">{evt.exceptionStacktrace}</pre>
                         </td>
                       </tr>
                     )}
-                  </>
+                  </Fragment>
                 )
               })}
             </tbody>

--- a/packages/web/audit/03-rail.md
+++ b/packages/web/audit/03-rail.md
@@ -24,10 +24,10 @@
 │    │
 │    │  (spacer — flex: 1)
 │    │
-├────┤  (divider top)
-│ ⚙  │  Settings
 └────┘
 ```
+
+(The bottom Settings gear was removed for launch — #473. No settings surface exists behind it yet.)
 
 Width: 56px. Each button: 36×36px, border-radius 4px.
 
@@ -47,7 +47,6 @@ Width: 56px. Each button: 36×36px, border-radius 4px.
 | 8 | Comments | Chat bubble | `C` | None | Stub |
 | 9 | Incidents | Warning triangle | _(none)_ | `<Link href="/incidents">` | **Navigates** |
 | 10 | Agents | Sunburst / rays | `A` | None | Stub |
-| 11 | Settings | Gear | _(none)_ | None | Stub |
 
 ---
 
@@ -100,9 +99,7 @@ group 1: Graph, Layers, Find
 group 2: NeatScript, Time travel, Blast radius, Diff
 ─── divider ───
 group 3: Comments, Incidents, Agents
-.rail-spacer (flex: 1 — pushes settings to bottom)
-─── divider (border-top on group wrapper) ───
-group 4: Settings
+.rail-spacer (flex: 1)
 ```
 
 ---

--- a/packages/web/audit/07-incidents-page.md
+++ b/packages/web/audit/07-incidents-page.md
@@ -93,12 +93,17 @@ interface IncidentsResponse {
   total: number
   events: Incident[]
 }
+// Canonical ErrorEvent fields from @neat.is/types (#474) — the table maps
+// affectedNode / errorType / errorMessage / exceptionStacktrace.
 interface Incident {
-  nodeId: string
+  id: string
   timestamp: string   // ISO 8601
-  type: string
-  message: string
-  stacktrace?: string  // fetched but not displayed
+  service: string
+  errorType?: string
+  errorMessage: string
+  exceptionType?: string
+  exceptionStacktrace?: string
+  affectedNode: string
 }
 ```
 

--- a/packages/web/audit/09-gaps-and-stubs.md
+++ b/packages/web/audit/09-gaps-and-stubs.md
@@ -44,7 +44,6 @@ When code state changes, this file changes in lockstep.
 | Comments (C) | disabled | Tooltip: "Comments — coming in v0.3.x". |
 | Incidents | wired | Routes to `/incidents`; badge from `/api/incidents`. |
 | Agents (A) | disabled | Tooltip: "Agents — coming in v0.3.x". |
-| Settings | disabled | Tooltip: "Settings — coming in v0.3.x". |
 
 ### Inspector
 


### PR DESCRIPTION
Two dashboard fixes for launch day.

**Settings gear (rail, bottom).** It's been a disabled "coming in v0.3.x" stub since ADR-056 and there's nothing behind it. A dead control pinned to a prime position reads as broken to a visitor, so it's removed rather than built under pressure. The ADR-056 stub audit moves with it: the `Rail: Settings` wired-or-disabled assertion in `contracts.test.ts` is gone and the audit tables no longer list it.

**Incidents page.** Every row rendered blank — node links pointed at `/?node=undefined`, type and message were empty. `IncidentsClient` was reading `nodeId`/`type`/`message` off events that actually carry the canonical `ErrorEvent` shape from `@neat.is/types` (`affectedNode`/`errorType`/`errorMessage`/`exceptionStacktrace`, ADR-061 envelope). The table now maps the real fields, the stacktrace toggle keys off `exceptionStacktrace`, and the row fragment is keyed properly.

Verified against a live daemon carrying 82 real error events: all four columns render, node links resolve, no console errors. `turbo build` / `test --force` / `lint` green, core contracts audit run uncached.

Refs #473 #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)