### PR TITLE
Resolve the bare verb's project from the registry

### DIFF
--- a/docs/contracts/cli-surface.md
+++ b/docs/contracts/cli-surface.md
@@ -40,7 +40,9 @@ neat divergences [--min-confidence N]                ← get_divergences
 
 ## REST-only data path
 
-Every verb hits `NEAT_API_URL` (default `http://localhost:8080`) via a shared client. **No `graph.json` reads at request time.** Same multi-project routing as MCP — `--project <name>` flag → `NEAT_PROJECT` env → `'default'` (ADR-026).
+Every verb hits `NEAT_API_URL` (default `http://localhost:8080`) via a shared client. **No `graph.json` reads at request time.** Multi-project routing follows `--project <name>` flag → `NEAT_PROJECT` env → registry resolution (ADR-026).
+
+When neither the flag nor the env is set, the bare verb resolves its target from the daemon's registered projects (`GET /projects`) rather than blindly routing to `'default'` (issue #500 — `npx neat.is` registers under the cwd basename, so no `'default'` slot exists after a one-command run): exactly one registered project is used; a project literally named `'default'` keeps the legacy unprefixed routes; several registered with no `'default'` errors and lists them (exit 2, never a silent pick); none registered errors clearly. A daemon that can't be reached still exits 3 with the "is the daemon running?" message.
 
 The CLI client and the MCP client share the same REST helper module. One endpoint surface, two consumers.
 

