### PR TITLE
Re-home machine-wide discovery off the write-locked registry

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -21,11 +21,16 @@ import { runDeploy, renderOtelEnvBlock } from './deploy/detect.js'
 import { pathsForProject } from './projects.js'
 import {
   addProject,
+  findDaemonByProject,
+  listMachineProjects,
   listProjects,
   ProjectNameCollisionError,
   pruneRegistry,
   removeProject,
+  removeDaemonRecord,
   setStatus,
+  signalDaemonStop,
+  type MachineProject,
 } from './registry.js'
 import {
   INSTALLERS,
@@ -131,11 +136,15 @@ export function usage(): void {
   console.log('  watch <path>   Start neat-core, watch <path>, re-extract on changes.')
   console.log('                 PORT (default 8080), OTEL_PORT (4318), HOST (0.0.0.0)')
   console.log('                 control listeners. NEAT_OTLP_GRPC=true also opens 4317.')
-  console.log('  list           List every project registered in the machine-level registry.')
-  console.log('  pause <name>   Mark a project paused — daemon stops watching until resumed.')
-  console.log('  resume <name>  Mark a project active again.')
+  console.log('  list           Report the daemons running on this machine (alias: ps).')
+  console.log('                 Reads ~/.neat/daemons/ and folds in any registered')
+  console.log('                 project no daemon has self-described yet.')
+  console.log('  ps             Alias of list.')
+  console.log('  pause <name>   Stop a project\'s daemon until it is started again.')
+  console.log('  resume <name>  Bring a paused project back; for a stopped daemon, re-run')
+  console.log('                 `neat <path>` to start it.')
   console.log('  uninstall <name>')
-  console.log('                 Remove a project from the registry. Does not touch')
+  console.log('                 Stop a project\'s daemon and retire it. Does not touch')
   console.log('                 neat-out/, policy.json, or any user file.')
   console.log('  prune          Drop registry entries whose path is gone from disk.')
   console.log('                 Flags: --json   emit the removed list as JSON')
@@ -358,6 +367,18 @@ export { printBanner, readPackageVersion }
 
 function printVersion(): void {
   process.stdout.write(`${readPackageVersion()}\n`)
+}
+
+// One `neat list` / `neat ps` row. A discovery-backed row reports the daemon's
+// state and ports; a legacy registry row (no daemon file yet) reports
+// `registered` and the registry status so the migration window stays legible.
+function formatMachineProjectRow(r: MachineProject): string {
+  if (r.ports) {
+    const where = r.pid !== undefined ? `\tpid=${r.pid}` : ''
+    return `${r.project}\t${r.state}\trest=${r.ports.rest} otlp=${r.ports.otlp} web=${r.ports.web}\t${r.projectPath}${where}`
+  }
+  const status = r.registryStatus ? `\t(${r.registryStatus})` : ''
+  return `${r.project}\t${r.state}${status}\t${r.projectPath}`
 }
 
 function printDiscoveryReport(opts: InitOptions, services: DiscoveredService[]): void {
@@ -813,26 +834,42 @@ export async function main(): Promise<void> {
     return
   }
 
-  if (cmd === 'list') {
-    const projects = await listProjects()
-    if (projects.length === 0) {
-      console.log('no projects registered. run `neat init <path>` to register one.')
+  // `list` / `ps` both report the daemons discovered on the machine. ADR-096
+  // §6 — discovery reads the lock-free `~/.neat/daemons/` directory and folds
+  // in any legacy registry entries no daemon has self-described yet, so a
+  // pre-migration install still lists its projects.
+  if (cmd === 'list' || cmd === 'ps') {
+    const rows = await listMachineProjects()
+    if (rows.length === 0) {
+      console.log('no daemons running and no projects registered. run `neat init <path>` to register one.')
       return
     }
-    for (const p of projects) {
-      const seen = p.lastSeenAt ? p.lastSeenAt : 'never'
-      const langs = p.languages.length > 0 ? p.languages.join(',') : '-'
-      console.log(`${p.name}\t${p.status}\t${langs}\t${p.path}\tlast-seen=${seen}`)
+    for (const r of rows) {
+      console.log(formatMachineProjectRow(r))
     }
     return
   }
 
+  // `pause` stops a project's daemon. Under one-daemon-per-project (ADR-096)
+  // that is the per-daemon shutdown driven by the discovery record's pid. While
+  // a project still lives only in the legacy registry (the migration window
+  // before #508 lands), it falls back to flipping the registry status the
+  // multi-project daemon reads.
   if (cmd === 'pause') {
     const name = positional[0]
     if (!name) {
       console.error('neat pause: missing <name>')
       usage()
       process.exit(2)
+    }
+    const daemon = await findDaemonByProject(name)
+    if (daemon) {
+      if (daemon.live && signalDaemonStop(daemon.record.pid)) {
+        console.log(`paused: ${name} (${daemon.record.projectPath}) — stopped daemon pid ${daemon.record.pid}`)
+      } else {
+        console.log(`paused: ${name} (${daemon.record.projectPath}) — daemon was not running`)
+      }
+      return
     }
     try {
       const entry = await setStatus(name, 'paused')
@@ -844,12 +881,25 @@ export async function main(): Promise<void> {
     return
   }
 
+  // `resume` brings a paused project back. Spawning a per-project daemon is the
+  // orchestrator's job (`neat <path>`), so against a stopped daemon record we
+  // point the operator at it; against a legacy registry entry we flip the
+  // status the multi-project daemon reads, preserving the pre-migration shape.
   if (cmd === 'resume') {
     const name = positional[0]
     if (!name) {
       console.error('neat resume: missing <name>')
       usage()
       process.exit(2)
+    }
+    const daemon = await findDaemonByProject(name)
+    if (daemon) {
+      if (daemon.live) {
+        console.log(`resume: ${name} (${daemon.record.projectPath}) — daemon already running`)
+      } else {
+        console.log(`resume: ${name} (${daemon.record.projectPath}) — run \`neat ${daemon.record.projectPath}\` to start its daemon again`)
+      }
+      return
     }
     try {
       const entry = await setStatus(name, 'active')
@@ -867,6 +917,10 @@ export async function main(): Promise<void> {
     return
   }
 
+  // `uninstall` retires a project. Under ADR-096 that means stopping its daemon
+  // (via the discovery record's pid) and clearing its discovery file, then
+  // dropping any legacy registry row. As before it never touches neat-out/,
+  // policy.json, or user files at the project path (ADR-048 #6).
   if (cmd === 'uninstall') {
     const name = positional[0]
     if (!name) {
@@ -874,12 +928,23 @@ export async function main(): Promise<void> {
       usage()
       process.exit(2)
     }
+    const daemon = await findDaemonByProject(name)
     const removed = await removeProject(name)
-    if (!removed) {
+    if (!daemon && !removed) {
       console.error(`neat uninstall: no project named "${name}"`)
       process.exit(1)
     }
-    console.log(`unregistered: ${removed.name} (${removed.path})`)
+    const projectPath = daemon?.record.projectPath ?? removed?.path ?? '(unknown path)'
+    if (daemon) {
+      if (daemon.live && signalDaemonStop(daemon.record.pid)) {
+        console.log(`uninstall: ${name} — stopped daemon pid ${daemon.record.pid}`)
+      }
+      // Clear the discovery copy. A live daemon clears its own on graceful stop,
+      // but removing it here covers a daemon that crashed without cleanup and
+      // makes the verb idempotent against a stale record.
+      await removeDaemonRecord(daemon.source)
+    }
+    console.log(`unregistered: ${name} (${projectPath})`)
     console.log('note: neat-out/, policy.json, and other files at the project path were left in place.')
     return
   }

--- a/packages/core/src/otel.ts
+++ b/packages/core/src/otel.ts
@@ -449,12 +449,18 @@ export async function buildOtelReceiver(
   }
 
   // One-time-per-service-name deprecation warning for spans landing on the
-  // legacy global endpoint. The replacement is the project-scoped URL
-  // (`/projects/<project>/v1/traces`) the installer writes into `.env.neat`
-  // from v0.4.4. The warning is once-per-name so a long-running daemon
-  // doesn't flood stderr while an operator is migrating.
+  // bare `/v1/traces` endpoint. Under one daemon per project (ADR-096) that
+  // route is the project's own ingest path and needs no migration, so the
+  // warning is gated on whether this receiver actually offers project-scoped
+  // routing: only a receiver wired with `onProjectSpan` (the multi-project
+  // daemon that mounts `/projects/<name>/v1/traces`) has somewhere to migrate
+  // an exporter to. A single-project receiver leaves the gate closed and never
+  // nags. Still once-per-name so a long-running daemon doesn't flood stderr
+  // while an operator migrates.
+  const offersProjectRouting = opts.onProjectSpan !== undefined
   const legacyEndpointWarned = new Set<string>()
   function warnLegacyEndpoint(serviceName: string): void {
+    if (!offersProjectRouting) return
     if (legacyEndpointWarned.has(serviceName)) return
     legacyEndpointWarned.add(serviceName)
     console.warn(

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1,20 +1,32 @@
 /**
- * Machine-level project registry (ADR-048).
+ * Machine-level project registry + machine-wide daemon discovery.
  *
- * One file: `~/.neat/projects.json`. Per-user, machine-local. Not synced.
- * `registry.ts` is the only module that opens it. Everything else — `init`,
- * `daemon`, `cli` — calls into the helpers below.
+ * This module owns two surfaces under `~/.neat/`:
  *
- * Two safety properties matter:
- *  1. Atomic writes. We tmp + fsync + rename so the daemon never sees a torn
- *     file when init races against it.
- *  2. Cross-process exclusion. We hold an exclusive lock on
- *     `~/.neat/projects.json.lock` for the read-modify-write window. Two
- *     concurrent `neat init` runs cannot both win and overwrite each other.
+ *  1. The legacy project registry at `~/.neat/projects.json` (ADR-048). One
+ *     file, per-user, machine-local, not synced. Under the project-daemon
+ *     contract (ADR-096) it is no longer the coordination point — it is read
+ *     once for migration and otherwise left to the additive writes the daemon
+ *     and orchestrator still perform. The read-modify-write helpers below keep
+ *     their atomic-write + exclusive-lock machinery for that legacy surface.
  *
- * The lock is a file we exclusively-create (`O_EXCL`), hold while we mutate,
- * and unlink on the way out. Crude but cross-platform; matches what
- * `proper-lockfile` does internally without pulling the dep in.
+ *  2. The machine-wide daemon discovery directory at `~/.neat/daemons/`
+ *     (ADR-096 §6). One file per running daemon — `<project>.json` — each owned
+ *     solely by the daemon that wrote it (on start) and removes it (on graceful
+ *     stop). Discovery is **append-only and lock-free**: a reader scans the
+ *     directory and reconciles liveness; it never acquires a shared lock, so it
+ *     can never deadlock against a daemon (#506). Losing or rebuilding the
+ *     directory costs discovery convenience, not correctness — each project's
+ *     own `neat-out/daemon.json` stays authoritative.
+ *
+ * `neat ps` / `neat list` and the per-daemon `pause` / `resume` / `uninstall`
+ * verbs read discovery, falling back to the legacy registry where no daemon
+ * file is present yet (the migration window before every daemon self-describes).
+ *
+ * The legacy lock is a file we exclusively-create (`O_EXCL`), hold while we
+ * mutate, and unlink on the way out. Crude but cross-platform; matches what
+ * `proper-lockfile` does internally without pulling the dep in. It never sits
+ * on the discovery path.
  */
 
 import { promises as fs } from 'node:fs'
@@ -53,6 +65,264 @@ export function registryLockPath(): string {
 // rather than the daemon mid-write.
 function daemonPidPath(): string {
   return path.join(neatHome(), 'neatd.pid')
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// #366 / ADR-096 §6 — machine-wide daemon discovery, lock-free.
+//
+// Each running daemon drops a `<project>.json` file into `~/.neat/daemons/`
+// on start and removes it on graceful stop. The file is a copy of that
+// project's authoritative `neat-out/daemon.json` record. A daemon owns only
+// its own file — there is no shared file and no shared lock. Discovery reads
+// the directory and reconciles liveness; it never acquires a lock, so it can
+// never deadlock against a daemon mid-write the way the registry lock did
+// (#506). The shape mirrors what the daemon writes (keystone #508); we read it
+// as plain JSON rather than importing the daemon's writer so the two stay
+// decoupled, and validate defensively so a malformed file is skipped, not
+// fatal.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface DaemonPorts {
+  rest: number
+  otlp: number
+  web: number
+}
+
+export interface DaemonRecord {
+  project: string
+  // Project root whose `neat-out/` holds the authoritative record.
+  projectPath: string
+  pid: number
+  status: 'running' | 'stopped'
+  ports: DaemonPorts
+  // ISO8601.
+  startedAt: string
+  neatVersion: string
+}
+
+// A discovered daemon plus the liveness verdict the reader reconciled. `live`
+// is true only when the record claims `running` AND its pid is actually alive
+// — a daemon that crashed without clearing its file reads as `running` but
+// `live: false`, so `neat ps` never reports a ghost as up.
+export interface DiscoveredDaemon {
+  record: DaemonRecord
+  live: boolean
+  // Where the discovery copy was read from. Useful for diagnostics and for the
+  // per-daemon verbs that clean a stale file.
+  source: string
+}
+
+export function daemonsDir(): string {
+  return path.join(neatHome(), 'daemons')
+}
+
+function isFiniteInt(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v)
+}
+
+// Parse one discovery file's contents into a DaemonRecord, or undefined when
+// the shape doesn't hold. Defensive on purpose: discovery is convenience, so a
+// half-written or hand-edited file is skipped rather than crashing `neat ps`.
+function parseDaemonRecord(raw: string): DaemonRecord | undefined {
+  let obj: unknown
+  try {
+    obj = JSON.parse(raw)
+  } catch {
+    return undefined
+  }
+  if (typeof obj !== 'object' || obj === null) return undefined
+  const r = obj as Record<string, unknown>
+  const ports = r.ports as Record<string, unknown> | undefined
+  if (
+    typeof r.project !== 'string' ||
+    typeof r.projectPath !== 'string' ||
+    !isFiniteInt(r.pid) ||
+    (r.status !== 'running' && r.status !== 'stopped') ||
+    typeof r.startedAt !== 'string' ||
+    typeof r.neatVersion !== 'string' ||
+    !ports ||
+    !isFiniteInt(ports.rest) ||
+    !isFiniteInt(ports.otlp) ||
+    !isFiniteInt(ports.web)
+  ) {
+    return undefined
+  }
+  return {
+    project: r.project,
+    projectPath: r.projectPath,
+    pid: r.pid,
+    status: r.status,
+    ports: { rest: ports.rest, otlp: ports.otlp, web: ports.web },
+    startedAt: r.startedAt,
+    neatVersion: r.neatVersion,
+  }
+}
+
+// Liveness for a discovered daemon. Exported (via the default probe) so the
+// verbs and tests reconcile the same way: `running` claim AND pid alive.
+export function isPidAlive(pid: number): boolean {
+  return isPidAliveDefault(pid)
+}
+
+export interface DiscoveryProbe {
+  isPidAlive(pid: number): boolean
+}
+
+const defaultDiscoveryProbe: DiscoveryProbe = { isPidAlive: isPidAliveDefault }
+
+/**
+ * Scan `~/.neat/daemons/` and return every well-formed discovery record with
+ * its reconciled liveness. Lock-free: a plain directory read, no rendezvous.
+ *
+ * A missing directory (no daemon has ever started under this model) yields an
+ * empty list — first run, nothing to discover. Malformed or unreadable files
+ * are skipped silently; discovery degrades to "fewer entries," never an error.
+ */
+export async function discoverDaemons(
+  probe: DiscoveryProbe = defaultDiscoveryProbe,
+): Promise<DiscoveredDaemon[]> {
+  const dir = daemonsDir()
+  let names: string[]
+  try {
+    names = await fs.readdir(dir)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw err
+  }
+  const out: DiscoveredDaemon[] = []
+  for (const name of names) {
+    if (!name.endsWith('.json')) continue
+    const file = path.join(dir, name)
+    let raw: string
+    try {
+      raw = await fs.readFile(file, 'utf8')
+    } catch {
+      continue
+    }
+    const record = parseDaemonRecord(raw)
+    if (!record) continue
+    const live = record.status === 'running' && probe.isPidAlive(record.pid)
+    out.push({ record, live, source: file })
+  }
+  out.sort((a, b) => a.record.project.localeCompare(b.record.project))
+  return out
+}
+
+/**
+ * Remove a daemon's discovery file. A daemon owns its own file, so this is for
+ * the per-daemon verbs reconciling a record whose daemon is gone (a crashed
+ * daemon that never cleared its own file) — never a rendezvous another process
+ * coordinates through. Best-effort: an already-absent file is success.
+ */
+export async function removeDaemonRecord(source: string): Promise<void> {
+  await fs.unlink(source).catch(() => {})
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// #366 / ADR-096 §8 — migration off the global registry.
+//
+// Installs carrying `~/.neat/projects.json` map their registered projects onto
+// per-project daemons on first run under this model. The discovery directory is
+// authoritative for "what's running"; the registry is read once to surface
+// projects that were registered before any daemon self-described, so the
+// machine-wide verbs still see them during the migration window. The registry
+// is no longer the coordination surface — nothing here writes it back.
+// ─────────────────────────────────────────────────────────────────────────
+
+// A unified view for the machine-wide verbs: a discovered daemon when one is
+// present, otherwise a legacy registry entry projected into the same shape so
+// `neat ps` / `neat list` render one table regardless of which surface the
+// project lives on yet.
+export interface MachineProject {
+  project: string
+  projectPath: string
+  // 'running' / 'stopped' come from a live discovery record; 'registered'
+  // marks a legacy registry entry with no daemon file yet (migration window).
+  state: 'running' | 'stopped' | 'registered'
+  // Present only when a discovery record backs this row.
+  ports?: DaemonPorts
+  // Legacy registry status when the row came from the registry; undefined for
+  // a discovery-backed row.
+  registryStatus?: RegistryStatus
+  pid?: number
+}
+
+/**
+ * The machine-wide project view the CLI verbs render. Discovery wins: every
+ * `~/.neat/daemons/` record becomes a row (running or stopped per liveness).
+ * Legacy registry entries whose path isn't already covered by a discovery
+ * record are folded in as `registered` rows so a pre-#508 install still lists
+ * its projects. Keyed on resolved path so a registry entry and its daemon
+ * record collapse to one row.
+ *
+ * Read-only on both surfaces. The registry is read once for migration; nothing
+ * here writes it back, in keeping with ADR-096 §8.
+ */
+export async function listMachineProjects(
+  probe: DiscoveryProbe = defaultDiscoveryProbe,
+): Promise<MachineProject[]> {
+  const discovered = await discoverDaemons(probe)
+  const byPath = new Map<string, MachineProject>()
+  for (const d of discovered) {
+    const key = await normalizeProjectPath(d.record.projectPath)
+    byPath.set(key, {
+      project: d.record.project,
+      projectPath: d.record.projectPath,
+      state: d.live ? 'running' : 'stopped',
+      ports: d.record.ports,
+      pid: d.record.pid,
+    })
+  }
+
+  // Migration read: legacy registry entries not already covered by a daemon
+  // record. Read once, never written back.
+  let legacy: RegistryEntry[] = []
+  try {
+    legacy = (await readRegistry()).projects
+  } catch {
+    // A corrupt legacy file shouldn't sink discovery — the daemons we found are
+    // still valid. Skip the legacy fold.
+    legacy = []
+  }
+  for (const entry of legacy) {
+    const key = await normalizeProjectPath(entry.path)
+    if (byPath.has(key)) continue
+    byPath.set(key, {
+      project: entry.name,
+      projectPath: entry.path,
+      state: 'registered',
+      registryStatus: entry.status,
+    })
+  }
+
+  return [...byPath.values()].sort((a, b) => a.project.localeCompare(b.project))
+}
+
+// Find a discovery record by project name, with its reconciled liveness. The
+// per-daemon verbs key on the project name the operator types; discovery is the
+// source of truth for whether a daemon is running and which pid to signal.
+export async function findDaemonByProject(
+  name: string,
+  probe: DiscoveryProbe = defaultDiscoveryProbe,
+): Promise<DiscoveredDaemon | undefined> {
+  const discovered = await discoverDaemons(probe)
+  return discovered.find((d) => d.record.project === name)
+}
+
+// Signal a running daemon to shut down via its discovery-recorded pid. SIGTERM
+// is the graceful-stop signal every daemon already wires (neatd.ts) — the
+// daemon clears its own discovery file on the way out. Returns true when the
+// signal was delivered, false when the pid was already gone (nothing to stop).
+export function signalDaemonStop(pid: number): boolean {
+  try {
+    process.kill(pid, 'SIGTERM')
+    return true
+  } catch (err) {
+    // ESRCH → already gone; treat as a no-op success of intent. EPERM and the
+    // rest surface as "couldn't signal" so the verb can report honestly.
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return false
+    throw err
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -11537,7 +11537,35 @@ describe('v0.4.4 substrate — project-scoped OTLP routing + runtime-kind + hook
       }
     })
 
-    it('legacy /v1/traces still routes via the existing onSpan handler and logs a one-time deprecation warning', async () => {
+    // ADR-096 §6 / #366 — under one daemon per project the bare `/v1/traces`
+    // is that project's own ingest path, so a single-project receiver routes it
+    // and never nags. The migrate-to-/projects warning fires only for a
+    // receiver that actually offers project-scoped routing (`onProjectSpan`
+    // wired), where an exporter has somewhere to migrate to.
+    function legacyTracesBody(serviceName: string) {
+      return {
+        resourceSpans: [
+          {
+            resource: { attributes: [{ key: 'service.name', value: { stringValue: serviceName } }] },
+            scopeSpans: [
+              {
+                spans: [
+                  {
+                    traceId: 'cc'.repeat(16),
+                    spanId: 'dd'.repeat(8),
+                    name: 'GET /',
+                    startTimeUnixNano: '1700000000000000000',
+                    endTimeUnixNano: '1700000000010000000',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }
+    }
+
+    it('single-project /v1/traces routes via onSpan and does not nag (ADR-096)', async () => {
       const { buildOtelReceiver } = await import('../../src/otel.js')
       const seen: string[] = []
       const warnings: string[] = []
@@ -11547,6 +11575,8 @@ describe('v0.4.4 substrate — project-scoped OTLP routing + runtime-kind + hook
         origWarn(msg as never, ...(rest as never[]))
       }
       try {
+        // No onProjectSpan — a single-project daemon's receiver. The bare route
+        // is the normal path, not a legacy one.
         const app = await buildOtelReceiver({
           onSpan: (span) => {
             seen.push(span.service)
@@ -11554,38 +11584,58 @@ describe('v0.4.4 substrate — project-scoped OTLP routing + runtime-kind + hook
         })
         const address = await app.listen({ port: 0, host: '127.0.0.1' })
         try {
-          const body = {
-            resourceSpans: [
-              {
-                resource: { attributes: [{ key: 'service.name', value: { stringValue: 'legacy-svc' } }] },
-                scopeSpans: [
-                  {
-                    spans: [
-                      {
-                        traceId: 'cc'.repeat(16),
-                        spanId: 'dd'.repeat(8),
-                        name: 'GET /',
-                        startTimeUnixNano: '1700000000000000000',
-                        endTimeUnixNano: '1700000000010000000',
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
+          const body = legacyTracesBody('solo-svc')
+          for (let i = 0; i < 2; i++) {
+            const r = await fetch(`${address}/v1/traces`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify(body),
+            })
+            expect(r.status).toBe(200)
           }
-          const r1 = await fetch(`${address}/v1/traces`, {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify(body),
-          })
-          expect(r1.status).toBe(200)
-          const r2 = await fetch(`${address}/v1/traces`, {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify(body),
-          })
-          expect(r2.status).toBe(200)
+          await app.flushPending()
+          expect(seen).toEqual(['solo-svc', 'solo-svc'])
+          const deprecation = warnings.filter((w) =>
+            w.includes('received span on the global endpoint'),
+          )
+          expect(deprecation).toHaveLength(0)
+        } finally {
+          await app.close()
+        }
+      } finally {
+        console.warn = origWarn
+      }
+    })
+
+    it('multi-project /v1/traces routes via onSpan and logs a one-time migrate warning', async () => {
+      const { buildOtelReceiver } = await import('../../src/otel.js')
+      const seen: string[] = []
+      const warnings: string[] = []
+      const origWarn = console.warn
+      console.warn = (msg: unknown, ...rest: unknown[]) => {
+        warnings.push(String(msg))
+        origWarn(msg as never, ...(rest as never[]))
+      }
+      try {
+        // onProjectSpan wired — a receiver that offers `/projects/<name>/...`,
+        // so the bare route is the legacy one and a span on it warns once.
+        const app = await buildOtelReceiver({
+          onSpan: (span) => {
+            seen.push(span.service)
+          },
+          onProjectSpan: () => {},
+        })
+        const address = await app.listen({ port: 0, host: '127.0.0.1' })
+        try {
+          const body = legacyTracesBody('legacy-svc')
+          for (let i = 0; i < 2; i++) {
+            const r = await fetch(`${address}/v1/traces`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify(body),
+            })
+            expect(r.status).toBe(200)
+          }
           await app.flushPending()
           expect(seen).toEqual(['legacy-svc', 'legacy-svc'])
           const deprecation = warnings.filter((w) =>

--- a/packages/core/test/cli-machine-verbs.test.ts
+++ b/packages/core/test/cli-machine-verbs.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { daemonsDir, type DaemonRecord } from '../src/registry.js'
+
+// #366 / ADR-096 — the machine-wide CLI verbs (`list` / `ps` / `pause` /
+// `resume` / `uninstall`) read the lock-free `~/.neat/daemons/` discovery
+// directory. These drive `main()` with a stubbed argv against an isolated
+// NEAT_HOME; the real ~/.neat and its live daemon are never touched. Every
+// discovery file uses a guaranteed-dead pid so no real process is signalled.
+
+const DEAD_PID = 2 ** 30
+
+let home: string
+let prevHome: string | undefined
+const origArgv = process.argv
+let exitSpy: ReturnType<typeof vi.spyOn>
+let logSpy: ReturnType<typeof vi.spyOn>
+let errSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(async () => {
+  home = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-cli-verbs-home-'))
+  prevHome = process.env.NEAT_HOME
+  process.env.NEAT_HOME = home
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new Error(`__exit__:${code ?? 0}`)
+  }) as never)
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(async () => {
+  exitSpy.mockRestore()
+  logSpy.mockRestore()
+  errSpy.mockRestore()
+  process.argv = origArgv
+  if (prevHome === undefined) delete process.env.NEAT_HOME
+  else process.env.NEAT_HOME = prevHome
+  await fs.rm(home, { recursive: true, force: true })
+})
+
+async function writeDaemonFile(over: Partial<DaemonRecord> = {}): Promise<void> {
+  const record: DaemonRecord = {
+    project: 'alpha',
+    projectPath: '/tmp/alpha',
+    pid: DEAD_PID,
+    status: 'running',
+    ports: { rest: 8080, otlp: 4318, web: 6328 },
+    startedAt: '2026-06-13T00:00:00.000Z',
+    neatVersion: '0.4.17',
+    ...over,
+  }
+  const dir = daemonsDir()
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(path.join(dir, `${record.project}.json`), JSON.stringify(record, null, 2) + '\n', 'utf8')
+}
+
+function logged(): string {
+  return logSpy.mock.calls.map((c) => String(c[0] ?? '')).join('\n')
+}
+
+async function runMain(args: string[]): Promise<void> {
+  // argv[1] is neutral so the module's auto-run guard doesn't fire on import.
+  process.argv = ['node', '/tmp/test-runner', ...args]
+  const { main } = await import('../src/cli.js')
+  await main()
+}
+
+describe('neat list / ps (discovery-backed)', () => {
+  it('reports nothing when no daemons run and nothing is registered', async () => {
+    await runMain(['list'])
+    expect(logged()).toContain('no daemons running and no projects registered')
+  })
+
+  it('lists a discovered daemon (dead pid → stopped) with its ports', async () => {
+    await writeDaemonFile({ project: 'alpha', pid: DEAD_PID })
+    await runMain(['list'])
+    const out = logged()
+    expect(out).toContain('alpha')
+    expect(out).toContain('stopped')
+    expect(out).toContain('rest=8080')
+    expect(out).toContain('otlp=4318')
+    expect(out).toContain('web=6328')
+  })
+
+  it('ps is an alias of list', async () => {
+    await writeDaemonFile({ project: 'beta', pid: DEAD_PID })
+    await runMain(['ps'])
+    expect(logged()).toContain('beta')
+  })
+})
+
+describe('neat pause (per-daemon)', () => {
+  it('reports the daemon was not running when its pid is dead', async () => {
+    await writeDaemonFile({ project: 'alpha', pid: DEAD_PID })
+    await runMain(['pause', 'alpha'])
+    expect(logged()).toContain('daemon was not running')
+  })
+})
+
+describe('neat uninstall (per-daemon)', () => {
+  it('clears the discovery file and reports the project unregistered', async () => {
+    await writeDaemonFile({ project: 'alpha', projectPath: '/tmp/alpha', pid: DEAD_PID })
+    await runMain(['uninstall', 'alpha'])
+    expect(logged()).toContain('unregistered: alpha')
+    // The discovery file is gone.
+    await expect(fs.access(path.join(daemonsDir(), 'alpha.json'))).rejects.toThrow()
+  })
+
+  it('errors when no daemon record and no registry entry exist', async () => {
+    await expect(runMain(['uninstall', 'ghost'])).rejects.toThrow('__exit__:1')
+  })
+})
+
+describe('neat resume (per-daemon)', () => {
+  it('points the operator at re-running the orchestrator for a stopped daemon', async () => {
+    await writeDaemonFile({ project: 'alpha', projectPath: '/tmp/alpha', pid: DEAD_PID })
+    await runMain(['resume', 'alpha'])
+    expect(logged()).toMatch(/start its daemon again/)
+  })
+})

--- a/packages/core/test/daemon-discovery.test.ts
+++ b/packages/core/test/daemon-discovery.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import {
+  addProject,
+  daemonsDir,
+  discoverDaemons,
+  findDaemonByProject,
+  listMachineProjects,
+  removeDaemonRecord,
+  type DaemonRecord,
+  type DiscoveryProbe,
+} from '../src/registry.js'
+
+// #366 / ADR-096 §6 — machine-wide discovery reads the lock-free
+// `~/.neat/daemons/` directory and reconciles liveness. These tests run against
+// an isolated NEAT_HOME tmpdir; the real ~/.neat and its live daemon are never
+// touched. No real PIDs are signalled — liveness goes through an injected probe.
+
+let home: string
+let prevHome: string | undefined
+
+beforeEach(async () => {
+  home = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-discovery-home-'))
+  prevHome = process.env.NEAT_HOME
+  process.env.NEAT_HOME = home
+})
+
+afterEach(async () => {
+  if (prevHome === undefined) delete process.env.NEAT_HOME
+  else process.env.NEAT_HOME = prevHome
+  await fs.rm(home, { recursive: true, force: true })
+})
+
+// Write one discovery file the way a daemon would (keystone #508): a copy of
+// its neat-out/daemon.json under ~/.neat/daemons/<project>.json.
+async function writeDaemonFile(record: DaemonRecord): Promise<string> {
+  const dir = daemonsDir()
+  await fs.mkdir(dir, { recursive: true })
+  const file = path.join(dir, `${record.project}.json`)
+  await fs.writeFile(file, JSON.stringify(record, null, 2) + '\n', 'utf8')
+  return file
+}
+
+function record(over: Partial<DaemonRecord> = {}): DaemonRecord {
+  return {
+    project: 'alpha',
+    projectPath: '/tmp/alpha',
+    pid: 4242,
+    status: 'running',
+    ports: { rest: 8080, otlp: 4318, web: 6328 },
+    startedAt: '2026-06-13T00:00:00.000Z',
+    neatVersion: '0.4.17',
+    ...over,
+  }
+}
+
+// A probe that treats a fixed PID set as alive — no real process signalling.
+function probe(alivePids: number[]): DiscoveryProbe {
+  const alive = new Set(alivePids)
+  return { isPidAlive: (pid) => alive.has(pid) }
+}
+
+describe('discoverDaemons', () => {
+  it('returns an empty list when no daemons directory exists', async () => {
+    expect(await discoverDaemons(probe([]))).toEqual([])
+  })
+
+  it('reports a running daemon as live when its pid is alive', async () => {
+    await writeDaemonFile(record({ project: 'alpha', pid: 4242 }))
+    const found = await discoverDaemons(probe([4242]))
+    expect(found).toHaveLength(1)
+    expect(found[0]!.record.project).toBe('alpha')
+    expect(found[0]!.live).toBe(true)
+    expect(found[0]!.record.ports).toEqual({ rest: 8080, otlp: 4318, web: 6328 })
+  })
+
+  it('reports a running record whose pid is dead as not live (a ghost daemon)', async () => {
+    await writeDaemonFile(record({ project: 'alpha', pid: 9999, status: 'running' }))
+    const found = await discoverDaemons(probe([])) // 9999 not alive
+    expect(found).toHaveLength(1)
+    expect(found[0]!.live).toBe(false)
+  })
+
+  it('reports a status=stopped record as not live even if the pid happens to be alive', async () => {
+    await writeDaemonFile(record({ project: 'alpha', pid: 4242, status: 'stopped' }))
+    const found = await discoverDaemons(probe([4242]))
+    expect(found[0]!.live).toBe(false)
+  })
+
+  it('skips malformed and non-json files without failing', async () => {
+    const dir = daemonsDir()
+    await fs.mkdir(dir, { recursive: true })
+    await fs.writeFile(path.join(dir, 'broken.json'), '{ not json', 'utf8')
+    await fs.writeFile(path.join(dir, 'partial.json'), JSON.stringify({ project: 'x' }), 'utf8')
+    await fs.writeFile(path.join(dir, 'notes.txt'), 'ignore me', 'utf8')
+    await writeDaemonFile(record({ project: 'good', pid: 4242 }))
+
+    const found = await discoverDaemons(probe([4242]))
+    expect(found.map((d) => d.record.project)).toEqual(['good'])
+  })
+
+  it('sorts records by project name', async () => {
+    await writeDaemonFile(record({ project: 'zeta', pid: 1 }))
+    await writeDaemonFile(record({ project: 'alpha', pid: 2 }))
+    const found = await discoverDaemons(probe([1, 2]))
+    expect(found.map((d) => d.record.project)).toEqual(['alpha', 'zeta'])
+  })
+})
+
+describe('findDaemonByProject', () => {
+  it('finds a daemon by project name with its liveness', async () => {
+    await writeDaemonFile(record({ project: 'alpha', pid: 4242 }))
+    const d = await findDaemonByProject('alpha', probe([4242]))
+    expect(d?.record.project).toBe('alpha')
+    expect(d?.live).toBe(true)
+    expect(d?.source.endsWith('alpha.json')).toBe(true)
+  })
+
+  it('returns undefined for an unknown project', async () => {
+    await writeDaemonFile(record({ project: 'alpha', pid: 4242 }))
+    expect(await findDaemonByProject('nope', probe([4242]))).toBeUndefined()
+  })
+})
+
+describe('removeDaemonRecord', () => {
+  it('removes a discovery file and is idempotent', async () => {
+    const file = await writeDaemonFile(record({ project: 'alpha', pid: 4242 }))
+    await removeDaemonRecord(file)
+    await expect(fs.access(file)).rejects.toThrow()
+    // Already gone — still resolves.
+    await expect(removeDaemonRecord(file)).resolves.toBeUndefined()
+  })
+})
+
+describe('listMachineProjects — discovery + legacy migration fold (ADR-096 §8)', () => {
+  it('renders a running discovery daemon as running with its ports', async () => {
+    await writeDaemonFile(record({ project: 'alpha', projectPath: '/tmp/alpha', pid: 4242 }))
+    const rows = await listMachineProjects(probe([4242]))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      project: 'alpha',
+      state: 'running',
+      ports: { rest: 8080, otlp: 4318, web: 6328 },
+      pid: 4242,
+    })
+  })
+
+  it('renders a dead discovery daemon as stopped', async () => {
+    await writeDaemonFile(record({ project: 'alpha', pid: 9999, status: 'running' }))
+    const rows = await listMachineProjects(probe([]))
+    expect(rows[0]!.state).toBe('stopped')
+  })
+
+  it('folds a legacy registry entry with no daemon file as a registered row', async () => {
+    // A pre-#508 install: registered in projects.json, no daemon file yet.
+    await addProject({ name: 'legacy-proj', path: home, status: 'active' })
+    const rows = await listMachineProjects(probe([]))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      project: 'legacy-proj',
+      state: 'registered',
+      registryStatus: 'active',
+    })
+    expect(rows[0]!.ports).toBeUndefined()
+  })
+
+  it('collapses a registry entry and its daemon record (same path) to one row', async () => {
+    // The realpath-normalized home is what the registry stores; the daemon
+    // record points at the same path, so the two must collapse.
+    const real = await fs.realpath(home)
+    await addProject({ name: 'alpha', path: home, status: 'active' })
+    await writeDaemonFile(record({ project: 'alpha', projectPath: real, pid: 4242 }))
+
+    const rows = await listMachineProjects(probe([4242]))
+    expect(rows).toHaveLength(1)
+    // Discovery wins — the row is running with ports, not a registered stub.
+    expect(rows[0]!.state).toBe('running')
+    expect(rows[0]!.ports).toBeDefined()
+  })
+
+  it('returns an empty list when nothing is running and nothing is registered', async () => {
+    expect(await listMachineProjects(probe([]))).toEqual([])
+  })
+})


### PR DESCRIPTION
Moves NEAT's machine-wide CLI surface off the write-locked `~/.neat/projects.json` registry and onto the lock-free `~/.neat/daemons/` discovery directory, the coordination shape the per-project-daemon refactor needs.

## What changed

**`registry.ts`** — adds a discovery layer beside the legacy registry helpers:
- `discoverDaemons()` scans `~/.neat/daemons/`, parses each `<project>.json` defensively (a malformed file is skipped, not fatal), and reconciles liveness: a record reads as up only when it claims `running` *and* its pid is actually alive, so a crashed daemon that never cleared its file never reads as a ghost.
- `listMachineProjects()` is the unified view the verbs render. Discovery wins; legacy `projects.json` entries with no daemon file yet fold in as `registered` rows so a pre-migration install still lists its projects. The registry is read once for that fold and never written back as a coordination surface (ADR-096 §8).
- `findDaemonByProject()` / `signalDaemonStop()` / `removeDaemonRecord()` back the per-daemon verbs.
- The reader holds no lock, so it can never deadlock against a daemon mid-write the way the registry lock did (#506). The registry's existing lock + atomic-write machinery stays in place for the legacy file the daemon and orchestrator still write — see the seam note below.

**`cli.ts`** — re-homes the verbs:
- `neat ps` (alias `neat list`) reports discovered daemons with their project and ports.
- `pause` / `uninstall` resolve the discovery record and stop the daemon by its own pid; `uninstall` also clears the discovery file. They fall back to the legacy registry while a project lives only in `projects.json`. None of them touch `neat-out/`, `policy.json`, or user files (ADR-048 #6).
- `resume` points the operator at re-running `neat <path>` to restart a stopped daemon (spawn is the orchestrator's job), keeping the registry status flip for the legacy path.

**`otel.ts`** — a single-project daemon no longer nags. The bare `/v1/traces` route is that project's own ingest path under one-daemon-per-project, so the "migrate to /projects/<name>/v1/traces" warning now fires only when the receiver actually offers project-scoped routing (`onProjectSpan` wired) — the one case an exporter has somewhere to migrate to.

## Tests
- New `daemon-discovery.test.ts` and `cli-machine-verbs.test.ts`, both against an isolated `NEAT_HOME` with guaranteed-dead pids — the real `~/.neat` and its live daemon are never touched, no real process is signalled.
- Updated the OTLP-routing audit to the ADR-096 shape: a single-project receiver routes the bare endpoint without nagging; a multi-project receiver still warns once per service.
- `npx turbo build test lint` green (full suite uncached); the ADR-048 lock/atomic-write audits stay green.

## Seam touching a #508 file
The registry's `projects.json` writes (`addProject` / `setStatus` / `removeProject`) and the daemon's/orchestrator's additive writes to it are left in place by design — discovery now reads daemon-owned files, so retiring those registry writes is a clean follow-up once every daemon self-describes via `neat-out/daemon.json` (#508). No #508-owned file (`daemon.ts`, `neatd.ts`, `orchestrator.ts`, `installers/templates.ts`) is touched; the discovery record is read as plain JSON per the keystone shape rather than importing the daemon's writer.

Implements ADR-096 §6 / §8 and the project-daemon contract (`docs/contracts/project-daemon.md`).

Refs #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)