### PR TITLE
Caret-pin nightly cross-deps to satisfy the lockstep contract

### DIFF
--- a/scripts/set-nightly-version.mjs
+++ b/scripts/set-nightly-version.mjs
@@ -50,8 +50,11 @@ for (const dir of LOCKSTEP_DIRS) {
     const deps = pkg[field]
     if (!deps) continue
     for (const name of Object.keys(deps)) {
-      // Pin EXACT (not `^`) — caret + prerelease resolution is unreliable.
-      if (LOCKSTEP_NAMES.has(name)) deps[name] = devVersion
+      // Caret-pin, matching the release convention the ADR-052 lockstep audit
+      // enforces. For same-tuple prereleases (all `0.4.20-dev.*`) caret resolves
+      // to the highest matching nightly, so a fresh `@nightly` install stays
+      // internally consistent.
+      if (LOCKSTEP_NAMES.has(name)) deps[name] = `^${devVersion}`
     }
   }
   // Ephemeral reformatting is fine — this file is never committed.


### PR DESCRIPTION
The nightly cron fired (06-16) but failed `turbo test` on the ADR-052 lockstep audit — `set-nightly-version.mjs` pinned cross-package deps **exact** (`0.4.20-dev.X`), while the contract requires **caret** (`^0.4.20-dev.X`), same as releases. So every nightly failed the gate and `@nightly` never published.

Caret-pin them. For same-tuple `-dev.*` prereleases, caret resolves to the highest matching nightly, so a fresh `npm install neat.is@nightly` stays internally consistent (the cross-resolution edge case only affects someone pinning an *old* exact nightly, which isn't the install path).

Verified locally: stamp → `^0.4.20-dev.20260617` cross-deps → ADR-052 lockstep audit passes → reverted clean.

Unblocks the `@nightly` channel (#527).

🤖 Generated with [Claude Code](https://claude.com/claude-code)