### PR TITLE
Fresh-macOS-VM e2e pipeline (e2e/tart)

### DIFF
--- a/e2e/tart/README.md
+++ b/e2e/tart/README.md
@@ -1,0 +1,187 @@
+# e2e/tart — fresh-macOS-VM install pipeline
+
+A throwaway-VM harness that runs NEAT's genuine **first-install** experience on a
+virgin Mac, every time, from a clean baseline.
+
+## Why this exists
+
+The maintainer's dev machine has accumulated NEAT state — a global `neat`, a
+populated `~/.neat`, built artifacts, sometimes an orphaned daemon lock. That
+state quietly masks a whole class of first-run bugs: a stale global shadowing the
+pinned version, an orphaned lock blocking the daemon, version skew between a
+global install and `npx`. None of those reproduce on the machine that carries the
+state. They only show up on a Mac that has never seen NEAT.
+
+So this harness spins up exactly that: a fresh macOS VM (via
+[Tart](https://github.com/cirruslabs/tart)) with Node 20.x, git, and chromium —
+and **nothing from NEAT**. It runs `npx neat.is@<version>` against a bundled
+sample app, drives traffic, asserts the graph NEAT builds, captures dashboard
+screenshots, collects everything back to the host, and deletes the VM. Repeatable
+across a version matrix.
+
+It does three jobs:
+
+1. **First-install reproduction** — the path the stateful dev machine masks.
+2. **Version-regression harness** — run a matrix (`./run.sh 0.4.16 0.4.17
+   0.4.18`) and diff the per-version artifacts to catch a UX or graph-shape
+   regression between releases.
+3. **Validation harness for the per-project-daemon refactor** — see
+   `docs/contracts/project-daemon.md`. That refactor moves to one daemon per
+   project, with the project served at the REST root (no `/projects/<name>`
+   prefix, no `default` resolution) and a bare `neat divergences` resolving to
+   the single project. The scenario asserts exactly that bare-verb behavior and
+   probes both the bare `/graph` and the prefixed `/projects/<name>/graph`, so it
+   stays green across the migration and turns red if either side breaks.
+
+## The pipeline flow
+
+```
+neat-base (baked once)
+   │  tart clone
+   ▼
+t-<version>  ──tart run --dir neat=<repo>──►  [ fresh macOS VM ]
+   │                                              │ scenario.sh:
+   │   ssh admin@<ip> scenario.sh <version>       │  npx neat.is@<v> <fixture>
+   │                                              │  start app, drive traffic
+   │                                              │  neat divergences / search /
+   │                                              │    root-cause / blast-radius
+   │                                              │  curl :8080/.../graph → OBSERVED>0
+   │                                              │  Playwright chromium screenshots
+   │   ◄── collect artifacts (mounted dir) ───────┘
+   ▼
+tart stop + tart delete   (the VM kills itself)
+```
+
+## Prerequisites
+
+```bash
+brew install cirruslabs/cli/tart                 # Tart (Apple Silicon)
+brew install hudochenkov/sshpass/sshpass         # unattended SSH (optional but
+                                                 # needed for a hands-off matrix)
+```
+
+## 1. Build the base image (once)
+
+```bash
+./base-image.sh
+```
+
+This clones `ghcr.io/cirruslabs/macos-sequoia-base:latest` to `neat-base`,
+boots it, and provisions it over SSH: Node 20.x + git via Homebrew, Playwright's
+bundled chromium (a fresh Mac has no system Chrome), and a hard check that there
+is **no** global `neat` and **no** `~/.neat`. The result is a reusable virgin
+baseline. Re-run only when you want to rebuild it (`tart delete neat-base`
+first). Default VM creds are the cirrus-image `admin`/`admin`; override with
+`VM_USER` / `VM_PASS`.
+
+## 2. Run a version (or a matrix)
+
+```bash
+./run.sh 0.4.18                    # single version
+./run.sh 0.4.16 0.4.17 0.4.18      # version matrix
+./run.sh latest                    # npm 'latest'
+```
+
+For each version `run.sh` clones `neat-base` → `t-<version>`, boots it with the
+repo mounted (`--dir neat=<repo-root>`), ssh's in to run `scenario.sh`, collects
+the artifacts, then `tart stop` + `tart delete`. Teardown is trapped, so a failed
+scenario never leaks a VM. The matrix keeps going on a per-version failure and
+exits non-zero if any version failed.
+
+## Where artifacts land
+
+The scenario writes into the mounted tree at
+`e2e/tart/artifacts/<version>/`, and `run.sh` mirrors that to
+`e2e/tart/artifacts/<version>/` on the host (same path; the mount makes them one
+place). Per version you get:
+
+| File                       | What it is                                            |
+|----------------------------|-------------------------------------------------------|
+| `summary.txt`              | The PASS/FAIL line for every assertion + RESULT       |
+| `01-npx-neat.log`          | Full `npx neat.is@<v>` output — banner, summary, token |
+| `02-npm-install.log`       | The OTel-dep install neat's patch asks for            |
+| `03-fixture-app.log`       | The instrumented fixture's stdout                     |
+| `05a-divergences.txt/.json`| `neat divergences` (bare verb) output                 |
+| `05b-search.txt`           | `neat search server`                                  |
+| `05c-root-cause.txt`       | `neat root-cause <node>`                              |
+| `05d-blast-radius.txt`     | `neat blast-radius <node>`                            |
+| `06-observed.txt`          | The OBSERVED-edge assertion report + VERDICT          |
+| `graph.json`               | The raw graph the assertions read                     |
+| `dashboard-graph.png`      | The cytoscape graph canvas                            |
+| `dashboard-full.png`       | Full-page dashboard (chrome + legend + canvas)        |
+| `dashboard-inspector.png`  | Inspector/divergence view, when reachable             |
+
+## What each assertion proves
+
+The scenario reuses the correctness approach of `e2e/capture`: it reads the graph
+from the daemon's REST and asserts OBSERVED edges, the load-bearing tier.
+
+- **fresh-state** — `~/.neat` absent and no global `neat`. Proves the VM is
+  virgin, i.e. this is the first-install path. A non-empty state here means the
+  base image drifted.
+- **orchestrator** — `npx neat.is@<version> <fixture>` exits 0. This is the
+  headline one-command UX (discover → instrument → daemon → dashboard on :6328 →
+  token line), not a hand-assembled path.
+- **divergences (bare verb)** — `neat divergences` with **no** `--project`
+  resolves to the single registered project instead of 404'ing on a missing
+  `default`. This is the bare-verb fix, and the exact shape the
+  per-project-daemon refactor formalizes (the daemon *is* the project).
+- **search / root-cause / blast-radius** — the query verbs run cleanly against
+  the fresh daemon; blast-radius reaches the database node downstream.
+- **observed** — the correctness core: the graph carries **> 0 OBSERVED edges**,
+  including a `CALLS → frontier` (the fixture's outbound HTTP) and a
+  `CONNECTS_TO → database` (the fixture's SQLite). File-grained where NEAT's
+  call-site processor landed `code.*`.
+- **screenshots** — Playwright (chromium) renders the loopback dashboard on
+  :6328 and captures the graph canvas. Best-effort: a render miss is a warning,
+  not a gate — the REST assertions are the gate.
+
+## The fixture (`fixture/`)
+
+A self-contained Brief-like Express service with zero external dependencies, so
+it runs on a virgin Mac with no Postgres, no creds, no internet:
+
+- **`CALLS → frontier`** — `/quote`, `/enrich`, `/report` make a real http
+  client call to a named upstream. By default that upstream is a tiny local stub
+  the same process starts, so the call always succeeds offline and the frontier
+  node has a name. Point `UPSTREAM_URL` at a real httpbin-style endpoint to
+  exercise the genuine-internet path.
+- **`CONNECTS_TO → database`** — `/items` and `/report` open a `better-sqlite3`
+  connection (in-process, file under the temp dir). The bundled OTel set has no
+  SQLite instrumentation, so the fixture closes that gap the way `neat extend`
+  does for any uncovered library: it emits a **real** CLIENT span carrying
+  `db.system`/`server.address` at the call site. NEAT's call-site processor
+  stamps `code.*` on it, so the edge lands file-grained.
+
+`neat init` injects `otel-init.cjs` and patches `package.json` with the OTel
+deps; the scenario runs `npm install` afterward (the orchestrator leaves the
+install to the caller) so the instrumentation is live when the app boots.
+
+## What's validated locally vs. needs Tart
+
+The **scenario logic** — the fixture forming the OBSERVED graph, the query verbs,
+the OBSERVED-edge assertion, and the Playwright capture — is validated on the
+maintainer's machine in full isolation (a throwaway `NEAT_HOME` + alternate
+ports, never the live daemon). The fixture forms both OBSERVED edges
+(`CALLS → frontier`, `CONNECTS_TO → database`) and `screenshot.mjs` captures the
+graph canvas.
+
+The **Tart-VM orchestration** (`base-image.sh`, `run.sh`) needs Tart + macOS
+virtualization, which can't run in CI here — the maintainer runs that side. The
+scenario it drives is the same one validated locally.
+
+## Notes / gotchas
+
+- **chromium, not Chrome.** A fresh Mac has no system Chrome; `screenshot.mjs`
+  launches Playwright's bundled chromium and `base-image.sh` bakes the browser
+  binary in.
+- **The dashboard login wall.** On the loopback dev path the REST API is open
+  (no token), but the dashboard's client gate still redirects to `/login` unless
+  the daemon reports `publicRead`. The scenario exports `NEAT_PUBLIC_READ=true`
+  so the headless screenshot reaches the canvas. (See `docs/contracts/` —
+  ADR-073 §3 / the auth surface.)
+- **Ports.** A fresh VM has exactly one daemon, so it takes the canonical
+  defaults: REST `:8080`, OTLP `:4318`, dashboard `:6328`.
+- **CLI base URL.** The query verbs reach the daemon via `NEAT_API_URL`
+  (default `http://localhost:8080`); the daemon's bind `PORT` only controls where
+  it listens. In the single-daemon VM the default is correct.

--- a/e2e/tart/artifacts/.gitignore
+++ b/e2e/tart/artifacts/.gitignore
@@ -1,0 +1,4 @@
+# Per-run artifacts (logs, query outputs, screenshots) land here. Keep the dir,
+# ignore its contents — collected fresh on every run.
+*
+!.gitignore

--- a/e2e/tart/base-image.sh
+++ b/e2e/tart/base-image.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# base-image.sh — one-time prep of the reusable virgin macOS base image.
+#
+# Bakes `neat-base`: a macOS VM that has Node 20.x, git, and Playwright's
+# bundled chromium, and NOTHING from NEAT — no global neat, no ~/.neat, no built
+# artifacts, no orphaned lock. Every `run.sh` clone starts from this exact
+# virgin baseline, so the scenario exercises the genuine first-install path the
+# maintainer's stateful dev machine masks.
+#
+# This script automates what it can from the host (clone, start, wait, stop).
+# The provisioning *inside* the VM happens over SSH; those steps are spelled out
+# as copy-pasteable blocks because they run against the VM's shell, not the
+# host's. Run this once; thereafter `run.sh` reuses `neat-base`.
+#
+# Requires: Tart (`brew install cirruslabs/cli/tart`) and Apple Silicon.
+set -euo pipefail
+
+BASE_IMAGE="${BASE_IMAGE:-ghcr.io/cirruslabs/macos-sequoia-base:latest}"
+BASE_VM="${BASE_VM:-neat-base}"
+VM_USER="${VM_USER:-admin}"
+VM_PASS="${VM_PASS:-admin}"          # cirrus base-image default creds
+NODE_MAJOR="${NODE_MAJOR:-20}"        # NEAT runs on Node 20.x
+
+say() { printf '\n\033[1m[base-image] %s\033[0m\n' "$*"; }
+
+# ── 0. Preflight ───────────────────────────────────────────────────────────
+command -v tart >/dev/null 2>&1 || {
+  echo "tart not found. Install it: brew install cirruslabs/cli/tart" >&2
+  exit 1
+}
+
+# ── 1. Clone the cirrus base image to a working VM ─────────────────────────
+if tart list | awk '{print $2}' | grep -qx "$BASE_VM"; then
+  say "$BASE_VM already exists. Delete it first to rebuild: tart delete $BASE_VM"
+  exit 0
+fi
+say "cloning $BASE_IMAGE → $BASE_VM (first pull is several GB; cached after)"
+tart clone "$BASE_IMAGE" "$BASE_VM"
+
+# ── 2. Boot it headless so we can SSH in to provision ──────────────────────
+say "starting $BASE_VM (headless) to provision it"
+tart run "$BASE_VM" --no-graphics &
+TART_RUN_PID=$!
+trap 'kill "$TART_RUN_PID" 2>/dev/null || true' EXIT
+
+say "waiting for the VM to get an IP"
+IP=""
+for _ in $(seq 1 60); do
+  IP="$(tart ip "$BASE_VM" 2>/dev/null || true)"
+  [ -n "$IP" ] && break
+  sleep 2
+done
+[ -n "$IP" ] || { echo "VM never got an IP" >&2; exit 1; }
+say "VM is up at $IP"
+
+# ── 3. Provision inside the VM over SSH ────────────────────────────────────
+# Run the provisioning as one heredoc'd remote script. `sshpass` lets us pass
+# the default admin/admin non-interactively; if you don't have it
+# (`brew install sshpass` / hudochenkov tap), run the block manually — it's
+# printed below for copy-paste.
+REMOTE_PROVISION=$(cat <<'PROVISION'
+set -euo pipefail
+echo "[vm] provisioning virgin base"
+
+# Homebrew ships preinstalled on the cirrus macOS images. Use it for node + git.
+eval "$(/opt/homebrew/bin/brew shellenv)" 2>/dev/null || true
+
+# Node 20.x — pin the major so the baseline matches NEAT's engines (>=20).
+brew install node@20 git || true
+# Put node@20 first on PATH for login shells.
+echo 'export PATH="/opt/homebrew/opt/node@20/bin:$PATH"' >> ~/.zprofile
+export PATH="/opt/homebrew/opt/node@20/bin:$PATH"
+echo "[vm] node: $(node -v)   npm: $(npm -v)   git: $(git --version)"
+
+# Playwright + its bundled chromium. A fresh Mac has no system Chrome, so the
+# screenshot step launches chromium specifically — install the browser binary
+# now so it's baked into the image and not re-downloaded every run.
+npm install -g playwright
+npx --yes playwright install chromium
+echo "[vm] chromium installed at: $(ls -d ~/Library/Caches/ms-playwright/chromium* 2>/dev/null | head -1)"
+
+# Make absolutely sure the baseline carries NO NEAT state. Nothing should exist
+# yet, but assert it — a dirty base image is the one thing that defeats this
+# whole harness.
+rm -rf ~/.neat
+npm ls -g neat.is >/dev/null 2>&1 && npm uninstall -g neat.is || true
+if command -v neat >/dev/null 2>&1; then
+  echo "[vm] WARNING: a global 'neat' is still on PATH — remove it before baking" >&2
+fi
+echo "[vm] verified virgin: ~/.neat absent=$([ -e ~/.neat ] && echo NO || echo YES), global neat absent=$(command -v neat >/dev/null 2>&1 && echo NO || echo YES)"
+
+echo "[vm] provisioning done"
+PROVISION
+)
+
+if command -v sshpass >/dev/null 2>&1; then
+  say "provisioning $BASE_VM over SSH (Node $NODE_MAJOR + git + chromium, clearing NEAT state)"
+  sshpass -p "$VM_PASS" ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+    "$VM_USER@$IP" "bash -lc '$REMOTE_PROVISION'"
+else
+  cat <<EOF
+
+  sshpass is not installed, so provisioning can't run automatically.
+  Install it (brew install hudochenkov/sshpass/sshpass) and re-run, OR
+  SSH in by hand and paste the provisioning block:
+
+      ssh $VM_USER@$IP        # password: $VM_PASS
+
+  Then run the block printed in this script's REMOTE_PROVISION heredoc
+  (Node $NODE_MAJOR via 'brew install node@20', 'npm i -g playwright',
+   'npx playwright install chromium', and 'rm -rf ~/.neat').
+
+  When it finishes, come back here and press Enter to finalize the image.
+EOF
+  read -r -p "  Press Enter once you've provisioned the VM... " _
+fi
+
+# ── 4. Shut the VM down cleanly so the baked disk is consistent ────────────
+say "stopping $BASE_VM to seal the baseline"
+sshpass -p "$VM_PASS" ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  "$VM_USER@$IP" "sudo shutdown -h now" 2>/dev/null || tart stop "$BASE_VM" || true
+
+# Give it a moment to power off, then drop the trap-managed run process.
+sleep 5
+kill "$TART_RUN_PID" 2>/dev/null || true
+trap - EXIT
+
+say "done. '$BASE_VM' is a reusable virgin baseline: Node $NODE_MAJOR + git + chromium, no NEAT state."
+say "Next: ./run.sh <version>   (e.g. ./run.sh 0.4.18)"

--- a/e2e/tart/fixture/.gitignore
+++ b/e2e/tart/fixture/.gitignore
@@ -1,0 +1,9 @@
+# Generated / installed at run time — never committed.
+node_modules/
+neat-out/
+package-lock.json
+otel-init.cjs
+.env.neat
+*.sqlite
+*.sqlite-wal
+*.sqlite-shm

--- a/e2e/tart/fixture/package.json
+++ b/e2e/tart/fixture/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "neat-tart-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Self-contained Brief-like service for the Tart fresh-VM e2e pipeline. An outbound HTTP call (CALLS -> frontier) and a better-sqlite3 connection (CONNECTS_TO -> database) so NEAT forms a believable OBSERVED graph with zero external deps. neat init injects otel-init before it runs.",
+  "main": "server.cjs",
+  "scripts": {
+    "start": "node server.cjs"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.3.0",
+    "express": "^4.19.2"
+  }
+}

--- a/e2e/tart/fixture/server.cjs
+++ b/e2e/tart/fixture/server.cjs
@@ -1,0 +1,236 @@
+// Tart e2e fixture — a small, self-contained "Brief-like" service.
+//
+// The point of this app is not to be load-bearing software; it's to be a
+// believable graph. When NEAT instruments it and we drive a little traffic,
+// the daemon should grow a handful of OBSERVED edges that look like a real
+// service: an outbound HTTP CALLS edge to a frontier host, and a CONNECTS_TO
+// edge to a database. Both have to form with zero external dependencies — no
+// Postgres, no creds, no internet — because this runs inside a fresh macOS VM.
+//
+// How each OBSERVED edge gets formed:
+//   - CALLS -> frontier:  /quote and /enrich make a real http client call to
+//     an upstream the app names by host. By default that upstream is a tiny
+//     local stub this same process starts (UPSTREAM_URL), so the app talks to
+//     a named host and the call always succeeds offline. Point UPSTREAM_URL at
+//     a real httpbin-style endpoint to exercise the genuine-internet path.
+//   - CONNECTS_TO -> database:  /items and /report open a better-sqlite3
+//     connection to a file under the OS temp dir and run real queries. SQLite
+//     is in-process, so the database "server" needs nothing installed.
+//
+// neat init injects otel-init before this file runs (NODE_OPTIONS=-r
+// ./otel-init.cjs, or the orchestrator wires it), so the auto-instrumentation
+// is live by the time the server boots. CJS on purpose: the
+// require-in-the-middle hooks the bundled OTel set installs wrap CJS require,
+// and better-sqlite3 + the http client are loaded through require here.
+
+const express = require('express')
+const http = require('node:http')
+const os = require('node:os')
+const path = require('node:path')
+const fs = require('node:fs')
+
+const PORT = Number.parseInt(process.env.PORT_APP || process.env.FIXTURE_PORT || '8080', 10)
+
+// The upstream the app "calls". Default is a local stub we start below on
+// STUB_PORT, addressed by an explicit host so the frontier node has a name.
+// Override with a public httpbin-style endpoint to test the real-internet path.
+const STUB_PORT = Number.parseInt(process.env.STUB_PORT || String(PORT + 1), 10)
+const UPSTREAM_URL = process.env.UPSTREAM_URL || `http://127.0.0.1:${STUB_PORT}`
+
+// SQLite lives in a writable temp dir so a read-only mount never blocks it.
+const DB_PATH =
+  process.env.FIXTURE_DB_PATH || path.join(os.tmpdir(), `neat-tart-fixture-${process.pid}.sqlite`)
+
+// ---------------------------------------------------------------------------
+// Database — a single better-sqlite3 connection, opened lazily and reused.
+//
+// The bundled OTel auto-instrumentation set covers pg / mysql / mongo / redis
+// but has no SQLite instrumentation, so a raw better-sqlite3 call emits no span
+// and no CONNECTS_TO edge would form. We close that gap the same honest way
+// `neat extend` does for an uncovered library: emit a *real* CLIENT span at the
+// call site carrying the db.* semconv NEAT's ingest reads (db.system + an
+// address resolve to a DatabaseNode and a CONNECTS_TO edge). The span is
+// genuine OTel, not a mock — and because it's created synchronously at the call
+// site, NEAT's call-site span processor stamps code.filepath/lineno on it, so
+// the CONNECTS_TO edge lands file-grained like the HTTP one.
+//
+// @opentelemetry/api is on the dependency tree because `neat init` adds it; we
+// require it lazily and degrade to a no-op span if it isn't present, so the app
+// still runs uninstrumented.
+const DB_SYSTEM = 'sqlite'
+const DB_ADDRESS = process.env.FIXTURE_DB_HOST || 'sqlite.local'
+
+let _tracer = null
+function tracer() {
+  if (_tracer !== null) return _tracer
+  try {
+    _tracer = require('@opentelemetry/api').trace.getTracer('neat-tart-fixture-db')
+  } catch (_e) {
+    _tracer = false // api not installed → run without DB spans
+  }
+  return _tracer
+}
+
+// Run a DB operation inside a real CLIENT span so NEAT forms CONNECTS_TO.
+function withDbSpan(op, statement, fn) {
+  const t = tracer()
+  if (!t) return fn()
+  const api = require('@opentelemetry/api')
+  const span = t.startSpan(`sqlite ${op}`, { kind: api.SpanKind.CLIENT })
+  span.setAttribute('db.system', DB_SYSTEM)
+  span.setAttribute('db.name', path.basename(DB_PATH))
+  span.setAttribute('server.address', DB_ADDRESS)
+  span.setAttribute('db.statement', statement)
+  try {
+    return fn()
+  } catch (err) {
+    span.recordException(err)
+    throw err
+  } finally {
+    span.end()
+  }
+}
+
+let db = null
+function getDb() {
+  if (db) return db
+  const Database = require('better-sqlite3')
+  db = new Database(DB_PATH)
+  db.pragma('journal_mode = WAL')
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS items (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `)
+  // Seed once so reads return rows.
+  const count = db.prepare('SELECT COUNT(*) AS n FROM items').get().n
+  if (count === 0) {
+    const insert = db.prepare('INSERT INTO items (name) VALUES (?)')
+    for (const name of ['alpha', 'bravo', 'charlie']) insert.run(name)
+  }
+  return db
+}
+
+// A small http client call to the named upstream. Returns the status so the
+// route can report it; the OBSERVED CALLS edge forms regardless of the body.
+function callUpstream(pathSuffix) {
+  return new Promise((resolve) => {
+    const url = new URL(pathSuffix || '/get', UPSTREAM_URL)
+    const req = http.get(
+      { hostname: url.hostname, port: url.port, path: url.pathname + url.search, timeout: 4000 },
+      (up) => {
+        let body = ''
+        up.on('data', (c) => {
+          body += c
+        })
+        up.on('end', () => resolve({ status: up.statusCode, body: body.slice(0, 200) }))
+      },
+    )
+    req.on('timeout', () => req.destroy(new Error('upstream timeout')))
+    req.on('error', (err) => resolve({ status: 0, error: String(err && err.message) }))
+  })
+}
+
+const app = express()
+app.use(express.json())
+
+// Liveness — the cheapest span, always available. run.sh polls this for boot.
+app.get('/health', (_req, res) => {
+  res.json({ ok: true, db: DB_PATH, upstream: UPSTREAM_URL })
+})
+
+// Outbound HTTP tier — forms CALLS -> frontier:<upstream host>.
+app.get('/quote', async (_req, res) => {
+  const up = await callUpstream('/get?symbol=NEAT')
+  res.json({ route: 'quote', upstream: UPSTREAM_URL, upstreamStatus: up.status })
+})
+
+// Outbound HTTP tier again, different call site — a second file/line origin
+// for the CALLS edge, so the graph shows more than one call point.
+app.get('/enrich', async (_req, res) => {
+  const up = await callUpstream('/get?enrich=1')
+  res.json({ route: 'enrich', upstreamStatus: up.status, sample: up.body })
+})
+
+// Database read tier — forms CONNECTS_TO -> database (sqlite).
+app.get('/items', (_req, res) => {
+  try {
+    const sql = 'SELECT id, name, created_at FROM items ORDER BY id'
+    const rows = withDbSpan('SELECT', sql, () => getDb().prepare(sql).all())
+    res.json({ route: 'items', count: rows.length, rows })
+  } catch (err) {
+    res.status(200).json({ route: 'items', error: String(err && err.message) })
+  }
+})
+
+// Database write tier — a second DB call site so the CONNECTS_TO edge has
+// real traffic and a believable callCount.
+app.post('/items', (req, res) => {
+  try {
+    const name = (req.body && req.body.name) || `item-${Date.now()}`
+    const sql = 'INSERT INTO items (name) VALUES (?)'
+    const info = withDbSpan('INSERT', sql, () => getDb().prepare(sql).run(name))
+    res.json({ route: 'items', inserted: { id: info.lastInsertRowid, name } })
+  } catch (err) {
+    res.status(200).json({ route: 'items', error: String(err && err.message) })
+  }
+})
+
+// A route that fans out to both tiers — DB read then an upstream call — so the
+// graph shows a handler that both reads its database and calls a frontier.
+app.get('/report', async (_req, res) => {
+  let count = -1
+  try {
+    const sql = 'SELECT COUNT(*) AS n FROM items'
+    count = withDbSpan('SELECT', sql, () => getDb().prepare(sql).get().n)
+  } catch (_e) {
+    /* edge still forms on the attempt */
+  }
+  const up = await callUpstream('/get?report=1')
+  res.json({ route: 'report', itemCount: count, upstreamStatus: up.status })
+})
+
+// ---------------------------------------------------------------------------
+// Boot — start the local stub first (only if UPSTREAM_URL points at it), then
+// the app, so the named upstream answers immediately.
+// ---------------------------------------------------------------------------
+function startApp() {
+  app.listen(PORT, '127.0.0.1', () => {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[fixture] listening on http://127.0.0.1:${PORT}  upstream=${UPSTREAM_URL}  db=${DB_PATH}`,
+    )
+  })
+}
+
+const usingLocalStub = !process.env.UPSTREAM_URL
+if (usingLocalStub) {
+  // A deterministic httpbin-ish stub: GET /get echoes a small JSON body.
+  const stub = http.createServer((req, res) => {
+    res.setHeader('content-type', 'application/json')
+    res.end(JSON.stringify({ url: req.url, origin: '127.0.0.1', service: 'neat-tart-stub' }))
+  })
+  stub.listen(STUB_PORT, '127.0.0.1', () => {
+    // eslint-disable-next-line no-console
+    console.log(`[fixture] local upstream stub on http://127.0.0.1:${STUB_PORT}`)
+    startApp()
+  })
+} else {
+  startApp()
+}
+
+// Clean up the WAL sidecars on exit so reruns start fresh.
+process.on('SIGTERM', () => {
+  try {
+    if (db) db.close()
+    for (const ext of ['', '-wal', '-shm']) {
+      const f = DB_PATH + ext
+      if (fs.existsSync(f)) fs.rmSync(f, { force: true })
+    }
+  } catch (_e) {
+    /* ignore */
+  }
+  process.exit(0)
+})

