### PR TITLE
Lead NEAT's framing with the AI coding context problem

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,13 @@ Agent guide for the NEAT repo. Read this first if you're a fresh Claude session 
 
 ## What NEAT is
 
-NEAT keeps a live semantic graph of a software system. Code, infrastructure, and runtime behavior land in one model, queryable over MCP and a REST API. The graph carries provenance on every edge: `EXTRACTED` from source, `OBSERVED` from OpenTelemetry, `INFERRED` where the trace stitcher bridges gaps, `STALE` when runtime stops speaking. Divergence between declared intent and observed reality is the load-bearing finding NEAT surfaces.
+NEAT solves the AI coding context problem. It keeps a live semantic graph of a software system — code, infrastructure, and runtime behavior fused into one model, queryable over MCP and a REST API — so an AI agent has accurate, full-stack context: enough to build whole feature sets and debug autonomously, instead of grepping files and guessing. The graph carries provenance on every edge: `EXTRACTED` from source, `OBSERVED` from OpenTelemetry, `INFERRED` where the trace stitcher bridges gaps, `STALE` when runtime stops speaking — so the agent knows how much to trust each claim. Divergence between declared intent and observed reality is one of the questions that fusion makes answerable; root-cause, blast-radius, and policy checks are others. The graph is the product; those queries are features of it, not the point.
 
 The extraction pipeline reads static code via tree-sitter (JavaScript, TypeScript, Python) and ingests live OTel spans to build and maintain the graph.
 
 ## What success looks like
 
-NEAT earns its keep when it finds a real bug in a real codebase it was not engineered against. The `OBSERVED` layer carries the load. Static analysis alone is what other tools already do.
+NEAT earns its keep when an agent, using the graph as its eyes, builds or debugs a real system more autonomously and accurately than the same agent without it — on a codebase NEAT was not engineered against. The `OBSERVED` layer carries the load: fusing runtime with static lets the agent see what the system actually does, not only what it declares. Static analysis alone is what other tools already do. A real bug surfaced along the way — say, through a divergence query — is evidence the model works; agent autonomy is the goal.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Release](https://img.shields.io/github/v/release/NEAT-Technologies/Neat)](https://github.com/NEAT-Technologies/Neat/releases)
 [![Website](https://img.shields.io/badge/website-neat.is-black)](https://neat.is)
 
-NEAT constructs a live deterministic architecture model of your codebase for AI to query, code, debug and write rules for. This achieves the following:
+NEAT solves the AI coding context problem. It constructs a live deterministic model of your codebase — static code and live runtime behavior fused into one graph — and hands your AI agents the grounded, full-stack context they need to query, code, debug, and write rules against it. This achieves the following:
 - Coding LLMs hallucinate less & are more accurate.
 - Rather than endlessly grepping files and guessing problems, NEAT provides time-travelling error logs along the model's nodes and edges so the LLM can infer exactly what's wrong.
 - Rules & Policies allow agents to write new features while adhering to rules set by previous features, other LLMs, or engineers. For example, only use postgres for services x and y, and mongoDB for services p and q (the possibilities are endless).

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -1,10 +1,10 @@
 # NEAT user guide
 
-NEAT builds a live graph of your system from your source code and your production traces at once, and shows you where the two disagree. This guide takes you from nothing to asking the graph real questions — on the command line and through an AI agent.
+NEAT builds a live graph of your system from your source code and your production traces at once — one accurate, full-stack model your AI agents can use as grounded context to build features and debug, instead of grepping files and guessing. This guide takes you from nothing to asking the graph real questions — on the command line and through an AI agent.
 
 Read it in order:
 
-1. **[Getting started](./getting-started.md)** — from nothing to your first divergence in about five minutes. One command, run your app, see where code and reality part ways.
+1. **[Getting started](./getting-started.md)** — from nothing to a live, queryable graph in about five minutes. One command, run your app, watch the model fill in.
 2. **[Core concepts](./concepts.md)** — the four ideas the whole model rests on: the graph, provenance, divergence, and the file as the unit.
 3. **[Querying the graph](./querying.md)** — every CLI query verb as a reference, each with a real example and the answer it returns.
 4. **[Using NEAT with an AI agent](./ai-agents.md)** — wire the graph into Claude Code (or any MCP client) and let the agent walk it for you, with provenance attached to every answer.

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -1,6 +1,6 @@
 # Core concepts
 
-A few ideas carry the whole model: the **graph**, **provenance**, **divergence**, **policies**, and the **file as the unit**. The graph is the engine — one model fused from static code and runtime telemetry; divergence and policies are two of the things you ask it. Understand these and everything else in NEAT follows.
+A few ideas carry the whole model: the **graph**, **provenance**, **divergence**, **policies**, and the **file as the unit**. The graph is the engine — one model fused from static code and runtime telemetry, built to give you and your AI agents accurate, full-stack context to act on; divergence and policies are two of the things you ask it. Understand these and everything else in NEAT follows.
 
 ## The graph
 


### PR DESCRIPTION
Re-centers NEAT's user-facing framing so the **AI coding context problem** is the headline: NEAT gives AI agents accurate, full-stack context — code and live runtime fused into one graph — to build feature sets and debug autonomously. The graph is the product; divergence, root-cause, blast-radius, and policies are features of it.

What changed:
- **README** — the lead now names the context problem and the agent-autonomy payoff.
- **CLAUDE.md** — "What NEAT is" leads with the context problem and ranks divergence as one of the questions the fusion answers, not the load-bearing finding; "What success looks like" is agent autonomy, with a surfaced bug as evidence the model works.
- **docs/guide** — the guide intro and getting-started entry lead with the graph-as-grounded-context for agents; "first divergence" becomes "first live, queryable graph."

Divergence stays a first-class feature — its concept, guide page, CLI verb, and contract are untouched. This pass only moves it from headline to one query among several.

Positioning follow-on to #499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)