### PR TITLE
Make the runtime layer engage on more app shapes, and say so when it can't

### DIFF
--- a/packages/core/src/installers/javascript.ts
+++ b/packages/core/src/installers/javascript.ts
@@ -65,7 +65,7 @@ import {
   renderNextInstrumentationNode,
   renderNodeOtelInit,
 } from './templates.js'
-import { resolve as _resolveRegistry } from '@neat.is/instrumentation-registry' // #391 uses _resolveRegistry for version-reconciled instrumentation advice
+import { resolve as resolveRegistry } from '@neat.is/instrumentation-registry'
 
 // ADR-069 §5 — three OTel packages land in `dependencies`. `dotenv` was a
 // fourth from v0.3.6 through v0.4.3; the generated `otel-init` templates
@@ -326,6 +326,53 @@ function allDeps(pkg: PackageJsonShape): Record<string, string> {
   return { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) }
 }
 
+// Issue #545 — web-framework signals. When a package depends on one of these
+// but the installer couldn't resolve an entry point, it's almost certainly a
+// runnable app whose runtime layer is about to silently fail to engage rather
+// than a true library. The orchestrator uses this to turn a quiet `lib-only N`
+// tally into a loud, actionable line. Presence is enough — version doesn't
+// matter for the warning.
+const WEB_FRAMEWORK_DEPS = [
+  'express',
+  'fastify',
+  'koa',
+  '@hapi/hapi',
+  'hapi',
+  'restify',
+  'connect',
+  '@nestjs/core',
+  'next',
+  'hono',
+  'elysia',
+  'polka',
+  'micro',
+] as const
+
+// True when the package declares a web-framework dependency — the signal that
+// a lib-only classification is more likely a missed app entry than a real
+// library.
+export function looksLikeWebApp(pkg: PackageJsonShape): boolean {
+  const deps = allDeps(pkg)
+  return WEB_FRAMEWORK_DEPS.some((name) => name in deps)
+}
+
+// Issue #546 — libraries whose calls aren't observed by the default
+// auto-instrumentation set. Resolved through the instrumentation registry (the
+// single source of truth, contract §3) rather than a hardcoded list: a
+// dependency whose registry coverage is `gap` produces no OBSERVED edges out of
+// the box. `sqlite3` / `better-sqlite3` are the motivating cases — in-process
+// drivers that never cross an instrumented wire. Returns the library names so
+// the orchestrator can name them in its guidance line.
+export function uninstrumentedLibraries(pkg: PackageJsonShape): string[] {
+  const deps = allDeps(pkg)
+  const out: string[] = []
+  for (const [name, version] of Object.entries(deps)) {
+    const entry = resolveRegistry(name, version)
+    if (entry && entry.coverage === 'gap') out.push(name)
+  }
+  return out
+}
+
 // ADR-074 §3 — Remix detection. A package is Remix-flavored when it declares
 // `remix` or any `@remix-run/*` package AND ships an entry-server file at one
 // of the canonical paths (`app/entry.server.{ts,tsx,js,jsx}`).
@@ -425,15 +472,29 @@ async function isTypeScriptProject(serviceDir: string): Promise<boolean> {
   return exists(path.join(serviceDir, 'tsconfig.json'))
 }
 
-// ADR-069 §2 + ADR-070 — entry resolution: pkg.main → pkg.bin → scripts.start
-// → scripts.dev → src/index.* → src/{server,main,app}.* → root index.*.
-// Returns the absolute path to the resolved entry, or null when the package
-// is lib-only (no resolvable entry).
+// ADR-069 §2 + ADR-070 + issue #545 — entry resolution: pkg.main → pkg.bin →
+// scripts.start → scripts.dev → src/index.* → src/{server,main,app}.* →
+// root {server,app,main}.* → root index.*. `pkg.main` is only accepted when
+// the file it names actually exists; a stale `main` (e.g. `dist/index.js` that
+// hasn't been built, or a leftover that was deleted) falls through to the rest
+// of the chain rather than marking the package lib-only. Returns the absolute
+// path to the resolved entry, or null when the package is lib-only (no
+// resolvable entry).
 const INDEX_EXTENSIONS = ['.ts', '.tsx', '.js', '.mjs', '.cjs']
 const INDEX_CANDIDATES = INDEX_EXTENSIONS.map((ext) => `index${ext}`)
 const SRC_INDEX_CANDIDATES = INDEX_EXTENSIONS.map((ext) => `src/index${ext}`)
 const SRC_NAMED_CANDIDATES = ['server', 'main', 'app'].flatMap((name) =>
   INDEX_EXTENSIONS.map((ext) => `src/${name}${ext}`),
+)
+// Issue #545 — a runnable app commonly keeps its entry at the repo root under
+// a conventional name (`server.js`, `app.js`, `main.js`) with no `scripts.start`
+// and a `pkg.main` that points at a build output that doesn't exist yet. Those
+// shapes resolved to lib-only before — the runtime layer never engaged. Root
+// named candidates sit just before the `index.*` root fallback so they're the
+// last resort after the manifest/script/src signals, but still keep the app
+// from silently dropping out of instrumentation.
+const ROOT_NAMED_CANDIDATES = ['server', 'app', 'main'].flatMap((name) =>
+  INDEX_EXTENSIONS.map((ext) => `${name}${ext}`),
 )
 
 // ADR-070 — script-entry tokeniser. Launchers and similar wrappers we strip
