### PR TITLE
Disambiguate the graph counters and quiet Next's lockfile patch on build

### DIFF
--- a/packages/web/app/components/GraphCanvas.tsx
+++ b/packages/web/app/components/GraphCanvas.tsx
@@ -301,7 +301,10 @@ export function GraphCanvas({
     const metaEl = document.querySelector('.canvas-tag .meta')
     if (metaEl) {
       const fileCount = full.nodes.filter((n) => n.type === 'FileNode').length
-      metaEl.textContent = `${fileCount} files · ${vis.edges.length} edges`
+      // #464 — this counter is canvas-scoped: files rendered and edges actually
+      // drawn on the canvas, not the full-graph totals the status bar reports.
+      // Say "drawn" so it reads as a different measure side-by-side.
+      metaEl.textContent = `${fileCount} files · ${vis.edges.length} drawn`
     }
     // refresh provenance counts (off the full graph so they don't jump while drilling)
     const counts: Record<string, number> = { STATIC: 0, OBSERVED: 0, INFERRED: 0, STALE: 0 }

--- a/packages/web/app/components/StatusBar.tsx
+++ b/packages/web/app/components/StatusBar.tsx
@@ -318,13 +318,16 @@ export function StatusBar({ project, graphData }: StatusBarProps) {
       <EnvironmentIndicator />
       <PublicReadIndicator />
       <SignOutButton />
-      <div className="st-item">
-        <span className="k">nodes</span>
+      {/* #464 — this is the whole-graph total from the API (every node type,
+          every edge type), not the file-scoped subset the canvas header draws.
+          Label it "graph total" so the two counters read as different measures
+          when a visitor sees them side by side. */}
+      <div className="st-item" title="Whole-graph totals from the daemon — every node and edge type, not just what the canvas draws">
+        <span className="k">graph total</span>
         <span className="v" id="st-nodes">{nodeCount}</span>
-      </div>
-      <div className="st-item">
-        <span className="k">edges</span>
+        <span className="k">nodes /</span>
         <span className="v" id="st-edges">{edgeCount}</span>
+        <span className="k">edges</span>
       </div>
       {healthy === false && (
         <div className="st-item">

--- a/packages/web/audit/06-statusbar.md
+++ b/packages/web/audit/06-statusbar.md
@@ -9,7 +9,7 @@
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────────┐
-│ ● neat  bloomberg-platform   nodes  247   edges  831    t [━━━━━━━━━━━━●] now ⌐ 14:22:31 UTC │
+│ ● neat  bloomberg-platform   graph total  247 nodes / 831 edges    t [━━━━━━━━━━━━●] now ⌐ 14:22:31 UTC │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -33,25 +33,25 @@ Label structure: `<span class="k">neat</span> <span class="v">{project}</span>`
 - `project` comes from `GET /api/health` response field `d.project`
 - Falls back to `—` until health check responds
 
-### 2. Nodes count (`.st-item`)
+### 2. Graph total (`.st-item`)
 
 ```
-nodes  247
+graph total  247 nodes / 831 edges
 ```
 
-- `k`: "nodes" — `--paper-3`
+One `.st-item` carrying both whole-graph counts under a shared `graph total`
+label, so it reads as the daemon's full-graph totals — every node and edge
+type — distinct from the canvas header, which counts only the files and edges
+drawn on the canvas (`N files · M drawn`). The label spells out the scope so the
+two counters don't read as contradictory totals of the same thing.
+
+- `k`: "graph total" — `--paper-3`
 - `v id="st-nodes"`: node count from `graphData.nodes.length` — `--paper-1`
-- Shows `—` until graph loads
-
-### 3. Edges count (`.st-item`)
-
-```
-edges  831
-```
-
-- `k`: "edges" — `--paper-3`
+- `k`: "nodes /" — `--paper-3`
 - `v id="st-edges"`: edge count from `graphData.edges.length` — `--paper-1`
-- Shows `—` until graph loads
+- `k`: "edges" — `--paper-3`
+- Hover title spells out the whole-graph scope
+- Shows `—` for each count until graph loads
 
 ### 4. "core offline" label (conditional)
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "dev": "next dev",
-    "build": "next build && node ./scripts/post-build-standalone.mjs",
+    "build": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next build && node ./scripts/post-build-standalone.mjs",
     "start": "node .next/standalone/packages/web/server.js",
     "prepublishOnly": "rm -rf .next && npm run build",
     "lint": "eslint app",


### PR DESCRIPTION
Two small visitor-facing DX cleanups in the web/build surface.

**#464 — counters that read as contradictory.** The canvas header and the status bar were showing different edge numbers side by side. Both are truthful, they just measure different things: the header counts the files and edges drawn on the canvas, while the status bar reports the daemon's whole-graph totals (every node and edge type, CONTAINS edges included). Nothing labelled them as different scopes, so a visitor read them as two totals of the same thing. Now the header reads `N files · M drawn` and the status bar reads `graph total X nodes / Y edges`, with a hover title spelling out the whole-graph scope. Neither number's source changed — only the labels. The status-bar audit doc tracks the new shape.

**#462 — scary non-fatal lockfile line on build.** `next build` printed `Failed to patch lockfile … Cannot read properties of undefined (reading 'os')`. Next decides the lockfile is missing the `@next/swc-*` platform binaries and tries to fetch registry metadata to patch them in, then trips over the response. npm correctly omits the other-platform optional binaries, so there's genuinely nothing to patch — this isn't a lockfile misconfig. Setting `NEXT_IGNORE_INCORRECT_LOCKFILE=1` on the web build (Next's own opt-out) skips the patch step. Build output is clean and the standalone bundle is unchanged.

Verified: fresh uncached web build via turbo is clean, `turbo build test lint` green, core contract audit passes uncached, and the status bar renders `graph total 16 nodes / 15 edges` against a 16-node/15-edge fixture.

Refs #464 #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)