### PR TITLE
Publish a nightly channel to npm

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,88 @@
+name: Nightly
+
+# Publishes a daily build of `main` to npm under the `nightly` dist-tag, the
+# TypeScript-nightly way: version `<next-patch>-dev.<YYYYMMDD>`, prerelease, so
+# `npm install neat.is` (= `latest`) never resolves to it. Install the channel
+# with `npx neat.is@nightly`.
+#
+# The version is stamped in CI and never committed (git history stays clean; only
+# npm carries the `-dev` versions). The build/test/lint gate is light by design —
+# a nightly is published-then-tested: the flow-harness validates the published
+# artifact downstream and promotes a green one to `@next`.
+
+on:
+  schedule:
+    - cron: '0 8 * * *' # ~midnight PST, daily
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    # Never publish from a fork.
+    if: github.repository == 'NEAT-Technologies/Neat'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - name: Stamp the nightly version
+        id: ver
+        run: |
+          version="$(node scripts/set-nightly-version.mjs)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Nightly version: $version"
+
+      # Light gate — build, test, lint (separate steps so build fully completes
+      # before test, same as ci.yml). The deep flow-harness gates `@next`, not this.
+      - run: npx turbo build
+      - run: npx turbo test
+      - run: npx turbo lint
+
+      - name: Publish the lockstep packages under @nightly
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          publish_one() {
+            local dir="$1"
+            local name version
+            name=$(node -p "require('./${dir}/package.json').name")
+            version=$(node -p "require('./${dir}/package.json').version")
+            echo
+            echo "── ${name}@${version} ──"
+            # Idempotent: a same-day re-run finds the version already published.
+            if npm view "${name}@${version}" version > /dev/null 2>&1; then
+              echo "  already on registry, skipping"
+              return 0
+            fi
+            ( cd "$dir" && npm publish --tag nightly )
+            echo "  published (nightly)"
+          }
+
+          # Dependency order. `@neat.is/instrumentation-registry` is NOT bumped —
+          # it stays at its own 1.0.0 line, already on the registry, referenced
+          # via `^1.0.0` by the dev packages.
+          publish_one packages/types
+          publish_one packages/core
+          publish_one packages/mcp
+          publish_one packages/claude-skill
+          publish_one packages/web
+          publish_one packages/neat.is
+
+      - name: Summary
+        run: |
+          v="${{ steps.ver.outputs.version }}"
+          {
+            echo "### Nightly published"
+            echo ""
+            echo "- version: \`$v\`"
+            echo "- install: \`npx neat.is@nightly\` (or \`@$v\` exact)"
+            echo "- commit: \`${{ github.sha }}\` (npm \`gitHead\` carries it too)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/runbook-publish.md
+++ b/docs/runbook-publish.md
@@ -53,6 +53,29 @@ The container publish step pushes the image to ghcr.io and then runs an auth smo
 
 If a future container smoke regresses past 30 seconds, the dominant step won't be Fastify or the auth wiring — it'll be something new the image started pulling at boot. Check `docker logs` against a locally-built image first.
 
+## Nightly channel (`@nightly`)
+
+A daily build of `main` ships to npm under the `nightly` dist-tag — the same shape
+TypeScript uses for `@next`. `.github/workflows/nightly.yml` runs on a UTC cron (and
+`workflow_dispatch`): it stamps an ephemeral `<next-patch>-dev.<YYYYMMDD>` version across the
+six version-locked packages (`scripts/set-nightly-version.mjs`, never committed — only npm
+carries the `-dev` versions), runs `build`/`test`/`lint`, and publishes each in dependency order
+with `npm publish --tag nightly`.
+
+Two things keep `latest` users safe: the `nightly` dist-tag, and the `-dev` prerelease string (a
+prerelease is never the default `npm install` target). `@neat.is/instrumentation-registry` rides
+its own `1.0.0` line and is left untouched.
+
+```bash
+npx neat.is@nightly                 # the newest nightly
+npm i -g neat.is@nightly
+npm view neat.is@nightly gitHead    # the exact commit it was built from
+```
+
+`@nightly` is bleeding-edge and build-gated only — the flow-harness validates each nightly
+downstream and promotes a green one to `@next`; releases to `@latest` are cut from a
+`@next`-validated commit.
+
 ## Routine publish (CI path)
 
 Five steps from a clean working tree on `main`:

--- a/scripts/set-nightly-version.mjs
+++ b/scripts/set-nightly-version.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Stamp an ephemeral nightly version across the lockstep packages, in CI only.
+//
+// The TypeScript-nightly shape: `<next-patch>-dev.<YYYYMMDD>`, e.g.
+// `0.4.20-dev.20260615` while `0.4.19` is the latest release. The version is a
+// prerelease, so `npm install neat.is` (which resolves the highest NON-prerelease
+// = the `latest` tag) never picks it up — the `nightly` dist-tag is belt, the
+// `-dev` prerelease string is suspenders.
+//
+// This is run by .github/workflows/nightly.yml and its writes are NEVER
+// committed — git history stays clean; only npm carries the `-dev` versions.
+// Prints the computed version to stdout so the workflow can capture it.
+//
+// Scope: the six version-locked packages only. `@neat.is/instrumentation-registry`
+// rides its own version line (1.0.0) and is already on the registry, so the dev
+// packages keep referencing it via `^1.0.0` and the nightly leaves it untouched.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+
+// The version-locked set (must all share one version). Cross-deps among these
+// get pinned to the exact dev version; deps outside it (instrumentation-registry,
+// third-party) are left alone.
+const LOCKSTEP_NAMES = new Set([
+  'neat.is',
+  '@neat.is/types',
+  '@neat.is/core',
+  '@neat.is/mcp',
+  '@neat.is/claude-skill',
+  '@neat.is/web',
+])
+const LOCKSTEP_DIRS = ['types', 'core', 'mcp', 'claude-skill', 'web', 'neat.is']
+const DEP_FIELDS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']
+
+// Base = next patch above the current release (the repo's committed version).
+const current = JSON.parse(readFileSync('packages/core/package.json', 'utf8')).version
+const [major, minor, patch] = current.split('-')[0].split('.').map(Number)
+const base = `${major}.${minor}.${patch + 1}`
+
+// UTC date stamp — one nightly per day, so date-only never collides.
+const now = new Date()
+const stamp = `${now.getUTCFullYear()}${String(now.getUTCMonth() + 1).padStart(2, '0')}${String(now.getUTCDate()).padStart(2, '0')}`
+
+const devVersion = `${base}-dev.${stamp}`
+
+for (const dir of LOCKSTEP_DIRS) {
+  const file = `packages/${dir}/package.json`
+  const pkg = JSON.parse(readFileSync(file, 'utf8'))
+  pkg.version = devVersion
+  for (const field of DEP_FIELDS) {
+    const deps = pkg[field]
+    if (!deps) continue
+    for (const name of Object.keys(deps)) {
+      // Pin EXACT (not `^`) — caret + prerelease resolution is unreliable.
+      if (LOCKSTEP_NAMES.has(name)) deps[name] = devVersion
+    }
+  }
+  // Ephemeral reformatting is fine — this file is never committed.
+  writeFileSync(file, JSON.stringify(pkg, null, 2) + '\n')
+}
+
+process.stdout.write(devVersion)


### PR DESCRIPTION
Phase 1 of the channel ladder (`@nightly` → `@next` → `@latest`): the daily `@nightly` channel, built the TypeScript way.

**What it does**
- `.github/workflows/nightly.yml` — daily UTC cron + `workflow_dispatch`; stamps the version, runs build/test/lint (separate steps), and publishes the six version-locked packages in dependency order with `npm publish --tag nightly`.
- `scripts/set-nightly-version.mjs` — computes `<next-patch>-dev.<YYYYMMDD>` and pins lockstep cross-deps exact, **ephemerally (never committed)**. Verified locally: produces `0.4.20-dev.<date>`, leaves `@neat.is/instrumentation-registry@1.0.0` untouched.
- `docs/runbook-publish.md` — a short `@nightly` section.

**Safety:** stable `npm install neat.is` users are untouched — a `-dev` prerelease is excluded from default/range resolution, and `nightly` is a separate dist-tag. Reuses `publish.yml`'s `NPM_TOKEN` + idempotent dep-ordered publish.

**After merge:** the cron activates on `main`; trigger it once via `workflow_dispatch` to smoke it before relying on the schedule. `npm view neat.is@nightly gitHead` gives the exact commit.

**Out of scope (Phase 2):** `@next` and the flow-harness that promotes green nightlies.

**Noted, not fixed here:** the runbook's older "five publishable packages / web not published" lines are stale (six lockstep + `instrumentation-registry`, and `web` *is* published) — left as a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)