### PR TITLE
Report a TypeScript service's language as typescript

### DIFF
--- a/packages/core/src/extract/services.ts
+++ b/packages/core/src/extract/services.ts
@@ -143,6 +143,22 @@ function detectJsFramework(pkg: PackageJson): string | undefined {
   return undefined
 }
 
+// A JS-manifest service is TypeScript when its package depends on `typescript`
+// or carries a tsconfig — otherwise we default to javascript. The per-file
+// extractor already routes by extension (`languageForPath`); this only sets the
+// ServiceNode's own `language` field, which the static walker can't read off a
+// single file. One readdir, conservative on the javascript side.
+async function detectJsServiceLanguage(
+  dir: string,
+  pkg: PackageJson,
+): Promise<'typescript' | 'javascript'> {
+  const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) }
+  if (deps['typescript'] !== undefined) return 'typescript'
+  const entries = await fs.readdir(dir).catch(() => [] as string[])
+  if (entries.some((name) => /^tsconfig(\..+)?\.json$/.test(name))) return 'typescript'
+  return 'javascript'
+}
+
 async function discoverNodeService(
   scanPath: string,
   dir: string,
@@ -158,11 +174,12 @@ async function discoverNodeService(
   }
   if (!pkg.name) return null
   const framework = detectJsFramework(pkg)
+  const language = await detectJsServiceLanguage(dir, pkg)
   const node: ServiceNode = {
     id: serviceId(pkg.name),
     type: NodeType.ServiceNode,
     name: pkg.name,
-    language: 'javascript',
+    language,
     version: pkg.version,
     dependencies: pkg.dependencies ?? {},
     repoPath: path.relative(scanPath, dir),

--- a/packages/core/test/discover-services.test.ts
+++ b/packages/core/test/discover-services.test.ts
@@ -62,4 +62,22 @@ describe('discoverServices', () => {
     const services = await discoverServices(path.join(FIXTURES, 'monorepo'))
     expect(services).toEqual([])
   })
+
+  it('marks a service with a tsconfig.json as typescript', async () => {
+    const services = await discoverServices(path.join(FIXTURES, 'service-language'))
+    const byName = new Map(services.map((s) => [s.node.name, s.node.language]))
+    expect(byName.get('fixture-ts-tsconfig')).toBe('typescript')
+  })
+
+  it('marks a service depending on typescript as typescript', async () => {
+    const services = await discoverServices(path.join(FIXTURES, 'service-language'))
+    const byName = new Map(services.map((s) => [s.node.name, s.node.language]))
+    expect(byName.get('fixture-ts-dep')).toBe('typescript')
+  })
+
+  it('marks a plain JS service (no tsconfig, no typescript dep) as javascript', async () => {
+    const services = await discoverServices(path.join(FIXTURES, 'service-language'))
+    const byName = new Map(services.map((s) => [s.node.name, s.node.language]))
+    expect(byName.get('fixture-plain-js')).toBe('javascript')
+  })
 })

--- a/packages/core/test/fixtures/service-language/plain-js/package.json
+++ b/packages/core/test/fixtures/service-language/plain-js/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fixture-plain-js",
+  "version": "1.0.0",
+  "dependencies": {
+    "express": "^4.19.0"
+  }
+}

--- a/packages/core/test/fixtures/service-language/ts-dep/package.json
+++ b/packages/core/test/fixtures/service-language/ts-dep/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fixture-ts-dep",
+  "version": "1.0.0",
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/core/test/fixtures/service-language/ts-tsconfig/package.json
+++ b/packages/core/test/fixtures/service-language/ts-tsconfig/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-ts-tsconfig",
+  "version": "1.0.0"
+}

--- a/packages/core/test/fixtures/service-language/ts-tsconfig/tsconfig.json
+++ b/packages/core/test/fixtures/service-language/ts-tsconfig/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext"
+  }
+}


### PR DESCRIPTION
A TypeScript service was coming through the graph with `language: javascript`. `discoverNodeService` in `extract/services.ts` set `language: 'javascript'` flat on the ServiceNode, regardless of the project. The per-file extractor already resolves `.ts`/`.tsx` correctly via `languageForPath`, so only the ServiceNode's own field was wrong.

This derives the field instead. A JS-manifest service reads as `typescript` when its package depends on `typescript` (in `dependencies` or `devDependencies`) or the service dir carries a `tsconfig.json` / `tsconfig.*.json`, otherwise it stays `javascript`. One readdir, conservative toward javascript.

Tests cover all three paths: a tsconfig-only service, a service that only lists `typescript` in devDependencies, and a plain JS service. The first two fail against the old hardcode.

Refs #541