### PR TITLE
Resolve the MCP server's daemon per project from neat-out/daemon.json

### DIFF
--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -45,7 +45,9 @@ Two MCP resources sit alongside the tools — same data, different access patter
 
 ## Configuration
 
-`NEAT_CORE_URL` — base URL for the core REST API. Default `http://localhost:8080`.
+`NEAT_CORE_URL` — base URL for the daemon's REST API. When set, it wins outright (that's how the hosted substrate pins the MCP server at a fixed daemon). `NEAT_API_URL` is honored as an alias for back-compat with older `neat skill` configs; `NEAT_CORE_URL` wins when both are set.
+
+When neither env var is set, the server resolves the **per-project daemon** for the project it was launched in (ADR-096 / `docs/contracts/project-daemon.md`): it walks up from the cwd to the nearest `neat-out/daemon.json` and talks to `http://localhost:<ports.rest>`. A missing, malformed, or `status: "stopped"` record falls through to the canonical `http://localhost:8080` default — resolution never throws.
 
 `NEAT_RESOURCE_POLL_MS` — interval in ms for the `neat://incidents/recent` change-detection poll. Default `5000`. `0` disables it.
 

--- a/packages/mcp/src/base-url.ts
+++ b/packages/mcp/src/base-url.ts
@@ -1,11 +1,90 @@
 // Resolve the daemon URL the MCP server talks to.
 //
-// `NEAT_CORE_URL` is the canonical name (the README and the MCP server both use
-// it). `NEAT_API_URL` is honored as an accepted alias so configs written by
-// older `neat skill` versions — which emitted `NEAT_API_URL` — still reach the
-// daemon (#488). `NEAT_CORE_URL` wins when both are set. Neither set falls back
-// to the loopback default. Lives in its own module so the resolution is
-// testable without importing index.ts, which starts the stdio transport on load.
-export function resolveBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
-  return env.NEAT_CORE_URL ?? env.NEAT_API_URL ?? 'http://localhost:8080'
+// Under the per-project daemon model (ADR-096 / docs/contracts/project-daemon.md)
+// each project runs its own daemon on its own ports and records them in
+// `<projectRoot>/neat-out/daemon.json`. The MCP server points at the daemon for
+// the project it was launched in, so resolution walks up from the cwd to the
+// nearest `neat-out/daemon.json` and uses its REST port. An explicit
+// `NEAT_CORE_URL` / `NEAT_API_URL` still wins — that's how the hosted/prod
+// substrate pins the MCP server at a fixed daemon — and the canonical loopback
+// default catches the case where neither the env nor a daemon record is present.
+//
+// `NEAT_API_URL` is honored as an accepted alias so configs written by older
+// `neat skill` versions — which emitted `NEAT_API_URL` — still reach the daemon
+// (#488). `NEAT_CORE_URL` wins when both are set.
+//
+// Lives in its own module so the resolution is testable without importing
+// index.ts, which starts the stdio transport on load.
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+const DEFAULT_BASE_URL = 'http://localhost:8080'
+
+// The slice of `neat-out/daemon.json` the MCP server depends on. The full record
+// (pid, projectPath, otlp/web ports, …) is owned by the daemon writer; the MCP
+// server only needs the REST port and the liveness status. We read the file as
+// plain JSON rather than importing the writer's type so this stays decoupled
+// from the daemon package that owns the schema.
+interface DaemonRecordShape {
+  status?: unknown
+  ports?: { rest?: unknown }
+}
+
+// Read the REST base URL out of a project's `neat-out/daemon.json`, walking up
+// from `cwd` to the filesystem root to find the nearest one. Returns undefined
+// for every failure mode — no file, unreadable, malformed JSON, a stopped
+// daemon, or a missing/invalid REST port — so the caller falls through to the
+// next precedence level rather than the MCP server failing to start.
+function resolveFromDaemonRecord(cwd: string): string | undefined {
+  let dir = cwd
+  // Walk parents until the path stops changing (the filesystem root, where
+  // dirname() is a fixed point).
+  for (;;) {
+    const url = readDaemonRecord(join(dir, 'neat-out', 'daemon.json'))
+    if (url !== undefined) return url
+
+    const parent = dirname(dir)
+    if (parent === dir) return undefined
+    dir = parent
+  }
+}
+
+function readDaemonRecord(path: string): string | undefined {
+  let raw: string
+  try {
+    raw = readFileSync(path, 'utf8')
+  } catch {
+    // No daemon.json here (the common case while walking up). Keep looking.
+    return undefined
+  }
+
+  let record: DaemonRecordShape
+  try {
+    record = JSON.parse(raw) as DaemonRecordShape
+  } catch {
+    // A daemon.json that exists but is garbage: a daemon caught mid-write, a
+    // truncated file. Treat it as absent rather than crashing the MCP server.
+    return undefined
+  }
+
+  if (record == null || typeof record !== 'object') return undefined
+  // A daemon that has marked itself stopped no longer answers on its ports.
+  if (record.status === 'stopped') return undefined
+
+  const rest = record.ports?.rest
+  if (typeof rest !== 'number' || !Number.isInteger(rest) || rest <= 0 || rest > 65535) {
+    return undefined
+  }
+
+  return `http://localhost:${rest}`
+}
+
+export function resolveBaseUrl(
+  env: NodeJS.ProcessEnv = process.env,
+  cwd: string = process.cwd(),
+): string {
+  const override = env.NEAT_CORE_URL ?? env.NEAT_API_URL
+  if (override) return override
+
+  return resolveFromDaemonRecord(cwd) ?? DEFAULT_BASE_URL
 }

