### PR TITLE
Lead user-facing copy with the graph engine; surface policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ Run it from inside your project (or `npx neat.is <path>`). It discovers your ser
 
 ## A more in-depth explanation:
 
-NEAT keeps a working architecture model of your system up to date from two streams at once:
+At the center of NEAT is **one live graph** of your system, fused from two streams into a single model you can query many ways:
 
 - **Static analysis** — tree-sitter over your source (JavaScript, TypeScript, Python), `package.json`, and yaml / env config. Every source file becomes a node; imports between them become edges; the calls each file makes to databases, queues, and external hosts are extracted from the code.
 - **Runtime telemetry** — OpenTelemetry spans, attributed back to the exact file and line that made the call. NEAT wires the instrumentation for you, so the runtime edge lands on the same file node the static edge does.
 
-**The file is the primary unit.** A relationship in the graph runs from a file — `src/services/billing.ts ──CALLS──▶ api.stripe.com` — not from a vague service blob. That's what makes a divergence precise: declared call site versus observed call site, for the same pair, at the same grain.
+Both streams land on the same nodes, so the graph holds what your code *declares* and what your system *does* side by side. From there, the useful questions fall out of one model: what would break if this node dies (blast radius), what broke first (root cause), which architectural rules a change would violate (policies), and where declared intent and observed reality part ways (divergence). Same graph, different traversals.
+
+**The file is the primary unit.** A relationship in the graph runs from a file — `src/services/billing.ts ──CALLS──▶ api.stripe.com` — not from a vague service blob. Anchoring relationships to files and lines is what keeps every one of those answers sharp: a finding names *this file*, calling *this target*, rather than a service-shaped shrug.
 
 Every edge carries a `provenance` tag so a consumer knows exactly how much weight a claim deserves:
 
@@ -61,9 +63,9 @@ neat search <query>      semantic match on node names and ids
 
 Every query verb honors `--json` and `--project <name>`. Exit codes branch on success (0), server error (1), misuse (2), and daemon unreachable (3).
 
-## What a divergence looks like
+## One example: what a divergence looks like
 
-Once your app has run, `neat divergences` reports where declared intent and observed behavior part ways:
+A divergence is one of the questions the graph answers, and the one that's hardest to get any other way — it needs both streams at once. Once your app has run, `neat divergences` reports where declared intent and observed behavior part ways:
 
 ```
 [missing-extracted] src/services/prices.ts ──CALLS──▶ folio-api.example.com   confidence 0.87
@@ -76,6 +78,17 @@ Once your app has run, `neat divergences` reports where declared intent and obse
 ```
 
 Two findings, two different bugs. The first is a call your code makes without saying so — worth knowing before it surprises you. The second is a dependency your code carries but never uses — dead weight, or a path you thought was live and isn't. Both come from comparing the same file against itself: what it says, versus what it did.
+
+## Policies: rules over the graph
+
+Divergence reports what *is*. Policies let you assert what *should be*. A `policy.json` in your project declares architectural rules as assertions over the same graph — for example, "only `service:billing` and `service:orders` may connect to `postgres:primary`," or "no file may call `legacy-api.internal`." Because the rules run against the live graph, they evaluate against both what your code declares and what production actually does.
+
+NEAT evaluates every policy continuously as the graph changes. When an edge violates a rule, the violation is surfaced — not buried in a one-off lint run. Two surfaces expose it:
+
+- **`neat policies`** lists what's currently violating, scoped to a node with `--node`, or dry-run a change with `--hypothetical-action`.
+- **`check_policies`** hands the same answer to an AI agent over MCP, so an agent writing a new feature can see which rules it would cross and the assertions it's working within — the rules previous features, other agents, or your engineers already set.
+
+A `block` action gates promotion of a `FrontierNode` (an external host the graph has newly seen) so unsanctioned external dependencies don't quietly settle into the model. The throughline: the graph already knows your architecture, so the rules you care about become assertions over it that stay true as the system moves.
 
 ## Run NEAT on a server
 

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -1,6 +1,6 @@
 # Core concepts
 
-Four ideas carry the whole model: the **graph**, **provenance**, **divergence**, and the **file as the unit**. Understand these and everything else in NEAT follows.
+A few ideas carry the whole model: the **graph**, **provenance**, **divergence**, **policies**, and the **file as the unit**. The graph is the engine — one model fused from static code and runtime telemetry; divergence and policies are two of the things you ask it. Understand these and everything else in NEAT follows.
 
 ## The graph
 
@@ -41,9 +41,9 @@ Every edge carries a `provenance` tag — a label for *where the claim came from
 
 Provenance is what makes NEAT honest. When it tells you `src/worker.ts` talks to Redis, it also tells you whether it knows that because your code says so, because it watched it happen, or because it inferred it. A consumer — you, or an AI agent — weights the claim accordingly. The full ranking and how confidence travels along a path is in [PROVENANCE.md](../../PROVENANCE.md).
 
-## Divergence: the load-bearing idea
+## Divergence: comparing the two halves
 
