### PR TITLE
Point the MCP server at the daemon URL neat skill writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Or edit `~/.claude/settings.json` by hand:
 }
 ```
 
+The `neat-mcp` binary above assumes a global install. Without one, run `neat skill --apply` instead — it writes the same `mcpServers.neat` entry using `npx -y @neat.is/mcp` so the server resolves without a global binary. Either form reads `NEAT_CORE_URL` for the daemon URL; set it to point the agent at a non-default daemon.
+
 In any Claude Code session, ask: *"Why is checkout-svc failing?"* NEAT walks the graph and answers with a traversal path, edge provenances, a confidence score, and a recommended fix.
 
 ## Repository layout

--- a/packages/claude-skill/claude_code_config.json
+++ b/packages/claude-skill/claude_code_config.json
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": ["-y", "@neat.is/mcp"],
       "env": {
-        "NEAT_API_URL": "http://localhost:8080"
+        "NEAT_CORE_URL": "http://localhost:8080"
       }
     }
   }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -194,6 +194,7 @@ export function usage(): void {
   console.log('')
   console.log('environment:')
   console.log('  NEAT_API_URL    base URL for the core REST API (default http://localhost:8080)')
+  console.log('                  alias: NEAT_CORE_URL (the name the MCP server reads)')
   console.log('  NEAT_PROJECT    project name when --project isn\'t passed')
 }
 
@@ -600,7 +601,7 @@ export const CLAUDE_SKILL_CONFIG = {
       command: 'npx',
       args: ['-y', '@neat.is/mcp'],
       env: {
-        NEAT_API_URL: 'http://localhost:8080',
+        NEAT_CORE_URL: 'http://localhost:8080',
       },
     },
   },
@@ -661,6 +662,9 @@ export async function runSkill(opts: SkillOptions): Promise<{ exitCode: number }
   console.log('')
   console.log('Manual install: copy mcpServers.neat from --print-config into ~/.claude.json,')
   console.log('then restart Claude Code. See packages/claude-skill/SKILL.md for the tool list.')
+  console.log('')
+  console.log('The MCP server reads NEAT_CORE_URL for the daemon URL — point it at a')
+  console.log('non-default daemon by editing that value in the generated config.')
   return { exitCode: 0 }
 }
 
@@ -995,8 +999,16 @@ function resolveProjectFlag(parsed: ParsedArgs): string | undefined {
   return undefined
 }
 
+// The daemon URL the CLI verbs talk to. `NEAT_API_URL` is the name the verbs
+// have always read, so it keeps precedence for existing users; `NEAT_CORE_URL`
+// is honored as an alias so a single env var works for both the CLI and the MCP
+// server (which names it `NEAT_CORE_URL`).
+function resolveDaemonUrl(): string {
+  return process.env.NEAT_API_URL ?? process.env.NEAT_CORE_URL ?? 'http://localhost:8080'
+}
+
 export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<number> {
-  const baseUrl = process.env.NEAT_API_URL ?? 'http://localhost:8080'
+  const baseUrl = resolveDaemonUrl()
   // ADR-073 §3 — read the bearer once and thread it into the single client
   // every verb shares, so no verb path can reach a secured daemon without it.
   const client = createHttpClient(baseUrl, resolveAuthToken())
@@ -1165,7 +1177,7 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
       const detail = err.responseBody.length > 0 ? err.responseBody : err.message
       console.error(`neat ${cmd}: ${detail.trim()}`)
     } else if (err instanceof TransportError) {
-      console.error(`neat ${cmd}: ${err.message}. Is the daemon running? (NEAT_API_URL=${process.env.NEAT_API_URL ?? 'http://localhost:8080'})`)
+      console.error(`neat ${cmd}: ${err.message}. Is the daemon running? (NEAT_API_URL=${resolveDaemonUrl()})`)
     } else {
       console.error(`neat ${cmd}: ${(err as Error).message}`)
     }

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -5583,13 +5583,17 @@ describe('Claude Code skill packaging', () => {
     expect(fileParsed).toEqual(CLAUDE_SKILL_CONFIG)
   })
 
-  it('snippet wires @neat.is/mcp over stdio with NEAT_API_URL', async () => {
+  it('snippet wires @neat.is/mcp over stdio with NEAT_CORE_URL', async () => {
     const { CLAUDE_SKILL_CONFIG } = await import('../../src/cli.js')
     const neat = CLAUDE_SKILL_CONFIG.mcpServers.neat
     expect(neat.type).toBe('stdio')
     expect(neat.command).toBe('npx')
     expect(neat.args).toContain('@neat.is/mcp')
-    expect(neat.env.NEAT_API_URL).toMatch(/^https?:\/\//)
+    // NEAT_CORE_URL is the canonical name the MCP server reads. The skill
+    // emitting NEAT_API_URL was #488 — the server ignored it on a non-default
+    // daemon and silently fell back to localhost:8080.
+    expect(neat.env.NEAT_CORE_URL).toMatch(/^https?:\/\//)
+    expect((neat.env as Record<string, unknown>).NEAT_API_URL).toBeUndefined()
   })
 
   it('runSkill --apply merges into ~/.claude.json without disturbing other entries', async () => {

--- a/packages/mcp/src/base-url.ts
+++ b/packages/mcp/src/base-url.ts
@@ -1,0 +1,11 @@
+// Resolve the daemon URL the MCP server talks to.
+//
+// `NEAT_CORE_URL` is the canonical name (the README and the MCP server both use
+// it). `NEAT_API_URL` is honored as an accepted alias so configs written by
+// older `neat skill` versions — which emitted `NEAT_API_URL` — still reach the
+// daemon (#488). `NEAT_CORE_URL` wins when both are set. Neither set falls back
+// to the loopback default. Lives in its own module so the resolution is
+// testable without importing index.ts, which starts the stdio transport on load.
+export function resolveBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  return env.NEAT_CORE_URL ?? env.NEAT_API_URL ?? 'http://localhost:8080'
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -9,6 +9,7 @@ import {
   HypotheticalActionSchema,
   type MCPToolName,
 } from '@neat.is/types'
+import { resolveBaseUrl } from './base-url.js'
 import { createHttpClient } from './client.js'
 import { registerResources } from './resources.js'
 import {
@@ -30,7 +31,7 @@ import {
   semanticSearch,
 } from './tools.js'
 
-const baseUrl = process.env.NEAT_CORE_URL ?? 'http://localhost:8080'
+const baseUrl = resolveBaseUrl()
 // ADR-073 §3 — carry the operator's bearer to a secured core. Sourced from
 // NEAT_AUTH_TOKEN, the same env the daemon enforces against; empty/unset
 // keeps the header off so a loopback dev core stays reachable.

--- a/packages/mcp/test/base-url.test.ts
+++ b/packages/mcp/test/base-url.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { resolveBaseUrl } from '../src/base-url.js'
+
+// #488 — the MCP server read only NEAT_CORE_URL, but `neat skill --apply` wrote
+// NEAT_API_URL into the generated config. On the default port it worked by
+// accident (fallback to localhost:8080); it broke silently the moment the
+// daemon wasn't at that default — the hosted-customer case. The server now
+// honors both names.
+
+describe('resolveBaseUrl', () => {
+  it('reads NEAT_API_URL when NEAT_CORE_URL is unset (the skill-generated case)', () => {
+    expect(resolveBaseUrl({ NEAT_API_URL: 'http://daemon.internal:9000' })).toBe(
+      'http://daemon.internal:9000',
+    )
+  })
+
+  it('NEAT_CORE_URL wins when both are set', () => {
+    expect(
+      resolveBaseUrl({
+        NEAT_CORE_URL: 'http://core.internal:9000',
+        NEAT_API_URL: 'http://api.internal:9001',
+      }),
+    ).toBe('http://core.internal:9000')
+  })
+
+  it('falls back to localhost:8080 when neither is set', () => {
+    expect(resolveBaseUrl({})).toBe('http://localhost:8080')
+  })
+})


### PR DESCRIPTION
The MCP server and `neat skill` disagreed on the env-var name for the daemon URL, so the config `neat skill --apply` generates pointed the server at a variable it didn't read. On the default port it worked by accident — the server fell back to `http://localhost:8080`, which happened to be right. It broke silently the moment the daemon wasn't at that default, which is the hosted-customer and agent-integration path.

