### PR TITLE
Let the daemon finish its graceful shutdown before exiting

### DIFF
--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -32,7 +32,7 @@ import { createRequire } from 'node:module'
 import type { FastifyInstance } from 'fastify'
 import { DEFAULT_PROJECT, getGraph, resetGraph, type NeatGraph } from './graph.js'
 import { extractFromDirectory } from './extract.js'
-import { loadGraphFromDisk, startPersistLoop } from './persist.js'
+import { loadGraphFromDisk, saveGraphToDisk, startPersistLoop } from './persist.js'
 import { Projects, pathsForProject, type ProjectPaths } from './projects.js'
 import { buildApi } from './api.js'
 import { buildOtelReceiver } from './otel.js'
@@ -418,7 +418,11 @@ async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
   const detachEvents = attachGraphToEventBus(graph, { project: entry.name })
   try {
     await extractFromDirectory(graph, entry.path)
-    const stopPersist = startPersistLoop(graph, outPath)
+    // The daemon owns shutdown, so the persist loop must not exit the process
+    // on a signal — that would end us before `stop()` clears the daemon.json,
+    // discovery copy, and pid file. `stop()` flushes this graph one last time
+    // as it tears the slot down (see below).
+    const stopPersist = startPersistLoop(graph, outPath, { exitOnSignal: false })
     await touchLastSeen(entry.name).catch(() => {})
 
     return {
@@ -1118,6 +1122,14 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
     }
     if (otlpApp) await otlpApp.close().catch(() => {})
     if (restApp) await restApp.close().catch(() => {})
+    // Listeners are down, so the graph is now at its final state. Flush each
+    // active slot once before tearing its persist loop down — the loops run
+    // with `exitOnSignal: false`, so this is where the shutdown save lives now.
+    for (const slot of slots.values()) {
+      if (slot.status === 'active' && slot.outPath) {
+        await saveGraphToDisk(slot.graph, slot.outPath).catch(() => {})
+      }
+    }
     for (const slot of slots.values()) {
       teardownSlot(slot)
     }

--- a/packages/core/src/persist.ts
+++ b/packages/core/src/persist.ts
@@ -122,14 +122,36 @@ export async function loadGraphFromDisk(graph: NeatGraph, outPath: string): Prom
   graph.import(payload.graph)
 }
 