@@ -537,7 +598,13 @@ export async function resolveEntry(
     const candidate = path.join(serviceDir, rel)
     if (await exists(candidate)) return candidate
   }
-  // 7) root index.* — original ADR-069 §3 fallback.
+  // 7) root server.*, app.*, main.* — issue #545. Common for a runnable app
+  // whose entry sits at the repo root rather than under src/.
+  for (const rel of ROOT_NAMED_CANDIDATES) {
+    const candidate = path.join(serviceDir, rel)
+    if (await exists(candidate)) return candidate
+  }
+  // 8) root index.* — original ADR-069 §3 fallback.
   for (const name of INDEX_CANDIDATES) {
     const candidate = path.join(serviceDir, name)
     if (await exists(candidate)) return candidate

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -41,6 +41,7 @@ import {
   pickInstaller,
   type InstallPlan,
 } from './installers/index.js'
+import { looksLikeWebApp, uninstrumentedLibraries } from './installers/javascript.js'
 import {
   detectPackageManager,
   runPackageManagerInstall,
@@ -220,7 +221,22 @@ export async function applyInstallersOver(
         if (!installPlans.has(key)) installPlans.set(key, cmd)
       }
     } else if (outcome.outcome === 'already-instrumented') already++
-    else if (outcome.outcome === 'lib-only') libOnly++
+    else if (outcome.outcome === 'lib-only') {
+      libOnly++
+      // Issue #545 — a lib-only package that carries a web-framework dependency
+      // is almost certainly a runnable app whose entry the installer couldn't
+      // find, not a true library. Left in the `lib-only N` tally it's silent;
+      // the runtime layer never engages and the user has no idea why. Name it
+      // loudly with the recovery path.
+      if (svc.pkg && looksLikeWebApp(svc.pkg)) {
+        const svcName = path.basename(svc.dir)
+        console.warn(
+          `neat: runtime layer won't engage for ${svcName}: no entry point found.\n` +
+            `  ${svc.dir} depends on a web framework but neat couldn't resolve an entry to instrument.\n` +
+            `  Add a "start" script to package.json, or point neat at the entry file directly.`,
+        )
+      }
+    }
     else if (outcome.outcome === 'browser-bundle') {
       browserBundle++
       console.log(`skipping ${svc.dir}: browser bundle; browser-OTel support lands in a future release.`)
@@ -279,6 +295,28 @@ export async function applyInstallersOver(
           `  Set OTEL_SERVICE_NAME=${svcName}\n` +
           `  See docs/installer-scope.md → "Manual setup for out-of-scope runtimes"`,
       )
+    }
+
+    // Issue #546 — a service can be fully instrumented and still produce an
+    // empty OBSERVED layer when it leans on a library the default
+    // auto-instrumentation set doesn't cover (sqlite3 is the motivating case:
+    // an in-process driver whose calls never cross an instrumented wire). The
+    // differentiator goes silently empty. Name the libraries and point at the
+    // extend path so the user knows why and what to do. Skip the lib-only and
+    // out-of-scope buckets — there's no OBSERVED layer for them to be missing
+    // from yet.
+    if (svc.pkg && (outcome.outcome === 'instrumented' || outcome.outcome === 'already-instrumented')) {
+      const gaps = uninstrumentedLibraries(svc.pkg)
+      if (gaps.length > 0) {
+        const svcName = path.basename(svc.dir)
+        const list = gaps.join(', ')
+        const verb = gaps.length === 1 ? 'this library' : 'these libraries'
+        console.warn(
+          `neat: calls to ${list} won't be observed by default in ${svcName}.\n` +
+            `  ${verb} aren't in the default instrumentation set, so they produce no OBSERVED edges.\n` +
+            `  Run \`neat list-uninstrumented\` to review them, then \`neat extend\` to capture them.`,
+        )
+      }
     }
   }
 

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -3539,6 +3539,47 @@ describe('SDK install — apply-side (ADR-069)', () => {
     }
   })
 
