### PR TITLE
Make the docs match the shipped tool surface and current contracts

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,13 +1,15 @@
 # NEAT API reference
 
-Reference for consumers building against NEAT's REST + SSE surface. Primary audience: the v0.3.0 frontend track. Secondary audience: any external client wanting to query the live graph.
+Reference for consumers building against NEAT's REST + SSE surface. Primary audience: the frontend track. Secondary audience: any external client wanting to query the live graph.
+
+This doc reflects the current v0.4.16 surface.
 
 **Status legend.** Each endpoint is marked:
 
-- ✅ **live** — on `main` today, deployed by `0.2.7` published packages
-- 🚧 **planned** — contract locked (ADR-051 / `docs/contracts/frontend-api.md`), implementation in v0.2.8 milestone, shape will not change
+- ✅ **live** — on `main` today, in the published packages
+- 🚧 **deferred** — contract locked (ADR-051 / `docs/contracts/frontend-api.md`), shape is stable, implementation waits for a successor ADR
 
-Build against shape, not implementation. Planned endpoints have locked contracts — their request/response shapes are stable; they just don't exist on `main` yet.
+Build against shape, not implementation. Deferred endpoints have locked contracts — their request/response shapes are stable; they just aren't wired yet.
 
 ---
 
@@ -20,6 +22,12 @@ Build against shape, not implementation. Planned endpoints have locked contracts
 - **Base URL:** `http://localhost:8080`
 
 OTel ingest runs on its own ports (`:4318` HTTP, `:4317` gRPC if `NEAT_OTLP_GRPC=true`) — not part of the consumer-facing API.
+
+## Authentication
+
+Auth is a delegated bearer token (ADR-073). Set `NEAT_AUTH_TOKEN` and the daemon enforces it on every public interface; REST and SSE callers send the token in `Authorization: Bearer <token>`. The daemon refuses to bind on a non-loopback address without one, so a public surface is always token-gated. On loopback, leaving the token unset keeps a dev core reachable header-free.
+
+OTel exporters send the same bearer; rotate the OTLP token independently with `NEAT_OTEL_TOKEN`. When TLS and auth already terminate in an upstream proxy, set `NEAT_AUTH_PROXY=true` so the daemon skips the request-side bearer check while the bind-authority gate still requires `NEAT_AUTH_TOKEN`. See the README's "Run NEAT on a server" section for the full deployment recipe.
 
 ## Multi-project routing
 
@@ -101,7 +109,7 @@ Full snapshot — every node, every edge, with provenance.
 }
 ```
 
-**Note:** can be large on real codebases (hundreds of nodes, thousands of edges). For initial render, fine. For incremental updates, subscribe to `/events` (planned) instead of polling.
+**Note:** can be large on real codebases (hundreds of nodes, thousands of edges). For initial render, fine. For incremental updates, subscribe to `/events` instead of polling.
 
 ### `GET /graph/node/:id` ✅
 
@@ -367,11 +375,11 @@ Dry-run policy evaluation. Returns what *would* fire if a hypothetical action we
 
 ---
 
-## Live updates (planned, v0.2.8)
+## Live updates
 
-### `GET /events` 🚧
+### `GET /events` ✅
 
-Server-Sent Events stream of live graph mutations. Dual-mounted per ADR-026:
+Server-Sent Events stream of live graph mutations, live since v0.2.8 (ADR-051). Dual-mounted per ADR-026:
 
 ```
 GET /events                         ← default project
@@ -382,7 +390,7 @@ GET /projects/:project/events       ← scoped
 
 **Stream format:** one event per SSE message. `event: <type>\ndata: <JSON>\n\n` per the SSE spec.
 