What changed:

- The MCP server now resolves the daemon URL from `NEAT_CORE_URL ?? NEAT_API_URL ?? http://localhost:8080`. `NEAT_CORE_URL` is canonical and wins when both are set; `NEAT_API_URL` is honored as an alias so every config already out there — the skill-generated `NEAT_API_URL` and the README's `NEAT_CORE_URL` — reaches the daemon. The resolver lives in its own small module so it's testable without booting the stdio transport.
- `neat skill`'s generated config, the byte-aligned `claude-skill/claude_code_config.json`, and the skill help text now name `NEAT_CORE_URL`.
- The CLI verbs keep reading `NEAT_API_URL` first (the name their users already set) and now accept `NEAT_CORE_URL` as an alias too, so one env var serves both the CLI and the MCP server. Global env help notes the alias.
- README "Wire NEAT into Claude Code" now explains both invocation forms honestly: `neat-mcp` for a global install, `npx -y @neat.is/mcp` (what `neat skill --apply` emits) without one. Both read `NEAT_CORE_URL`.

Tests:

- New `packages/mcp/test/base-url.test.ts`: reads `NEAT_API_URL` when `NEAT_CORE_URL` is unset (the skill-generated case), `NEAT_CORE_URL` wins when both are set, and falls back to `localhost:8080` when neither is set.
- The skill-config contract test now asserts the snippet carries `NEAT_CORE_URL` and no longer `NEAT_API_URL`. The byte-for-byte contract against `claude_code_config.json` still holds.

Verified a `neat skill --print-config` now emits `NEAT_CORE_URL`, and the resolver honors a non-default daemon URL from either name. `npx turbo build test lint` green.

Refs #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)