### PR TITLE
Discover Python projects with a root manifest

### DIFF
--- a/packages/core/src/extract/services.ts
+++ b/packages/core/src/extract/services.ts
@@ -38,6 +38,14 @@ function workspaceGlobs(pkg: RootPackageJson): string[] | null {
   return null
 }
 
+async function hasPythonManifest(dir: string): Promise<boolean> {
+  return (
+    (await exists(path.join(dir, 'pyproject.toml'))) ||
+    (await exists(path.join(dir, 'requirements.txt'))) ||
+    (await exists(path.join(dir, 'setup.py')))
+  )
+}
+
 async function loadGitignore(scanPath: string): Promise<Ignore | null> {
   const gitignorePath = path.join(scanPath, '.gitignore')
   if (!(await exists(gitignorePath))) return null
@@ -239,7 +247,15 @@ export async function discoverServices(scanPath: string): Promise<DiscoveredServ
   if (wsGlobs) {
     candidateDirs.push(...(await expandWorkspaceGlobs(scanPath, wsGlobs)))
   } else {
-    if (rootPkg && rootPkg.name) candidateDirs.push(scanPath)
+    if (rootPkg && rootPkg.name) {
+      candidateDirs.push(scanPath)
+    } else if (await hasPythonManifest(scanPath)) {
+      // A Python project commonly keeps its manifest at the repo root with the
+      // code in a subpackage and no package.json anywhere. The walk only visits
+      // descendants, so without this the root manifest is never seen and the
+      // whole project discovers zero services.
+      candidateDirs.push(scanPath)
+    }
     const ig = await loadGitignore(scanPath)
     await walkDirs(
       scanPath,
@@ -248,11 +264,7 @@ export async function discoverServices(scanPath: string): Promise<DiscoveredServ
       async (dir) => {
         if (await exists(path.join(dir, 'package.json'))) {
           candidateDirs.push(dir)
-        } else if (
-          (await exists(path.join(dir, 'pyproject.toml'))) ||
-          (await exists(path.join(dir, 'requirements.txt'))) ||
-          (await exists(path.join(dir, 'setup.py')))
-        ) {
+        } else if (await hasPythonManifest(dir)) {
           candidateDirs.push(dir)
         }
       },

--- a/packages/core/test/discover-services.test.ts
+++ b/packages/core/test/discover-services.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { discoverServices } from '../src/extract/services.js'
@@ -79,5 +81,41 @@ describe('discoverServices', () => {
     const services = await discoverServices(path.join(FIXTURES, 'service-language'))
     const byName = new Map(services.map((s) => [s.node.name, s.node.language]))
     expect(byName.get('fixture-plain-js')).toBe('javascript')
+  })
+
+  describe('root manifest, no package.json', () => {
+    let tmp: string
+
+    afterEach(async () => {
+      if (tmp) await fs.rm(tmp, { recursive: true, force: true })
+    })
+
+    it('discovers a Python project whose pyproject.toml sits at the root', async () => {
+      tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-py-root-'))
+      await fs.writeFile(
+        path.join(tmp, 'pyproject.toml'),
+        '[tool.poetry]\nname = "fixture-py-root"\nversion = "1.2.3"\n',
+      )
+      await fs.mkdir(path.join(tmp, 'app'))
+      await fs.writeFile(path.join(tmp, 'app', 'main.py'), 'def handler():\n    return 1\n')
+
+      const services = await discoverServices(tmp)
+      expect(services).toHaveLength(1)
+      expect(services[0]!.node.name).toBe('fixture-py-root')
+      expect(services[0]!.node.language).toBe('python')
+    })
+
+    it('still discovers a JS project from its root package.json', async () => {
+      tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-js-root-'))
+      await fs.writeFile(
+        path.join(tmp, 'package.json'),
+        JSON.stringify({ name: 'fixture-js-root', version: '0.1.0' }),
+      )
+
+      const services = await discoverServices(tmp)
+      expect(services).toHaveLength(1)
+      expect(services[0]!.node.name).toBe('fixture-js-root')
+      expect(services[0]!.node.language).toBe('javascript')
+    })
   })
 })


### PR DESCRIPTION
A Python project commonly keeps `pyproject.toml` at the repo root with the code in a subpackage like `app/` and no `package.json` anywhere. The directory walk in `discoverServices` only visits descendants, so the root manifest was never reachable. That left these projects with zero services discovered and nothing extracted, even when the root pyproject was a perfectly valid `[tool.poetry]` manifest.

Now the scan root counts as a service candidate when it carries a Python manifest and there's no usable root `package.json`. A small `hasPythonManifest` helper does the pyproject / requirements / setup.py check; the walk callback uses the same helper so the root check and the descendant check stay in step. JS discovery is untouched.

Covered by two cases in the discovery test: a temp project with a root `pyproject.toml` plus a `.py` file in a subdir and no `package.json` now yields one Python service, and a JS root with `package.json` still discovers as before. The Python case fails against the old code.

Refs #542