### PR TITLE
Anchor the parent-span fallback edge to the parent's call site

### DIFF
--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -563,6 +563,13 @@ interface ParentSpanCacheEntry {
   // fallback in handleSpan uses this so the auto-created parent ServiceNode
   // lands on the same env-tagged id the OTel emitter advertised.
   env: string
+  // The parent span's own `code.*` call site, when its SpanProcessor captured
+  // one (file-awareness.md §4). The parent-span fallback below originates its
+  // edge from the parent's FileNode instead of the bare parent ServiceNode when
+  // this is present, so the fallback edge anchors to file:line rather than
+  // pinning to a service node (issue #536). Undefined when the parent carried no
+  // call site — never fabricated (§6), so the service-level fallback stands.
+  callSite?: CallSite
   expiresAt: number
 }
 
@@ -572,7 +579,7 @@ function parentSpanKey(traceId: string, spanId: string): string {
   return `${traceId}:${spanId}`
 }
 
-function cacheSpanService(span: ParsedSpan, now: number): void {
+function cacheSpanService(span: ParsedSpan, now: number, callSite: CallSite | null): void {
   if (!span.traceId || !span.spanId) return
   const key = parentSpanKey(span.traceId, span.spanId)
   // Map preserves insertion order, so deleting + re-inserting bumps an entry to
@@ -581,6 +588,7 @@ function cacheSpanService(span: ParsedSpan, now: number): void {
   parentSpanCache.set(key, {
     service: span.service,
     env: span.env ?? 'unknown',
+    ...(callSite ? { callSite } : {}),
     expiresAt: now + PARENT_SPAN_CACHE_TTL_MS,
   })
   while (parentSpanCache.size > PARENT_SPAN_CACHE_SIZE) {
@@ -594,14 +602,18 @@ function lookupParentSpan(
   traceId: string,
   parentSpanId: string,
   now: number,
-): { service: string; env: string } | null {
+): { service: string; env: string; callSite?: CallSite } | null {
   const entry = parentSpanCache.get(parentSpanKey(traceId, parentSpanId))
   if (!entry) return null
   if (entry.expiresAt <= now) {
     parentSpanCache.delete(parentSpanKey(traceId, parentSpanId))
     return null
   }
-  return { service: entry.service, env: entry.env }
+  return {
+    service: entry.service,
+    env: entry.env,
+    ...(entry.callSite ? { callSite: entry.callSite } : {}),
+  }
 }
 
 // Test seam: lets unit tests start from a clean slate.
@@ -1044,9 +1056,6 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
   // when the span carries an env signal.
   const sourceId = ensureServiceNode(ctx.graph, span.service, env)
   const isError = span.statusCode === 2
-  // Stash this span in the parent-span cache so any later child whose address
-  // resolution misses can still resolve the cross-service edge via parentSpanId.
-  cacheSpanService(span, nowMs)
 
   // File-first OBSERVED origin (file-awareness.md §4). When the injected
   // SpanProcessor captured a call site on this outbound (CLIENT/PRODUCER) span,
@@ -1056,6 +1065,12 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
   // (SERVER) parent-fallback side, which carries no call site.
   const sourceServiceNode = ctx.graph.getNodeAttributes(sourceId) as ServiceNode
   const callSite = callSiteFromSpan(span, sourceServiceNode, ctx.scanPath)
+
+  // Stash this span in the parent-span cache so any later child whose address
+  // resolution misses can still resolve the cross-service edge via parentSpanId.
+  // The call site rides along so the fallback edge anchors to this span's
+  // file:line when this span turns out to be a parent (issue #536).
+  cacheSpanService(span, nowMs, callSite)
   const observedSource = (): string =>
     callSite ? ensureObservedFileNode(ctx.graph, span.service, sourceId, callSite) : sourceId
   // Evidence for the OBSERVED edge — populated from the span's code.* semconv
@@ -1147,13 +1162,30 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
       const parent = lookupParentSpan(span.traceId, span.parentSpanId, nowMs)
       if (parent && parent.service !== span.service) {
         const parentId = ensureServiceNode(ctx.graph, parent.service, parent.env)
+        // When the parent span carried a `code.*` call site, originate the edge
+        // from the parent's FileNode so it anchors to file:line instead of the
+        // bare parent ServiceNode (issue #536). Without a cached call site the
+        // edge stays service-coarse — never fabricated (file-awareness.md §6).
+        const fallbackSource = parent.callSite
+          ? ensureObservedFileNode(ctx.graph, parent.service, parentId, parent.callSite)
+          : parentId
+        const fallbackEvidence: { file: string; line?: number } | undefined =
+          parent.callSite
+            ? {
+                file: parent.callSite.relPath,
+                ...(parent.callSite.line !== undefined
+                  ? { line: parent.callSite.line }
+                  : {}),
+              }
+            : undefined
         upsertObservedEdge(
           ctx.graph,
           EdgeType.CALLS,
-          parentId,
+          fallbackSource,
           sourceId,
           ts,
           isError,
+          fallbackEvidence,
         )
       }
     }

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -17,6 +17,7 @@ import {
   promoteFrontierNodes,
   readErrorEvents,
   readStaleEvents,
+  resetParentSpanCache,
   stitchTrace,
   thresholdForEdgeType,
   type IngestContext,
@@ -1109,5 +1110,124 @@ describe('handleSpan code.* evidence (issue #395)', () => {
     expect(edge.evidence).toBeDefined()
     expect(edge.evidence!.file).toBe('src/repo.ts')
     expect(edge.evidence!.line).toBe(88)
+  })
+})
+
+describe('handleSpan parent-fallback call site (issue #536)', () => {
+  let tmpDir: string
+  let ctx: IngestContext
+
+  beforeEach(async () => {
+    resetParentSpanCache()
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-parent-callsite-'))
+    ctx = { graph: newGraph(), errorsPath: path.join(tmpDir, 'errors.ndjson') }
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+    resetParentSpanCache()
+  })
+
+  it('anchors the fallback edge to the parent call site when the parent carried code.*', async () => {
+    // Parent CLIENT span on service-a carrying a call site but NO peer address,
+    // so it mints no edge of its own — only its spanId + call site land in the
+    // parent-span cache for the child to resolve against.
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        service: 'service-a',
+        spanId: 'parent-1',
+        attributes: {
+          'code.filepath': 'src/caller.ts',
+          'code.lineno': 17,
+          'code.function': 'callDownstream',
+        },
+      }),
+    )
+
+    // Child SERVER span (kind 2) on service-b whose parent is the cached CLIENT
+    // span. No peer address, so address-based resolution misses and the
+    // parent-span fallback is the only path that produces the CALLS edge.
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        service: 'service-b',
+        spanId: 'child-1',
+        parentSpanId: 'parent-1',
+        kind: 2,
+        attributes: {},
+      }),
+    )
+
+    // The fallback edge now originates from the parent's FileNode — file:line —
+    // instead of pinning to service:service-a.
+    const fileNodeId = 'file:service-a:src/caller.ts'
+    expect(ctx.graph.hasNode(fileNodeId)).toBe(true)
+
+    const fileEdgeId = `${EdgeType.CALLS}:OBSERVED:${fileNodeId}->service:service-b`
+    expect(ctx.graph.hasEdge(fileEdgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(fileEdgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.source).toBe(fileNodeId)
+    expect(edge.evidence).toBeDefined()
+    expect(edge.evidence!.file).toBe('src/caller.ts')
+    expect(edge.evidence!.line).toBe(17)
+
+    // The old service-coarse edge is not minted in parallel.
+    const serviceEdgeId = `${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`
+    expect(ctx.graph.hasEdge(serviceEdgeId)).toBe(false)
+
+    // The parent's CONTAINS edge to its FileNode lands too.
+    let containsFound = false
+    ctx.graph.forEachEdge((_id, attrs) => {
+      const e = attrs as GraphEdge
+      if (
+        e.type === EdgeType.CONTAINS &&
+        e.source === 'service:service-a' &&
+        e.target === fileNodeId
+      ) {
+        containsFound = true
+      }
+    })
+    expect(containsFound).toBe(true)
+  })
+
+  it('keeps the service-level fallback when the parent carried no call site (no fabrication)', async () => {
+    // Parent CLIENT span on service-a with no code.* and no peer address.
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        service: 'service-a',
+        spanId: 'parent-2',
+        attributes: {},
+      }),
+    )
+
+    // Child SERVER span resolving only via the parent-span cache.
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        service: 'service-b',
+        spanId: 'child-2',
+        parentSpanId: 'parent-2',
+        kind: 2,
+        attributes: {},
+      }),
+    )
+
+    // No call site to anchor on → the edge stays service-coarse, evidence-free.
+    const serviceEdgeId = `${EdgeType.CALLS}:OBSERVED:service:service-a->service:service-b`
+    expect(ctx.graph.hasEdge(serviceEdgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(serviceEdgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.source).toBe('service:service-a')
+    expect(edge.evidence).toBeUndefined()
+
+    // No FileNode was fabricated for the parent.
+    let fileNodeCount = 0
+    ctx.graph.forEachNode((_id, attrs) => {
+      if ((attrs as { type: string }).type === NodeType.FileNode) fileNodeCount++
+    })
+    expect(fileNodeCount).toBe(0)
   })
 })


### PR DESCRIPTION
When OTel ingest can't resolve a span's peer by address, it falls back to the cached parent span to mint the cross-service CALLS edge. That cache only held the parent's service and env, so the resulting edge pinned to a service node — even in the common case where the parent span had already captured the exact `code.*` call site that made the call. Those service-level fallback edges are a chunk of why the graph still surfaces service nodes that are attribution stand-ins rather than real topology.

This caches the parent span's call site alongside its service and env, and the fallback path now originates the edge from the parent's FileNode with file-grained evidence whenever that call site is present. The edge lands at file:line instead of the service node, and divergence can compare it against the declared call site at the sharper grain.

The conservative half holds: a parent that genuinely carried no call site still falls back to the service node exactly as it did before — no synthesized path, no fabricated line, per the otel-ingest and file-awareness contracts.

Two behavioral tests cover both sides: a parent carrying `code.*` yields a file-grained edge with evidence, and a parent without one keeps the service-coarse fallback and creates no FileNode. The existing issue #133 audit (parent without a call site) stays green unchanged.

Refs #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)