--- a/e2e/tart/run.sh
+++ b/e2e/tart/run.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# run.sh — host-side runner for the fresh-macOS-VM e2e pipeline.
+#
+# For each version in the matrix it: clones a virgin VM off neat-base, runs it
+# headless with the repo mounted in, ssh's in to run scenario.sh, collects the
+# artifacts (query outputs + screenshots + logs) the scenario wrote to the
+# mount, then stops and DELETES the VM — every run gets a fresh Mac, every run
+# kills itself. Teardown happens even on failure (trap), so a broken scenario
+# never leaks a VM.
+#
+# Usage:
+#   ./run.sh 0.4.18                 # one version
+#   ./run.sh 0.4.16 0.4.17 0.4.18   # a version matrix
+#   ./run.sh latest                 # whatever npm 'latest' points at
+#
+# Requires: Tart + a baked `neat-base` (run ./base-image.sh once first).
+set -uo pipefail
+
+# ── Config ─────────────────────────────────────────────────────────────────
+BASE_VM="${BASE_VM:-neat-base}"
+VM_USER="${VM_USER:-admin}"
+VM_PASS="${VM_PASS:-admin}"          # cirrus base-image default creds; parameterize
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+# Where collected artifacts land on the host. The scenario writes into the
+# mounted repo's e2e/tart/artifacts/<version>/; we copy those out to here too so
+# results survive even if the mount is read-only / transient.
+HOST_ARTIFACTS="${HOST_ARTIFACTS:-$HERE/artifacts}"
+
+VERSIONS=("$@")
+if [ "${#VERSIONS[@]}" -eq 0 ]; then
+  echo "usage: $0 <version> [version...]   e.g. $0 0.4.16 0.4.17 0.4.18" >&2
+  exit 2
+fi
+
+say()  { printf '\n\033[1m[run] %s\033[0m\n' "$*"; }
+warn() { printf '\033[33m[run] %s\033[0m\n' "$*" >&2; }
+
+command -v tart >/dev/null 2>&1 || { echo "tart not found (brew install cirruslabs/cli/tart)" >&2; exit 1; }
+tart list | awk '{print $2}' | grep -qx "$BASE_VM" || {
+  echo "base image '$BASE_VM' not found — run ./base-image.sh first" >&2; exit 1; }
+
+# sshpass keeps the SSH non-interactive with the default creds. Fall back to a
+# clear message if it isn't installed.
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10)
+if command -v sshpass >/dev/null 2>&1; then
+  SSH() { sshpass -p "$VM_PASS" ssh "${SSH_OPTS[@]}" "$VM_USER@$1" "$2"; }
+else
+  warn "sshpass not installed — SSH steps will prompt for the '$VM_PASS' password each time."
+  warn "install it for unattended matrix runs: brew install hudochenkov/sshpass/sshpass"
+  SSH() { ssh "${SSH_OPTS[@]}" "$VM_USER@$1" "$2"; }
+fi
+
+# ── Per-version teardown, always runs ──────────────────────────────────────
+CURRENT_VM=""
+teardown_vm() {
+  local vm="$1"
+  [ -n "$vm" ] || return 0
+  say "tearing down $vm (stop + delete — the VM kills itself)"
+  tart stop "$vm" 2>/dev/null || true
+  # stop is async; give it a beat, then force-delete.
+  sleep 3
+  tart delete "$vm" 2>/dev/null || true
+}
+# Trap covers Ctrl-C / unexpected exit mid-run so a VM is never orphaned.
+trap 'teardown_vm "$CURRENT_VM"; exit 130' INT TERM
+
+OVERALL_RC=0
+declare -a RESULTS=()
+
+# ── Per-version run ────────────────────────────────────────────────────────
+run_one() {
+  local version="$1"
+  local vm="t-${version//[^a-zA-Z0-9]/-}"
+  CURRENT_VM="$vm"
+  local rc=0
+
+  say "==== neat.is@$version  →  VM $vm ===="
+
+  # Fresh clone off the virgin baseline.
+  tart clone "$BASE_VM" "$vm" || { warn "clone failed for $vm"; RESULTS+=("$version: CLONE-FAIL"); CURRENT_VM=""; return 1; }
+
+  # Boot headless with the repo mounted read-only at a named tag. Tart exposes
+  # --dir mounts under /Volumes/My Shared Files/<tag> inside the VM. The
+  # scenario reads the fixture + screenshot script from there and writes
+  # artifacts back into the same tree (the mount is read-write unless :ro).
+  say "booting $vm with the repo mounted (--dir neat=$REPO_ROOT)"
+  tart run "$vm" --no-graphics --dir "neat=$REPO_ROOT" &
+  local run_pid=$!
+
+  # Wait for an IP.
+  local ip=""
+  for _ in $(seq 1 60); do
+    ip="$(tart ip "$vm" 2>/dev/null || true)"
+    [ -n "$ip" ] && break
+    sleep 2
+  done
+  if [ -z "$ip" ]; then
+    warn "$vm never got an IP"; RESULTS+=("$version: BOOT-FAIL")
+    kill "$run_pid" 2>/dev/null || true
+    teardown_vm "$vm"; CURRENT_VM=""; return 1
+  fi
+  say "$vm is up at $ip"
+
+  # Wait for SSH to answer.
+  local ssh_ok=0
+  for _ in $(seq 1 30); do
+    if SSH "$ip" "true" 2>/dev/null; then ssh_ok=1; break; fi
+    sleep 2
+  done
+  [ "$ssh_ok" = "1" ] || { warn "ssh to $vm never came up"; RESULTS+=("$version: SSH-FAIL"); kill "$run_pid" 2>/dev/null||true; teardown_vm "$vm"; CURRENT_VM=""; return 1; }
+
+  # Run the scenario inside the VM. It reads/writes the mount; --login so the
+  # provisioned PATH (node@20, global playwright) is in scope.
+  local mount='/Volumes/My Shared Files/neat'
+  say "running scenario.sh inside $vm"
+  if SSH "$ip" "bash -lc 'export NEAT_MOUNT=\"$mount/e2e/tart\"; chmod +x \"$mount/e2e/tart/scenario.sh\"; \"$mount/e2e/tart/scenario.sh\" $version'"; then
+    say "$vm scenario PASSED"
+    RESULTS+=("$version: PASS")
+  else
+    rc=$?
+    warn "$vm scenario FAILED (rc=$rc)"
+    RESULTS+=("$version: FAIL")
+    OVERALL_RC=1
+  fi
+
+  # Collect artifacts. The scenario already wrote them into the mounted tree at
+  # e2e/tart/artifacts/<version>/; mirror that into HOST_ARTIFACTS so results
+  # outlive the VM and any per-run mount semantics.
+  local src="$REPO_ROOT/e2e/tart/artifacts/$version"
+  local dst="$HOST_ARTIFACTS/$version"
+  if [ -d "$src" ]; then
+    mkdir -p "$dst"
+    cp -R "$src/." "$dst/" 2>/dev/null || true
+    say "artifacts collected → $dst"
+    ls "$dst" 2>/dev/null | sed 's/^/    /'
+  else
+    warn "no artifacts found at $src (scenario may have died before writing)"
+  fi
+
+  # The VM kills itself.
+  kill "$run_pid" 2>/dev/null || true
+  teardown_vm "$vm"
+  CURRENT_VM=""
+  return "$rc"
+}
+
+mkdir -p "$HOST_ARTIFACTS"
+for v in "${VERSIONS[@]}"; do
+  run_one "$v" || true   # keep going through the matrix; OVERALL_RC tracks failures
+done
+
+# ── Matrix summary ─────────────────────────────────────────────────────────
+say "==== MATRIX RESULTS ===="
+for r in "${RESULTS[@]}"; do
+  printf '    %s\n' "$r"
+done
+say "artifacts under: $HOST_ARTIFACTS"
+exit "$OVERALL_RC"

