### PR TITLE
Drop live dashboard sockets so a graceful stop doesn't hang

### DIFF
--- a/packages/core/src/web-spawn.ts
+++ b/packages/core/src/web-spawn.ts
@@ -274,7 +274,14 @@ export async function spawnWebUI(
   // first connection triggers ensureStarted(), then every socket is piped
   // through to the internal Next server. A raw TCP proxy forwards SSE and any
   // other streaming response transparently.
+  // Live front-side sockets, so stop() can force them down. A raw net.Server
+  // has no http.Server-style closeAllConnections(), and its close() waits for
+  // every open connection to end on its own — which a browser dashboard's
+  // keep-alive / EventSource sockets never do (#518).
+  const liveSockets = new Set<net.Socket>()
   const front = net.createServer((socket) => {
+    liveSockets.add(socket)
+    socket.on('close', () => liveSockets.delete(socket))
     socket.on('error', () => socket.destroy())
     ensureStarted()
       .then(() => {
@@ -305,7 +312,17 @@ export async function spawnWebUI(
   async function stop(): Promise<void> {
     if (stopped) return
     stopped = true
-    await new Promise<void>((resolve) => front.close(() => resolve()))
+    await new Promise<void>((resolve) => {
+      front.close(() => resolve())
+      // `front.close()` only fires its callback once every existing connection
+      // has ended. The dashboard holds long-lived keep-alive / EventSource (SSE)
+      // sockets piped through this raw TCP front, and a live browser tab never
+      // drops them on its own — so destroy the live sockets here and the
+      // callback resolves promptly. Graceful stop then completes whether or not
+      // a dashboard tab is open.
+      for (const socket of liveSockets) socket.destroy()
+      liveSockets.clear()
+    })
     if (!child || !child.pid) return
     try {
       child.kill('SIGTERM')

--- a/packages/core/test/web-spawn.test.ts
+++ b/packages/core/test/web-spawn.test.ts
@@ -291,4 +291,60 @@ describe('spawnWebUI — per-project port + lazy spawn (ADR-096 §5, §7)', () =
       }),
     ).resolves.toBeUndefined()
   })
+
+  // #518 — net.Server.close() only fires its callback once every existing
+  // connection ends. A live dashboard holds keep-alive / EventSource sockets
+  // piped through the front that never close on their own, so stop() must drop
+  // them itself or the whole shutdown chain hangs (50s+ in the field). Assert
+  // stop() completes promptly with such a connection still open, and frees the
+  // port.
+  it('stop() completes promptly with a live proxied connection still open (#518)', async () => {
+    const root = await mkTmpProject()
+    tmpDirs.push(root)
+    const webPort = await freePort()
+    await writeDaemonJson(root, { ports: { rest: 8080, web: webPort } })
+    process.env.NEAT_SCAN_PATH = root
+    delete process.env.NEAT_WEB_PORT
+    const serverEntry = await writeStubServer(root)
+
+    const handle = await spawnWebUI(8080, { serverEntry, skipBuildCheck: true })
+    handles.push(handle)
+
+    // Hold a connection open through the front, piped to the upstream — the
+    // analogue of a browser tab's keep-alive / EventSource socket.
+    const sock = net.connect(handle.port, '127.0.0.1')
+    await new Promise<void>((resolve, reject) => {
+      sock.once('connect', () => resolve())
+      sock.once('error', reject)
+    })
+    sock.write('GET / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n')
+    // Wait for the front to spawn the upstream and pipe the socket through.
+    for (let i = 0; i < 80 && !handle.started(); i++) {
+      await new Promise((r) => setTimeout(r, 50))
+    }
+    expect(handle.started()).toBe(true)
+
+    // Without forcing the live socket down, front.close() never resolves and
+    // stop() hangs. Assert it finishes well inside that window.
+    const outcome = await Promise.race([
+      handle.stop().then(() => 'stopped' as const),
+      new Promise<'timeout'>((r) => setTimeout(() => r('timeout'), 3000)),
+    ])
+    expect(outcome).toBe('stopped')
+
+    // The front port is freed despite the still-open client socket.
+    await expect(
+      new Promise<void>((resolve, reject) => {
+        const s = net.createServer()
+        s.once('error', reject)
+        s.listen(webPort, '127.0.0.1', () => s.close(() => resolve()))
+      }),
+    ).resolves.toBeUndefined()
+
+    try {
+      sock.destroy()
+    } catch {
+      /* already gone */
+    }
+  }, 20000)
 })


### PR DESCRIPTION
## What

A per-project daemon now finishes its graceful shutdown promptly even while the dashboard is open in a browser. `stop()` destroys the live front-proxy sockets so `front.close()` resolves immediately, and the daemon flips `daemon.json` to `stopped`, removes `~/.neat/daemons/<project>.json` and `~/.neat/neatd.pid`, and frees the web port — regardless of open dashboard tabs.

## Why

The web UI front (`web-spawn.ts`) is a raw TCP proxy: each browser connection is piped through to the internal Next server. `net.Server.close()` only fires its callback once **every** existing connection ends, and a live dashboard holds long-lived keep-alive / EventSource (SSE) sockets that never close on their own. So `await new Promise((resolve) => front.close(() => resolve()))` waited indefinitely, blocking the whole `neatd.ts` shutdown chain (`Promise.allSettled([handle.stop(), web.stop()]).finally(() => process.exit(0))`) — `stop()` never reached the child kill and `process.exit(0)` never ran. Observed hang: 50s+, until the tab closed.

This defeated #514's clean-graceful-stop guarantee in the normal operator case (dashboard open), via a different trigger than #514's persist-loop race.

## The change

`stop()` tracks the live front sockets in a `Set` and destroys them alongside `front.close()`. A raw `net.Server` has no `http.Server`-style `closeAllConnections()`, so this is the socket-tracking equivalent. Once the live sockets are dropped, `front.close()` resolves and shutdown completes.

## Tests

- `web-spawn.test.ts`: `stop()` completes promptly (raced against a 3s ceiling) with a live proxied connection still open, and the front port is freed.
- `npx turbo build test lint --force` green (web rebuilt explicitly; uncached).

End-to-end, with a real chromium dashboard (Playwright) open on `:6328` and **the tab left open**, `kill -TERM` stopped the daemon in **~288 ms**: process dead, `<project>/neat-out/daemon.json` → `stopped`, `~/.neat/daemons/<project>.json` removed, `~/.neat/neatd.pid` removed, rest `:8080` and web `:6328` both freed.

Refs #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)