### PR TITLE
Make bare `npx neat.is` the whole zero-to-graph path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ NEAT is in active development. Capability ships as patch releases on the `npx ne
 npx neat.is
 ```
 
+(run from inside your project; or `npx neat.is <path>`)
+
 ## What it does
 
 NEAT keeps a working architecture model of your system up to date from two streams at once:

--- a/packages/core/src/banner.ts
+++ b/packages/core/src/banner.ts
@@ -1,0 +1,48 @@
+import path from 'node:path'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+// The `neat --version` family reads its answer from the bundled package's
+// own package.json. Reading at run time keeps the published bin in lockstep
+// with whatever version `tsup` shipped without a build-time substitution.
+// `dist/cli.cjs` sits one level below the package root.
+export function readPackageVersion(): string {
+  const here =
+    typeof __dirname !== 'undefined'
+      ? __dirname
+      : path.dirname(fileURLToPath(import.meta.url))
+  // dist/ → package root. tsup writes both cjs and mjs to dist/, so the
+  // parent-of-parent walk is the same in either format.
+  const candidates = [
+    path.resolve(here, '../package.json'),
+    path.resolve(here, '../../package.json'),
+  ]
+  for (const candidate of candidates) {
+    try {
+      const raw = readFileSync(candidate, 'utf8')
+      const parsed = JSON.parse(raw) as { name?: string; version?: string }
+      if (parsed.name === '@neat.is/core' && typeof parsed.version === 'string') {
+        return parsed.version
+      }
+    } catch {
+      // try the next candidate
+    }
+  }
+  return 'unknown'
+}
+
+// The ASCII banner. Shared between the CLI's `neat init` discovery report and
+// the one-command orchestrator (issue #483) so the artwork lives in exactly
+// one place — no duplicated glyphs to drift apart.
+export function printBanner(): void {
+  console.log('███╗   ██╗███████╗ █████╗ ████████╗')
+  console.log('████╗  ██║██╔════╝██╔══██╗╚══██╔══╝')
+  console.log('██╔██╗ ██║█████╗  ███████║   ██║   ')
+  console.log('██║╚██╗██║██╔══╝  ██╔══██║   ██║   ')
+  console.log('██║ ╚████║███████╗██║  ██║   ██║   ')
+  console.log('╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝   ╚═╝   ')
+  console.log('')
+  console.log('  Network Expressive Architecting Tool')
+  console.log(`  neat.is  ·  v${readPackageVersion()}  ·  Apache 2.0`)
+  console.log('')
+}

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import path from 'node:path'
-import { promises as fs, readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
+import { promises as fs } from 'node:fs'
+import { printBanner, readPackageVersion } from './banner.js'
 import { DEFAULT_PROJECT, getGraph, resetGraph } from './graph.js'
 import { extractFromDirectory } from './extract.js'
 import {
@@ -86,8 +86,37 @@ export interface InitResult {
   writtenFiles: string[]
 }
 
-function usage(): void {
-  console.log('usage: neat <command> [args] [--project <name>]')
+// True when this run came in through `npx neat.is` rather than a global
+// `neat` binary on PATH. npx never puts `neat`/`neatd`/`neat-mcp` on PATH —
+// only `npm i -g neat.is` does — so an npx user who copies a bare `neat init`
+// example from the help screen hits `command not found`. We render every
+// example with the prefix that actually works for how they invoked us.
+//
+// Two robust signals: npm sets `npm_command` / `npm_execpath` for anything it
+// spawns (including `npx`), and an npx run resolves argv[1] under a temporary
+// `_npx` cache dir rather than a global bin dir. Either one is enough.
+export function isNpxInvocation(): boolean {
+  if (process.env.npm_command === 'exec') return true
+  const execpath = process.env.npm_execpath ?? ''
+  if (execpath.includes('npx')) return true
+  const entry = process.argv[1] ?? ''
+  if (entry.includes('/_npx/') || entry.includes('\\_npx\\')) return true
+  return false
+}
+
+// The command prefix every help example renders with. `npx neat.is` for an
+// npx run, plain `neat` for a global install.
+export function commandPrefix(): string {
+  return isNpxInvocation() ? 'npx neat.is' : 'neat'
+}
+
+export function usage(): void {
+  const neat = commandPrefix()
+  console.log('Installed via npx? Prefix commands with `npx neat.is`, or install once: `npm i -g neat.is`.')
+  console.log('')
+  console.log(`usage: ${neat} <command> [args] [--project <name>]`)
+  console.log('')
+  console.log(`Run \`${neat}\` with no command from inside your project to go zero-to-graph in one step.`)
   console.log('')
   console.log('lifecycle commands:')
   console.log('  init <path>    One-time install: discover, extract, register, plan SDK install.')
@@ -127,30 +156,30 @@ function usage(): void {
   console.log('')
   console.log('query commands (mirror the MCP tools, ADR-050):')
   console.log('  root-cause <node-id>             Walk inbound edges to find what broke first.')
-  console.log('                                   example: neat root-cause service:<name>')
+  console.log(`                                   example: ${neat} root-cause service:<name>`)
   console.log('  blast-radius <node-id>           BFS outbound — what would break if this dies.')
-  console.log('                                   example: neat blast-radius database:<host>')
+  console.log(`                                   example: ${neat} blast-radius database:<host>`)
   console.log('  dependencies <node-id>           Transitive outbound dependencies.')
   console.log('                                   Flags: --depth N (default 3, max 10)')
-  console.log('                                   example: neat dependencies service:<name> --depth 2')
+  console.log(`                                   example: ${neat} dependencies service:<name> --depth 2`)
   console.log('  observed-dependencies <node-id>  OBSERVED-only outbound edges (runtime traffic).')
-  console.log('                                   example: neat observed-dependencies service:<name>')
+  console.log(`                                   example: ${neat} observed-dependencies service:<name>`)
   console.log('  incidents [<node-id>]            Recent error events; per-node when an id is given.')
   console.log('                                   Flags: --limit N (default 20)')
-  console.log('                                   example: neat incidents service:<name> --limit 5')
+  console.log(`                                   example: ${neat} incidents service:<name> --limit 5`)
   console.log('  search <query>                   Semantic (or substring) match on node names/ids.')
-  console.log('                                   example: neat search "checkout"')
+  console.log(`                                   example: ${neat} search "checkout"`)
   console.log('  diff --against <snapshot>        Compare the live graph to a saved snapshot.')
-  console.log('                                   example: neat diff --against ./snapshots/baseline.json')
+  console.log(`                                   example: ${neat} diff --against ./snapshots/baseline.json`)
   console.log('  stale-edges                      Recent OBSERVED → STALE transitions.')
   console.log('                                   Flags: --limit N, --edge-type CALLS|CONNECTS_TO|...')
-  console.log('                                   example: neat stale-edges --edge-type CALLS')
+  console.log(`                                   example: ${neat} stale-edges --edge-type CALLS`)
   console.log('  policies                         Current policy violations.')
   console.log('                                   Flags: --node <id>, --hypothetical-action <json>')
-  console.log('                                   example: neat policies --node service:<name> --json')
+  console.log(`                                   example: ${neat} policies --node service:<name> --json`)
   console.log('  divergences                      Where code (EXTRACTED) and production (OBSERVED) disagree.')
   console.log('                                   Flags: --type <list>, --min-confidence <0..1>, --node <id>')
-  console.log('                                   example: neat divergences --min-confidence 0.7')
+  console.log(`                                   example: ${neat} divergences --min-confidence 0.7`)
   console.log('')
   console.log('flags:')
   console.log('  --project <name>   Name the project this command targets. Default: "default".')
@@ -316,50 +345,14 @@ function assignFlag(out: ParsedArgs, field: (typeof STRING_FLAGS)[number][1], va
 // Per-type node/edge counts + compat formatting moved into summary.ts as
 // part of the value-forward findings block (issue #305 / ADR-073 §5).
 
-// The `neat --version` family reads its answer from the bundled package's
-// own package.json. Reading at run time keeps the published bin in lockstep
-// with whatever version `tsup` shipped without a build-time substitution.
-// `dist/cli.cjs` sits one level below the package root.
-export function readPackageVersion(): string {
-  const here =
-    typeof __dirname !== 'undefined'
-      ? __dirname
-      : path.dirname(fileURLToPath(import.meta.url))
-  // dist/ → package root. tsup writes both cjs and mjs to dist/, so the
-  // parent-of-parent walk is the same in either format.
-  const candidates = [
-    path.resolve(here, '../package.json'),
-    path.resolve(here, '../../package.json'),
-  ]
-  for (const candidate of candidates) {
-    try {
-      const raw = readFileSync(candidate, 'utf8')
-      const parsed = JSON.parse(raw) as { name?: string; version?: string }
-      if (parsed.name === '@neat.is/core' && typeof parsed.version === 'string') {
-        return parsed.version
-      }
-    } catch {
-      // try the next candidate
-    }
-  }
-  return 'unknown'
-}
+// `readPackageVersion` + `printBanner` live in banner.ts so the orchestrator
+// can print the same artwork without pulling in the whole CLI dispatch (and
+// without a cli ↔ orchestrator import cycle). Re-exported here so existing
+// importers of `cli.js` (e.g. the banner test, MCP) keep resolving them.
+export { printBanner, readPackageVersion }
 
 function printVersion(): void {
   process.stdout.write(`${readPackageVersion()}\n`)
-}
-
-export function printBanner(): void {
-  console.log('███╗   ██╗███████╗ █████╗ ████████╗')
-  console.log('████╗  ██║██╔════╝██╔══██╗╚══██╔══╝')
-  console.log('██╔██╗ ██║█████╗  ███████║   ██║   ')
-  console.log('██║╚██╗██║██╔══╝  ██╔══██║   ██║   ')
-  console.log('██║ ╚████║███████╗██║  ██║   ██║   ')
-  console.log('╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝   ╚═╝   ')
-  console.log('')
-  console.log('  Network Expressive Architecting Tool')
-  console.log(`  neat.is  ·  v${readPackageVersion()}  ·  Apache 2.0`)
-  console.log('')
 }
 
 function printDiscoveryReport(opts: InitOptions, services: DiscoveredService[]): void {
@@ -671,20 +664,47 @@ export async function runSkill(opts: SkillOptions): Promise<{ exitCode: number }
   return { exitCode: 0 }
 }
 
-async function main(): Promise<void> {
-  const [, , cmd, ...rest] = process.argv
+export async function main(): Promise<void> {
+  const argv = process.argv.slice(2)
+  // First token, for the help/version flag checks. The command dispatch below
+  // keys off the first *positional* (flag-stripped) instead, so a bare
+  // `npx neat.is --no-open` still reaches the orchestrator.
+  const cmd0 = argv[0]
 
-  if (!cmd || cmd === '-h' || cmd === '--help') {
+  // `-h` / `--help` print the usage screen and exit clean.
+  if (cmd0 === '-h' || cmd0 === '--help') {
     usage()
     process.exit(0)
   }
 
-  if (cmd === '--version' || cmd === '-v' || cmd === 'version') {
+  // The dispatcher honors three spellings: --version, -v, version.
+  if (cmd0 === '--version' || cmd0 === '-v' || cmd0 === 'version') {
     printVersion()
     process.exit(0)
   }
 
-  const parsed = parseArgs(rest)
+  // No positional command — `npx neat.is` (optionally with flags like
+  // `--no-open`) run from inside a repo. This is the zero-to-graph path
+  // (issue #483): run the orchestrator on the current working directory, the
+  // same dispatch the explicit `neat <path>` form takes (project name =
+  // basename of cwd). We detect "no command" by the absence of any
+  // positional after flag-stripping, so a bare `npx neat.is --no-instrument`
+  // still lands here instead of treating the flag as a command.
+  const argvParsed = parseArgs(argv)
+  if (argvParsed.positional.length === 0) {
+    const orchestratorCode = await tryOrchestrator(process.cwd(), argvParsed)
+    // tryOrchestrator returns null only when its path isn't a directory,
+    // which can't happen for process.cwd(); the non-null branch always runs.
+    if (orchestratorCode !== null && orchestratorCode !== 0) process.exit(orchestratorCode)
+    return
+  }
+
+  // From here on, the first positional is the command. Reuse the already-
+  // parsed flags and drop the command token from the positional list, so each
+  // verb's `parsed.positional[0]` stays the verb's own first argument (e.g.
+  // the node-id for `root-cause`), unchanged from the pre-#483 dispatch.
+  const cmd = argvParsed.positional[0] as string
+  const parsed: ParsedArgs = { ...argvParsed, positional: argvParsed.positional.slice(1) }
   const { positional, apply, dryRun, noInstall } = parsed
   const project = parsed.project ?? DEFAULT_PROJECT
 

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -34,6 +34,7 @@ import { ensureNeatOutIgnored } from './gitignore.js'
 import { saveGraphToDisk } from './persist.js'
 import { pathsForProject } from './projects.js'
 import { addProject, listProjects, ProjectNameCollisionError, setStatus } from './registry.js'
+import { printBanner } from './banner.js'
 import {
   isEmptyPlan,
   pickInstaller,
@@ -605,6 +606,10 @@ export async function runOrchestrator(opts: OrchestratorOptions): Promise<Orches
     return result
   }
 
+  // ASCII banner up front — this is the one-command zero-to-graph path's
+  // first impression (issue #483). Same artwork `neat init` prints, shared
+  // through banner.ts so it's never duplicated.
+  printBanner()
   console.log(`neat: ${opts.scanPath}`)
   console.log('')
 
@@ -618,6 +623,18 @@ export async function runOrchestrator(opts: OrchestratorOptions): Promise<Orches
   const { graph, services, languages } = persisted
   result.steps.discovery = { services: services.length, languages }
   console.log(`discovered ${services.length} service(s) across ${languages.length} language(s)`)
+
+  // No services means nothing to instrument and no graph worth spawning a
+  // daemon for. Bail with a clear pointer instead of standing up an empty
+  // daemon (issue #483) — most often the operator ran from outside their
+  // project root.
+  if (services.length === 0) {
+    console.error(
+      `neat: no services found in ${opts.scanPath} — run from inside your project root, or \`npx neat.is <path>\``,
+    )
+    result.exitCode = 2
+    return result
+  }
 
   // ── Confirmation prompt (default yes; --no-instrument or no-TTY skip)
   let runApply = !opts.noInstrument
@@ -769,4 +786,16 @@ function printSummary(
   for (const [t, c] of [...byEdge.entries()].sort()) console.log(`  ${t}: ${c}`)
   console.log('')
   console.log(`dashboard: ${dashboardUrl}`)
+  // Be honest about the auth posture (issue #483). The bare first-touch path
+  // pins the daemon to loopback with no token (see spawnDaemonDetached), so
+  // there's nothing to log in with. When the operator has set
+  // NEAT_AUTH_TOKEN, the daemon enforces it and the user needs it to reach
+  // the dashboard and to route OTel — so we print the real value rather than
+  // fabricating one the daemon wouldn't accept.
+  const token = process.env.NEAT_AUTH_TOKEN
+  if (typeof token === 'string' && token.length > 0) {
+    console.log(`auth token: ${token}`)
+  } else {
+    console.log('running locally — open the dashboard, no token needed')
+  }
 }

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -6173,9 +6173,12 @@ describe('CLI surface contract (ADR-050)', () => {
     for (const verb of QUERY_VERBS) {
       // Verb name appears as the leftmost token of a help line.
       expect(usageBody, `usage() must mention "${verb}"`).toMatch(new RegExp(`\\b${verb}\\b`))
-      // Each verb has at least one example invocation in usage().
+      // Each verb has at least one example invocation in usage(). Examples
+      // render through the `${neat}` command-prefix variable (issue #483 —
+      // `npx neat.is <verb>` for an npx run, `neat <verb>` for a global
+      // install), so the source carries the templated form.
       expect(usageBody, `usage() must show an example for "${verb}"`).toMatch(
-        new RegExp(`example:\\s+neat\\s+${verb}\\b`),
+        new RegExp(`example:\\s+\\$\\{neat\\}\\s+${verb}\\b`),
       )
     }
     // Exit codes block.
@@ -6208,11 +6211,13 @@ describe('CLI surface contract (ADR-050)', () => {
     expect(readPackageVersion()).toBe(pkg.version)
     // The dispatcher honors three spellings: --version, -v, version. The
     // contract surface is the argv shape; we assert against the source so
-    // the test cost stays inside the package, not a subprocess.
+    // the test cost stays inside the package, not a subprocess. The check
+    // keys off the first argv token (`cmd0`) — issue #483 split flag-only
+    // bare invocation away from the positional-command dispatch.
     const cli = readFileSync(join(CORE_SRC, 'cli.ts'), 'utf8')
-    expect(cli).toMatch(/cmd === '--version'/)
-    expect(cli).toMatch(/cmd === '-v'/)
-    expect(cli).toMatch(/cmd === 'version'/)
+    expect(cli).toMatch(/cmd0 === '--version'/)
+    expect(cli).toMatch(/cmd0 === '-v'/)
+    expect(cli).toMatch(/cmd0 === 'version'/)
   })
 })
 

--- a/packages/core/test/cli-bare-invocation.test.ts
+++ b/packages/core/test/cli-bare-invocation.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Stub the orchestrator so `main()`'s bare-invocation path is observable
+// without standing up a daemon or touching disk. The bare path resolves
+// `process.cwd()` (always a real directory) and hands off to runOrchestrator
+// — we assert the hand-off, not the orchestration.
+const runOrchestrator = vi.fn(async () => ({
+  exitCode: 0,
+  steps: {
+    discovery: { services: 1, languages: ['typescript'] },
+    extraction: { nodesAdded: 0, edgesAdded: 0 },
+    gitignore: 'unchanged' as const,
+    apply: { instrumented: 0, alreadyInstrumented: 0, libOnly: 0, skipped: true },
+    daemon: 'skipped' as const,
+    browser: 'skipped' as const,
+  },
+}))
+
+vi.mock('../src/orchestrator.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/orchestrator.js')>()
+  return { ...actual, runOrchestrator }
+})
+
+describe('bare `npx neat.is` invocation (issue #483)', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>
+  let logSpy: ReturnType<typeof vi.spyOn>
+  const origArgv = process.argv
+
+  beforeEach(() => {
+    runOrchestrator.mockClear()
+    // process.exit must not actually exit the test runner — throw a sentinel
+    // the test can catch so control flow stops where `main()` would have.
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__exit__:${code ?? 0}`)
+    }) as never)
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    exitSpy.mockRestore()
+    logSpy.mockRestore()
+    process.argv = origArgv
+  })
+
+  it('no command → runs the orchestrator on cwd, does not print usage', async () => {
+    // argv[1] is a neutral path: the module's auto-run guard only fires for a
+    // `cli.cjs`/`neat` entry, so importing cli.js here doesn't kick off a
+    // stray main() of its own.
+    process.argv = ['node', '/tmp/test-runner']
+    const { main } = await import('../src/cli.js')
+    await main()
+
+    expect(runOrchestrator).toHaveBeenCalledTimes(1)
+    const arg = runOrchestrator.mock.calls[0]![0] as { scanPath: string }
+    expect(arg.scanPath).toBe(process.cwd())
+    // usage() leads with the npx-prefix header line — its absence proves we
+    // didn't fall into the help branch.
+    const printed = logSpy.mock.calls.map((c) => String(c[0] ?? '')).join('\n')
+    expect(printed).not.toContain('Prefix commands with')
+  })
+
+  it('`-h` → prints usage, never touches the orchestrator', async () => {
+    process.argv = ['node', '/tmp/test-runner', '-h']
+    const { main } = await import('../src/cli.js')
+    await expect(main()).rejects.toThrow('__exit__:0')
+
+    expect(runOrchestrator).not.toHaveBeenCalled()
+    const printed = logSpy.mock.calls.map((c) => String(c[0] ?? '')).join('\n')
+    expect(printed).toContain('Prefix commands with')
+  })
+
+  it('`--help` → prints usage, never touches the orchestrator', async () => {
+    process.argv = ['node', '/tmp/test-runner', '--help']
+    const { main } = await import('../src/cli.js')
+    await expect(main()).rejects.toThrow('__exit__:0')
+
+    expect(runOrchestrator).not.toHaveBeenCalled()
+  })
+})
+
+describe('usage() command-prefix awareness (issue #483)', () => {
+  const origEnv = { ...process.env }
+  const origArgv = process.argv
+  let logSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+    process.env = { ...origEnv }
+    process.argv = origArgv
+  })
+
+  function lines(): string {
+    return logSpy.mock.calls.map((c) => String(c[0] ?? '')).join('\n')
+  }
+
+  it('renders the `npx neat.is` prefix under the npx signal', async () => {
+    delete process.env.npm_execpath
+    process.env.npm_command = 'exec'
+    const { usage } = await import('../src/cli.js')
+    usage()
+    const out = lines()
+    expect(out).toContain('npx neat.is root-cause')
+    expect(out).toContain('Prefix commands with `npx neat.is`')
+  })
+
+  it('renders the bare `neat` prefix for a global install', async () => {
+    delete process.env.npm_command
+    delete process.env.npm_execpath
+    process.argv = ['/usr/local/bin/node', '/usr/local/bin/neat', '--help']
+    const { usage } = await import('../src/cli.js')
+    usage()
+    const out = lines()
+    expect(out).toContain('example: neat root-cause')
+    expect(out).not.toContain('npx neat.is root-cause')
+  })
+})


### PR DESCRIPTION
Bare `npx neat.is` is now the entire no-NEAT → working-graph path in one command. Run it from inside a repo and it discovers services, extracts the static graph, instruments with OTel, spawns the daemon, opens the dashboard, and prints the summary — no path argument, no follow-up commands.

What changed:

- **Bare invocation runs the orchestrator on cwd.** No positional command (even with flags like `--no-open`) dispatches through the same single `tryOrchestrator` → `runOrchestrator` seam the explicit `neat <path>` form uses, with the project name defaulting to the basename of cwd. `-h`/`--help` still print usage and exit 0; `npx neat.is <path>` is unchanged.
- **Graceful empty-dir handling.** When discovery finds zero services, the orchestrator prints `no services found in <cwd> — run from inside your project root, or npx neat.is <path>` and exits non-zero instead of standing up an empty daemon.
- **Banner on the one-command path.** `runOrchestrator` leads with the ASCII banner. The artwork (and `readPackageVersion`) moved to a small `banner.ts` so `neat init` and the orchestrator share one copy — no duplicated glyphs, no cli ↔ orchestrator import cycle. The banner prints once per invocation in both flows.
- **Honest auth line in the summary.** Next to the dashboard URL: the real token when `NEAT_AUTH_TOKEN` is set (the operator needs it to log in / route OTel), otherwise `running locally — open the dashboard, no token needed`. No fabricated token the loopback-no-token daemon wouldn't enforce.
- **npx-aware help.** `usage()` detects npx vs global install (`npm_command`/`npm_execpath`/`_npx` path) and renders every example with the matching command prefix through a single `${neat}` variable, plus a header line pointing npx users at the prefix or a one-time `npm i -g neat.is`.
- **README.** The "One command" block stays `npx neat.is` (now true) with one line under it: `(run from inside your project; or npx neat.is <path>)`.

Tests:

- New `cli-bare-invocation.test.ts`: bare `main()` with no command runs the orchestrator on cwd and does not print usage; `-h`/`--help` print usage and never touch the orchestrator; `usage()` renders the `npx neat.is` prefix under the npx signal and bare `neat` otherwise.
- Contract audit updated for the renamed version-flag token and the templated help examples.
- Full workspace `build test lint` green (uncached); 897 core tests pass.

Verification (one-command path against a throwaway copy of `demo/`, isolated `NEAT_HOME`, alt ports `18080/14318/16328`, `--no-open` — never touched the live demo):

```
███╗   ██╗███████╗ █████╗ ████████╗
████╗  ██║██╔════╝██╔══██╗╚══██╔══╝
██╔██╗ ██║█████╗  ███████║   ██║
██║╚██╗██║██╔══╝  ██╔══██║   ██║
██║ ╚████║███████╗██║  ██║   ██║
╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝   ╚═╝

  Network Expressive Architecting Tool
  neat.is  ·  v0.4.15  ·  Apache 2.0

neat: /private/tmp/neat-483-demo.XXXXXX

discovered 2 service(s) across 1 language(s)
skipped instrumentation (--no-instrument)

=== summary ===
graph: 16 nodes, 15 edges
  ...
dashboard: http://localhost:6328
running locally — open the dashboard, no token needed
```

Empty-dir run prints the no-services line and exits 2; daemon was stopped and alt ports freed after capture.

Refs #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)