--- a/e2e/tart/scenario.sh
+++ b/e2e/tart/scenario.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# scenario.sh — runs INSIDE the Tart VM (a virgin macOS install).
+#
+# This is the fresh-install path the maintainer's stateful dev machine masks.
+# On a virgin Mac there is no global neat, no ~/.neat, no built artifacts, no
+# orphaned lock — so this exercises the genuine `npx neat.is@<version>` UX a new
+# user gets, and asserts the graph it produces. run.sh ssh's in and runs this.
+#
+# Usage (inside the VM):
+#   scenario.sh <version>
+#     <version>  the neat.is version to test, e.g. 0.4.18 (or "latest").
+#
+# It reads the repo + fixture from the read-only host mount and writes all
+# artifacts (query outputs, logs, screenshots, a PASS/FAIL summary) to the
+# mounted artifacts dir so run.sh can collect them on the host after teardown.
+set -uo pipefail
+
+VERSION="${1:?usage: scenario.sh <version>}"
+
+# ── Layout ────────────────────────────────────────────────────────────────
+# The host mounts the repo root read-only at MOUNT (default /Volumes/My Shared
+# Files, Tart's --dir mount point). The fixture lives under it; artifacts are
+# written to a per-version subdir of the mount's `artifacts/`.
+MOUNT="${NEAT_MOUNT:-/Volumes/My Shared Files/neat}"
+FIXTURE_SRC="${NEAT_FIXTURE_SRC:-$MOUNT/e2e/tart/fixture}"
+ARTIFACTS="${NEAT_ARTIFACTS:-$MOUNT/e2e/tart/artifacts/$VERSION}"
+SCREENSHOT_MJS="${NEAT_SCREENSHOT:-$MOUNT/e2e/tart/screenshot.mjs}"
+
+# Work happens in a writable temp dir — the mount may be read-only, and we want
+# a virgin copy of the fixture each run.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/neat-tart-XXXXXX")"
+FIXTURE="$WORK/fixture"
+
+# Canonical local ports. In a fresh VM there is exactly one daemon, so the
+# defaults are free and the orchestrator takes them.
+REST_PORT="${PORT:-8080}"
+WEB_PORT="${NEAT_WEB_PORT:-6328}"
+APP_PORT="${FIXTURE_APP_PORT:-9099}"   # the fixture's own port (not a NEAT port)
+# The CLI reaches the daemon at this URL (NEAT_API_URL); default is fine for the
+# single-daemon fresh VM.
+export NEAT_API_URL="${NEAT_API_URL:-http://localhost:$REST_PORT}"
+
+# Loopback dev surface: the orchestrator pins the daemon to 127.0.0.1 with no
+# token, so the REST API is open server-side — but the dashboard's client-side
+# auth gate still redirects to /login unless the daemon reports publicRead. We
+# export NEAT_PUBLIC_READ=true so the daemon the orchestrator spawns serves the
+# no-login dashboard the headless screenshot needs. (The daemon inherits this
+# from the orchestrator's process env.)
+export NEAT_PUBLIC_READ="${NEAT_PUBLIC_READ:-true}"
+
+mkdir -p "$ARTIFACTS"
+SUMMARY="$ARTIFACTS/summary.txt"
+: > "$SUMMARY"
+
+PASS=0
+FAIL=0
+APP_PID=0
+note() { echo "$*" | tee -a "$SUMMARY"; }
+pass() { PASS=$((PASS + 1)); note "PASS  $*"; }
+fail() { FAIL=$((FAIL + 1)); note "FAIL  $*"; }
+
+# Final teardown + report. Defined early so any step can bail out through it.
+finish() {
+  note ""
+  kill "${APP_PID:-0}" 2>/dev/null || true
+  note "=== SUMMARY · neat.is@$VERSION · PASS=$PASS FAIL=$FAIL ==="
+  rm -rf "$WORK" 2>/dev/null || true
+  if [ "$FAIL" -gt 0 ]; then
+    note "RESULT: FAIL"
+    exit 1
+  fi
+  note "RESULT: PASS"
+  exit 0
+}
+
+note "=== NEAT Tart fresh-VM scenario · neat.is@$VERSION · $(date -u +%FT%TZ) ==="
+note "node: $(node -v 2>/dev/null)   npm: $(npm -v 2>/dev/null)"
+note "work dir: $WORK"
+note "artifacts: $ARTIFACTS"
+note ""
+
+# A fresh VM should have NO prior NEAT state. Record it as evidence — this is
+# the whole point of the harness (the stateful-machine masking the first-run
+# bug class). A non-empty ~/.neat here means the base image wasn't clean.
+if [ -e "$HOME/.neat" ]; then
+  fail "fresh-state: ~/.neat already exists on this VM — base image is not virgin"
+  ls -la "$HOME/.neat" >> "$SUMMARY" 2>&1 || true
+else
+  pass "fresh-state: no ~/.neat (virgin VM, first-install path)"
+fi
+if command -v neat >/dev/null 2>&1; then
+  fail "fresh-state: a global 'neat' is on PATH — base image is not virgin"
+else
+  pass "fresh-state: no global neat (npx pulls the pinned version)"
+fi
+note ""
+
+# ── 1. Copy the fixture off the read-only mount into a writable dir ─────────
+note "[1] copying fixture → $FIXTURE"
+mkdir -p "$FIXTURE"
+# Copy source only — never the host's node_modules / neat-out / artifacts.
+( cd "$FIXTURE_SRC" && cp package.json server.cjs "$FIXTURE/" ) || {
+  fail "copy: could not read fixture from $FIXTURE_SRC"; finish; }
+pass "copy: fixture staged"
+
+# ── 2. The headline one-command flow ───────────────────────────────────────
+# `npx neat.is@<version> <path>` is the real first-run UX: it discovers,
+# extracts, instruments (writes otel-init + patches package.json), spawns the
+# daemon, and opens the dashboard on :6328 with the loopback no-token surface.
+# We capture its full output — the banner, the summary, and the token line —
+# as the artifact a new user would see.
+note ""
+note "[2] npx neat.is@$VERSION $FIXTURE  (one-command flow)"
+# --no-open: the VM is headless; we drive the dashboard with Playwright instead.
+( cd "$FIXTURE" && npx -y "neat.is@$VERSION" "$FIXTURE" --no-open ) \
+  > "$ARTIFACTS/01-npx-neat.log" 2>&1
+ORCH_RC=$?
+tail -40 "$ARTIFACTS/01-npx-neat.log" | sed 's/^/  /' >> "$SUMMARY"
+if [ "$ORCH_RC" -eq 0 ]; then
+  pass "orchestrator: npx neat.is@$VERSION exited 0"
+else
+  fail "orchestrator: npx neat.is@$VERSION exited $ORCH_RC (see 01-npx-neat.log)"
+fi
+
+# The orchestrator patches package.json with the OTel deps but leaves the
+# install to the user ("Run npm install afterwards"). Do it so otel-init can
+# load @opentelemetry/sdk-node when the app boots.
+note ""
+note "[2b] npm install (picks up the OTel deps neat added)"
+( cd "$FIXTURE" && npm install --no-audit --no-fund ) > "$ARTIFACTS/02-npm-install.log" 2>&1 \
+  && pass "install: OTel deps installed" \
+  || fail "install: npm install failed (see 02-npm-install.log)"
+
+# Resolve the project name the orchestrator registered (basename of the dir).
+PROJECT="$(node -e '
+  const fs=require("fs"),path=require("path"),os=require("os");
+  const reg=path.join(process.env.NEAT_HOME||path.join(os.homedir(),".neat"),"projects.json");
+  const want=path.resolve(process.argv[1]);
+  try{const raw=JSON.parse(fs.readFileSync(reg,"utf8"));
+    const es=Array.isArray(raw)?raw:(raw.projects||Object.values(raw));
+    for(const e of es){const p=e&&(e.path||e.root||e.dir);
+      if(p&&path.resolve(p)===want){process.stdout.write(e.name||path.basename(p));process.exit(0)}}
+  }catch(_e){}
+  process.stdout.write(path.basename(want));
+' "$FIXTURE")"
+note "project registered as: $PROJECT"
+
+# Wait for the daemon REST to answer (the orchestrator detaches it).
+note ""
+note "[2c] waiting for daemon REST on :$REST_PORT"
+DAEMON_UP=0
+for i in $(seq 1 30); do
+  code="$(curl -sS --max-time 1 -o /dev/null -w '%{http_code}' "$NEAT_API_URL/projects" 2>/dev/null || echo 000)"
+  if [ "$code" = "200" ]; then DAEMON_UP=1; break; fi
+  sleep 1
+done
+[ "$DAEMON_UP" = "1" ] && pass "daemon: REST answering on :$REST_PORT" \
+  || fail "daemon: REST never came up on :$REST_PORT"
+
+# ── 3. Start the instrumented fixture app ──────────────────────────────────
+note ""
+note "[3] starting the instrumented fixture on :$APP_PORT"
+(
+  cd "$FIXTURE" || exit 1
+  PORT_APP="$APP_PORT" STUB_PORT="$((APP_PORT + 1))" \
+  NODE_OPTIONS="--require $FIXTURE/otel-init.cjs" \
+    node server.cjs
+) > "$ARTIFACTS/03-fixture-app.log" 2>&1 &
+APP_PID=$!
+# Wait for /health.
+APP_UP=0
+for i in $(seq 1 20); do
+  code="$(curl -sS --max-time 1 -o /dev/null -w '%{http_code}' "http://127.0.0.1:$APP_PORT/health" 2>/dev/null || echo 000)"
+  if [ "$code" = "200" ]; then APP_UP=1; break; fi
+  sleep 1
+done
+[ "$APP_UP" = "1" ] && pass "app: fixture answering /health on :$APP_PORT" \
+  || fail "app: fixture never answered /health (see 03-fixture-app.log)"
+
+# ── 4. Drive traffic so every tier emits spans ─────────────────────────────
+note ""
+note "[4] driving traffic (8 iterations across all routes)"
+for i in $(seq 1 8); do
+  for r in /quote /enrich /items /report; do
+    curl -sS -o /dev/null --max-time 4 "http://127.0.0.1:$APP_PORT$r"
+  done
+  curl -sS -o /dev/null --max-time 4 -X POST -H 'content-type: application/json' \
+    -d "{\"name\":\"run-$i\"}" "http://127.0.0.1:$APP_PORT/items"
+done
+pass "traffic: drove 8x5 requests"
+
+# Let the OTel batch span processor flush to the daemon.
+note "    waiting 10s for span batch flush"
+sleep 10
+
+# ── 5. The series of NEAT operations and queries ───────────────────────────
+note ""
+note "[5] NEAT operations and queries"
+
+# 5a. Bare-verb resolution — `neat divergences` with NO --project must resolve
+# to the single registered project, not 404. This is exactly the bare-verb fix.
+note ""
+note "[5a] neat divergences  (BARE verb — no --project; the bare-verb fix)"
+DIV_OUT="$ARTIFACTS/05a-divergences.txt"
+neat divergences > "$DIV_OUT" 2>&1
+DIV_RC=$?
+neat divergences --json > "$ARTIFACTS/05a-divergences.json" 2>&1 || true
+sed 's/^/  /' "$DIV_OUT" | head -20 >> "$SUMMARY"
+if [ "$DIV_RC" -eq 0 ] && ! grep -qiE '404|not found|several projects|could not pick|pass --project' "$DIV_OUT"; then
+  pass "divergences: bare verb resolved to '$PROJECT' (no 404, no ambiguity)"
+else
+  fail "divergences: bare verb did not resolve cleanly (rc=$DIV_RC — see 05a)"
+fi
+
+# 5b. semantic search — a term that exists in the graph.
+note ""
+note "[5b] neat search server"
+neat search server > "$ARTIFACTS/05b-search.txt" 2>&1 \
+  && pass "search: returned (rc 0)" \
+  || fail "search: non-zero exit (see 05b)"
+sed 's/^/  /' "$ARTIFACTS/05b-search.txt" | head -10 >> "$SUMMARY"
+
+# Pick a real node id from the graph for the traversal verbs — the fixture's
+# server file node, which carries both OBSERVED outbound edges.
+GRAPH_JSON="$ARTIFACTS/graph.json"
+
+# Fetch the project graph across both REST shapes:
+#   - current dual-mount model: the project lives at /projects/<name>/graph,
+#     and the bare /graph resolves to a (possibly absent) `default` project,
+#     which returns an empty {nodes:[],edges:[]} — valid JSON but zero nodes.
+#   - per-project-daemon model: the daemon IS the project, so the bare /graph
+#     carries it and there is no /projects/<name> prefix.
+# So we can't trust "valid JSON" — we accept a graph only once it has nodes,
+# trying the prefixed route first, then the bare root. Whichever yields nodes
+# wins, keeping the harness green across the refactor.
+graph_has_nodes() {
+  node -e 'try{const g=JSON.parse(require("fs").readFileSync(process.argv[1]));process.exit((g.nodes&&g.nodes.length>0)?0:1)}catch(_e){process.exit(1)}' "$1" 2>/dev/null
+}
+: > "$GRAPH_JSON"
+for url in "$NEAT_API_URL/projects/$PROJECT/graph" "$NEAT_API_URL/graph"; do
+  if curl -sS --max-time 5 "$url" -o "$GRAPH_JSON" 2>/dev/null && graph_has_nodes "$GRAPH_JSON"; then
+    note "graph fetched from: $url"
+    break
+  fi
+done
+NODE_ID="$(node -e '
+  try{const g=JSON.parse(require("fs").readFileSync(process.argv[1]));
+    const n=(g.nodes||[]).find(x=>x.id&&x.id.indexOf("server.cjs")!==-1)
+          ||(g.nodes||[]).find(x=>x.id&&x.id.startsWith("file:"));
+    process.stdout.write(n?n.id:"");
+  }catch(_e){process.stdout.write("")}
+' "$GRAPH_JSON")"
+note "node id for traversals: ${NODE_ID:-<none found>}"
+
+# 5c. root-cause — exercises the inbound traversal. A healthy node legitimately
+# has no root cause, so we assert the verb runs cleanly, not that it finds one.
+note ""
+note "[5c] neat root-cause $NODE_ID"
+if [ -n "$NODE_ID" ]; then
+  neat root-cause "$NODE_ID" > "$ARTIFACTS/05c-root-cause.txt" 2>&1 \
+    && pass "root-cause: ran (rc 0)" \
+    || fail "root-cause: non-zero exit (see 05c)"
+  sed 's/^/  /' "$ARTIFACTS/05c-root-cause.txt" | head -8 >> "$SUMMARY"
+else
+  fail "root-cause: no node id resolved from the graph"
+fi
+
+# 5d. blast-radius — outbound BFS; should reach the database node downstream.
+note ""
+note "[5d] neat blast-radius $NODE_ID"
+if [ -n "$NODE_ID" ]; then
+  neat blast-radius "$NODE_ID" > "$ARTIFACTS/05d-blast-radius.txt" 2>&1
+  BR_RC=$?
+  sed 's/^/  /' "$ARTIFACTS/05d-blast-radius.txt" | head -10 >> "$SUMMARY"
+  if [ "$BR_RC" -eq 0 ] && grep -qiE 'database:|affected' "$ARTIFACTS/05d-blast-radius.txt"; then
+    pass "blast-radius: reached downstream nodes (incl. database)"
+  else
+    fail "blast-radius: rc=$BR_RC or no downstream reach (see 05d)"
+  fi
+else
+  fail "blast-radius: no node id resolved from the graph"
+fi
+
+# ── 6. The correctness core — assert OBSERVED edges exist (>0) ─────────────
+# This is the same shape e2e/capture asserts: read the graph from REST and
+# require OBSERVED edges. We require both an outbound CALLS (frontier) and a
+# CONNECTS_TO (database), file-grained where the call-site processor landed.
+note ""
+note "[6] OBSERVED-edge assertion (the correctness core)"
+OBS_REPORT="$(node -e '
+  let g;
+  try{ g = JSON.parse(require("fs").readFileSync(process.argv[1])); }
+  catch(e){ console.log("ERR could not read graph: "+e.message); process.exit(3); }
+  const edges = g.edges||[];
+  const obs = edges.filter(e=>e.provenance==="OBSERVED");
+  const calls = obs.filter(e=>e.type==="CALLS");
+  const conn  = obs.filter(e=>e.type==="CONNECTS_TO");
+  console.log("observed_total="+obs.length);
+  console.log("observed_calls="+calls.length);
+  console.log("observed_connects_to="+conn.length);
+  for(const e of obs.slice(0,12)) console.log("  "+e.type+" "+e.source+" -> "+e.target+" spans="+((e.signal&&e.signal.spanCount)||"?"));
+  if(obs.length===0){ console.log("VERDICT fail-no-observed"); process.exit(1); }
+  if(calls.length===0){ console.log("VERDICT fail-no-calls"); process.exit(1); }
+  if(conn.length===0){ console.log("VERDICT fail-no-connects"); process.exit(1); }
+  console.log("VERDICT ok");
+' "$GRAPH_JSON" 2>&1)"
+OBS_RC=$?
+echo "$OBS_REPORT" | sed 's/^/  /' | tee -a "$SUMMARY"
+echo "$OBS_REPORT" > "$ARTIFACTS/06-observed.txt"
+if [ "$OBS_RC" -eq 0 ]; then
+  pass "observed: >0 OBSERVED edges, incl. CALLS->frontier and CONNECTS_TO->database"
+else
+  fail "observed: assertion failed (see 06-observed.txt — VERDICT line)"
+fi
+
+# ── 7. Dashboard screenshots (Playwright chromium) ─────────────────────────
+note ""
+note "[7] dashboard screenshots → $ARTIFACTS"
+if [ -f "$SCREENSHOT_MJS" ]; then
+  # Run from a dir where 'playwright' resolves. The base image installs
+  # playwright globally; link it in if a local resolve is needed.
+  node "$SCREENSHOT_MJS" \
+    --url "http://localhost:$WEB_PORT" \
+    --out "$ARTIFACTS" \
+    --project "$PROJECT" > "$ARTIFACTS/07-screenshot.log" 2>&1 || true
+  SHOTS="$(ls "$ARTIFACTS"/*.png 2>/dev/null | wc -l | tr -d ' ')"
+  if [ "${SHOTS:-0}" -ge 1 ]; then
+    pass "screenshots: captured $SHOTS PNG(s)"
+  else
+    # Screenshots are best-effort; a miss is a warning, not a hard fail.
+    note "WARN  screenshots: none captured (see 07-screenshot.log)"
+  fi
+else
+  note "WARN  screenshots: $SCREENSHOT_MJS not found on the mount — skipping"
+fi
+
+# ── 8. Tear down the fixture app and report ────────────────────────────────
+finish

