### PR TITLE
Report only this daemon's own project from GET /projects

### DIFF
--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -45,7 +45,7 @@ Bare arrays from REST endpoints are a contract violation. Why: an object can gro
 | `GET /stale-events?limit=N&edgeType=X` | recent STALE transitions | `{ count, total, events: StaleEvent[] }` |
 | `GET /policies` | parsed `policy.json` | `{ version, policies: Policy[] }` |
 | `GET /policies/violations?severity=X&policyId=X` | current violations, filterable | `{ violations: PolicyViolation[] }` |
-| `GET /projects` | machine-registered projects (single-mount; not dual-mounted) | `Array<RegistryEntry>` *(the one bare-array exception — `/projects` is the switcher entry-point and its consumers (web, MCP) treat it as a list primitive)* |
+| `GET /projects` | the project(s) this daemon serves (single-mount; not dual-mounted). A per-project daemon (ADR-096 §4) returns only its own project; the legacy multi-project daemon returns the machine-wide registry | `Array<RegistryEntry>` *(the one bare-array exception — its consumers (the dashboard's project pin, the CLI's bare-verb resolver) treat it as a list primitive)* |
 | `GET /projects/:project` | singular project lookup | `{ project: RegistryEntry }` |
 | `GET /api/config` | daemon auth-mode negotiation (ADR-073 §3a); always unauthenticated | `{ publicRead: boolean, authProxy: boolean }` |
 

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -10,6 +10,7 @@ import type {
   GraphNode,
   Policy,
   PolicyViolation,
+  RegistryEntry,
 } from '@neat.is/types'
 import { DivergenceTypeSchema, PoliciesCheckBodySchema, PolicySeveritySchema } from '@neat.is/types'
 import type { DivergenceType } from '@neat.is/types'
@@ -81,6 +82,13 @@ export interface BuildApiOptions {
     status: (name: string) => 'bootstrapping' | 'active' | 'broken' | undefined
     list: () => Array<{ name: string; status: 'bootstrapping' | 'active' | 'broken'; elapsedMs: number }>
   }
+  // ADR-096 §4/§5 — the per-project daemon's identity. When set, this daemon
+  // serves exactly this one project: `GET /projects` reports only it (the
+  // dashboard pins to "the project this daemon serves," not a machine-wide
+  // list), and the daemon-wide `/health` carries it at the top level for the
+  // spawn-reuse identity check. Absent → the legacy multi-project daemon, whose
+  // `/projects` is the machine-wide registry passthrough.
+  singleProject?: { name: string; path: string }
 }
 
 interface SerializedGraph {
@@ -868,15 +876,37 @@ export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> 
     return {
       ok: true,
       uptimeMs,
+      // ADR-096 §7 — a per-project daemon carries its project at the top level
+      // so a spawn can confirm a daemon found on a reused port is serving THIS
+      // project before reusing it. The legacy multi-project daemon omits it and
+      // is matched against the `projects` array instead.
+      ...(opts.singleProject ? { project: opts.singleProject.name } : {}),
       projects,
     }
   })
 
-  // Multi-project switcher (ADR-051 #4). Direct passthrough of the
-  // machine-level registry from registry.ts (ADR-048) — distinct from the
-  // dual-mount routing in ADR-026, which exposes per-project endpoints.
-  // Returns Array<{ name, path, status, registeredAt, lastSeenAt?, languages }>.
+  // ADR-096 §4 — "the daemon is the project." A per-project daemon reports only
+  // its own project here, so the dashboard pins to the project this daemon
+  // serves rather than to whichever machine-registered project happens to be
+  // active. The legacy multi-project daemon hands back the machine-level
+  // registry (ADR-048) — the one documented bare-array GET. Either way the
+  // response is `Array<RegistryEntry>`, which the dashboard and the CLI's
+  // bare-verb resolver treat as a list primitive.
   app.get('/projects', async (_req, reply) => {
+    if (opts.singleProject) {
+      const phase = opts.bootstrap?.status(opts.singleProject.name)
+      const entry: RegistryEntry = {
+        name: opts.singleProject.name,
+        path: opts.singleProject.path,
+        registeredAt: new Date(startedAt).toISOString(),
+        languages: [],
+        // The daemon is serving this project, so it's active unless its
+        // bootstrap broke. ('bootstrapping' still reads as active — the project
+        // is the one to land on; its graph route answers 503 until ready.)
+        status: phase === 'broken' ? 'broken' : 'active',
+      }
+      return [entry]
+    }
     try {
       return await listRegistryProjects()
     } catch (err) {

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -788,30 +788,16 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
             }))
           },
         },
