### PR TITLE
Prune dead-path entries from the project registry

### DIFF
--- a/docs/contracts/project-registry.md
+++ b/docs/contracts/project-registry.md
@@ -56,6 +56,19 @@ Writes acquire exclusive flock on `~/.neat/projects.json.lock`. 5s timeout; fail
 
 `neat uninstall <name>` removes the entry. **Does not** delete `neat-out/`, `policy.json`, or user files. Reverses SDK-install patch via `neat-rollback.patch` if user opts in.
 
+## Pruning dead-path entries
+
+Ephemeral tmp-dir projects leave entries whose `path` no longer exists on disk. The registry keeps itself clean rather than carrying those entries forever.
+
+Pruning is removal of user-facing state, so it is conservative on two axes:
+
+- **Definite ENOENT only.** An entry is a prune candidate only when stat on its `path` returns `ENOENT` — the directory is genuinely gone. A transient stat failure (`EACCES`, `EBUSY`, an unmounted drive) leaves the entry untouched. An `active` project whose path still exists is never a candidate.
+- **Staleness gate on auto-prune.** The daemon prunes on boot and on `SIGHUP` reload. There it drops a gone-path entry only once its `lastSeenAt` (falling back to `registeredAt`) is older than `NEAT_REGISTRY_PRUNE_TTL_MS` (default 7 days). A recently-active project whose path is briefly unavailable survives; the TTL is the safety margin before removal. Below the TTL, a gone-path entry is still marked `broken` as before.
+
+`neat prune` is an explicit one-shot cleanup. As deliberate user intent it drops every gone-path entry immediately, regardless of TTL, and prints what it removed (`--json` emits the removed list). Entries whose paths still exist are kept.
+
+Both paths go through the same lock + atomic tmp+rename write as every other mutation — pruning is never a raw rewrite, so the atomicity invariant holds. Authority lives in `pruneRegistry()` in `registry.ts`.
+
 ## Path normalization
 
 Stored as resolved absolute path. Two `init` calls from different relative paths to the same dir don't create two entries.

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -23,6 +23,7 @@ import {
   addProject,
   listProjects,
   ProjectNameCollisionError,
+  pruneRegistry,
   removeProject,
   setStatus,
 } from './registry.js'