-// Periodic save + best-effort save on SIGTERM/SIGINT. Returns a cleanup that
-// clears the interval and unhooks the signal handlers — important for tests so
-// they don't keep the process alive.
+export interface PersistLoopOptions {
+  // How often the periodic background save fires. Defaults to 60s.
+  intervalMs?: number
+  // Whether a SIGTERM/SIGINT should flush the graph and then exit the process.
+  // Defaults to true, which is what the standalone owners (`neat serve`,
+  // `neat watch`) want: the persist loop is the only thing holding the process
+  // open, so it owns the shutdown — flush, then exit.
+  //
+  // The daemon owns its own orderly shutdown (it closes its listeners, flushes
+  // every slot, clears its `daemon.json` + the machine-wide discovery copy, and
+  // removes its pid file before exiting). It runs many persist loops, one per
+  // project, and an exiting signal handler inside any of them would end the
+  // process out from under that teardown — leaving the discovery copy and pid
+  // file behind. So the daemon passes `false`: each loop still saves on its
+  // interval and unhooks cleanly on teardown, but the daemon decides when the
+  // process exits.
+  exitOnSignal?: boolean
+}
+
+// Periodic save + (optionally) a best-effort save-and-exit on SIGTERM/SIGINT.
+// Returns a cleanup that clears the interval and unhooks any signal handlers —
+// important for tests so they don't keep the process alive, and for the daemon
+// so a torn-down slot's loop stops reacting to signals.
 export function startPersistLoop(
   graph: NeatGraph,
   outPath: string,
-  intervalMs = 60_000,
+  opts: PersistLoopOptions = {},
 ): () => void {
+  const intervalMs = opts.intervalMs ?? 60_000
+  const exitOnSignal = opts.exitOnSignal ?? true
   let stopped = false
 
   const tick = async (): Promise<void> => {
@@ -145,26 +167,32 @@ export function startPersistLoop(
     void tick()
   }, intervalMs)
 
-  const onSignal = (signal: NodeJS.Signals): void => {
-    void (async () => {
-      try {
-        await saveGraphToDisk(graph, outPath)
-      } catch (err) {
-        console.error(`persist: ${signal} save failed`, err)
-      } finally {
-        process.exit(0)
+  const onSignal = exitOnSignal
+    ? (signal: NodeJS.Signals): void => {
+        void (async () => {
+          try {
+            await saveGraphToDisk(graph, outPath)
+          } catch (err) {
+            console.error(`persist: ${signal} save failed`, err)
+          } finally {
+            process.exit(0)
+          }
+        })()
       }
-    })()
-  }
+    : null
 
-  process.on('SIGTERM', onSignal)
-  process.on('SIGINT', onSignal)
+  if (onSignal) {
+    process.on('SIGTERM', onSignal)
+    process.on('SIGINT', onSignal)
+  }
 
   return () => {
     stopped = true
     clearInterval(interval)
-    process.off('SIGTERM', onSignal)
-    process.off('SIGINT', onSignal)
+    if (onSignal) {
+      process.off('SIGTERM', onSignal)
+      process.off('SIGINT', onSignal)
+    }
   }
 }
 

--- a/packages/core/test/persist.test.ts
+++ b/packages/core/test/persist.test.ts
@@ -146,10 +146,35 @@ describe('persistence', () => {
     const sigtermBefore = process.listenerCount('SIGTERM')
     const sigintBefore = process.listenerCount('SIGINT')
 
-    const stop = startPersistLoop(graph, outPath, 50)
+    const stop = startPersistLoop(graph, outPath, { intervalMs: 50 })
     try {
       expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore + 1)
       expect(process.listenerCount('SIGINT')).toBe(sigintBefore + 1)
+
+      await new Promise((r) => setTimeout(r, 120))
+      const raw = await fs.readFile(outPath, 'utf8')
+      expect(JSON.parse(raw).graph.nodes.length).toBeGreaterThan(0)
+    } finally {
+      stop()
+    }
+
+    expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore)
+    expect(process.listenerCount('SIGINT')).toBe(sigintBefore)
+  })
+
+  it('startPersistLoop with exitOnSignal:false installs no signal handlers but still saves on its interval', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, DEMO_PATH)
+
+    const sigtermBefore = process.listenerCount('SIGTERM')
+    const sigintBefore = process.listenerCount('SIGINT')
+
+    // The daemon owns shutdown, so its persist loops must not register a
+    // process-exiting signal handler — that would race the daemon's teardown.
+    const stop = startPersistLoop(graph, outPath, { intervalMs: 50, exitOnSignal: false })
+    try {
+      expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore)
+      expect(process.listenerCount('SIGINT')).toBe(sigintBefore)
 
       await new Promise((r) => setTimeout(r, 120))
       const raw = await fs.readFile(outPath, 'utf8')

--- a/packages/core/test/project-daemon.test.ts
+++ b/packages/core/test/project-daemon.test.ts
@@ -420,4 +420,44 @@ describe('per-project daemon — §1 spans land in the right graph, none drop (A
     // here rather than on a project this daemon doesn't host.
     expect(list[0]!.status).toBe('active')
   })
