### PR TITLE
Open the SSE stream at connect time with an initial comment frame

### DIFF
--- a/packages/core/src/streaming.ts
+++ b/packages/core/src/streaming.ts
@@ -1,6 +1,8 @@
 // SSE handler for the frontend-facing event stream (ADR-051 #1).
 // Subscribes to the bus in events.ts, filters by project, writes
-// `event: <type>\ndata: <json>\n\n` frames to the client.
+// `event: <type>\ndata: <json>\n\n` frames to the client. An initial
+// `:open\n\n` comment goes out at the handshake so EventSource opens
+// right away instead of waiting on the first event or heartbeat.
 //
 // Backpressure: per-connection queue cap of 1000 outstanding writes; once
 // hit, the connection is dropped with `event: error data: { reason:
@@ -36,6 +38,17 @@ export function handleSse(
   reply.raw.setHeader('Connection', 'keep-alive')
   reply.raw.setHeader('X-Accel-Buffering', 'no')
   reply.raw.flushHeaders?.()
+
+  // Flushing headers leaves the response body empty, so the browser's
+  // EventSource stays in CONNECTING (readyState 0) until the first body byte
+  // lands — which, on a quiet graph, is the first real event or the 30s
+  // heartbeat, whichever comes first. Write a comment line right away so the
+  // stream opens at the handshake and EventSource fires onopen immediately.
+  // A colon-prefixed comment is a no-op per the SSE spec (clients ignore it,
+  // same as the heartbeat), so it sits outside the locked ADR-051 taxonomy.
+  // Written raw, bypassing the backpressure accounting below, exactly like
+  // the heartbeat does.
+  reply.raw.write(':open\n\n')
 
   let pending = 0
   let dropped = false

--- a/packages/core/test/daemon-events.test.ts
+++ b/packages/core/test/daemon-events.test.ts
@@ -202,6 +202,38 @@ describe('daemon slots feed the event bus (issue #475)', () => {
     expect(envelopes).toEqual([])
   })
 
+  it('e2e: a real /events connection receives the :open frame at connect time, before any span (issue #356)', { timeout: 20_000 }, async () => {
+    const sandbox = await setupSandbox(['evt-open'])
+    pendingCleanups.push(sandbox.cleanup)
+    const { startDaemon } = await import('../src/daemon.js')
+    const handle = await startDaemon()
+    pendingCleanups.push(handle.stop)
+    await handle.initialBootstrap
+    expect(handle.restAddress).not.toBe('')
+
+    const abort = new AbortController()
+    pendingCleanups.push(async () => abort.abort())
+    const sseRes = await fetch(`${handle.restAddress}/projects/evt-open/events`, {
+      headers: { accept: 'text/event-stream' },
+      signal: abort.signal,
+    })
+    expect(sseRes.status).toBe(200)
+
+    // Read the first chunk off the body. The fix writes `:open\n\n` right at
+    // the handshake, so the first byte arrives without any graph mutation and
+    // long before the 30s heartbeat — on unfixed main this read would hang
+    // until the heartbeat tick. A short race guards against that hang.
+    const reader = sseRes.body!.getReader()
+    const decoder = new TextDecoder()
+    const firstChunk = await Promise.race([
+      reader.read().then(({ value }) => decoder.decode(value ?? new Uint8Array())),
+      new Promise<string>((resolve) => setTimeout(() => resolve(''), 5_000)),
+    ])
+    expect(firstChunk, 'first body chunk on connect').toContain(':open')
+
+    abort.abort()
+  })
+
   it('e2e: a span on the live OTLP receiver arrives as an edge-added frame on a real /events connection', { timeout: 20_000 }, async () => {
     const sandbox = await setupSandbox(['evt-wire'])
     pendingCleanups.push(sandbox.cleanup)

--- a/packages/core/test/streaming.test.ts
+++ b/packages/core/test/streaming.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+import {
+  EVENT_BUS_CHANNEL,
+  eventBus,
+  type NeatEventEnvelope,
+} from '../src/events.js'
+import { handleSse, SSE_HEARTBEAT_MS } from '../src/streaming.js'
+
+// Issue #356. handleSse set the SSE headers and flushed them, then waited on
+// the bus or the 30s heartbeat before writing anything to the body. Until the
+// first body byte lands, a browser's EventSource stays in CONNECTING (0) and
+// the StatusBar renders "reconnecting" — up to 30s of a dashboard that looks
+// stuck on a healthy, idle daemon. The fix writes an initial `:open\n\n`
+// comment right after flushHeaders so the stream opens at the handshake.
+
+// Minimal stand-ins for the Fastify req/reply pair handleSse touches. raw is
+// an EventEmitter so the close/error wiring binds without throwing; every
+// write is captured in order.
+function makeFakeReply(): {
+  reply: any
+  writes: string[]
+  raw: EventEmitter & Record<string, any>
+} {
+  const writes: string[] = []
+  const raw = new EventEmitter() as EventEmitter & Record<string, any>
+  raw.writableEnded = false
+  raw.setHeader = vi.fn()
+  raw.flushHeaders = vi.fn()
+  raw.write = vi.fn((chunk: string, cb?: () => void) => {
+    writes.push(chunk)
+    // Async-drain callback like the real socket, so pending decrements.
+    if (cb) queueMicrotask(cb)
+    return true
+  })
+  raw.end = vi.fn(() => {
+    raw.writableEnded = true
+  })
+  return { reply: { raw }, writes, raw }
+}
+
+function makeFakeReq(): any {
+  const raw = new EventEmitter()
+  return { raw }
+}
+
+describe('handleSse initial frame (issue #356)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('writes an :open comment at connect time, before any event or the heartbeat', () => {
+    vi.useFakeTimers()
+    const { reply, writes, raw } = makeFakeReply()
+    const req = makeFakeReq()
+
+    handleSse(req, reply, { project: 'p-open' })
+
+    // The very first body byte lands synchronously at the handshake — no bus
+    // traffic, no advancing of the heartbeat timer. On unfixed main this
+    // array is empty here and stays empty until the 30s tick.
+    expect(writes.length).toBeGreaterThan(0)
+    expect(writes[0]).toBe(':open\n\n')
+    // It's a comment, so it carries no event:/data: lines — outside the
+    // locked ADR-051 taxonomy.
+    expect(writes[0]).not.toContain('event:')
+    expect(writes[0]).not.toContain('data:')
+
+    // Sanity: we're well short of the heartbeat interval; nothing else fired.
+    vi.advanceTimersByTime(SSE_HEARTBEAT_MS - 1)
+    expect(writes).toEqual([':open\n\n'])
+
+    raw.emit('close')
+  })
+
+  it('still fires the heartbeat on its interval and still flows real events after the open frame', async () => {
+    vi.useFakeTimers()
+    const { reply, writes, raw } = makeFakeReply()
+    const req = makeFakeReq()
+
+    handleSse(req, reply, { project: 'p-flow', heartbeatMs: 1_000 })
+    expect(writes[0]).toBe(':open\n\n')
+
+    // Heartbeat still lands on its interval, unchanged by the initial frame.
+    vi.advanceTimersByTime(1_000)
+    expect(writes).toContain(':heartbeat\n\n')
+
+    // A real node-added/edge-added on the bus still routes to a frame.
+    const nodeEnvelope: NeatEventEnvelope = {
+      project: 'p-flow',
+      type: 'node-added',
+      payload: { node: { id: 'service:checkout' } },
+    } as NeatEventEnvelope
+    eventBus.emit(EVENT_BUS_CHANNEL, nodeEnvelope)
+
+    const edgeEnvelope: NeatEventEnvelope = {
+      project: 'p-flow',
+      type: 'edge-added',
+      payload: { edge: { id: 'e1', provenance: 'OBSERVED' } },
+    } as NeatEventEnvelope
+    eventBus.emit(EVENT_BUS_CHANNEL, edgeEnvelope)
+
+    // Let the write callbacks drain.
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(writes.some((w) => w.startsWith('event: node-added'))).toBe(true)
+    expect(writes.some((w) => w.startsWith('event: edge-added'))).toBe(true)
+
+    // The open frame was first and is not duplicated by anything the bus did.
+    expect(writes.filter((w) => w === ':open\n\n')).toHaveLength(1)
+
+    raw.emit('close')
+  })
+})