--- a/e2e/tart/screenshot.mjs
+++ b/e2e/tart/screenshot.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// Playwright (chromium) dashboard capture — runs INSIDE the Tart VM.
+//
+// Navigates to the NEAT dashboard (loopback, no token locally), waits for the
+// cytoscape canvas to render, and writes a few PNGs to the artifacts dir on the
+// mounted host directory. Chromium specifically: a fresh macOS VM has no Chrome,
+// so we always launch the bundled chromium (`channel` is left unset → chromium).
+//
+// Resilient on purpose: every wait has a bounded timeout and a fallback, so a
+// dashboard that renders slowly (or a view that isn't reachable) downgrades to a
+// best-effort full-page shot rather than hanging the whole pipeline.
+//
+// Usage:
+//   node screenshot.mjs --url http://localhost:6328 --out /path/to/artifacts \
+//                       [--project <name>]
+//
+// Env fallbacks: DASHBOARD_URL, ARTIFACTS_DIR, NEAT_PROJECT.
+
+import { mkdir } from 'node:fs/promises'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+import { execSync } from 'node:child_process'
+
+// Resolve playwright robustly. ESM bare imports don't search the global
+// node_modules, and a fresh VM installs playwright globally — so resolve it
+// against the global root (npm root -g) and import by absolute path. Falls back
+// to a plain bare import when playwright is local to the run dir.
+function pickChromium(mod) {
+  // ESM import of the CJS playwright package surfaces `chromium` either as a
+  // named export (local import) or under `.default` (absolute-path import).
+  return mod.chromium ?? (mod.default && mod.default.chromium)
+}
+
+async function loadChromium() {
+  // 1) local resolve (run dir has playwright)
+  try {
+    const c = pickChromium(await import('playwright'))
+    if (c) return c
+  } catch {
+    /* fall through */
+  }
+  // 2) global resolve via `npm root -g`
+  try {
+    const globalRoot = execSync('npm root -g', { encoding: 'utf8' }).trim()
+    const req = createRequire(path.join(globalRoot, 'noop.js'))
+    const c = pickChromium(await import(req.resolve('playwright')))
+    if (c) return c
+  } catch {
+    /* fall through to the error below */
+  }
+  throw new Error(
+    'could not load playwright (local or global). ' +
+      'Install it: npm install -g playwright && npx playwright install chromium',
+  )
+}
+
+function arg(name, fallbackEnv, def) {
+  const i = process.argv.indexOf(`--${name}`)
+  if (i !== -1 && process.argv[i + 1]) return process.argv[i + 1]
+  if (fallbackEnv && process.env[fallbackEnv]) return process.env[fallbackEnv]
+  return def
+}
+
+const BASE = arg('url', 'DASHBOARD_URL', 'http://localhost:6328').replace(/\/$/, '')
+const OUT = arg('out', 'ARTIFACTS_DIR', './artifacts')
+const PROJECT = arg('project', 'NEAT_PROJECT', '')
+
+// Compose the dashboard URL. Passing ?project pins the view in a multi-project
+// dashboard; harmless when there's only one project (it resolves to it anyway).
+const dashUrl = PROJECT ? `${BASE}/?project=${encodeURIComponent(PROJECT)}` : `${BASE}/`
+
+const log = (m) => console.log(`[screenshot] ${m}`)
+
+async function safeShot(page, file, label) {
+  try {
+    await page.screenshot({ path: file, fullPage: false })
+    log(`captured ${label} → ${file}`)
+    return true
+  } catch (err) {
+    log(`WARN: ${label} screenshot failed: ${err.message}`)
+    return false
+  }
+}
+
+async function main() {
+  await mkdir(OUT, { recursive: true })
+
+  const chromium = await loadChromium()
+  // Always bundled chromium — a fresh VM has no system Chrome.
+  const browser = await chromium.launch({ args: ['--no-sandbox'] })
+  const context = await browser.newContext({ viewport: { width: 1600, height: 1000 } })
+  const page = await context.newPage()
+  page.setDefaultTimeout(20_000)
+
+  let ok = true
+  try {
+    log(`navigating to ${dashUrl}`)
+    await page.goto(dashUrl, { waitUntil: 'domcontentloaded', timeout: 30_000 })
+
+    // The canvas container is <div id="cy">. Wait for it, then for cytoscape to
+    // mount its inner <canvas> layers — that's the signal the graph drew.
+    try {
+      await page.waitForSelector('#cy', { timeout: 20_000 })
+      await page.waitForSelector('#cy canvas', { timeout: 20_000 })
+      log('cytoscape canvas mounted')
+    } catch (_e) {
+      log('WARN: never saw #cy canvas within timeout — capturing whatever rendered')
+      ok = false
+    }
+
+    // Give cose layout a beat to settle and the legend counts to populate.
+    // The legend count cells start as "—" and fill once the graph loads; wait
+    // for at least one to change, but don't block forever on it.
+    try {
+      await page.waitForFunction(
+        () => {
+          const cells = Array.from(document.querySelectorAll('.legend .ct'))
+          return cells.some((c) => c.textContent && c.textContent.trim() !== '—')
+        },
+        { timeout: 12_000 },
+      )
+      log('legend counts populated')
+    } catch (_e) {
+      log('WARN: legend counts stayed empty — graph may be small or still loading')
+    }
+    await page.waitForTimeout(1500)
+
+    // 1) The graph canvas — the headline shot.
+    ok = (await safeShot(page, path.join(OUT, 'dashboard-graph.png'), 'graph canvas')) && ok
+
+    // 2) A full-page shot for context (chrome + legend + canvas together).
+    try {
+      await page.screenshot({ path: path.join(OUT, 'dashboard-full.png'), fullPage: true })
+      log(`captured full page → ${path.join(OUT, 'dashboard-full.png')}`)
+    } catch (err) {
+      log(`WARN: full-page screenshot failed: ${err.message}`)
+    }
+
+    // 3) Best-effort inspector/divergence view. The dashboard surfaces
+    // divergences on the canvas and via an inspector panel; clicking a node
+    // opens it. We try a node click, then capture; if nothing opens, this is a
+    // no-op and the earlier shots stand.
+    try {
+      // Cytoscape draws to <canvas>, so DOM-clicking a node isn't reliable;
+      // instead click near the canvas center to trigger any hover/inspect, then
+      // look for the inspector aside.
+      const box = await page.locator('#cy').boundingBox()
+      if (box) {
+        await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2)
+        await page.waitForTimeout(800)
+      }
+      const inspector = page.locator('.inspect, aside.inspect, [class*="inspect"]').first()
+      if (await inspector.count()) {
+        await safeShot(page, path.join(OUT, 'dashboard-inspector.png'), 'inspector view')
+      } else {
+        log('no inspector panel reachable — skipping (graph shots stand)')
+      }
+    } catch (err) {
+      log(`inspector capture skipped: ${err.message}`)
+    }
+  } finally {
+    await browser.close()
+  }
+
+  if (!ok) {
+    log('completed with warnings (canvas may not have fully rendered)')
+    // Don't hard-fail the pipeline on a soft render miss; the assertions in
+    // scenario.sh are the correctness gate. Exit 0 so screenshots are
+    // best-effort, not a blocker.
+  }
+  log('done')
+}
+
+main().catch((err) => {
+  console.error('[screenshot] fatal:', err)
+  // A Playwright launch failure (no chromium) should be visible but not abort
+  // the whole run after the assertions already passed; exit 0, log loudly.
+  process.exit(0)
+})