+
+  // §2/§6 — a graceful stop is the daemon's to finish. It flushes the graph,
+  // flips its neat-out/ record to "stopped", and removes both the machine-wide
+  // discovery copy and the pid file. The persist loops it runs no longer exit
+  // the process on a signal (exitOnSignal: false), so this teardown runs to
+  // completion instead of being cut short mid-cleanup (#514).
+  it('graceful stop flips daemon.json to stopped and removes the discovery copy + pid file (#514)', async () => {
+    const sandbox = await setupSandbox(['stop-svc'])
+    pending.push(sandbox.cleanup)
+    const { startDaemon, readDaemonRecord, daemonDiscoveryPath } = await import('../src/daemon.js')
+    const projectPath = sandbox.projectPaths.get('stop-svc')!
+
+    const handle = await startDaemon({
+      project: 'stop-svc',
+      projectPath,
+      restPort: 18092,
+      otlpPort: 14392,
+      webPort: 16392,
+    })
+    // stop() is idempotent; queue it so a failed assertion still tears down.
+    pending.push(handle.stop)
+    await handle.initialBootstrap
+
+    const discoveryPath = daemonDiscoveryPath('stop-svc', sandbox.home)
+    const pidPath = path.join(sandbox.home, 'neatd.pid')
+
+    // Running: both records present, the authoritative one reads "running".
+    expect(await fileExists(discoveryPath)).toBe(true)
+    expect(await fileExists(pidPath)).toBe(true)
+    expect((await readDaemonRecord(projectPath))!.status).toBe('running')
+
+    await handle.stop()
+
+    // Stopped: the discovery copy and pid file are gone, and the neat-out/
+    // record is flipped to "stopped" (kept so a later read tells "shut down
+    // cleanly" from "never ran").
+    expect(await fileExists(discoveryPath)).toBe(false)
+    expect(await fileExists(pidPath)).toBe(false)
+    expect((await readDaemonRecord(projectPath))!.status).toBe('stopped')
+  })
 })


### PR DESCRIPTION
## What

On a graceful `SIGTERM`/`SIGINT`, a per-project daemon now finishes its own teardown before the process exits: it flushes each project's graph, marks `<project>/neat-out/daemon.json` `status: "stopped"`, removes the machine-wide discovery copy at `~/.neat/daemons/<project>.json`, and removes `~/.neat/neatd.pid` — for every daemon, siblings included.

## Why it wasn't happening

The daemon runs one persist loop per project (`startPersistLoop`), and each loop registers its own `SIGTERM`/`SIGINT` handler that flushes the graph and then calls `process.exit(0)`. That is exactly what the standalone owners (`neat serve`, `neat watch`) want — there the persist loop is the only thing holding the process open, so it owns the shutdown.

Inside the daemon, that handler runs in parallel with the daemon's own shutdown handler. The persist loop only has to write one snapshot file, so its `process.exit(0)` lands first — ending the process while the daemon's longer chain (close listeners → flush slots → clear `daemon.json` → unlink the discovery copy → unlink the pid file) is still mid-flight. The neat-out record, the discovery copy, and the pid file were all left as they were at spawn.

`neatd`'s shutdown handler already awaits `handle.stop()` before its own `process.exit(0)`; the gap was the second, faster exit inside the persist loop.

## The change

- `startPersistLoop` takes a `PersistLoopOptions` ({ `intervalMs`, `exitOnSignal` }). `exitOnSignal` defaults to `true`, so `neat serve` / `neat watch` are unchanged.
- The daemon passes `exitOnSignal: false`. Its persist loops keep saving on the interval and unhook cleanly on teardown, but no longer install a process-exiting signal handler.
- The daemon owns the shutdown flush: `stop()` now saves every active slot's graph once the listeners are down, then tears the loops down and clears `daemon.json` / the discovery copy / the pid file.

## Tests

- `persist.test.ts`: `exitOnSignal: false` installs no `SIGTERM`/`SIGINT` handler (and still saves on its interval) — the regression guard for the competing exit.
- `project-daemon.test.ts`: a graceful `stop()` flips `daemon.json` to `stopped` and removes the discovery copy + pid file.
- `npx turbo build test lint` green (core: 967 passed).

Verified end-to-end against the issue's repro (bare orchestrator spawns the daemon, real `SIGTERM`): after stop, `~/.neat/daemons/<project>.json` gone, `~/.neat/neatd.pid` gone, `<project>/neat-out/daemon.json` `status: "stopped"` — confirmed for both a single daemon and the two-daemon sibling case.

Refs #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)