### PR TITLE
Surface @supabase/supabase-js calls as declared edges

### DIFF
--- a/docs/contracts/static-extraction.md
+++ b/docs/contracts/static-extraction.md
@@ -94,7 +94,7 @@ Other extensions are skipped silently by `walkSourceFiles` per `IGNORED_DIRS` an
 | `aliases.ts`         | host:port aliases on existing ServiceNodes     | n/a            |
 | `databases/*`        | DatabaseNode + CONNECTS_TO                     | ❌ — #140      |
 | `configs.ts`         | ConfigNode + CONFIGURED_BY                     | ❌ — #140      |
-| `calls/{aws,grpc,http,kafka,redis}.ts` | CALLS / PUBLISHES_TO / CONSUMES_FROM | ✅          |
+| `calls/{aws,grpc,http,kafka,redis,supabase}.ts` | CALLS / PUBLISHES_TO / CONSUMES_FROM | ✅          |
 | `infra/{docker-compose,dockerfile,k8s,terraform}.ts` | InfraNode + DEPENDS_ON / RUNS_ON | ❌ — #140 |
 
 New producers under `calls/` for source-level DB connections (`new pg.Pool(...)`) and inter-service imports land under issue #141. They follow the same interface, same evidence shape, same idempotency.

--- a/packages/core/src/extract/calls/index.ts
+++ b/packages/core/src/extract/calls/index.ts
@@ -20,6 +20,7 @@ import { kafkaEndpointsFromFile } from './kafka.js'
 import { redisEndpointsFromFile } from './redis.js'
 import { awsEndpointsFromFile } from './aws.js'
 import { grpcEndpointsFromFile } from './grpc.js'