-**Locked event taxonomy (eight types — no quiet additions per ADR-051 #2):**
+The stream carries eight live event types. **Locked taxonomy — no quiet additions per ADR-051 #2:**
 
 | Event type | Payload |
 |---|---|
@@ -478,7 +486,7 @@ curl http://localhost:8080/projects
 curl http://localhost:8080/projects/myrepo/graph
 ```
 
-For the planned SSE endpoint, point a browser EventSource at `http://localhost:8080/events` after the v0.2.8 milestone implementation lands (tracking issue #24, contract: `docs/contracts/frontend-api.md`).
+For the SSE stream, point a browser EventSource at `http://localhost:8080/events` (contract: `docs/contracts/frontend-api.md`).
 
 ---
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -55,9 +55,11 @@ This file is the index. Each rule has a short summary and a link to its full per
 
 ### Future contracts — opened at the start of each milestone
 
-_None queued. v0.2.8 is the last milestone in the v0.2.x sequence. Successor contracts (WebSocket transport, per-event filtering, additional language SDK installers, MVP-success-PR experiment) open as their gating work surfaces._
+The v0.3.x–v0.4.x run opened the contracts above #23: delegated auth and the one-command CLI (#32), `neat sync` (#33), the env dimension and framework installers (#34, #35), the OBSERVED e2e harness (#36), and the instrumentation-registry / `/neat extend` / installer-scope cluster (#37–#42). All have landed.
 
-The full reasoning and per-milestone sequencing live in `docs/plans/2026-05-04-v0.2.x-sequencing.md`. The current state of the active milestone lives in `docs/plans/<latest-date>-v0.2.x-status.md`.
+The next arc is the governance kernel — provenance-routed mutation gating (ADR-093), the FRONTIER staged-proposal provenance (ADR-094), and divergence-as-a-policy-bundle (ADR-095). Those ADRs are accepted and queued for the post-v0.5 governance work; their contracts open as that build ladder starts. Successor frontend contracts (WebSocket transport, per-event filtering) and additional language SDK installers open as their gating work surfaces.
+
+Per-milestone sequencing lives in the dated plan files under `docs/plans/`; the governance build ladder is in `docs/plans/2026-06-09-governance-kernel-build-ladder.md`.
 
 ## Cross-cutting rules (applied everywhere; not yet split out)
 

--- a/docs/contracts/cli-surface.md
+++ b/docs/contracts/cli-surface.md
@@ -1,20 +1,20 @@
 ---
 name: cli-surface
-description: Nine `neat <verb>` commands mirroring the MCP tool allowlist. REST-only data path. Two output modes (human + --json). Exit codes branch on misuse vs server error vs daemon-down.
+description: Ten `neat <verb>` commands mirroring the MCP tool allowlist. REST-only data path. Two output modes (human + --json). Exit codes branch on misuse vs server error vs daemon-down.
 governs:
   - "packages/core/src/cli.ts"
   - "packages/core/src/cli-verbs.ts"
   - "packages/core/src/cli-client.ts"
-adr: [ADR-050, ADR-039, ADR-026]
+adr: [ADR-050, ADR-039, ADR-026, ADR-060]
 ---
 
 # CLI surface contract
 
 The first of two v0.2.8 contracts. Sibling: [`frontend-api.md`](./frontend-api.md).
 
-Closes the terminal-vs-agent gap. Today every reach into the graph goes through MCP. Engineers debugging at a terminal need the same nine tools without a Claude wrapper.
+Closes the terminal-vs-agent gap. Today every reach into the graph goes through MCP. Engineers debugging at a terminal need the same query tools without a Claude wrapper.
 
-## Nine verbs, locked
+## Ten verbs, locked
 
 ```
 neat root-cause <node-id>                            ← get_root_cause
@@ -26,9 +26,10 @@ neat search <query>                                  ← semantic_search
 neat diff [--since <date>]                           ← get_graph_diff
 neat stale-edges                                     ← get_recent_stale_edges
 neat policies [--node <id>] [--hypothetical-action <action>]   ← check_policies
+neat divergences [--min-confidence N]                ← get_divergences
 ```
 
-The verb set is locked the same way the MCP allowlist is locked (ADR-039). Adding a tenth verb requires a successor ADR.
+`divergences` joined the verb set with the divergence query (ADR-060). The verb set is locked the same way the MCP allowlist is locked (ADR-039). Adding an eleventh verb requires a successor ADR.
 
 ## Naming convention
 
@@ -85,10 +86,10 @@ Each verb's `--help` lists args, flags, exit codes, and one example invocation. 
 
 ## Authority
 
-`packages/core/src/cli.ts` extends to dispatch the new verbs. New file `packages/core/src/cli-verbs.ts` for the nine handlers if the surface gets large. REST client at `packages/core/src/cli-client.ts`, shared with `packages/mcp/src/client.ts`.
+`packages/core/src/cli.ts` extends to dispatch the new verbs. New file `packages/core/src/cli-verbs.ts` for the handlers if the surface gets large. REST client at `packages/core/src/cli-client.ts`, shared with `packages/mcp/src/client.ts`.
 
 ## Enforcement
 
-`it.todo` for v0.2.8 #23. Regression tests cover: nine verbs registered, REST-only data path, exit-code branching, `--json` shape matches the three-part schema, `--project` propagation matches ADR-026.
+`it.todo` for v0.2.8 #23. Regression tests cover: every verb registered, REST-only data path, exit-code branching, `--json` shape matches the three-part schema, `--project` propagation matches ADR-026.
 
 Full rationale: [ADR-050](../decisions.md#adr-050--cli-surface-contract).

--- a/docs/contracts/persistence.md
+++ b/docs/contracts/persistence.md
@@ -3,7 +3,7 @@ name: persistence
 description: Snapshot at <projectDir>/neat-out/graph.json. SCHEMA_VERSION bumps on shape change only. Forward-only migrations. Append-only ndjson sidecars (errors, stale-events, policy-violations).
 governs:
   - "packages/core/src/persist.ts"
-adr: [ADR-041, ADR-017, ADR-019, ADR-026, ADR-031]
+adr: [ADR-041, ADR-017, ADR-019, ADR-026, ADR-031, ADR-068, ADR-074]
 ---
 
 # Persistence contract
@@ -18,7 +18,11 @@ Named projects: `~/.neat/projects/<name>/graph.json` per ADR-026.
 
 ## Schema versioning
 
-`SCHEMA_VERSION = 2` today (v1→v2 migration removed `pgDriverVersion` per ADR-019).
+`SCHEMA_VERSION = 4` today. Migration chain:
+
+- **v1 → v2** removed `pgDriverVersion` from ServiceNode (ADR-019); compat traversal reads `dependencies[driver]` instead.
+- **v2 → v3** narrowed the provenance enum to four settled values (ADR-068); any edge still carrying the pre-v0.3.5 `FRONTIER` provenance literal is rewritten to OBSERVED on load and re-keyed to the OBSERVED edge-id wire format.
+- **v3 → v4** added the ServiceNode env discriminator (ADR-074); the v4 wire format is a superset of v3, so the env-less `service:<name>` form reads as `env='unknown'` and the migration is a version-only bump.
 
 **Schema growth (ADR-031) does not bump the version.** Adding optional fields → snapshot regenerates, version stays. Only **shape changes** bump the version. Each shape change adds a `migrate_vN_to_vN+1` function and bumps the constant.
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -22,21 +22,6 @@ NEAT_SCAN_PATH=./demo \
 
 Defaults: `PORT=8080`, `HOST=0.0.0.0`, snapshot path `./neat-out/graph.json`. Override any of those with env vars.
 
-## Verify M1 (once #4, #5, #6, #9 land)
-
-```bash
-# in one terminal
-NEAT_SCAN_PATH=./demo npm run dev --workspace @neat.is/core
-
-# in another
-curl -s localhost:8080/health | jq
-curl -s localhost:8080/graph  | jq '.nodes[] | select(.id | contains("service-b"))'
-# → should have dependencies.pg: "7.4.0"
-
-curl -s localhost:8080/graph | jq '.nodes[] | select(.type == "DatabaseNode")'
-# → payments-db with engineVersion: "15", compatibleDrivers including pg ≥ 8.0.0
-```
-
 ## Add a compat rule
 
 `packages/core/compat.json` is the data. Edit it, restart core, re-scan:
@@ -75,7 +60,7 @@ npm run build --workspace @neat.is/mcp
   | node packages/mcp/dist/index.cjs
 ```
 
-You should see two JSON-RPC responses: `serverInfo` from `initialize`, then a tool list with all six tools.
+You should see two JSON-RPC responses: `serverInfo` from `initialize`, then a tool list with all sixteen tools (ten read + six `/neat extend`).
 
 ## Enable OTLP/gRPC ingest
 

--- a/packages/claude-skill/SKILL.md
+++ b/packages/claude-skill/SKILL.md
@@ -4,21 +4,35 @@ This skill exposes NEAT's live semantic graph to Claude Code over MCP. Once inst
 
 ## What you get
 
-Nine MCP tools, served by `@neat.is/mcp` over stdio:
+Sixteen MCP tools, served by `@neat.is/mcp` over stdio — ten read-only graph queries plus six `/neat extend` tools for instrumentation. The canonical list lives in `MCP_TOOL_NAMES` (`@neat.is/types`); the server registrations are the source for every description below.
+
+### Read tools
 
 | Tool | What it does |
 |------|--------------|
-| `get_graph` | Snapshot of the full graph for a project — every node, every edge, with provenance. |
-| `get_node` | One node by id, with its incoming and outgoing edges. |
-| `get_dependencies` | Transitive closure of `DEPENDS_ON` / `CONNECTS_TO` from a starting node. |
-| `get_root_cause` | Walks incoming edges from a failing node and returns the first divergence — typically a version mismatch or a config gap. |
-| `get_blast_radius` | BFS outbound from a starting node — every service / database / config that would feel a change here. |
-| `get_recent_errors` | Last N error events, ordered by `lastObserved`. |
-| `semantic_search` | Embedding-based search over node names + descriptions. |
-| `check_policies` | Runs the project's `policy.json` rules against the live graph. Returns active violations. |
-| `get_compatibility` | Compatibility matrix lookups — what's known about a `<driver, engine>` pair. |
+| `get_root_cause` | Trace a failing node up its dependency graph to the underlying cause. Use when something is breaking and you want the upstream culprit. |
+| `get_blast_radius` | List every node downstream of a node — what would break if it failed or was redeployed. |
+| `get_dependencies` | Transitive outgoing dependencies, BFS to depth N, each carrying distance, edge type, and provenance (EXTRACTED vs OBSERVED). |
+| `get_observed_dependencies` | Only the runtime (OBSERVED via OTel) outgoing dependencies — compare what code declares against what production does. |
+| `get_incident_history` | Recent OTel error events recorded against a node, most recent first. |
+| `get_divergences` | Places where the code (EXTRACTED) and production (OBSERVED) disagree, ranked by confidence × severity. The most NEAT-shaped query — reach for it on "is anything weird?" |
+| `get_graph_diff` | Diff a saved graph snapshot against the current live graph — added/removed/changed nodes and edges. |
+| `get_recent_stale_edges` | Most recent OBSERVED → STALE transitions — integrations that have gone quiet. |
+| `check_policies` | Inspect or dry-run the project's `policy.json`. Returns current violations, or violations a hypothetical action would cause. |
+| `semantic_search` | Search nodes by natural-language query (embedding vectors when available, substring fallback otherwise). |
 
-All nine read from the live graph the daemon maintains in memory. No fs reads of `graph.json` at request time.
+### Extend tools (`/neat extend`, ADR-081 / ADR-086)
+
+| Tool | What it does |
+|------|--------------|
+| `neat_list_uninstrumented` | List libraries that need instrumentation beyond the auto-instrumentations bundle. |
+| `neat_lookup_instrumentation` | Look up the registry entry for a library — canonical instrumentation package, version, registration snippet. |
+| `neat_describe_project_instrumentation` | Describe the current OTel state: which hook files exist, whether `.env.neat` is present, which OTel deps are installed. |
+| `neat_dry_run_extension` | Preview what an apply would do — the exact file diff, deps to add, install command — without changing anything. |
+| `neat_apply_extension` | Install an instrumentation package and splice its registration into the OTel hook file. Idempotent. |
+| `neat_rollback_extension` | Undo the last apply for a library — removes the dep and registration. |
+
+The ten read tools read from the live graph the daemon maintains in memory. No fs reads of `graph.json` at request time. The extend tools modify instrumentation files, `package.json`, and the lockfile only; NEAT never calls an LLM and the agent reasons over their output (ADR-084).
 
 ## Install
 
@@ -54,7 +68,7 @@ This merges the `neat` server into `~/.claude.json` without touching other entri
 
 - Auto-detection of an alternate Claude Code config path. The installer assumes `~/.claude.json`.
 - Per-project skill overrides. The skill is user-scoped; project-level MCP config can be added later as a follow-up.
-- Tool-level disable flags. All nine tools are wired in; if you want to hide one, edit the snippet by hand.
+- Tool-level disable flags. All sixteen tools are wired in; if you want to hide one, edit the snippet by hand.
 
 ## Where to look when it doesn't work
 

--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -1,6 +1,6 @@
 # @neat.is/mcp
 
-The NEAT MCP server. Stdio JSON-RPC, eight tools and two resources, talks to a running `@neat.is/core` instance over HTTP.
+The NEAT MCP server. Stdio JSON-RPC, sixteen tools and two resources, talks to a running `@neat.is/core` instance over HTTP. The tool surface is single-sourced from `MCP_TOOL_NAMES` in `@neat.is/types` (ADR-091) — ten read-only graph queries plus six `/neat extend` tools.
 
 ## When to use these tools
 
@@ -10,6 +10,7 @@ Rule of thumb: if the question would take more than two file reads to answer fro
 
 | Question shape                                       | Tool                       |
 |------------------------------------------------------|----------------------------|
+| "Is anything weird?" / "find me a bug"               | `get_divergences`          |
 | "Why is X failing?" / "What's the root cause of …"   | `get_root_cause`           |
 | "What breaks if I redeploy X?" / blast assessment    | `get_blast_radius`         |
 | "What does X depend on?" / dependency tree           | `get_dependencies`         |
@@ -18,8 +19,22 @@ Rule of thumb: if the question would take more than two file reads to answer fro
 | "Find nodes matching …"                              | `semantic_search`          |
 | "What changed since the last snapshot?"              | `get_graph_diff`           |
 | "Which integrations have gone quiet?"                | `get_recent_stale_edges`   |
+| "Any policy violations right now?"                   | `check_policies`           |
 
 If a tool returns "not found" or empty, check that core is running (`curl $NEAT_CORE_URL/health`) before falling back to source reads.
+
+## Extend tools
+
+Six `/neat extend` tools sit alongside the read tools for filling instrumentation gaps (ADR-081 / ADR-086). Three diagnose, three operate; NEAT never calls an LLM and never auto-applies — the agent reasons over their output.
+
+| Tool                                    | What it does                                                              |
+|-----------------------------------------|---------------------------------------------------------------------------|
+| `neat_list_uninstrumented`              | Libraries needing instrumentation beyond the auto-instrumentations bundle |
+| `neat_lookup_instrumentation`           | Registry entry for a library — package, version, registration snippet     |
+| `neat_describe_project_instrumentation` | Current OTel state: hook files, `.env.neat`, installed OTel deps           |
+| `neat_dry_run_extension`                | Preview an apply — file diff, deps, install command — no changes           |
+| `neat_apply_extension`                  | Install an instrumentation package and splice in its registration (idempotent) |
+| `neat_rollback_extension`               | Undo the last apply for a library                                         |
 
 ## Resources
 

--- a/packages/mcp/skill.md
+++ b/packages/mcp/skill.md
@@ -5,7 +5,7 @@ description: Query a live semantic graph of a running software system — depend
 
 # NEAT skill
 
-NEAT keeps a continuously updated graph of a software system from static analysis + OpenTelemetry. This skill exposes it over six MCP tools.
+NEAT keeps a continuously updated graph of a software system from static analysis + OpenTelemetry. This skill exposes it over sixteen MCP tools: ten read-only graph queries plus six `/neat extend` tools for instrumentation. The canonical list is `MCP_TOOL_NAMES` in `@neat.is/types`.
 
 ## When to invoke
 
@@ -13,14 +13,18 @@ Reach for these tools when a question would take multiple file reads to answer f
 
 | Prompt                                                  | Tool                       |
 |---------------------------------------------------------|----------------------------|
+| "Is anything weird?" / "find me a bug"                  | `get_divergences`          |
 | "Why is payments-db failing?"                           | `get_root_cause`           |
 | "What breaks if I redeploy service-a?"                  | `get_blast_radius`         |
 | "What does service-a depend on?"                        | `get_dependencies`         |
 | "What does service-b actually call at runtime?"         | `get_observed_dependencies`|
 | "Show me recent errors on database:payments-db"         | `get_incident_history`     |
+| "What changed since the last snapshot?"                 | `get_graph_diff`           |
+| "Which integrations have gone quiet?"                   | `get_recent_stale_edges`   |
+| "Any policy violations right now?"                      | `check_policies`           |
 | "Find nodes matching pg"                                | `semantic_search`          |
 
-## Tool reference
+## Read tools
 
 ### `get_root_cause`
 
@@ -36,9 +40,9 @@ Inputs: `nodeId`, optional `depth` (default 10, max 20).
 
 ### `get_dependencies`
 
-Outgoing dependency tree, deduped to the most trustworthy provenance per (target, edge type) pair.
+Outgoing dependency tree, deduped to the most trustworthy provenance per (target, edge type) pair. BFS to depth N (default 3, max 10); `depth=1` returns direct dependencies only.
 
-Inputs: `nodeId`.
+Inputs: `nodeId`, optional `depth`.
 
 ### `get_observed_dependencies`
 
@@ -52,11 +56,75 @@ Recent OTel error events recorded against a node, newest first.
 
 Inputs: `nodeId`, optional `limit` (default 20, max 100).
 
+### `get_divergences`
+
+Places where what the code declares (EXTRACTED) doesn't match what production observed (OBSERVED), ranked by confidence × severity. The single most NEAT-shaped query — reach for it on "is anything weird?" or "find me a bug" on an unfamiliar codebase, before `get_root_cause` when no specific node is failing.
+
+Inputs: all optional — `type` (one or more of `missing-observed`, `missing-extracted`, `version-mismatch`, `host-mismatch`, `compat-violation`), `minConfidence` (0.0–1.0), `node` (scope to one node id).
+
+### `get_graph_diff`
+
+Diff a saved graph snapshot against the current live graph — added/removed/changed nodes and edges, with both snapshot timestamps. For change reviews and post-incidents.
+
+Inputs: `againstSnapshot` (path or http(s) URL of the "before" snapshot).
+
+### `get_recent_stale_edges`
+
+Most recent OBSERVED → STALE edge transitions — integrations that have gone quiet. A `CALLS` edge that just went stale usually means an upstream stopped calling.
+
+Inputs: optional `limit` (default 50, max 200), optional `edgeType` filter (e.g. `CALLS`).
+
+### `check_policies`
+
+Inspect or dry-run the project's `policy.json` — architectural assertions in five shapes (structural / compatibility / provenance / ownership / blast-radius). Without `hypotheticalAction` it returns currently-recorded violations; with one, the violations the action would cause.
+
+Inputs: optional `scope`, optional `hypotheticalAction`.
+
 ### `semantic_search`
 
-Free-text match across node ids and names. Keyword-only for the MVP; vector search is a post-MVP enhancement.
+Search nodes by natural-language query. Uses embedding vectors when an embedder is available (Ollama `nomic-embed-text` → in-process MiniLM → substring fallback) — phrase the query the way you'd describe what you want.
 
 Inputs: `query`.
+
+## Extend tools (`/neat extend`)
+
+Six surgical tools for filling instrumentation gaps (ADR-081 / ADR-086). Three are read-only diagnostics; three modify instrumentation files, `package.json`, and the lockfile only. NEAT never calls an LLM — the agent reasons over their output and NEAT never auto-applies.
+
+### `neat_list_uninstrumented`
+
+List first-party, third-party, and gap libraries that need an explicit instrumentation package beyond the auto-instrumentations bundle.
+
+Inputs: none (optional `project`).
+
+### `neat_lookup_instrumentation`
+
+Look up the registry entry for a library — canonical instrumentation package, version, and registration snippet if one exists.
+
+Inputs: `library` (npm package name), optional `installedVersion`.
+
+### `neat_describe_project_instrumentation`
+
+Describe the project's current OTel state: which hook files exist, whether `.env.neat` is present, which OTel deps are installed.
+
+Inputs: none (optional `project`).
+
+### `neat_dry_run_extension`
+
+Preview what `neat_apply_extension` would do — the exact file diff, deps to add, install command — without making any changes.
+
+Inputs: `library`, `instrumentation_package`, `version`, `registration_snippet`.
+
+### `neat_apply_extension`
+
+Install an instrumentation package and splice its registration into the existing OTel hook file. Idempotent — calling twice with the same args is a no-op.
+
+Inputs: `library`, `instrumentation_package`, `version`, `registration_snippet`.
+
+### `neat_rollback_extension`
+
+Undo the last `neat_apply_extension` for a library — removes the dep from `package.json` and the registration from the hook file. Run the package manager manually afterward to sync the lockfile.
+
+Inputs: `library`.
 
 ## Provenance and confidence
 
@@ -73,4 +141,4 @@ npm install -g @neat.is/mcp
 neat install
 ```
 
-This registers the server with Claude Code and the six tools become available in any session.
+This registers the server with Claude Code and all sixteen tools become available in any session.


### PR DESCRIPTION
A pass over the integrator- and agent-facing docs to fix things that simply disagree with the shipped code (the Tier 1 set from `docs/plans/2026-06-09-docs-audit-and-change-plan.md`). Each fix is grounded in the source, not assumptions.

**The phantom tool surface.** The published Claude Code skill (`packages/claude-skill/SKILL.md`) named four tools that don't exist (`get_compatibility`, `get_graph`, `get_node`, `get_recent_errors`) and omitted eleven real ones. It now lists the real sixteen — the ten read-only graph queries plus the six `/neat extend` tools — sourced from `MCP_TOOL_NAMES` and the server registrations in `packages/mcp/src/index.ts`. The two MCP-package docs got the same treatment: `packages/mcp/skill.md` (was "six tools") and `packages/mcp/CLAUDE.md` (was "eight tools") both now cover the full sixteen.

**Reference docs vs reality:**
- `docs/api-reference.md` — auth is now described as the delegated `NEAT_AUTH_TOKEN` bearer model (ADR-073), and the `/events` SSE stream is documented as live with its eight event types (ADR-051) rather than planned. Carries a one-line note that it reflects the v0.4.16 surface.
- `docs/contracts/persistence.md` — `SCHEMA_VERSION = 4`, with the v2→v3 (four-value provenance, ADR-068) and v3→v4 (ServiceNode env discriminator, ADR-074) migrations spelled out from the `persist.ts` comments.
- `docs/contracts/cli-surface.md` — ten verbs, including `divergences` (ADR-060), cross-checked against `cli.ts`.
- `docs/contracts.md` — the milestone tail reflects the v0.3.x–v0.4.x contracts landing and points at the queued post-v0.5 governance ADRs (093/094/095).
- `docs/runbook.md` — drops the long-closed "Verify M1" scaffold; the rest is current.

Out of scope and untouched: the README, `docs/guide/*`, and the Tier 3 forward-planning contracts.

`npx turbo build test lint` green; the core contract audit passes uncached (602 tests).

Refs the docs audit plan (`docs/plans/2026-06-09-docs-audit-and-change-plan.md`).