--- a/packages/core/src/cli-client.ts
+++ b/packages/core/src/cli-client.ts
@@ -69,7 +69,7 @@ export function resolveAuthToken(env: NodeJS.ProcessEnv = process.env): string |
 
 export function createHttpClient(baseUrl: string, bearerToken?: string): HttpClient {
   const root = baseUrl.replace(/\/$/, '')
-  const authHeader = bearerToken && bearerToken.length > 0
+  const authHeader: Record<string, string> = bearerToken && bearerToken.length > 0
     ? { authorization: `Bearer ${bearerToken}` }
     : {}
   return {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -44,6 +44,7 @@ import {
   formatHuman,
   formatJson,
   HttpError,
+  type HttpClient,
   resolveAuthToken,
   runBlastRadius,
   runDependencies,
@@ -1012,12 +1013,85 @@ export const QUERY_VERBS: Set<string> = new Set([
 
 // ADR-050 #2: --project flag → NEAT_PROJECT env → undefined (server's
 // `default` slot). undefined keeps legacy unprefixed routes; explicit names
-// route through /projects/:project/...
+// route through /projects/:project/... Returns undefined when neither was set,
+// which is the signal to resolveProjectForVerb that it should look at the
+// registered projects and pick intelligently.
 function resolveProjectFlag(parsed: ParsedArgs): string | undefined {
   if (parsed.project) return parsed.project
   const env = process.env.NEAT_PROJECT
   if (env && env.length > 0 && env !== DEFAULT_PROJECT) return env
   return undefined
+}
+
+// Thrown when a bare query verb (no --project, no NEAT_PROJECT) can't pick a
+// project on its own — either nothing is registered, or several are and none
+// is named `default`. Carries an exit code so the dispatcher can surface a
+// helpful message instead of letting the request 404 on the `default` slot.
+export class ProjectResolutionError extends Error {
+  constructor(
+    message: string,
+    public readonly exitCode: number = 2,
+  ) {
+    super(message)
+    this.name = 'ProjectResolutionError'
+  }
+}
+
+// What `GET /projects` hands back (registry.ts RegistryEntry passthrough). We
+// only read `name`, so keep the shape minimal.
+interface RegistryProjectSummary {
+  name: string
+}
+
+// Decide which project a bare query verb should route to (issue #500). When the
+// user passed --project or set NEAT_PROJECT, that wins untouched. Otherwise we
+// ask the daemon which projects it has registered and pick:
+//
+//   • exactly one registered → use it (the one-command `npx neat.is` case, so
+//     `neat divergences` "just works" without --project)
+//   • a project literally named `default` exists → keep the legacy default
+//     routing (return undefined → unprefixed routes the server maps to default)
+//   • several registered, none `default` → don't guess; error and list them
+//   • none registered → error clearly rather than 404 on `default`
+//
+// A daemon that can't be reached lets the TransportError propagate, so the verb
+// still exits 3 with the existing "is the daemon running?" message.
+export async function resolveProjectForVerb(
+  client: HttpClient,
+  parsed: ParsedArgs,
+): Promise<string | undefined> {
+  const explicit = resolveProjectFlag(parsed)
+  if (explicit) return explicit
+
+  // Bare verb. Let TransportError out (exit 3); only HttpError/parse issues
+  // become a resolution error here.
+  const projects = await client.get<RegistryProjectSummary[]>('/projects')
+
+  if (projects.some((p) => p.name === DEFAULT_PROJECT)) {
+    // Back-compat: a real `default` project exists, so the legacy unprefixed
+    // routes resolve. Returning undefined keeps that path.
+    return undefined
+  }
+
+  if (projects.length === 1) {
+    return projects[0]!.name
+  }
+
+  if (projects.length === 0) {
+    throw new ProjectResolutionError(
+      'No projects are registered with the daemon yet. Run `npx neat.is` in a repo to build a graph first, then re-run this command.',
+    )
+  }
+
+  const names = projects
+    .map((p) => p.name)
+    .sort()
+    .map((n) => `  ${n}`)
+    .join('\n')
+  throw new ProjectResolutionError(
+    `Several projects are registered and none is named "default", so I can't pick one for you.\n` +
+      `Pass --project <name> to choose:\n${names}`,
+  )
 }
 
 // The daemon URL the CLI verbs talk to. `NEAT_API_URL` is the name the verbs
@@ -1033,11 +1107,13 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
   // ADR-073 §3 — read the bearer once and thread it into the single client
   // every verb shares, so no verb path can reach a secured daemon without it.
   const client = createHttpClient(baseUrl, resolveAuthToken())
-  const project = resolveProjectFlag(parsed)
   const positional = parsed.positional
 
-  // Per-verb arg/flag validation. Misuse exits 2 before any network call.
-  let work: Promise<VerbResult>
+  // Per-verb arg/flag validation runs first so misuse exits 2 before any
+  // network call (ADR-050 #4). Each case builds a thunk that takes the
+  // resolved project — we resolve the project (issue #500) only after the verb
+  // proves well-formed, since resolution itself hits the daemon's /projects.
+  let makeWork: (project: string | undefined) => Promise<VerbResult>
   switch (cmd) {
     case 'root-cause': {
       const node = positional[0]
@@ -1045,7 +1121,7 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
         console.error('neat root-cause: missing <node-id>')
         return 2
       }
-      work = runRootCause(client, {
+      makeWork = (project) => runRootCause(client, {
         errorNode: node,
         ...(parsed.errorId ? { errorId: parsed.errorId } : {}),
         ...(project ? { project } : {}),
@@ -1058,7 +1134,7 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
         console.error('neat blast-radius: missing <node-id>')
         return 2
       }
-      work = runBlastRadius(client, {
+      makeWork = (project) => runBlastRadius(client, {
         nodeId: node,
         ...(parsed.depth !== null ? { depth: parsed.depth } : {}),
         ...(project ? { project } : {}),
@@ -1071,7 +1147,7 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
         console.error('neat dependencies: missing <node-id>')
         return 2
       }
-      work = runDependencies(client, {
+      makeWork = (project) => runDependencies(client, {
         nodeId: node,
         ...(parsed.depth !== null ? { depth: parsed.depth } : {}),
         ...(project ? { project } : {}),
@@ -1084,7 +1160,7 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
         console.error('neat observed-dependencies: missing <node-id>')
         return 2
       }
-      work = runObservedDependencies(client, {
+      makeWork = (project) => runObservedDependencies(client, {
         nodeId: node,
         ...(project ? { project } : {}),
       })
@@ -1092,7 +1168,7 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
     }
     case 'incidents': {
       // node-id is optional — bare `neat incidents` returns the global log.
-      work = runIncidents(client, {
+      makeWork = (project) => runIncidents(client, {
         ...(positional[0] ? { nodeId: positional[0] } : {}),
         ...(parsed.limit !== null ? { limit: parsed.limit } : {}),
         ...(project ? { project } : {}),
@@ -1105,7 +1181,7 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
         console.error('neat search: missing <query>')
         return 2
       }
-      work = runSearch(client, { query: q, ...(project ? { project } : {}) })
+      makeWork = (project) => runSearch(client, { query: q, ...(project ? { project } : {}) })
       break
     }
     case 'diff': {
@@ -1118,14 +1194,14 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
         console.error('neat diff: --against <snapshot-path> is required')
         return 2
       }
-      work = runDiff(client, {
+      makeWork = (project) => runDiff(client, {
         againstSnapshot: against,
         ...(project ? { project } : {}),
       })
       break
     }
     case 'stale-edges': {
-      work = runStaleEdges(client, {
+      makeWork = (project) => runStaleEdges(client, {
         ...(parsed.limit !== null ? { limit: parsed.limit } : {}),
         ...(parsed.edgeType ? { edgeType: parsed.edgeType } : {}),
         ...(project ? { project } : {}),
@@ -1144,7 +1220,7 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
           return 2
         }
       }
-      work = runPolicies(client, {
+      makeWork = (project) => runPolicies(client, {
         ...(parsed.node ? { nodeId: parsed.node } : {}),
         ...(hypothetical ? { hypotheticalAction: hypothetical } : {}),
         ...(project ? { project } : {}),
@@ -1171,7 +1247,7 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
         }
         typeFilter = out
       }
-      work = runDivergences(client, {
+      makeWork = (project) => runDivergences(client, {
         ...(typeFilter ? { type: typeFilter } : {}),
         ...(parsed.minConfidence !== null ? { minConfidence: parsed.minConfidence } : {}),
         ...(parsed.node ? { node: parsed.node } : {}),
@@ -1186,7 +1262,13 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
   }
 
   try {
-    const result = await work
+    // Resolve which project to route to (issue #500). When --project /
+    // NEAT_PROJECT are set this is a no-op; otherwise it asks the daemon's
+    // /projects list and picks the single registered one (or keeps `default`).
+    // A TransportError from here means the daemon is down — same exit-3 path as
+    // any verb call.
+    const project = await resolveProjectForVerb(client, parsed)
+    const result = await makeWork(project)
     if (parsed.json) process.stdout.write(formatJson(result) + '\n')
     else process.stdout.write(formatHuman(result) + '\n')
     return 0
@@ -1194,6 +1276,12 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
     // Server / transport errors land on stderr per ADR-050 #3 (stderr for
     // diagnostics, stdout for results — never mix). Exit code branches per
     // ADR-050 #4: 1 for HttpError, 3 for TransportError.
+    if (err instanceof ProjectResolutionError) {
+      // Couldn't pick a project on the user's behalf (none registered, or
+      // several and none named `default`). The message already says what to do.
+      console.error(`neat ${cmd}: ${err.message}`)
+      return err.exitCode
+    }
     if (err instanceof HttpError) {
       const detail = err.responseBody.length > 0 ? err.responseBody : err.message
       console.error(`neat ${cmd}: ${detail.trim()}`)

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -5888,8 +5888,16 @@ describe('CLI surface contract (ADR-050)', () => {
       req: import('node:http').IncomingMessage,
       res: import('node:http').ServerResponse,
     ): void => {
-      captures.push({ url: req.url ?? '' })
+      const url = req.url ?? ''
+      captures.push({ url })
       res.setHeader('content-type', 'application/json')
+      // The bare-verb path (no flag, no env) lists registered projects first
+      // (issue #500). A registered `default` keeps the legacy unprefixed route,
+      // which is exactly what step 3 below asserts.
+      if (url === '/projects') {
+        res.end(JSON.stringify([{ name: 'default' }]))
+        return
+      }
       res.end(JSON.stringify({ matches: [] }))
     }
 
@@ -5901,7 +5909,7 @@ describe('CLI surface contract (ADR-050)', () => {
       await withStubServer(stubHandler, async (baseUrl) => {
         process.env.NEAT_API_URL = baseUrl
 
-        // 1. Flag wins — even when env is set.
+        // 1. Flag wins — even when env is set. No /projects lookup needed.
         delete process.env.NEAT_PROJECT
         process.env.NEAT_PROJECT = 'env-proj'
         let parsed = parseArgs(['flag-proj-only', '--project', 'flag-proj'])
@@ -5909,13 +5917,14 @@ describe('CLI surface contract (ADR-050)', () => {
         expect(code).toBe(0)
         expect(captures[captures.length - 1]!.url).toContain('/projects/flag-proj/search')
 
-        // 2. Env used when no flag.
+        // 2. Env used when no flag. Still no /projects lookup.
         parsed = parseArgs(['somequery'])
         code = await runQueryVerb('search', parsed)
         expect(code).toBe(0)
         expect(captures[captures.length - 1]!.url).toContain('/projects/env-proj/search')
 
-        // 3. Neither set → unprefixed (server resolves to default).
+        // 3. Neither set, and a registered `default` exists → unprefixed
+        //    (server resolves it to default). Back-compat per issue #500.
         delete process.env.NEAT_PROJECT
         parsed = parseArgs(['stillquery'])
         code = await runQueryVerb('search', parsed)
@@ -6017,14 +6026,22 @@ describe('CLI surface contract (ADR-050)', () => {
   it('exit code 0 on success (ADR-050 #4)', async () => {
     const { runQueryVerb, parseArgs } = await import('../../src/cli.js')
     const stubHandler = (
-      _req: import('node:http').IncomingMessage,
+      req: import('node:http').IncomingMessage,
       res: import('node:http').ServerResponse,
     ): void => {
       res.setHeader('content-type', 'application/json')
+      // The bare verb resolves against the registry first (issue #500); one
+      // registered project lets it route and the search then returns clean.
+      if ((req.url ?? '') === '/projects') {
+        res.end(JSON.stringify([{ name: 'only-proj' }]))
+        return
+      }
       res.end(JSON.stringify({ matches: [] }))
     }
     const prevApi = process.env.NEAT_API_URL
+    const prevProject = process.env.NEAT_PROJECT
     const prevWrite = process.stdout.write
+    delete process.env.NEAT_PROJECT
     process.stdout.write = (() => true) as typeof process.stdout.write
     try {
       await withStubServer(stubHandler, async (baseUrl) => {
@@ -6037,6 +6054,8 @@ describe('CLI surface contract (ADR-050)', () => {
       process.stdout.write = prevWrite
       if (prevApi === undefined) delete process.env.NEAT_API_URL
       else process.env.NEAT_API_URL = prevApi
+      if (prevProject === undefined) delete process.env.NEAT_PROJECT
+      else process.env.NEAT_PROJECT = prevProject
     }
   })
 

--- a/packages/core/test/cli-project-resolution.test.ts
+++ b/packages/core/test/cli-project-resolution.test.ts
@@ -1,0 +1,175 @@
+// Issue #500 — a bare query verb (no --project, no NEAT_PROJECT) must resolve
+// the target project from the daemon's registered projects instead of blindly
+// routing to `default`, which 404s after a one-command `npx neat.is` run (the
+// orchestrator registers under the cwd basename, not `default`).
+//
+// These drive runQueryVerb against an isolated stub daemon on an ephemeral
+// loopback port. They never touch the real ~/.neat registry or the real
+// daemon ports — the stub answers GET /projects and the verb endpoint itself.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import http from 'node:http'
+import { parseArgs, runQueryVerb } from '../src/cli.js'
+
+interface StubState {
+  // What GET /projects returns.
+  projects: { name: string }[]
+  // Every request path the stub saw, in order. Lets us assert routing.
+  seen: string[]
+}
+
+// Stand up a stub daemon that answers GET /projects with `state.projects` and
+// any /graph/divergences request (default or /projects/:name/...) with an
+// empty divergence result. Records request paths into `state.seen`.
+async function withStubDaemon(
+  state: StubState,
+  fn: (baseUrl: string) => Promise<void>,
+): Promise<void> {
+  const server = http.createServer((req, res) => {
+    const url = req.url ?? ''
+    state.seen.push(url)
+    if (url === '/projects') {
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify(state.projects))
+      return
+    }
+    if (url.includes('/graph/divergences')) {
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({ totalAffected: 0, divergences: [] }))
+      return
+    }
+    res.statusCode = 404
+    res.end(JSON.stringify({ error: 'not found', path: url }))
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const addr = server.address()
+  if (!addr || typeof addr === 'string') throw new Error('listen() gave no address')
+  const baseUrl = `http://127.0.0.1:${addr.port}`
+  try {
+    await fn(baseUrl)
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+}
+
+describe('bare query verb project resolution (#500)', () => {
+  let prevApi: string | undefined
+  let prevCore: string | undefined
+  let prevProject: string | undefined
+  const prevErr = console.error
+  // Silence the dispatcher's stderr; capture it for the assertions that need it.
+  let stderr = ''
+
+  beforeEach(() => {
+    prevApi = process.env.NEAT_API_URL
+    prevCore = process.env.NEAT_CORE_URL
+    prevProject = process.env.NEAT_PROJECT
+    // Isolation: no inherited NEAT_PROJECT can leak into resolution.
+    delete process.env.NEAT_PROJECT
+    delete process.env.NEAT_CORE_URL
+    stderr = ''
+    console.error = (...args: unknown[]) => {
+      stderr += args.join(' ') + '\n'
+    }
+  })
+
+  afterEach(() => {
+    console.error = prevErr
+    if (prevApi === undefined) delete process.env.NEAT_API_URL
+    else process.env.NEAT_API_URL = prevApi
+    if (prevCore === undefined) delete process.env.NEAT_CORE_URL
+    else process.env.NEAT_CORE_URL = prevCore
+    if (prevProject === undefined) delete process.env.NEAT_PROJECT
+    else process.env.NEAT_PROJECT = prevProject
+  })
+
+  // Test 1 — single registered project, no --project. Was: routes to `default`
+  // and 404s. Now: routes to the one registered project.
+  it('routes a bare verb to the single registered project', async () => {
+    const state: StubState = { projects: [{ name: 'northsea-code' }], seen: [] }
+    await withStubDaemon(state, async (baseUrl) => {
+      process.env.NEAT_API_URL = baseUrl
+      const code = await runQueryVerb('divergences', parseArgs([]))
+      expect(code).toBe(0)
+      // The verb request must be project-scoped to the one registered name —
+      // not the legacy unprefixed `default` route.
+      expect(state.seen).toContain('/projects')
+      expect(state.seen.some((p) => p.startsWith('/projects/northsea-code/graph/divergences'))).toBe(
+        true,
+      )
+      expect(state.seen.some((p) => p === '/graph/divergences')).toBe(false)
+    })
+  })
+
+  // Test 2 — several projects, none named `default`, no --project. Don't guess:
+  // helpful error listing them, non-zero exit (not a silent pick, not a 404).
+  it('errors helpfully when several projects are registered and none is default', async () => {
+    const state: StubState = {
+      projects: [{ name: 'alpha' }, { name: 'beta' }, { name: 'gamma' }],
+      seen: [],
+    }
+    await withStubDaemon(state, async (baseUrl) => {
+      process.env.NEAT_API_URL = baseUrl
+      const code = await runQueryVerb('divergences', parseArgs([]))
+      expect(code).not.toBe(0)
+      // No verb request was made — we never guessed a project.
+      expect(state.seen.some((p) => p.includes('/graph/divergences'))).toBe(false)
+      // The error names every project so the user can pick one.
+      expect(stderr).toMatch(/--project/)
+      expect(stderr).toContain('alpha')
+      expect(stderr).toContain('beta')
+      expect(stderr).toContain('gamma')
+    })
+  })
+
+  // Test 3 — a project literally named `default` exists. Back-compat: keep
+  // routing through the legacy unprefixed routes the server maps to `default`.
+  it('keeps the default project on the legacy unprefixed route', async () => {
+    const state: StubState = {
+      projects: [{ name: 'default' }, { name: 'other' }],
+      seen: [],
+    }
+    await withStubDaemon(state, async (baseUrl) => {
+      process.env.NEAT_API_URL = baseUrl
+      const code = await runQueryVerb('divergences', parseArgs([]))
+      expect(code).toBe(0)
+      // Unprefixed route — the server resolves it to project=default.
+      expect(state.seen.some((p) => p === '/graph/divergences')).toBe(true)
+      expect(state.seen.some((p) => p.startsWith('/projects/'))).toBe(false)
+    })
+  })
+
+  // Test 4 — explicit --project <name> is unchanged: route straight to it and
+  // never even hit /projects.
+  it('routes explicit --project untouched and skips the registry lookup', async () => {
+    const state: StubState = {
+      projects: [{ name: 'alpha' }, { name: 'beta' }],
+      seen: [],
+    }
+    await withStubDaemon(state, async (baseUrl) => {
+      process.env.NEAT_API_URL = baseUrl
+      const code = await runQueryVerb('divergences', parseArgs(['--project', 'beta']))
+      expect(code).toBe(0)
+      expect(state.seen.some((p) => p.startsWith('/projects/beta/graph/divergences'))).toBe(true)
+      // Explicit project needs no resolution round-trip.
+      expect(state.seen).not.toContain('/projects')
+    })
+  })
+
+  // Test 5 — daemon unreachable. The resolution lookup fails as a transport
+  // error and the verb keeps its exit-3 / "daemon running?" behavior.
+  it('exits 3 with the daemon-down message when the registry lookup cannot connect', async () => {
+    // Bind then immediately free a port so a connect refuses.
+    const probe = http.createServer()
+    await new Promise<void>((resolve) => probe.listen(0, '127.0.0.1', resolve))
+    const addr = probe.address()
+    if (!addr || typeof addr === 'string') throw new Error('listen() gave no address')
+    const port = addr.port
+    await new Promise<void>((resolve) => probe.close(() => resolve()))
+
+    process.env.NEAT_API_URL = `http://127.0.0.1:${port}`
+    const code = await runQueryVerb('divergences', parseArgs([]))
+    expect(code).toBe(3)
+    expect(stderr.toLowerCase()).toMatch(/daemon|cannot reach/)
+  })
+})


### PR DESCRIPTION
After a one-command `npx neat.is` run, the orchestrator registers the project under the cwd basename, but every CLI query verb routed to a project literally named `default` whenever `--project` was omitted. No such project exists, so `neat divergences` — and `root-cause`, `blast-radius`, `dependencies`, `observed-dependencies`, `incidents`, `search`, `policies`, `stale-edges` — all 404'd with `project not found`. The headline getting-started flow couldn't run a single query without `--project <basename>`.

Now a bare verb (no `--project`, no `NEAT_PROJECT`) asks the daemon which projects it has registered (`GET /projects`) and picks intelligently:

- exactly one registered project -> use it (the common one-command case, so `neat divergences` just works)
- a project literally named `default` exists -> keep the legacy unprefixed routes (back-compat)
- several registered and none is `default` -> error and list the names so the user can pass `--project` (exit 2, never a silent pick)
- none registered -> error clearly instead of 404ing on `default`
- daemon unreachable -> unchanged exit 3 with the "is the daemon running?" message

Explicit `--project <name>` is untouched and skips the lookup entirely. The resolution lives in one place (`resolveProjectForVerb`) so every verb benefits, and it runs after per-verb argument validation so misuse still exits 2 before any network call.

Tests drive `runQueryVerb` against an isolated stub daemon on an ephemeral loopback port — the real `~/.neat` registry and default ports are never touched. The cli-surface contract now describes the registry-backed resolution.

Refs #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)