@@ -135,6 +136,8 @@ export function usage(): void {
   console.log('  uninstall <name>')
   console.log('                 Remove a project from the registry. Does not touch')
   console.log('                 neat-out/, policy.json, or any user file.')
+  console.log('  prune          Drop registry entries whose path is gone from disk.')
+  console.log('                 Flags: --json   emit the removed list as JSON')
   console.log('  version        Print the installed @neat.is/core version and exit.')
   console.log('                 Aliases: --version, -v.')
   console.log('  skill          Install or print the Claude Code MCP drop-in.')
@@ -877,6 +880,24 @@ export async function main(): Promise<void> {
     }
     console.log(`unregistered: ${removed.name} (${removed.path})`)
     console.log('note: neat-out/, policy.json, and other files at the project path were left in place.')
+    return
+  }
+
+  if (cmd === 'prune') {
+    // #463 — one-shot cleanup of registry entries whose path is gone. Explicit
+    // user intent, so it drops any ENOENT entry immediately regardless of the
+    // auto-prune TTL. Only definite ENOENT entries go — a project whose path
+    // still exists, or one behind a transient stat error, is left alone.
+    const removed = await pruneRegistry({ ttlMs: 0 })
+    if (parsed.json) {
+      console.log(JSON.stringify(removed.map((p) => ({ name: p.name, path: p.path })), null, 2))
+      return
+    }
+    if (removed.length === 0) {
+      console.log('nothing to prune — every registered project path still exists.')
+      return
+    }
+    console.log(`pruned ${removed.length} project${removed.length === 1 ? '' : 's'}: ${removed.map((p) => p.name).join(', ')}`)
     return
   }
 

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -39,6 +39,7 @@ import { attachGraphToEventBus } from './events.js'
 import { handleSpan, makeErrorSpanWriter } from './ingest.js'
 import {
   listProjects,
+  pruneRegistry,
   registryPath,
   setStatus,
   touchLastSeen,
@@ -453,6 +454,26 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
   }
 
   async function loadAll(): Promise<void> {
+    // #463 — drop long-dead entries before bootstrapping the rest. An entry
+    // whose path is gone (definite ENOENT) and that's been quiet past the TTL
+    // gets removed instead of marked `broken` and logged forever. Conservative
+    // by design: a transient stat error or a fresh ENOENT entry stays, and the
+    // staleness TTL is the safety margin. Best-effort — a prune failure never
+    // blocks the daemon from coming up.
+    try {
+      const pruned = await pruneRegistry()
+      for (const entry of pruned) {
+        console.log(
+          `neatd: pruned project "${entry.name}" — registered path ${entry.path} is gone`,
+        )
+        slots.delete(entry.name)
+        bootstrapStatus.delete(entry.name)
+        bootstrapStartedAt.delete(entry.name)
+      }
+    } catch (err) {
+      console.warn(`neatd: registry prune skipped — ${(err as Error).message}`)
+    }
+
     const projects = await listProjects()
     const seen = new Set<string>()
     const pending: Promise<void>[] = []

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -410,3 +410,113 @@ export async function removeProject(name: string): Promise<RegistryEntry | undef
   })
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// #463 — prune dead-path entries so the registry doesn't accumulate zombies.
+//
+// Ephemeral tmp-dir projects (smoke runs, throwaway demos) leave entries whose
+// `path` is gone from disk. Without pruning the daemon logs an ENOENT warning
+// for each on every startup forever and `/api/health` lists them as permanent
+// `broken` rows. Pruning removes user-facing state, so it's deliberately
+// conservative: we only ever drop an entry on a *definite* ENOENT (the path is
+// genuinely gone). A transient stat failure — EACCES, EBUSY, an unmounted
+// drive — leaves the entry untouched; it isn't dead, just unreachable.
+//
+// Two modes:
+//  - Auto-prune (daemon bootstrap / reload) gates removal on a staleness TTL.
+//    An ENOENT entry is only dropped if its `lastSeenAt` is older than the TTL,
+//    so a recently-active project whose path is temporarily unavailable stays.
+//  - `neat prune` is explicit user intent, so it drops any ENOENT entry
+//    immediately regardless of age.
+// ─────────────────────────────────────────────────────────────────────────
+
+const DAY_MS = 24 * 60 * 60 * 1000
+// Default 7 days, mirroring NEAT_STALE_THRESHOLDS' env-override shape.
+export const DEFAULT_PRUNE_TTL_MS = 7 * DAY_MS
+
+export function pruneTtlMs(): number {
+  const raw = process.env.NEAT_REGISTRY_PRUNE_TTL_MS
+  if (!raw) return DEFAULT_PRUNE_TTL_MS
+  const n = Number.parseInt(raw, 10)
+  if (Number.isFinite(n) && n >= 0) return n
+  console.warn(
+    `[neat] NEAT_REGISTRY_PRUNE_TTL_MS could not be parsed (${raw}); using default ${DEFAULT_PRUNE_TTL_MS}ms`,
+  )
+  return DEFAULT_PRUNE_TTL_MS
+}
+
+// Classify a single path: 'gone' (definite ENOENT), 'present' (stat succeeded,
+// directory exists), or 'unknown' (a transient/ambiguous error — never prune).
+// Exported so the daemon and tests can probe the same logic.
+export type PathStatus = 'gone' | 'present' | 'unknown'
+
+async function statPathStatus(p: string): Promise<PathStatus> {
+  try {
+    const stat = await fs.stat(p)
+    return stat.isDirectory() ? 'present' : 'unknown'
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'ENOENT' ? 'gone' : 'unknown'
+  }
+}
+
+export interface PruneOptions {
+  // Override the staleness gate. Auto-prune passes a TTL; `neat prune` passes
+  // `ttlMs: 0` to drop any ENOENT entry immediately. Default is the env-driven
+  // TTL.
+  ttlMs?: number
+  // Override the path probe (tests drive ENOENT / EACCES / present branches
+  // without a real filesystem). Defaults to a real stat.
+  statPath?: (p: string) => Promise<PathStatus>
+  // Clock injection for the staleness comparison; defaults to Date.now().
+  now?: () => number
+}
+
+/**
+ * Remove registry entries whose `path` is definitely gone (ENOENT). Goes
+ * through the same lock + atomic-write path as every other mutation — never a
+ * raw rewrite — so the contract's atomicity invariant holds.
+ *
+ * Staleness gate: an ENOENT entry is dropped only when `ttlMs` is 0 (explicit
+ * `neat prune`) or its `lastSeenAt` (falling back to `registeredAt`) is older
+ * than `ttlMs`. A fresh ENOENT entry under a non-zero TTL is left in place — the
+ * daemon still marks it `broken`, the TTL is the safety margin before removal.
+ *
+ * Returns the entries that were removed.
+ */
+export async function pruneRegistry(opts: PruneOptions = {}): Promise<RegistryEntry[]> {
+  const ttlMs = opts.ttlMs ?? pruneTtlMs()
+  const statPath = opts.statPath ?? statPathStatus
+  const now = opts.now ?? Date.now
+
+  return withLock(async () => {
+    const reg = await readRegistry()
+    const removed: RegistryEntry[] = []
+    const kept: RegistryEntry[] = []
+    for (const entry of reg.projects) {
+      const status = await statPath(entry.path)
+      if (status !== 'gone') {
+        // Present, or a transient/ambiguous error — keep it. We only prune on a
+        // definite ENOENT.
+        kept.push(entry)
+        continue
+      }
+      // Path is gone. Drop it immediately when there's no TTL gate, otherwise
+      // only once it's been quiet longer than the TTL.
+      if (ttlMs <= 0) {
+        removed.push(entry)
+        continue
+      }
+      const lastSeen = Date.parse(entry.lastSeenAt ?? entry.registeredAt)
+      const age = now() - (Number.isFinite(lastSeen) ? lastSeen : 0)
+      if (age > ttlMs) {
+        removed.push(entry)
+      } else {
+        kept.push(entry)
+      }
+    }
+    if (removed.length === 0) return []
+    reg.projects = kept
+    await writeRegistry(reg)
+    return removed
+  })
+}
+