### PR DESCRIPTION
The SSE handler set its headers and flushed them, then wrote nothing to the body until a real event fired or the 30s heartbeat landed. A browser's `EventSource` only leaves CONNECTING for OPEN once the first body byte arrives, so on a quiet graph the dashboard's SSE pill showed "reconnecting" for up to 30 seconds on first load — a first-impression bug on a perfectly healthy idle daemon.

The fix writes a single `:open` comment frame right after `flushHeaders`, before the listener subscribe and the heartbeat. A colon-prefixed comment is a no-op per the SSE spec, so it gets the stream open at the handshake without touching the locked ADR-051 event taxonomy (it's not one of the eight named types) and without any client-side handling — same shape the heartbeat already uses. It goes out raw, bypassing the per-connection `pending`/cap accounting exactly like the heartbeat, so backpressure is untouched. It fires for every connection, reconnects included. The 30s heartbeat keeps running for idle-proxy keepalive.

A comment frame was chosen over a named `ready`/`connected` event specifically because it avoids the taxonomy lock — no contract change, no ADR successor, no new client handling.

Tests, both fail-before on unfixed main / pass-after:
- `packages/core/test/streaming.test.ts` drives `handleSse` directly and asserts the `:open` frame lands synchronously at connect time, before any bus traffic and well short of the heartbeat interval (fake timers). A second case pins that the heartbeat still fires on its interval and that real `node-added`/`edge-added` events still flow, with the open frame neither duplicated nor corrupting the write order.
- `packages/core/test/daemon-events.test.ts` adds a wire-level case: a real HTTP `/events` connection on a bound daemon receives `:open` in its first body chunk before any span is driven (with the unfixed handler this read would hang until the heartbeat).

`npx turbo build test lint` green (909 core tests).

Refs #356