+import { supabaseEndpointsFromFile } from './supabase.js'
 
 export interface CallExtractResult {
   nodesAdded: number
@@ -71,6 +72,7 @@ async function addExternalEndpointEdges(
       endpoints.push(...redisEndpointsFromFile(maskedFile, service.dir))
       endpoints.push(...awsEndpointsFromFile(maskedFile, service.dir))
       endpoints.push(...grpcEndpointsFromFile(maskedFile, service.dir))
+      endpoints.push(...supabaseEndpointsFromFile(maskedFile, service.dir))
     }
     if (endpoints.length === 0) continue
 

--- a/packages/core/src/extract/calls/supabase.ts
+++ b/packages/core/src/extract/calls/supabase.ts
@@ -1,0 +1,121 @@
+import path from 'node:path'
+import { infraId } from '@neat.is/types'
+import { lineOf, snippet, type ExternalEndpoint, type SourceFile } from './shared.js'
+
+// Supabase clients in JS/TS:
+//
+//   import { createClient } from '@supabase/supabase-js'
+//   const supabase = createClient(process.env.SUPABASE_URL, key)
+//   const db = createClient('https://abc.supabase.co', key)
+//   supabase.from('orders').select()
+//   db.auth.getUser()
+//
+//   import { createServerClient } from '@supabase/ssr'
+//   const supabase = createServerClient(url, key, { cookies })
+//
+// Supabase apps talk to *.supabase.co exclusively through these client
+// constructors. The HTTP-call extractor never sees the host: it lives behind
+// `createClient`, and in the common case the URL is `process.env.SUPABASE_URL`
+// (or `EXPO_PUBLIC_SUPABASE_URL`), not a literal. So a production-observed
+// `service → *.supabase.co` CALLS edge arrives with no declared twin and shows
+// up as a false `missing-extracted` divergence. This extractor closes that gap.
+//
+// Classification is import-aware, the same discipline grpc.ts / aws.ts use
+// (#238): a bare `createClient(...)` is too common a name to claim without the
+// `@supabase/*` import in scope. The constructor names map to the package that
+// owns them:
+//   - `createClient`                       ← @supabase/supabase-js
+//   - `createServerClient` / `createBrowserClient` ← @supabase/ssr
+const SUPABASE_JS_IMPORT_RE =
+  /(?:from\s+['"`]|require\(\s*['"`])@supabase\/supabase-js['"`]/
+const SUPABASE_SSR_IMPORT_RE =
+  /(?:from\s+['"`]|require\(\s*['"`])@supabase\/ssr['"`]/
+
+// First argument of a Supabase client constructor. Group 1 is the constructor
+// name, group 2 (when present) is a string-literal URL. A non-literal first arg
+// (`process.env.SUPABASE_URL`, a config getter) leaves group 2 undefined — we
+// still match the construction, we just can't resolve the literal host.
+const SUPABASE_CLIENT_RE =
+  /\b(createClient|createServerClient|createBrowserClient)\s*\(\s*(?:['"`]([^'"`]*)['"`])?/g
+
+// A *.supabase.co host pulled out of a literal URL argument. We only treat the
+// constructor's URL as a resolvable host when the literal actually names a
+// supabase.co domain — anything else (a self-hosted Supabase behind a custom
+// domain, a placeholder) stays the unresolved env target rather than a guessed
+// host. Reading the literal is the only honest host source (file-awareness §6).
+function hostFromLiteral(literal: string | undefined): string | null {
+  if (!literal) return null
+  const m = /^https?:\/\/([^/:'"`\s]+)/.exec(literal.trim())
+  if (!m) return null
+  const host = m[1]!
+  if (!/\.supabase\.(co|in)$/i.test(host)) return null
+  return host
+}
+
+interface ImportContext {
+  hasSupabaseJs: boolean
+  hasSupabaseSsr: boolean
+}
+
+function readImports(content: string): ImportContext {
+  return {
+    hasSupabaseJs: SUPABASE_JS_IMPORT_RE.test(content),
+    hasSupabaseSsr: SUPABASE_SSR_IMPORT_RE.test(content),
+  }
+}
+
+// A constructor name is only a Supabase client when the package that owns it is
+// imported in the same file. `createClient` needs @supabase/supabase-js;
+// `createServerClient` / `createBrowserClient` need @supabase/ssr. Without the
+// import in scope we refuse to emit — a bare `createClient` could be anything.
+function constructorMatchesImport(name: string, ctx: ImportContext): boolean {
+  if (name === 'createClient') return ctx.hasSupabaseJs
+  return ctx.hasSupabaseSsr
+}
+
+export function supabaseEndpointsFromFile(
+  file: SourceFile,
+  serviceDir: string,
+): ExternalEndpoint[] {
+  const ctx = readImports(file.content)
+  if (!ctx.hasSupabaseJs && !ctx.hasSupabaseSsr) return []
+
+  const out: ExternalEndpoint[] = []
+  const seen = new Set<string>()
+  SUPABASE_CLIENT_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = SUPABASE_CLIENT_RE.exec(file.content)) !== null) {
+    const ctor = m[1]!
+    if (!constructorMatchesImport(ctor, ctx)) continue
+
+    // When the first argument is a literal *.supabase.co URL we resolve the
+    // real host. Otherwise the URL is env-driven (`process.env.SUPABASE_URL`,
+    // a config getter) and unknowable statically — the edge still has to land,
+    // so it resolves to a stable `supabase:env` target. That target is honest:
+    // we read the @supabase import and the `createClient` call, but not a host,
+    // so we don't fabricate one (file-awareness §6).
+    const host = hostFromLiteral(m[2])
+    const name = host ?? 'env'
+    if (seen.has(name)) continue
+    seen.add(name)
+
+    const line = lineOf(file.content, m[0])
+    out.push({
+      infraId: infraId('supabase', name),
+      name,
+      kind: 'supabase',
+      edgeType: 'CALLS',
+      // `createClient(...)` from @supabase/supabase-js (or createServerClient /
+      // createBrowserClient from @supabase/ssr) with the import in scope — a
+      // framework-aware recognizer matched the SDK shape. Verified-call-site
+      // tier (ADR-066), the same grade aws.ts / grpc.ts emit at.
+      confidenceKind: 'verified-call-site',
+      evidence: {
+        file: path.relative(serviceDir, file.path),
+        line,
+        snippet: snippet(file.content, line),
+      },
+    })
+  }
+  return out
+}

--- a/packages/core/test/calls.test.ts
+++ b/packages/core/test/calls.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import { resetGraph, getGraph } from '../src/graph.js'
 import { extractFromDirectory } from '../src/extract.js'
 import type { GraphEdge, InfraNode } from '@neat.is/types'
+import { EdgeType } from '@neat.is/types'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const FIXTURES = path.resolve(__dirname, 'fixtures', 'calls')
@@ -85,5 +86,49 @@ describe('call extraction beyond HTTP', () => {
     const edgeId =
       'CALLS:file:fixture-grpc-service:index.js->infra:grpc-service:orders.internal:50051'
     expect(graph.hasEdge(edgeId)).toBe(true)
+  })
+
+  it('emits supabase CALLS edges for both literal and env-driven client URLs', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    // Literal `https://abcdefgh.supabase.co` URL → the real host resolves.
+    expect(graph.hasNode('infra:supabase:abcdefgh.supabase.co')).toBe(true)
+    const litNode = graph.getNodeAttributes(
+      'infra:supabase:abcdefgh.supabase.co',
+    ) as InfraNode
+    expect(litNode.kind).toBe('supabase')
+
+    const litEdgeId =
+      'CALLS:file:fixture-supabase-service:index.ts->infra:supabase:abcdefgh.supabase.co'
+    expect(graph.hasEdge(litEdgeId)).toBe(true)
+    const litEdge = graph.getEdgeAttributes(litEdgeId) as GraphEdge
+    expect(litEdge.evidence?.file).toBe('index.ts')
+    expect(litEdge.evidence?.line).toBeGreaterThan(0)
+    expect(litEdge.evidence?.snippet).toContain('createClient')
+
+    // Env-driven `process.env.SUPABASE_URL` → the host is unknowable, so the
+    // edge lands on the stable `supabase:env` target rather than a guessed host.
+    // This is the edge that kills the false `missing-extracted` divergence.
+    expect(graph.hasNode('infra:supabase:env')).toBe(true)
+    const envEdgeId =
+      'CALLS:file:fixture-supabase-service:index.ts->infra:supabase:env'
+    expect(graph.hasEdge(envEdgeId)).toBe(true)
+  })
+
+  it('does not emit supabase edges from a test file (test-scope exclusion)', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    // The __tests__/client.spec.ts fixture constructs a client against
+    // testonly.supabase.co — ADR-065 #1 keeps it from minting an outbound
+    // CALLS edge. (The test file is still registered service-internal via its
+    // structural CONTAINS edge; only outbound inference is filtered.)
+    expect(graph.hasNode('infra:supabase:testonly.supabase.co')).toBe(false)
+    graph.forEachEdge((id, attrs) => {
+      const e = attrs as GraphEdge
+      if (e.type !== EdgeType.CALLS) return
+      expect(id).not.toContain('client.spec.ts')
+    })
   })
 })

