### PR TITLE
Bump to 0.4.17

### DIFF
--- a/packages/claude-skill/package.json
+++ b/packages/claude-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/claude-skill",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "Claude Code skill drop-in for NEAT — wires the @neat.is/mcp server into Claude's MCP config",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/core",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "NEAT graph engine: tree-sitter extraction, OTel ingest, REST API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -51,7 +51,7 @@
     "@fastify/cors": "^10.0.0",
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
-    "@neat.is/types": "^0.4.16",
+    "@neat.is/types": "^0.4.17",
     "chokidar": "^4.0.3",
     "fastify": "^5.0.0",
     "graphology": "^0.25.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/mcp",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "NEAT MCP server: exposes graph queries to AI agents over stdio",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@neat.is/types": "^0.4.16",
+    "@neat.is/types": "^0.4.17",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/neat.is/package.json
+++ b/packages/neat.is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neat.is",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "NEAT — live semantic graph of a software system, queryable from AI agents over MCP. Install once, get the neat / neatd / neat-mcp CLIs.",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -26,9 +26,9 @@
     "README.md"
   ],
   "dependencies": {
-    "@neat.is/core": "^0.4.16",
-    "@neat.is/mcp": "^0.4.16",
-    "@neat.is/claude-skill": "^0.4.16",
-    "@neat.is/web": "^0.4.16"
+    "@neat.is/core": "^0.4.17",
+    "@neat.is/mcp": "^0.4.17",
+    "@neat.is/claude-skill": "^0.4.17",
+    "@neat.is/web": "^0.4.17"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/types",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "Shared Zod schemas, types, and runtime constants for NEAT",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/web",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "NEAT web shell — minimal Next.js app fronting the core API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "@neat.is/types": "^0.4.16",
+    "@neat.is/types": "^0.4.17",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cytoscape": "^3.33.3",


### PR DESCRIPTION
Cuts 0.4.17 and ships the batch that's been sitting on `main` since 0.4.16. `latest` is still 0.4.16, so users have none of it yet — this is what moves the line.

What's in the release since 0.4.16:

- Incidents recorded from failing HTTP responses, not just ERROR spans (#490)
- MCP server points at the daemon URL the neat skill writes (#489)
- SSE stream opens at connect time with an initial comment frame (#492)
- Registry prunes dead-path entries, plus a `neat prune` verb (#493)
- Canvas counter labels disambiguated; Next's lockfile-patch build warning quieted (#496)
- `@supabase/supabase-js` calls surface as declared edges (#497)
- Docs match the shipped tool surface and current contracts (#498)
- User-facing copy leads with the graph engine and surfaces policies (#499)
- Bare query verbs resolve to the single registered project instead of defaulting to `default` (#501) — the getting-started flow can finally run a query without `--project`

Six-package lockstep bump to 0.4.17 (versions + internal `^0.4.16 → ^0.4.17`); `@neat.is/instrumentation-registry` stays `^1.0.0`. The tarball pre-publish smoke is green: capture harness over http/protobuf and http/json (file-grained OBSERVED, zero service-level, identical shape), SSE `edge-added` frames, the bare one-command path, and the #501 bare-verb resolution all hold on the packed artifact.

Refs #490, #489, #492, #493, #496, #497, #498, #499, #500, #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)