+  it('§2 — entry resolution: root server.js wins when pkg.main is stale and there is no start script (#545)', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { dir, cleanup } = await makeNodeService()
+    try {
+      // The jaredhanson/todos-fastify-sqlite shape: `main` points at a file
+      // that doesn't exist, scripts is empty, and the real entry is a
+      // root-level server.js. This resolved to lib-only before #545.
+      await writePkg(dir, {
+        name: 'todos',
+        main: 'index.js',
+        scripts: {},
+        dependencies: { fastify: '^4.0.0' },
+      })
+      await fs2.writeFile(path2.join(dir, 'server.js'), `console.log('hi')\n`)
+      const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+      const plan = await javascriptInstaller.plan(dir)
+      expect(plan.libOnly).toBeFalsy()
+      expect(plan.entryFile).toBe(path2.join(dir, 'server.js'))
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('§2 — entry resolution: root app.js and main.js also resolve (#545)', async () => {
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const { javascriptInstaller } = await import('../../src/installers/javascript.js')
+    for (const name of ['app.js', 'main.js']) {
+      const { dir, cleanup } = await makeNodeService()
+      try {
+        await writePkg(dir, { name: 'svc' })
+        await fs2.writeFile(path2.join(dir, name), `console.log('hi')\n`)
+        const plan = await javascriptInstaller.plan(dir)
+        expect(plan.entryFile).toBe(path2.join(dir, name))
+      } finally {
+        await cleanup()
+      }
+    }
+  })
+
   it('§2 — lib-only package (no resolvable entry) is skipped with reason "lib-only"', async () => {
     const { javascriptInstaller } = await import('../../src/installers/javascript.js')
     const { dir, cleanup } = await makeNodeService()
@@ -4248,6 +4289,117 @@ describe('SDK install — apply-side (ADR-069)', () => {
       expect(JSON.stringify(b)).toBe(JSON.stringify(a))
     } finally {
       await cleanup()
+    }
+  })
+})
+
+describe('Runtime layer fails loud, never silent (#545 #546)', () => {
+  async function makeService(
+    pkg: Record<string, unknown>,
+    files: Record<string, string> = {},
+  ): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+    const os2 = await import('node:os')
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    const base = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-failloud-'))
+    const dir = await fs2.realpath(base)
+    await fs2.writeFile(path2.join(dir, 'package.json'), JSON.stringify(pkg, null, 2))
+    for (const [rel, body] of Object.entries(files)) {
+      const full = path2.join(dir, rel)
+      await fs2.mkdir(path2.dirname(full), { recursive: true })
+      await fs2.writeFile(full, body)
+    }
+    return { dir, cleanup: () => fs2.rm(dir, { recursive: true, force: true }) }
+  }
+
+  // applyInstallersOver always runs the real installer; stub the package-manager
+  // install so no network/lockfile work happens and the test stays hermetic.
+  const stubInstall = {
+    runInstall: async (cmd: { pm: 'npm'; cwd: string; args: string[] }) => ({
+      pm: cmd.pm,
+      cwd: cmd.cwd,
+      args: cmd.args,
+      exitCode: 0,
+      stderr: '',
+    }),
+    resolveManager: async (dir: string) => ({ pm: 'npm' as const, cwd: dir, args: ['install'] }),
+  }
+
+  it('warns loudly when a lib-only package looks like an app (#545)', async () => {
+    const { discoverServices } = await import('../../src/extract/services.js')
+    const { applyInstallersOver } = await import('../../src/orchestrator.js')
+    // Web-framework dep present, but no entry the installer can resolve → lib-only.
+    const { dir, cleanup } = await makeService({
+      name: 'app-shaped',
+      dependencies: { express: '^4.0.0' },
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const services = await discoverServices(dir)
+      const tally = await applyInstallersOver(services, 'proj', stubInstall)
+      expect(tally.libOnly).toBe(1)
+      const joined = warn.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(joined).toContain("runtime layer won't engage")
+      expect(joined).toContain('no entry point found')
+    } finally {
+      warn.mockRestore()
+      await cleanup()
+    }
+  })
+
+  it('does not warn for a genuine library with no app signal (#545)', async () => {
+    const { discoverServices } = await import('../../src/extract/services.js')
+    const { applyInstallersOver } = await import('../../src/orchestrator.js')
+    const { dir, cleanup } = await makeService({ name: 'pure-lib' })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const services = await discoverServices(dir)
+      const tally = await applyInstallersOver(services, 'proj', stubInstall)
+      expect(tally.libOnly).toBe(1)
+      const joined = warn.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(joined).not.toContain("runtime layer won't engage")
+    } finally {
+      warn.mockRestore()
+      await cleanup()
+    }
+  })
+
+  it('warns about uninstrumented libraries on an instrumented service (#546)', async () => {
+    const { discoverServices } = await import('../../src/extract/services.js')
+    const { applyInstallersOver } = await import('../../src/orchestrator.js')
+    // Fastify + sqlite3 with a resolvable root entry → instrumented, but
+    // sqlite3's calls produce no OBSERVED edges by default.
+    const { dir, cleanup } = await makeService(
+      {
+        name: 'todos',
+        main: 'index.js',
+        scripts: {},
+        dependencies: { fastify: '^4.0.0', sqlite3: '^5.1.0' },
+      },
+      { 'server.js': "console.log('hi')\n" },
+    )
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const services = await discoverServices(dir)
+      const tally = await applyInstallersOver(services, 'proj', stubInstall)
+      expect(tally.instrumented).toBe(1)
+      const joined = warn.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(joined).toContain('sqlite3')
+      expect(joined).toContain("won't be observed by default")
+      expect(joined).toContain('neat list-uninstrumented')
+      expect(joined).toContain('neat extend')
+    } finally {
+      warn.mockRestore()
+      await cleanup()
+    }
+  })
+
+  it('the registry classifies sqlite3 / better-sqlite3 as a coverage gap (#546)', async () => {
+    const { resolve } = await import('@neat.is/instrumentation-registry')
+    for (const lib of ['sqlite3', 'better-sqlite3']) {
+      const entry = resolve(lib, '5.1.0')
+      expect(entry).not.toBeNull()
+      expect(entry!.coverage).toBe('gap')
     }
   })
 })