+        // ADR-096 §4/§5/§7 — hand the daemon's identity to buildApi so the REST
+        // surface reflects "the daemon is the project": `GET /projects` reports
+        // only this project (the dashboard pins to it), and the daemon-wide
+        // `/health` carries it at the top level for the spawn-reuse identity
+        // check. Absent for the legacy multi-project daemon.
+        singleProject:
+          singleProject && singleProjectPath
+            ? { name: singleProject, path: singleProjectPath }
+            : undefined,
       })
-      // ADR-096 / contract §7 — the daemon-wide `/health` must carry the
-      // project name so a spawn can confirm a daemon found on a reused port is
-      // actually serving THIS project before reusing it (the spawn-reuse
-      // identity check). The legacy `/health` payload (api.ts) is daemon-wide
-      // and has no top-level `project`; rather than reach into api.ts (Wave 2
-      // territory), the single-project daemon stamps it here via an onSend hook
-      // that augments only the `/health` body. A different project's daemon on
-      // a reused port then answers with its own name and the spawn knows it's
-      // not-mine.
-      if (singleProject) {
-        restApp.addHook('onSend', async (req, _reply, payload) => {
-          if (req.url.split('?')[0] !== '/health') return payload
-          if (typeof payload !== 'string') return payload
-          try {
-            const body = JSON.parse(payload) as Record<string, unknown>
-            if (typeof body !== 'object' || body === null) return payload
-            body.project = singleProject
-            return JSON.stringify(body)
-          } catch {
-            return payload
-          }
-        })
-      }
       restAddress = await restApp.listen({ port: restPort, host })
       console.log(`neatd: REST listening on ${restAddress}`)
     } catch (err) {

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -8720,11 +8720,15 @@ describe('REST API canonicalization (ADR-061)', () => {
     expect(offenders, offenders.join('\n')).toEqual([])
   })
   it('the documented /projects bare-array exception is the only bare-array GET return (ADR-061 #2)', () => {
-    // listRegistryProjects() returns Array<RegistryEntry>; api.ts hands
-    // it back directly from `app.get('/projects', ...)`. The contract
-    // documents this as the one allowed bare-array GET (rest-api.md §29
-    // table footnote).
-    expect(API_TS).toMatch(/app\.get\(['"]\/projects['"][\s\S]{0,200}return\s+await\s+listRegistryProjects/)
+    // `/projects` returns Array<RegistryEntry> — the one allowed bare-array GET
+    // (rest-api.md §29 table footnote). A per-project daemon (ADR-096 §4) hands
+    // back a single-element array describing its own project; the legacy
+    // multi-project daemon passes the machine-wide registry through. Both
+    // branches keep the bare-array shape the consumers rely on.
+    // Per-project branch returns the bare array of its own project.
+    expect(API_TS).toMatch(/app\.get\(['"]\/projects['"][\s\S]{0,800}return\s+\[entry\]/)
+    // Legacy branch still passes the machine-wide registry through.
+    expect(API_TS).toMatch(/app\.get\(['"]\/projects['"][\s\S]{0,900}return\s+await\s+listRegistryProjects/)
   })
 
   // ── Class C: response shape via Zod schemas ──────────────────────────

--- a/packages/core/test/project-daemon.test.ts
+++ b/packages/core/test/project-daemon.test.ts
@@ -383,4 +383,41 @@ describe('per-project daemon — §1 spans land in the right graph, none drop (A
     expect(await healthIsForProjectForTest(restPort, 'ident-svc')).toBe(true)
     expect(await healthIsForProjectForTest(restPort, 'someone-else')).toBe(false)
   })
+
+  // §4/§5 — "the daemon is the project." GET /projects reports only the project
+  // this daemon serves, even when the machine registry holds others (and even
+  // when this one is marked `paused` there by sibling-pause). So the dashboard,
+  // which pins to the first active entry, lands on this daemon's own project
+  // instead of a sibling it doesn't host (#513).
+  it('GET /projects reports only the daemon\'s own project, active, ignoring siblings in the registry (#513)', async () => {
+    // Two projects on the machine. The orchestrator pauses the idle sibling
+    // when the other activates — so this daemon's project sits `paused` in the
+    // machine registry while its daemon is up and serving it.
+    const sandbox = await setupSandbox(['pa-svc', 'pb-svc'])
+    pending.push(sandbox.cleanup)
+    const { startDaemon } = await import('../src/daemon.js')
+    const { setStatus } = await import('../src/registry.js')
+    await setStatus('pa-svc', 'paused')
+
+    const projectPath = sandbox.projectPaths.get('pa-svc')!
+    const handle = await startDaemon({
+      project: 'pa-svc',
+      projectPath,
+      restPort: 0,
+      otlpPort: 0,
+    })
+    pending.push(handle.stop)
+    await handle.initialBootstrap
+
+    const res = await fetch(`${handle.restAddress}/projects`)
+    expect(res.status).toBe(200)
+    const list = (await res.json()) as Array<{ name: string; status?: string }>
+
+    // Only this daemon's project — never the sibling, never the machine list.
+    expect(list.map((p) => p.name)).toEqual(['pa-svc'])
+    // Reported active: the daemon is serving it, regardless of the registry's
+    // `paused` sibling-pause bookkeeping. The dashboard's first-active pin lands
+    // here rather than on a project this daemon doesn't host.
+    expect(list[0]!.status).toBe('active')
+  })
 })


### PR DESCRIPTION
## What

A per-project daemon's `GET /projects` now reports only the project it serves, so the dashboard pins to that project instead of to whichever machine-registered project happens to be active.

## Why

Under one-daemon-per-project (project-daemon contract §4 — "the daemon is the project"), the dashboard's `resolveProjectFromList()` trusts `/projects` to be *only this daemon's* project and pins to the first active entry. But the endpoint was still a passthrough of the machine-wide registry, so a per-project daemon returned every registered project.

With two projects on a machine, the orchestrator pauses the idle sibling when the other activates. Project A's daemon then returned `[{projA: paused}, {projB: active}]`, the dashboard pinned to `projB`, and project A's daemon — which doesn't host `projB` — answered `/api/graph?project=projB` with a 404, blanking the page. Single-project installs were unaffected.

## The change

- `BuildApiOptions` gains `singleProject` (`{ name, path }`) — the daemon's identity.
- `GET /projects`, when `singleProject` is set, returns a one-element `Array<RegistryEntry>` for that project, reported `active` unless its bootstrap broke (so the dashboard's first-active pin resolves to it). The legacy multi-project daemon keeps the machine-wide registry passthrough — still the one documented bare-array GET.
- The daemon-wide `/health` stamps the project at the top level natively in `buildApi` (for the spawn-reuse identity check). That folds the stamp into `buildApi`, so `daemon.ts` drops the `onSend` hook it used to do this.
- `rest-api.md` §29 and the `/projects` contract audit are reconciled with the per-project shape.

`resolveProjectForVerb` (the CLI's bare-verb project resolver) also benefits: a per-project daemon now reports exactly one project, so `neat divergences` etc. resolve it directly instead of erroring "several registered."

## Tests

- `project-daemon.test.ts`: with two projects registered and this daemon's own marked `paused`, `GET /projects` returns only its own project, reported `active`.
- The existing `/health carries the project name` test now exercises the native stamp (the `onSend` hook is gone).
- Web `single-project-resolution` / `project-resolution` tests confirm `AppShell` pins to the single-project list.
- `npx turbo build test lint --force` green (uncached, so the core→web boundary isn't cache-masked).

Verified against the issue's exact two-project repro: with the registry showing `projA: paused, projB: active`, project A's dashboard (`:6328`) returns `[{"name":"projA",…,"status":"active"}]` and `/api/graph?project=projA` → **200** (no blank page), while project B runs.

Refs #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)