-Static analysis alone tells you what your code *says*. Runtime telemetry alone tells you what your system *did*. NEAT holds both in one graph, and the interesting part is where they don't match. That mismatch is a **divergence**, and it's the finding NEAT exists to surface.
+Static analysis alone tells you what your code *says*. Runtime telemetry alone tells you what your system *did*. NEAT holds both in one graph, and one of the most useful things to ask is where they don't match. That mismatch is a **divergence** — the question that needs both halves of the graph at once, which is why it's the natural place to start on an unfamiliar system.
 
 Two shapes matter most:
 
@@ -53,6 +53,17 @@ Two shapes matter most:
 The other types (`stale`, `confidence-mismatch`, and grain differences) refine the same idea: compare what's declared against what's observed, and report where they part.
 
 Because relationships originate from files, a divergence is sharp: it names *this file*, declaring or observing *this call*, to *this target*. That's the difference between "checkout seems flaky" and "`src/checkout/tax.ts` calls a tax API your code never declares, and it's the slowest edge in the path."
+
+## Policies: rules over the graph
+
+Divergence reports what the graph *is*. **Policies** let you say what it *should be*. A `policy.json` in your project declares architectural rules as assertions over the same graph — for example, "only `service:billing` and `service:orders` may connect to `postgres:primary`," or "no file may call `legacy-api.internal`." This is the governance layer: your code carries its declared intent in its imports and call sites, and a policy carries the intent you want held across the whole system, expressed once and checked against the live model.
+
+Because the rules run against the graph, they evaluate against both sides of it — what your code declares and what production actually did. NEAT evaluates them continuously as the graph changes, so a violation surfaces when it appears rather than waiting for a one-off lint pass. Two surfaces expose the current state:
+
+- **`neat policies`** lists what's violating, optionally scoped to a node, or dry-runs a hypothetical change before you make it.
+- **`check_policies`** hands the same answer to an AI agent over MCP, so an agent writing a feature can read the rules it's working within instead of guessing them.
+
+One action goes beyond reporting today: a `block`-action policy gates promotion of a `FrontierNode` — an external host the graph has newly observed — so an unsanctioned external dependency doesn't quietly settle into the model. The shape of the idea is the same throughout: the graph already knows your architecture, so the rules you care about become assertions over it that stay true as the system moves.
 
 ## The file as the unit
 
@@ -70,7 +81,7 @@ NEAT runs as a daemon (`neatd`) that holds the graph for one or more projects an
 - a **dashboard** on `:6328` that draws the live graph,
 - an **OTLP receiver** on `:4318` that ingests your app's spans.
 
-It also speaks **MCP**, so an AI agent can query the graph as a set of tools — see [Using NEAT with an AI agent](./ai-agents.md). The static graph updates as your files change; the observed graph updates as your spans arrive; divergences are computed on demand by comparing the two.
+It also speaks **MCP**, so an AI agent can query the graph as a set of tools — see [Using NEAT with an AI agent](./ai-agents.md). The static graph updates as your files change; the observed graph updates as your spans arrive; divergences are computed on demand by comparing the two; and policies are evaluated continuously against the live model.
 
 ## Next
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started
 
-This walks you from nothing to your first divergence — the moment NEAT shows you a place where your code and your running system disagree. It takes about five minutes plus however long it takes to exercise your app.
+This walks you from nothing to a live, queryable graph of your system — and then shows you the range of what you can ask it. It takes about five minutes plus however long it takes to exercise your app.
 
 ## What you need
 
@@ -60,15 +60,18 @@ Within a few seconds, watch the dashboard. New edges appear, tagged `OBSERVED` �
 
 > **One setup note.** The OpenTelemetry SDK's default wire protocol is `http/protobuf`, and NEAT's generated instrumentation pins `http/json` for you so spans land correctly out of the box. If you supply your own OTel config, set `OTEL_EXPORTER_OTLP_PROTOCOL=http/json` so NEAT sees your traffic.
 
-## 3. Find your first divergence
+## 3. Ask the graph
 
-Now the point of all this. Once your app has run, ask NEAT where your code and your traffic disagree:
+Now you have what NEAT is really about: one graph holding what your code *declares* and what your system *does*, side by side. The dashboard is the easiest way in — it's already open from step 1, and it shows the live graph with both kinds of edges drawn on it. From here the graph answers a range of questions:
 