--- a/packages/instrumentation-registry/src/registry.json
+++ b/packages/instrumentation-registry/src/registry.json
@@ -455,5 +455,15 @@
     "versions": [
       { "range": "*", "coverage": "bundled", "notes": "superagent uses Node's http/https internally; covered by @opentelemetry/instrumentation-http via auto-instrumentations-node." }
     ]
+  },
+  "sqlite3": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "No OTel instrumentation package for the sqlite3 driver. Its queries run in-process and don't cross an instrumented HTTP/wire boundary, so they aren't observed by default. Trace them with a manual span around the query calls, or run `neat list-uninstrumented` to surface the gap." }
+    ]
+  },
+  "better-sqlite3": {
+    "versions": [
+      { "range": "*", "coverage": "gap", "notes": "No OTel instrumentation package for better-sqlite3. Its synchronous queries run in-process and don't cross an instrumented HTTP/wire boundary, so they aren't observed by default. Trace them with a manual span around the query calls, or run `neat list-uninstrumented` to surface the gap." }
+    ]
   }
 }


### PR DESCRIPTION
Refs #545 #546

NEAT's OBSERVED layer is the differentiator, and two gaps let it go quietly dark on real apps. Both surfaced in a real-app bug hunt against `jaredhanson/todos-fastify-sqlite`.

## Entry detection (#545)

A runnable app whose real entry sits at the repo root as `server.js` / `app.js` / `main.js` — with a `pkg.main` that points at a build output that doesn't exist and no `scripts.start` — resolved to lib-only and never got instrumented. `resolveEntry` already falls through a stale `pkg.main`; it now also tries those conventional root-level names just before the existing `index.*` root fallback. The todos repo (`main: "index.js"` missing, empty scripts, entry at root `server.js`) now resolves `server.js` and instruments.

## Fail loud, never silent (#546)

When a service still can't be instrumented, or it can but its calls won't be observed, the orchestrator now names it instead of folding it into a quiet `lib-only N` line:

- A **lib-only package that carries a web-framework dependency** (express/fastify/koa/hapi/nest/next/hono/…) gets a loud warning: it's almost certainly an app whose entry we couldn't find, with the recovery path — add a `start` script or point neat at the entry.
- A service that depends on a **library the default instrumentation set doesn't cover** gets the libraries named, with a pointer to `neat list-uninstrumented` and `neat extend`.

The uninstrumented-library check runs through `@neat.is/instrumentation-registry` (the single source of truth) rather than a hardcoded list. `sqlite3` and `better-sqlite3` join the registry as `gap` entries so the in-process-driver case the bug report hit is recognized.

Detection and guidance only — nothing is auto-added to the instrumentation or extend set; that stays a maintainer scope decision.

## Tests

- root `server.js` wins when `pkg.main` is stale and there's no start script; `app.js` / `main.js` too
- the lib-only-but-app-shaped warning fires (and stays quiet for a genuine library)
- the uninstrumented-library guidance fires on an instrumented fastify+sqlite3 service
- the registry classifies sqlite3 / better-sqlite3 as a coverage gap

`npx turbo build test lint` is green across all packages.