### PR DESCRIPTION
A throwaway-VM harness that runs NEAT's genuine first-install experience on a virgin Mac, every time, from a clean baseline — using [Tart](https://github.com/cirruslabs/tart).

## Why

The maintainer's dev machine carries NEAT state: a global `neat`, a populated `~/.neat`, built artifacts, sometimes an orphaned lock. That state masks a whole class of first-run bugs that only a Mac that has never seen NEAT will surface — a stale global shadowing the pinned version (#505), an orphaned lock, version skew. This harness spins up exactly that virgin Mac.

It does three jobs:
1. **First-install reproduction** — the path the stateful dev machine masks.
2. **Version-regression harness** — run a matrix and diff the per-version artifacts.
3. **Validation harness for the per-project-daemon refactor** (the project-daemon contract) — it asserts the bare-verb behavior (`neat divergences` with no `--project` resolving to the single project) and probes both the bare `/graph` and the prefixed `/projects/<name>/graph`, so it stays green across the migration.

## Flow

`neat-base` (baked once) → `tart clone` → `tart run --dir neat=<repo>` → ssh in → `scenario.sh <version>` runs `npx neat.is@<v> <fixture>`, drives traffic, runs `neat divergences / search / root-cause / blast-radius`, asserts `OBSERVED` edges over REST, captures Playwright (chromium) screenshots → collect artifacts off the mount → `tart stop` + `tart delete` (the VM kills itself). Loops over a version matrix; teardown is trapped so a failure never leaks a VM.