-```bash
-npx neat.is divergences
-```
+- **Divergence** — where do declared intent and observed reality part ways? The question that needs both streams at once, so it's the natural one to start with.
+- **Root cause** — a node is failing; walk inbound edges to the upstream component that broke first.
+- **Blast radius** — what breaks downstream if this node dies or gets redeployed?
+- **Policies** — which architectural rules would a change violate? (See [policies](#where-to-go-next) below.)
 
-A divergence is a place where the static graph (what your code declares) and the observed graph (what production did) don't line up. Two common shapes:
+### Your first divergence
+
+A divergence is a place where the static graph (what your code declares) and the observed graph (what production did) don't line up. The dashboard surfaces them on the graph itself — look for the flagged edges once your app has run. Two common shapes:
 
 ```
 [missing-extracted] src/services/prices.ts ──CALLS──▶ folio-api.example.com   confidence 0.87
@@ -82,10 +85,19 @@ The first is a call your code makes without visibly naming it — often dynamic 
 
 Both findings come from comparing the *same file* against itself: what it says it does, versus what it did. That file-level precision is what makes a divergence a lead worth chasing instead of a vague "something's off with this service."
 
+You can also ask from the command line. The query verbs target a registered project by name — the project NEAT just created is registered under your directory's name, so pass it explicitly:
+
+```bash
+npx neat.is divergences --project <your-project-name>
+```
+
+`npx neat.is list` shows the registered project names. The verbs also honor `--json` for piping into other tools. See [Querying the graph](./querying.md) for the full set.
+
 ## Where to go next
 
-- **[Core concepts](./concepts.md)** — the graph model, provenance, and how to read a divergence with confidence.
-- **[Querying the graph](./querying.md)** — `root-cause`, `blast-radius`, `dependencies`, and the rest of the CLI.
+- **[Core concepts](./concepts.md)** — the graph model, provenance, divergence, and policies.
+- **[Querying the graph](./querying.md)** — `root-cause`, `blast-radius`, `dependencies`, `policies`, and the rest of the CLI.
+- **[Policies](./concepts.md#policies-rules-over-the-graph)** — declare architectural rules as assertions over the graph and have NEAT surface what violates them as the system moves.
 - **[Using NEAT with an AI agent](./ai-agents.md)** — wire the graph into Claude Code (or any MCP client) and ask questions in plain language.
 - **[Troubleshooting](./troubleshooting.md)** — no OBSERVED edges? Daemon won't start? Start here.
 

--- a/docs/guide/querying.md
+++ b/docs/guide/querying.md
@@ -25,7 +25,7 @@ Grab the id from either, then feed it to the verb you want.
 
 ### `divergences` — where code and production disagree
 
-The one that justifies the whole graph. It compares what your code declares (`EXTRACTED`) against what production did (`OBSERVED`) and reports where they part ways.
+The query that needs both halves of the graph at once. It compares what your code declares (`EXTRACTED`) against what production did (`OBSERVED`) and reports where they part ways — the natural first question on an unfamiliar system.
 
 ```bash
 npx neat.is divergences --min-confidence 0.7


### PR DESCRIPTION
A positioning re-take of the user-facing copy. The copy was already accurate — this is a framing pass so the graph itself reads as the engine, policies get the body coverage the hook already promises, and divergence sits as one example among several rather than the spine.

The maintainer's README hook (lines 1–17: the AI-grounding lead, the three bullets, the TL;DR) is untouched.

## What changed, per file

**`README.md` (body only)**
- The "more in-depth" intro now leads with the graph as one fused model you query many ways — blast radius, root cause, policies, divergence as different traversals of the same graph.
- New **Policies** section: declare assertions over the graph in `policy.json`, NEAT evaluates them continuously as the graph moves, violations surface via `neat policies` and the `check_policies` MCP tool, and a `block` action gates `FrontierNode` promotion. Scoped to shipped capability only — no enforcement/kernel claims.
- The divergence section is retitled "One example: what a divergence looks like" and framed as the query that needs both halves of the graph at once.
- Provenance table, MCP-tools line, server/proxy/Claude-Code sections left as-is.

**`docs/guide/getting-started.md`**
- Arc reframed from "zero → your first divergence" to "zero → a queryable graph; here's the range of what you ask it," with divergence first among root-cause / blast-radius / policies.
- The "see your divergences" moment now leans on the dashboard (already open, resolves the registered project). The CLI form is shown as `npx neat.is divergences --project <name>` with a pointer to `neat list` — see the finding below.
- Policies added to "Where to go next."

**`docs/guide/concepts.md`**
- New **Policies** concept (the governance layer: code's declared intent vs the rules you assert over the whole system), at shipped altitude.
- Divergence reframed as one of several questions; intro and "how it runs" updated to match.

**`docs/guide/querying.md`**
- Light alignment: the `divergences` verb blurb reframed from "the one that justifies the whole graph" to "the query that needs both halves at once."

## Empirical finding: the bare `npx neat.is divergences` routing papercut

Tested in full isolation (a copy of the demo fixture in /tmp, isolated `NEAT_HOME`, alt ports — the real demo and the live daemon were never touched):

- **Bare `neat divergences`** → `{"error":"project not found","project":"default"}`. The bare query verb resolves to project `default` (`cli.ts:716`), but `init`/the orchestrator registers the project under the cwd basename (`orchestrator.ts:658`) and leaves the in-memory slot on `DEFAULT_PROJECT` (`orchestrator.ts:124`). No `default` project exists, so it 404s.
- **`neat divergences --project <basename>`** → resolves correctly, returned the 8 divergences.

So the old getting-started command (`npx neat.is divergences` with no project) would have 404'd against a freshly-created project. The doc now steers the first-divergence moment to the dashboard and shows the CLI form with the explicit `--project` flag. The papercut itself is a code fix tracked separately; this PR only stops the docs from depending on the broken path.

## Verification

`npx turbo build test lint` green across the workspace; core's contract audits run uncached (599 contract tests pass) since the README is in the governed set.

Left open for maintainer review — positioning and the README are the maintainer's surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)