--- a/packages/mcp/test/base-url.test.ts
+++ b/packages/mcp/test/base-url.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { resolveBaseUrl } from '../src/base-url.js'
 
 // #488 — the MCP server read only NEAT_CORE_URL, but `neat skill --apply` wrote
@@ -7,7 +10,7 @@ import { resolveBaseUrl } from '../src/base-url.js'
 // daemon wasn't at that default — the hosted-customer case. The server now
 // honors both names.
 
-describe('resolveBaseUrl', () => {
+describe('resolveBaseUrl env overrides', () => {
   it('reads NEAT_API_URL when NEAT_CORE_URL is unset (the skill-generated case)', () => {
     expect(resolveBaseUrl({ NEAT_API_URL: 'http://daemon.internal:9000' })).toBe(
       'http://daemon.internal:9000',
@@ -23,7 +26,100 @@ describe('resolveBaseUrl', () => {
     ).toBe('http://core.internal:9000')
   })
 
-  it('falls back to localhost:8080 when neither is set', () => {
-    expect(resolveBaseUrl({})).toBe('http://localhost:8080')
+  it('falls back to localhost:8080 when neither an env nor a daemon record is present', () => {
+    // Point the cwd at an empty temp dir so the walk-up finds no daemon.json.
+    const dir = mkdtempSync(join(tmpdir(), 'neat-mcp-baseurl-empty-'))
+    try {
+      expect(resolveBaseUrl({}, dir)).toBe('http://localhost:8080')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+// ADR-096 / docs/contracts/project-daemon.md — one daemon per project, each
+// recording its allocated ports in `<projectRoot>/neat-out/daemon.json`. The
+// MCP server resolves the daemon for the project it was launched in by walking
+// up from the cwd to the nearest such record and using its REST port. All
+// fixtures live in an isolated temp dir; nothing here touches a real daemon,
+// real ports, or `~/.neat`.
+
+describe('resolveBaseUrl daemon.json resolution', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'neat-mcp-baseurl-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  function writeDaemonJson(projectRoot: string, record: unknown): void {
+    const dir = join(projectRoot, 'neat-out')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'daemon.json'), JSON.stringify(record), 'utf8')
+  }
+
+  const running = (rest: number): Record<string, unknown> => ({
+    project: 'alpha',
+    projectPath: root,
+    pid: 4242,
+    status: 'running',
+    ports: { rest, otlp: 4318, web: 6328 },
+    startedAt: '2026-06-13T00:00:00.000Z',
+    neatVersion: '0.4.17',
+  })
+
+  it('resolves the daemon REST port from neat-out/daemon.json at the cwd', () => {
+    writeDaemonJson(root, running(8123))
+    expect(resolveBaseUrl({}, root)).toBe('http://localhost:8123')
+  })
+
+  it('walks up parent directories to the nearest daemon.json', () => {
+    writeDaemonJson(root, running(8200))
+    const nested = join(root, 'packages', 'svc', 'src')
+    mkdirSync(nested, { recursive: true })
+    expect(resolveBaseUrl({}, nested)).toBe('http://localhost:8200')
+  })
+
+  it('lets an explicit NEAT_CORE_URL override beat the daemon record', () => {
+    writeDaemonJson(root, running(8123))
+    expect(resolveBaseUrl({ NEAT_CORE_URL: 'http://core.internal:9000' }, root)).toBe(
+      'http://core.internal:9000',
+    )
+  })
+
+  it('lets the NEAT_API_URL alias beat the daemon record', () => {
+    writeDaemonJson(root, running(8123))
+    expect(resolveBaseUrl({ NEAT_API_URL: 'http://daemon.internal:9000' }, root)).toBe(
+      'http://daemon.internal:9000',
+    )
+  })
+
+  it('falls back to localhost:8080 when the daemon has marked itself stopped', () => {
+    writeDaemonJson(root, { ...running(8123), status: 'stopped' })
+    expect(resolveBaseUrl({}, root)).toBe('http://localhost:8080')
+  })
+
+  it('falls back to localhost:8080 on a malformed (garbage) daemon.json', () => {
+    const dir = join(root, 'neat-out')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'daemon.json'), '{ this is not json', 'utf8')
+    expect(resolveBaseUrl({}, root)).toBe('http://localhost:8080')
+  })
+
+  it('falls back to localhost:8080 when the REST port is missing', () => {
+    writeDaemonJson(root, {
+      project: 'alpha',
+      status: 'running',
+      ports: { otlp: 4318, web: 6328 },
+    })
+    expect(resolveBaseUrl({}, root)).toBe('http://localhost:8080')
+  })
+
+  it('falls back to localhost:8080 when the REST port is out of range', () => {
+    writeDaemonJson(root, running(70000))
+    expect(resolveBaseUrl({}, root)).toBe('http://localhost:8080')
   })
 })


### PR DESCRIPTION
The MCP server talked to a single hardcoded URL (`NEAT_CORE_URL ?? NEAT_API_URL ?? http://localhost:8080`). Under the per-project daemon model each project runs its own daemon on its own ports, so the MCP server needs to find the right one for the project it was launched in.

Resolution now works in precedence order:

1. An explicit `NEAT_CORE_URL` / `NEAT_API_URL` wins — that's how the hosted/prod substrate pins the server at a fixed daemon (`NEAT_CORE_URL` wins when both are set).
2. Otherwise walk up from the cwd to the nearest `neat-out/daemon.json` and use `http://localhost:<ports.rest>`.
3. Otherwise the canonical `http://localhost:8080` default.

Every daemon.json failure mode — absent, unreadable, malformed JSON, `status: "stopped"`, missing or out-of-range REST port — falls through to the next level rather than throwing, so the server always starts. The file is read as plain JSON against the pinned `daemon.json` shape; nothing is imported from the daemon package that owns the schema, so this stays decoupled from the in-flight writer PR and falls back gracefully on `main` where no daemon.json exists yet.

Scope is `packages/mcp/` only. The `base-url` tests cover a fixture record resolving to its REST port, the parent-directory walk-up, both env overrides beating the record, and every garbage case landing on 8080 — all against an isolated temp dir, never a real daemon, real ports, or `~/.neat`.

Refs #366. Implements ADR-096 and the project-daemon contract (`docs/contracts/project-daemon.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)