--- a/packages/core/test/registry-prune.test.ts
+++ b/packages/core/test/registry-prune.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import {
+  addProject,
+  listProjects,
+  normalizeProjectPath,
+  pruneRegistry,
+  readRegistry,
+  registryPath,
+  touchLastSeen,
+  DEFAULT_PRUNE_TTL_MS,
+  type PathStatus,
+} from '../src/registry.js'
+
+// #463 — the registry used to accumulate entries whose `path` was gone from
+// disk: smoke runs and tmp-dir demos left zombie rows the daemon logged an
+// ENOENT warning for on every startup, forever, and `/api/health` reported as
+// permanent `broken`. These tests pin the prune behaviour. Every one runs
+// against an ISOLATED NEAT_HOME tmpdir — the real ~/.neat is never touched.
+
+let home: string
+let prevHome: string | undefined
+// A real, existing directory used as a stand-in "live" project path. Its
+// registry-stored form is the realpath-normalized version (macOS resolves
+// /var/folders → /private/var/folders), so fake-stat probes key on `liveDir`.
+let liveDir: string
+
+beforeEach(async () => {
+  home = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-prune-home-'))
+  prevHome = process.env.NEAT_HOME
+  process.env.NEAT_HOME = home
+  liveDir = await normalizeProjectPath(home)
+})
+
+afterEach(async () => {
+  if (prevHome === undefined) delete process.env.NEAT_HOME
+  else process.env.NEAT_HOME = prevHome
+  delete process.env.NEAT_REGISTRY_PRUNE_TTL_MS
+  await fs.rm(home, { recursive: true, force: true })
+})
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+// A stat probe that reports each path by its name. Lets us drive the
+// gone/present/unknown branches deterministically without a real filesystem.
+function fakeStat(byName: Record<string, PathStatus>): (p: string) => Promise<PathStatus> {
+  return async (p) => byName[p] ?? 'gone'
+}
+
+describe('pruneRegistry — auto-prune (TTL-gated)', () => {
+  it('removes a gone-path entry whose lastSeenAt is older than the TTL', async () => {
+    await addProject({ name: 'live', path: home }) // path exists (the home dir)
+    await addProject({ name: 'dead', path: '/private/tmp/neatd-project-dead-Xx' })
+
+    // Backdate the dead entry past the TTL.
+    const stale = new Date(Date.now() - (DEFAULT_PRUNE_TTL_MS + DAY_MS)).toISOString()
+    await touchLastSeen('dead', stale)
+
+    const removed = await pruneRegistry({
+      statPath: fakeStat({ [liveDir]: 'present' }), // every other path → 'gone'
+    })
+
+    expect(removed.map((p) => p.name)).toEqual(['dead'])
+    const names = (await listProjects()).map((p) => p.name)
+    expect(names).toEqual(['live'])
+  })
+
+  it('keeps a fresh gone-path entry (recent lastSeenAt) — daemon still marks it broken', async () => {
+    await addProject({ name: 'recent', path: '/private/tmp/neatd-project-recent-Yy' })
+    // addProject sets registeredAt = now; lastSeenAt undefined → falls back to
+    // registeredAt, which is fresh. Should survive auto-prune.
+
+    const removed = await pruneRegistry({ statPath: fakeStat({}) }) // all gone
+    expect(removed).toEqual([])
+    expect((await listProjects()).map((p) => p.name)).toEqual(['recent'])
+  })
+
+  it('NEAT_REGISTRY_PRUNE_TTL_MS overrides the default TTL', async () => {
+    await addProject({ name: 'dead', path: '/private/tmp/gone-zz' })
+    // 1h old — under the 7-day default, but over a 1-minute override.
+    await touchLastSeen('dead', new Date(Date.now() - 60 * 60 * 1000).toISOString())
+
+    // Default TTL: kept.
+    expect(await pruneRegistry({ statPath: fakeStat({}) })).toEqual([])
+
+    process.env.NEAT_REGISTRY_PRUNE_TTL_MS = String(60_000)
+    const removed = await pruneRegistry({ statPath: fakeStat({}) })
+    expect(removed.map((p) => p.name)).toEqual(['dead'])
+  })
+})
+
+describe('neat prune — one-shot (ttlMs: 0)', () => {
+  it('removes every gone-path entry immediately regardless of age, keeps live ones', async () => {
+    await addProject({ name: 'live', path: home })
+    await addProject({ name: 'recoverable', path: '/private/tmp/neatd-project-recoverable-VgHei1' })
+    await addProject({ name: 'brief-demo', path: '/private/tmp/brief-demo' })
+    // brief-demo was just registered (fresh) — explicit prune drops it anyway.
+
+    const removed = await pruneRegistry({
+      ttlMs: 0,
+      statPath: fakeStat({ [liveDir]: 'present' }),
+    })
+
+    expect(removed.map((p) => p.name).sort()).toEqual(['brief-demo', 'recoverable'])
+    expect((await listProjects()).map((p) => p.name)).toEqual(['live'])
+  })
+
+  it('removes nothing when every registered path exists', async () => {
+    await addProject({ name: 'a', path: home })
+    const removed = await pruneRegistry({ ttlMs: 0, statPath: fakeStat({ [liveDir]: 'present' }) })
+    expect(removed).toEqual([])
+    expect((await listProjects()).map((p) => p.name)).toEqual(['a'])
+  })
+})
+
+describe('pruneRegistry — conservative on transient errors', () => {
+  it('leaves an entry intact on a non-ENOENT stat error (EACCES / EBUSY)', async () => {
+    await addProject({ name: 'unreachable', path: '/mnt/unmounted/project' })
+    await touchLastSeen('unreachable', new Date(0).toISOString()) // ancient — would prune if gone
+
+    // 'unknown' models EACCES/EBUSY/unmounted: not a definite ENOENT.
+    const autoRemoved = await pruneRegistry({
+      statPath: fakeStat({ '/mnt/unmounted/project': 'unknown' }),
+    })
+    expect(autoRemoved).toEqual([])
+
+    // Even explicit `neat prune` (ttlMs: 0) must not drop it — it isn't dead.
+    const forceRemoved = await pruneRegistry({
+      ttlMs: 0,
+      statPath: fakeStat({ '/mnt/unmounted/project': 'unknown' }),
+    })
+    expect(forceRemoved).toEqual([])
+    expect((await listProjects()).map((p) => p.name)).toEqual(['unreachable'])
+  })
+
+  it('never prunes an active project whose path still exists', async () => {
+    await addProject({ name: 'live', path: home })
+    const removed = await pruneRegistry({ ttlMs: 0, statPath: fakeStat({ [liveDir]: 'present' }) })
+    expect(removed).toEqual([])
+  })
+})
+
+describe('pruneRegistry — atomicity invariant', () => {
+  it('leaves a well-formed registry file after prune (re-parseable, version 1)', async () => {
+    await addProject({ name: 'live', path: home })
+    await addProject({ name: 'dead', path: '/private/tmp/gone-aa' })
+
+    await pruneRegistry({ ttlMs: 0, statPath: fakeStat({ [liveDir]: 'present' }) })
+
+    // Raw bytes parse cleanly and trail with a newline (writeAtomically shape).
+    const raw = await fs.readFile(registryPath(), 'utf8')
+    expect(raw.endsWith('\n')).toBe(true)
+    const parsed = JSON.parse(raw)
+    expect(parsed.version).toBe(1)
+
+    // And the schema-validated read agrees.
+    const reg = await readRegistry()
+    expect(reg.version).toBe(1)
+    expect(reg.projects.map((p) => p.name)).toEqual(['live'])
+  })
+
+  it('integration: prunes a real gone path, keeps a real existing one', async () => {
+    const existing = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-prune-proj-'))
+    const gone = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-prune-gone-'))
+    try {
+      await addProject({ name: 'keeper', path: existing })
+      await addProject({ name: 'ghost', path: gone })
+      await fs.rm(gone, { recursive: true, force: true }) // path is now ENOENT for real
+
+      const removed = await pruneRegistry({ ttlMs: 0 }) // real stat
+      expect(removed.map((p) => p.name)).toEqual(['ghost'])
+      expect((await listProjects()).map((p) => p.name)).toEqual(['keeper'])
+    } finally {
+      await fs.rm(existing, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('DEFAULT_PRUNE_TTL_MS', () => {
+  it('defaults to 7 days', () => {
+    expect(DEFAULT_PRUNE_TTL_MS).toBe(7 * DAY_MS)
+  })
+})


### PR DESCRIPTION
The project registry never cleaned up entries whose `path` was gone from disk — leftover tmp-dir and smoke-run projects. The daemon logged an ENOENT warning for each on every startup, and `/api/health` listed them as permanent zombie `status: "broken"` rows. Every visitor running the daemon saw the spam.

## What changed

**Auto-prune on boot and on reload.** `loadAll` (which runs at startup and on every SIGHUP reload) now prunes before bootstrapping. An entry whose path is genuinely gone — a *definite* ENOENT — and whose `lastSeenAt` (falling back to `registeredAt`) is older than the TTL gets removed instead of marked `broken` and logged forever. The TTL defaults to 7 days and is overridable via `NEAT_REGISTRY_PRUNE_TTL_MS`, mirroring how `NEAT_STALE_THRESHOLDS` works. Below the TTL a gone-path entry is still marked `broken` as before — the TTL is the safety margin.

**`neat prune`** does an immediate one-shot cleanup regardless of TTL. As explicit user intent it drops every gone-path entry right away and prints what it removed (`pruned 2 projects: recoverable, brief-demo`). `--json` emits the removed list. Added to `usage()` in the lifecycle section.

**Conservative by design.** Pruning removes user-facing state, so we only ever drop on a definite ENOENT. A transient stat error (EACCES, EBUSY, an unmounted drive) leaves the entry untouched — it isn't dead, just unreachable. An `active` project whose path still exists is never touched.

**Atomicity preserved.** Both paths go through the existing lock + atomic tmp+rename write via `pruneRegistry()` — never a raw rewrite — so the registry contract's atomicity invariant holds.

The contract doc (`docs/contracts/project-registry.md`) gains a Pruning section.

## Tests

New `registry-prune.test.ts`, all against an isolated `NEAT_HOME` tmpdir:

- A gone-path entry older than the TTL is auto-pruned on bootstrap; a fresh gone-path entry is kept (still marked broken).
- `neat prune` removes every gone-path entry immediately regardless of age, keeps existing paths, prints the list.
- A transient non-ENOENT stat error leaves the entry intact under both auto-prune and explicit prune.
- The registry file stays well-formed after prune (re-parseable, trailing newline, `version: 1`), plus a real-filesystem integration case.

`npx turbo build test lint` green.

Refs #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)