--- a/packages/core/test/fixtures/calls/supabase-service/__tests__/client.spec.ts
+++ b/packages/core/test/fixtures/calls/supabase-service/__tests__/client.spec.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js'
+
+// Same client construction as production code, but in a test file. Test-scope
+// exclusion (ADR-065 #1) must keep this from minting any outbound CALLS edge.
+const supabase = createClient('https://testonly.supabase.co', 'anon-key')
+
+export async function fetchOrders() {
+  return supabase.from('orders').select('*')
+}

--- a/packages/core/test/fixtures/calls/supabase-service/index.ts
+++ b/packages/core/test/fixtures/calls/supabase-service/index.ts
@@ -1,0 +1,21 @@
+import { createClient } from '@supabase/supabase-js'
+import { createServerClient } from '@supabase/ssr'
+
+// Env-driven URL — the common production case. The literal host is unknowable
+// at static time, so the edge lands on the stable supabase:env target.
+const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!)
+
+// Literal URL — the host resolves directly.
+const direct = createClient('https://abcdefgh.supabase.co', 'anon-key')
+
+// @supabase/ssr server client, env-driven.
+const server = createServerClient(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!, {
+  cookies: {},
+})
+
+export async function load() {
+  const { data } = await supabase.from('orders').select('*')
+  const user = await server.auth.getUser()
+  const file = await direct.storage.from('avatars').download('a.png')
+  return { data, user, file }
+}

--- a/packages/core/test/fixtures/calls/supabase-service/package.json
+++ b/packages/core/test/fixtures/calls/supabase-service/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fixture-supabase-service",
+  "version": "1.0.0",
+  "dependencies": {
+    "@supabase/supabase-js": "^2.0.0",
+    "@supabase/ssr": "^0.5.0"
+  }
+}

--- a/packages/types/src/confidence.ts
+++ b/packages/types/src/confidence.ts
@@ -21,8 +21,9 @@ export type ExtractedConfidenceKind =
   | 'structural'
   // 0.85 — framework-aware call-site recognizer matched the SDK shape. Today's
   // covers kafkajs producer.send / consumer.subscribe, AWS SDK Bucket/TableName
-  // near a *Client, grpc-js Client construction with the import context, and
-  // import-aware *Client classification (#238).
+  // near a *Client, grpc-js Client construction with the import context,
+  // import-aware *Client classification (#238), and @supabase/supabase-js /
+  // @supabase/ssr createClient construction with the import in scope (#482).
   | 'verified-call-site'
   // 0.5 — URL-shaped literal with structural support. Today's `redis://host` /
   // `rediss://host` URL captures fit here: the scheme proves it's a redis URL,


### PR DESCRIPTION
Supabase apps reach `*.supabase.co` only through `createClient` (or `@supabase/ssr`'s `createServerClient` / `createBrowserClient`), and the host usually comes from `process.env.SUPABASE_URL` rather than a literal. The HTTP-call extractor never sees it, so production-observed Supabase traffic arrives with no declared twin and surfaces as a false `missing-extracted` divergence on every Supabase codebase — the exact noise the northsea debugging session hit (a real `service → *.supabase.co` call flagged at 0.87 purely because nothing static surfaced it).

This adds `calls/supabase.ts` in the same import-aware shape `aws.ts` and `grpc.ts` already use:

- Fires only when `@supabase/supabase-js` or `@supabase/ssr` is imported in the file — a bare `createClient` with no Supabase import in scope is left alone.
- Reads the constructor's URL argument. A literal `https://abc.supabase.co` resolves to the real host (`infra:supabase:abc.supabase.co`). An env-driven URL we can't resolve statically lands on a stable `infra:supabase:env` target instead of a guessed hostname — we read the SDK call but not a host, so we don't fabricate one.
- Emits a `CALLS` edge with file/line/snippet evidence at the verified-call-site tier (0.85), clearing the precision floor.
- Honors test-scope exclusion: a `createClient` in a `*.spec.ts` mints no outbound edge.

Tests in `calls.test.ts` cover both URL forms and the test-scope case, with a `supabase-service` fixture. They fail on unfixed main (no edge surfaces) and pass after.

Refs #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)