### PR TITLE
Wire the contracts to Claude on read, not only on edit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit",
+        "matcher": "Edit|Write|MultiEdit|Read",
         "hooks": [
           {
             "type": "command",

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -203,7 +203,7 @@ If you write code that violates a rule and you believe the rule should change, *
 Three layers, increasing in precision:
 
 1. **Session start** — CLAUDE.md auto-loads this index file. You see the rule list before any tool call.
-2. **Pre-edit** — when you call `Edit`, `Write`, or `MultiEdit`, the PreToolUse hook at `docs/contracts/_hook.sh` reads the target file path, finds every contract in `docs/contracts/*.md` whose `governs:` frontmatter matches, and surfaces those contract bodies as additional context for that specific edit.
+2. **On-read + pre-edit** — when you call `Read`, `Edit`, `Write`, or `MultiEdit`, the PreToolUse hook at `docs/contracts/_hook.sh` reads the target file path and finds every contract in `docs/contracts/*.md` whose `governs:` frontmatter matches. On `Read` it surfaces a concise pointer (contract name + one-line + path), so you know the file is governed while you're understanding it; on an edit it surfaces the full contract bodies as binding context for that write.
 3. **CI** — `packages/core/test/audits/contracts.test.ts` encodes contract rules as test assertions. Any code that violates a rule fails the test on every PR.
 
 Three points of contact, three different precision levels. The index is broad and always loaded. The hook is narrow and edit-scoped. The tests are mechanical and PR-gated.

--- a/docs/contracts/_hook.sh
+++ b/docs/contracts/_hook.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 # PreToolUse hook for NEAT contracts.
-# Wired in .claude/settings.json against Edit, Write, MultiEdit.
+# Wired in .claude/settings.json against Edit, Write, MultiEdit, and Read.
 #
 # Reads the tool payload from stdin, finds every contract in
 # docs/contracts/*.md whose `governs:` frontmatter glob matches the target
-# file path, and surfaces the matching contract bodies as additionalContext.
-# The model reads the binding rules at the moment of writing.
+# file path, and surfaces the match as additionalContext:
+#   - on Edit / Write / MultiEdit: the full contract body — the binding rules
+#     at the moment of writing.
+#   - on Read: a concise pointer (name + one-line + path), so an agent reading
+#     to understand the code knows it's governed, without burying it in the
+#     full contract on every file it opens.
 #
 # Output is a JSON object keyed `hookSpecificOutput.additionalContext`.
 # If no contracts match, the hook is a silent no-op (exit 0, empty output).
@@ -13,6 +17,9 @@
 set -euo pipefail
 
 INPUT=$(cat)
+
+# Which tool fired — Read gets a concise pointer, edits get the full body.
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
 
 # Pick the file path off whichever shape the tool input arrived in.
 # Edit / Write use file_path; MultiEdit nests edits but still has file_path.
@@ -69,12 +76,25 @@ if [ ${#RELEVANT[@]} -eq 0 ]; then
   exit 0
 fi
 
-# Build the additionalContext payload.
-CONTEXT="The following NEAT contracts govern this file. Read them before editing — they are binding."$'\n'
-for c in "${RELEVANT[@]}"; do
-  CONTEXT+=$'\n\n----\n\n'
-  CONTEXT+="$(cat "$c")"
-done
+# Build the additionalContext payload. Edits get the full binding text; reads
+# get a concise pointer so the agent stays contract-aware without the noise of
+# the full contract on every file it opens.
+if [ "$TOOL_NAME" = "Read" ]; then
+  CONTEXT="This file is governed by binding NEAT contract(s), surfaced on read. Read the contract before changing the file:"$'\n'
+  for c in "${RELEVANT[@]}"; do
+    base=$(basename "$c")
+    name=$(awk -F': ' '/^name:/ { print $2; exit }' "$c")
+    desc=$(awk '/^description:/ { sub(/^description: */, ""); gsub(/^"|"$/, ""); print; exit }' "$c")
+    CONTEXT+=$'\n'"- ${name:-$base} — docs/contracts/${base}"
+    [ -n "$desc" ] && CONTEXT+=$'\n'"  ${desc}"
+  done
+else
+  CONTEXT="The following NEAT contracts govern this file. Read them before editing — they are binding."$'\n'
+  for c in "${RELEVANT[@]}"; do
+    CONTEXT+=$'\n\n----\n\n'
+    CONTEXT+="$(cat "$c")"
+  done
+fi
 
 # Emit the structured PreToolUse response.
 jq -n --arg ctx "$CONTEXT" '{


### PR DESCRIPTION
The "wire the contracts to Claude itself" step. The PreToolUse contract hook fired on `Edit|Write|MultiEdit`; it now also fires on **`Read`**, so a coding agent sees the governing contract while it's *understanding* the code, before it touches anything.

- `.claude/settings.json`: `Read` added to the matcher.
- `docs/contracts/_hook.sh`: branches on `tool_name` — **Read** → a concise pointer (name + one-line + path); **edits** → the full binding body (unchanged). The governs-glob matching is untouched.
- `contracts.md`: the contract-loading description updated (on-read + pre-edit).

Verified: read on a governed file surfaces the concise pointer; edit surfaces the full body; read on an ungoverned file is a silent no-op.

Refs #566