### PR TITLE
Build each package before testing it

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
     "test": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["build"],
       "outputs": []
     },
     "lint": {


### PR DESCRIPTION
The `test` turbo task depended only on `^build` (build *upstream* packages), not on the package's own `build`. `ci.yml` runs `turbo build` and `turbo test` as separate steps so the build always finished first; `publish.yml` runs `turbo build test lint` as one command, so `@neat.is/core#test` could start before `@neat.is/core#build` wrote `dist/neatd.cjs`, and the two-daemon test's daemon spawn couldn't locate the entry.

Depending the `test` task on `build` serializes build-before-test per package, so the combined invocation behaves like the separate one. Unblocks the v0.4.19 publish (CI was green on the same commit; only the publish gate raced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)