### PR TITLE
Pin the instrumentation registry at ^1.0.0 in core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10568,7 +10568,7 @@
         "@fastify/cors": "^10.0.0",
         "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
-        "@neat.is/instrumentation-registry": "*",
+        "@neat.is/instrumentation-registry": "^1.0.0",
         "@neat.is/types": "^0.4.15",
         "chokidar": "^4.0.3",
         "fastify": "^5.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,11 +47,11 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
-    "@neat.is/instrumentation-registry": "*",
+    "@neat.is/instrumentation-registry": "^1.0.0",
     "@fastify/cors": "^10.0.0",
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
-    "@neat.is/instrumentation-registry": "*",
+    "@neat.is/instrumentation-registry": "^1.0.0",
     "@neat.is/types": "^0.4.15",
     "chokidar": "^4.0.3",
     "fastify": "^5.0.0",


### PR DESCRIPTION
The registry contract names the caret range as the version-safety mechanism — 1.x refreshes flow without a NEAT release, a schema break waits for one. Core's dependency declaration now carries it. Refs #469