## Files (`e2e/tart/`)

- `fixture/` — self-contained Express service. A real outbound HTTP call forms `CALLS → frontier`; a `better-sqlite3` connection forms `CONNECTS_TO → database`. Zero external deps (no Postgres, no creds, no internet). SQLite has no bundled OTel instrumentation, so the fixture emits a real CLIENT span at the call site (the way `neat extend` does for any uncovered library) — the edge still lands file-grained.
- `base-image.sh` — one-time prep of the virgin baseline (Node 20.x + git + chromium, no NEAT state). Host steps scripted; the SSH-into-VM provisioning is automated via `sshpass` and printed for manual paste.
- `run.sh` — host-side matrix runner (clone → run+mount → ssh → collect → stop+delete), trap-cleaned.
- `scenario.sh` — runs inside the VM: the headline one-command flow + the query series + the OBSERVED-edge assertion, writing a PASS/FAIL summary to the mounted artifacts dir.
- `screenshot.mjs` — Playwright chromium capture of the `:6328` dashboard canvas, resilient (bounded waits, best-effort).
- `README.md` — end-to-end usage and what each assertion proves.

## Validated locally vs. needs Tart

Validated on the maintainer's machine **in full isolation** (throwaway `NEAT_HOME` + alternate ports, never the live daemon):
- The fixture forms both OBSERVED edges: `CALLS file:neat-tart-fixture:server.cjs → frontier` and `CONNECTS_TO file:neat-tart-fixture:server.cjs → database:sqlite.local`, file-grained.
- `neat divergences` (bare verb) resolves to the single project; `blast-radius` reaches the database node downstream.
- `screenshot.mjs` renders and captures the cytoscape graph canvas showing both Extracted and Observed edges.

**Needs Tart** (macOS virtualization, can't run in CI here, so the maintainer runs it): the VM orchestration in `base-image.sh` / `run.sh`. The scenario it drives is the same one validated locally.

Additive only — nothing outside `e2e/tart/` is touched. Please do **not** auto-merge; the Tart side wants a maintainer run first.

Refs #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)