### PR TITLE
Lint that every contract names its enforcement pillar

### DIFF
--- a/docs/contracts/canvas-layout.md
+++ b/docs/contracts/canvas-layout.md
@@ -7,6 +7,7 @@ governs:
   - "packages/web/app/components/ObservedOverlay.tsx"
   - "packages/web/lib/layout/**"
 adr: [ADR-098, ADR-101, ADR-089]
+enforcement: [review]
 ---
 
 # Live canvas layout contract

--- a/docs/contracts/cli-surface.md
+++ b/docs/contracts/cli-surface.md
@@ -6,6 +6,7 @@ governs:
   - "packages/core/src/cli-verbs.ts"
   - "packages/core/src/cli-client.ts"
 adr: [ADR-050, ADR-039, ADR-026, ADR-060, ADR-102]
+enforcement: [lint, review]
 ---
 
 # CLI surface contract

--- a/docs/contracts/client-profiles.md
+++ b/docs/contracts/client-profiles.md
@@ -7,6 +7,7 @@ governs:
   - "packages/mcp/src/base-url.ts"
   - "packages/web/lib/resolve-project.ts"
 adr: [ADR-102, ADR-101, ADR-096, ADR-073]
+enforcement: [lint, review]
 ---
 
 # Client profile contract

--- a/docs/contracts/comms-voice.md
+++ b/docs/contracts/comms-voice.md
@@ -10,7 +10,7 @@ governs:
   - "docs/api-reference.md"
   - "docs/architecture.md"
 adr: [ADR-027, ADR-053]
-enforcement: [review]
+enforcement: [lint, review]
 ---
 
 # Comms-voice contract

--- a/docs/contracts/comms-voice.md
+++ b/docs/contracts/comms-voice.md
@@ -10,6 +10,7 @@ governs:
   - "docs/api-reference.md"
   - "docs/architecture.md"
 adr: [ADR-027, ADR-053]
+enforcement: [review]
 ---
 
 # Comms-voice contract

--- a/docs/contracts/daemon.md
+++ b/docs/contracts/daemon.md
@@ -9,6 +9,7 @@ governs:
   - "packages/core/src/extract/index.ts"
   - "packages/core/src/persist.ts"
 adr: [ADR-049, ADR-063, ADR-048, ADR-026, ADR-027, ADR-071, ADR-072]
+enforcement: [lint, review]
 ---
 
 # Daemon contract

--- a/docs/contracts/env-dimension.md
+++ b/docs/contracts/env-dimension.md
@@ -8,6 +8,7 @@ governs:
   - "packages/core/src/extract"
   - "packages/core/src/persist.ts"
 adr: [ADR-074, ADR-028, ADR-031, ADR-066]
+enforcement: [lint, review]
 ---
 
 # Env-dimension at ingest contract

--- a/docs/contracts/extend-skill.md
+++ b/docs/contracts/extend-skill.md
@@ -6,6 +6,7 @@ governs:
   - "packages/core/src/extend/**"
   - "packages/core/src/orchestrator.ts"
 adr: [ADR-081, ADR-086, ADR-080]
+enforcement: [lint, review]
 ---
 
 # `/neat extend` skill contract

--- a/docs/contracts/file-awareness.md
+++ b/docs/contracts/file-awareness.md
@@ -12,6 +12,7 @@ governs:
   - "packages/core/src/traverse.ts"
   - "packages/core/src/divergences.ts"
 adr: [ADR-087, ADR-089, ADR-100]
+enforcement: [lint, review]
 ---
 
 # File-awareness contract

--- a/docs/contracts/framework-installers.md
+++ b/docs/contracts/framework-installers.md
@@ -4,6 +4,7 @@ description: The JS SDK installer extends the framework dispatch pattern v0.3.8 
 governs:
   - "packages/core/src/installers/javascript.ts"
 adr: [ADR-074, ADR-073, ADR-047, ADR-069, ADR-070]
+enforcement: [lint, review]
 ---
 
 # Framework installer paths contract

--- a/docs/contracts/frontend-api.md
+++ b/docs/contracts/frontend-api.md
@@ -10,6 +10,7 @@ governs:
   - "packages/core/src/watch.ts"
   - "packages/core/src/policy.ts"
 adr: [ADR-051, ADR-040, ADR-026, ADR-048]
+enforcement: [lint, review]
 ---
 
 # Frontend-facing API contract

--- a/docs/contracts/frontier-promotion.md
+++ b/docs/contracts/frontier-promotion.md
@@ -7,6 +7,7 @@ governs:
   - "packages/core/src/extract/aliases.ts"
   - "packages/core/src/watch.ts"
 adr: [ADR-035, ADR-023, ADR-029, ADR-030, ADR-068]
+enforcement: [lint, review]
 ---
 
 # FrontierNode promotion contract

--- a/docs/contracts/get-blast-radius.md
+++ b/docs/contracts/get-blast-radius.md
@@ -5,6 +5,7 @@ governs:
   - "packages/core/src/traverse.ts"
   - "packages/types/src/results.ts"
 adr: [ADR-038, ADR-029, ADR-031]
+enforcement: [lint, review]
 ---
 
 # `getBlastRadius` contract

--- a/docs/contracts/get-root-cause.md
+++ b/docs/contracts/get-root-cause.md
@@ -6,6 +6,7 @@ governs:
   - "packages/core/src/compat.ts"
   - "packages/types/src/results.ts"
 adr: [ADR-037, ADR-014, ADR-029, ADR-031]
+enforcement: [lint, review]
 ---
 
 # `getRootCause` contract

--- a/docs/contracts/hosted-storage.md
+++ b/docs/contracts/hosted-storage.md
@@ -4,6 +4,7 @@ description: Hosted NEAT stores the graph, embeddings, and bounded traversal in 
 governs:
   - "packages/core/src/persist.ts"
 adr: [ADR-103, ADR-041, ADR-096]
+enforcement: [review]
 ---
 
 # Hosted storage contract

--- a/docs/contracts/identity.md
+++ b/docs/contracts/identity.md
@@ -7,6 +7,7 @@ governs:
   - "packages/types/src/nodes.ts"
   - "packages/types/src/identity.ts"
 adr: [ADR-028]
+enforcement: [lint, review]
 ---
 
 # Identity contract

--- a/docs/contracts/init.md
+++ b/docs/contracts/init.md
@@ -6,6 +6,7 @@ governs:
   - "packages/core/src/installers/**"
   - "packages/core/src/registry.ts"
 adr: [ADR-046, ADR-026, ADR-027]
+enforcement: [lint, review]
 ---
 
 # `neat init` contract

--- a/docs/contracts/installer-scope.md
+++ b/docs/contracts/installer-scope.md
@@ -6,6 +6,7 @@ governs:
   - "packages/core/src/installers/python.ts"
   - "packages/core/src/orchestrator.ts"
 adr: [ADR-082, ADR-085]
+enforcement: [lint, review]
 ---
 
 # Installer scope contract

--- a/docs/contracts/instrumentation-registry.md
+++ b/docs/contracts/instrumentation-registry.md
@@ -5,6 +5,7 @@ governs:
   - "packages/instrumentation-registry/**"
   - "packages/core/src/installers/javascript.ts"
 adr: [ADR-080, ADR-086]
+enforcement: [lint, review]
 ---
 
 # Instrumentation registry contract

--- a/docs/contracts/llm-policy.md
+++ b/docs/contracts/llm-policy.md
@@ -6,6 +6,7 @@ governs:
   - "packages/mcp/**"
   - "packages/instrumentation-registry/scripts/**"
 adr: [ADR-084, ADR-086]
+enforcement: [review]
 ---
 
 # LLM usage policy contract

--- a/docs/contracts/mcp-tools.md
+++ b/docs/contracts/mcp-tools.md
@@ -4,6 +4,7 @@ description: MCP tool surface — manifest-driven, all read-only over REST, thre
 governs:
   - "packages/mcp/src/**"
 adr: [ADR-039, ADR-091, ADR-102]
+enforcement: [lint, review]
 ---
 
 # MCP tool surface contract

--- a/docs/contracts/observed-e2e.md
+++ b/docs/contracts/observed-e2e.md
@@ -9,6 +9,7 @@ governs:
   - "packages/core/src/extract/**"
   - ".github/workflows/e2e-brief.yml"
 adr: [ADR-075, ADR-033, ADR-068, ADR-073]
+enforcement: [lint, breaker, review]
 ---
 
 # OBSERVED e2e contract

--- a/docs/contracts/one-command-cli.md
+++ b/docs/contracts/one-command-cli.md
@@ -11,6 +11,7 @@ governs:
   - "packages/core/src/registry.ts"
   - "Dockerfile"
 adr: [ADR-073, ADR-046, ADR-047, ADR-049, ADR-051, ADR-052, ADR-058, ADR-063, ADR-069, ADR-070]
+enforcement: [lint, review]
 ---
 
 # One-command CLI + deployment + delegated auth contract

--- a/docs/contracts/otel-ingest.md
+++ b/docs/contracts/otel-ingest.md
@@ -6,6 +6,7 @@ governs:
   - "packages/core/src/otel.ts"
   - "packages/core/src/otel-grpc.ts"
 adr: [ADR-033, ADR-029, ADR-030, ADR-068]
+enforcement: [lint, review]
 ---
 
 # OTel ingest contract

--- a/docs/contracts/package-split.md
+++ b/docs/contracts/package-split.md
@@ -5,6 +5,7 @@ governs:
   - "packages/core/**"
   - "packages/instrumentation-registry/**"
 adr: [ADR-083, ADR-086, ADR-080]
+enforcement: [review]
 ---
 
 # Package split contract

--- a/docs/contracts/persistence.md
+++ b/docs/contracts/persistence.md
@@ -4,6 +4,7 @@ description: Snapshot at <projectDir>/neat-out/graph.json. SCHEMA_VERSION bumps 
 governs:
   - "packages/core/src/persist.ts"
 adr: [ADR-041, ADR-017, ADR-019, ADR-026, ADR-031, ADR-068, ADR-074]
+enforcement: [lint, review]
 ---
 
 # Persistence contract

--- a/docs/contracts/policy-schema.md
+++ b/docs/contracts/policy-schema.md
@@ -6,6 +6,7 @@ governs:
   - "packages/core/src/policy.ts"
   - "packages/core/src/watch.ts"
 adr: [ADR-042]
+enforcement: [lint, review]
 ---
 
 # Policy schema contract

--- a/docs/contracts/policy-tools.md
+++ b/docs/contracts/policy-tools.md
@@ -7,6 +7,7 @@ governs:
   - "packages/mcp/src/resources.ts"
   - "packages/core/src/api.ts"
 adr: [ADR-045, ADR-039, ADR-040, ADR-026]
+enforcement: [lint, review]
 ---
 
 # Policy tool surface contract

--- a/docs/contracts/project-daemon.md
+++ b/docs/contracts/project-daemon.md
@@ -8,6 +8,7 @@ governs:
   - "packages/core/src/orchestrator.ts"
   - "packages/core/src/registry.ts"
 adr: [ADR-096, ADR-049, ADR-063, ADR-048, ADR-059, ADR-073]
+enforcement: [lint, review]
 ---
 
 # Project-daemon contract

--- a/docs/contracts/project-registry.md
+++ b/docs/contracts/project-registry.md
@@ -6,6 +6,7 @@ governs:
   - "packages/core/src/cli.ts"
   - "packages/core/src/daemon.ts"
 adr: [ADR-048, ADR-046, ADR-049]
+enforcement: [lint, review]
 ---
 
 # Machine-level project registry contract

--- a/docs/contracts/publish-system.md
+++ b/docs/contracts/publish-system.md
@@ -12,6 +12,7 @@ governs:
   - ".github/workflows/publish.yml"
   - "scripts/publish.sh"
 adr: [ADR-052, ADR-064, ADR-059]
+enforcement: [lint, review]
 ---
 
 # Publish system contract

--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -4,6 +4,7 @@ description: Routes dual-mount at /X and /projects/:project/X per ADR-026. JSON 
 governs:
   - "packages/core/src/api.ts"
 adr: [ADR-040, ADR-026, ADR-061]
+enforcement: [lint, review]
 ---
 
 # REST API contract

--- a/docs/contracts/schema.md
+++ b/docs/contracts/schema.md
@@ -4,6 +4,7 @@ description: Schema additions in @neat.is/types are growth (commit-and-go). Rena
 governs:
   - "packages/types/src/**"
 adr: [ADR-031, ADR-019]
+enforcement: [lint, review]
 ---
 
 # Schema growth vs schema shape

--- a/docs/contracts/sdk-install.md
+++ b/docs/contracts/sdk-install.md
@@ -5,6 +5,7 @@ governs:
   - "packages/core/src/installers/**"
   - "packages/core/src/cli.ts"
 adr: [ADR-047, ADR-046, ADR-027, ADR-069, ADR-070]
+enforcement: [lint, review]
 ---
 
 # SDK install contract

--- a/docs/contracts/static-extraction.md
+++ b/docs/contracts/static-extraction.md
@@ -5,6 +5,7 @@ governs:
   - "packages/core/src/extract/**"
   - "packages/core/src/watch.ts"
 adr: [ADR-032, ADR-065, ADR-030, ADR-031, ADR-024, ADR-055]
+enforcement: [lint, review]
 ---
 
 # Static-extraction contract

--- a/docs/contracts/sync.md
+++ b/docs/contracts/sync.md
@@ -5,6 +5,7 @@ governs:
   - "packages/core/src/cli.ts"
   - "packages/core/src/orchestrator.ts"
 adr: [ADR-074, ADR-073, ADR-046, ADR-048, ADR-049]
+enforcement: [lint, review]
 ---
 
 # `neat sync` contract

--- a/docs/contracts/trace-stitcher.md
+++ b/docs/contracts/trace-stitcher.md
@@ -4,6 +4,7 @@ description: stitchTrace fires only on ERROR spans, walks EXTRACTED outbound edg
 governs:
   - "packages/core/src/ingest.ts"
 adr: [ADR-034, ADR-027, ADR-029, ADR-030]
+enforcement: [lint, review]
 ---
 
 # Trace stitcher contract

--- a/docs/contracts/traversal.md
+++ b/docs/contracts/traversal.md
@@ -5,6 +5,7 @@ governs:
   - "packages/core/src/traverse.ts"
   - "packages/types/src/results.ts"
 adr: [ADR-036, ADR-029, ADR-030, ADR-031]
+enforcement: [lint, review]
 ---
 
 # Traversal contract

--- a/docs/contracts/web-bootstrap.md
+++ b/docs/contracts/web-bootstrap.md
@@ -6,6 +6,7 @@ governs:
   - "packages/web/package.json"
   - "packages/neat.is/package.json"
 adr: [ADR-059, ADR-049, ADR-052]
+enforcement: [lint, review]
 ---
 
 # Web UI bootstrap contract

--- a/docs/contracts/web-completeness.md
+++ b/docs/contracts/web-completeness.md
@@ -6,6 +6,7 @@ governs:
   - "packages/web/app/**/page.tsx"
   - "packages/web/audit/09-gaps-and-stubs.md"
 adr: [ADR-056]
+enforcement: [lint, review]
 ---
 
 # Web shell completeness contract

--- a/docs/contracts/web-debugging.md
+++ b/docs/contracts/web-debugging.md
@@ -7,6 +7,7 @@ governs:
   - "packages/web/app/components/DebugPanel.tsx"
   - "packages/web/lib/proxy.ts"
 adr: [ADR-058]
+enforcement: [lint, review]
 ---
 
 # Web shell debugging surface contract

--- a/docs/contracts/web-multi-project.md
+++ b/docs/contracts/web-multi-project.md
@@ -15,6 +15,7 @@ governs:
   - "packages/web/lib/fixtures.ts"
   - "packages/web/app/api/**"
 adr: [ADR-057, ADR-062, ADR-026, ADR-051, ADR-101]
+enforcement: [lint, review]
 ---
 
 # Web shell multi-project routing contract

--- a/docs/contracts/web-shell.md
+++ b/docs/contracts/web-shell.md
@@ -13,6 +13,7 @@ governs:
   - "packages/web/app/policies/**"
   - "packages/web/app/settings/**"
 adr: [ADR-097, ADR-101, ADR-056, ADR-057, ADR-062]
+enforcement: [lint, review]
 ---
 
 # Web shell IA contract

--- a/docs/quirks/enforcement-lint.md
+++ b/docs/quirks/enforcement-lint.md
@@ -1,0 +1,39 @@
+# Quirks — enforcement lint (Refs #568)
+
+Edge cases and judgement calls hit while making ADR-104 / `docs/contracts/contract-enforcement.md` real in CI. The correction wave reads this.
+
+## Pre-existing red tests in contracts.test.ts (not mine)
+
+`npx vitest run test/audits/contracts.test.ts` is already red on a clean `origin/main`, before any of my edits. Stashing my changes and running the file gives the same failures:
+
+- `Runtime layer fails loud, never silent (#545 #546) > the registry classifies sqlite3 / better-sqlite3 as a coverage gap` — `resolve('sqlite3', '5.1.0')` / `better-sqlite3` returns null instead of a `gap`-coverage entry. Instrumentation-registry **data**, nothing to do with contract frontmatter.
+- `Runtime layer fails loud, never silent (#545 #546) > warns about uninstrumented libraries on an instrumented service` — same registry root cause.
+- `Daemon contract (ADR-049) > ADR-071 — span for a still-broken slot emits the rate-limited drop log once per minute` — timing-flaky; shows up in some runs and not others (run count flips between 2 and 3 failures).
+
+My 107 added test rows all pass. I did **not** touch these — out of scope, and they predate this branch. Flagging so nobody blames the enforcement-lint PR for a red audit file.
+
+## Tag-honesty judgement calls
+
+The backlog pass picks a pillar from each contract's nature. Where I could have over-claimed, I deliberately didn't:
+
+- **The `policy` pillar is not active yet** (🟡 "opens with the kernel arc" per the contract table). Several contracts are architecturally *policy*-shaped — `client-profiles` ("no daemon reads the client profile store"), `mcp-tools` ("MCP read-only"), `llm-policy` ("no LLM call on any path"), `project-daemon` ("no machine-wide write-locked registry"). I did **not** tag any of them `policy`, because that would imply an enforcement mechanism that doesn't exist. They're tagged with what holds them today (`lint` where a structural assertion exists, else `review`). These are the prime migration candidates when the governance kernel lands — re-tag them `policy` then.
+
+- **`llm-policy` → `[review]`, not `[lint]`.** Its rule ("NEAT holds no LLM key, makes no LLM call on any user-facing or daemon path") is genuinely grep-mechanizable — a lint that scans production `src` for LLM SDK imports would hold most of it. But that lint does not exist today, so claiming `lint` would be dishonest. Good follow-up: add the grep guard, then bump the tag to `[lint, review]`.
+
+- **`package-split` → `[review]`.** Its body claims the substrate/installer boundary is "held by a directory boundary + lint rules." I could not find that boundary lint in `contracts.test.ts` (it may be an eslint rule elsewhere, or aspirational). Didn't claim `lint` on the strength of a body sentence I couldn't verify.
+
+- **`comms-voice` → `[review]`** even though a `Comms-voice contract` describe block exists. That block only lints the file's own frontmatter shape and a canary phrase — not the substantive "forward-looking framing" rule, which is a human/LLM judgement. So `review` is the honest home for the rule itself.
+
+- **`canvas-layout`, `hosted-storage` → `[review]`.** `canvas-layout` is behavioral UI determinism (ELK layout, 750ms batch, never auto-reflow) — would need a browser e2e to mechanize, which isn't there. `hosted-storage` describes a Postgres backend that isn't built yet. Both are honest `review` (the default for "genuinely unmechanizable / not built").
+
+- **`observed-e2e` → `[lint, breaker, review]`.** The live Brief e2e harness is the `breaker`-shaped enforcement; `lint` holds the structural file/workflow-existence checks the ADR-075 block already makes. Mirrors `divergence-query`'s shape.
+
+Everything else with a dedicated describe block asserting its substantive rules got `[lint, review]`, matching the calibration of the already-tagged contracts (`provenance`, `lifecycle`, `policy-*`).
+
+## Scope notes
+
+- The lint walks `docs/contracts/` and skips `_*` (hook helpers) and `contracts.md`. The actual index is `docs/contracts.md`, one directory **up**, so it never appears in the walk — the `contracts.md` filter is defensive only, in case an index is ever co-located by mistake.
+- Tags were inserted as the **last** frontmatter field (right after `adr:`, before the closing `---`). No contract **bodies** were touched, per the brief.
+- The presence check is `it.each` per file, so a missing tag names the offending contract instead of failing as one opaque aggregate.
+- I did **not** add an `enforcement` column to the `docs/contracts.md` index table — out of scope (the brief said frontmatter only), and the contract doesn't ask for it.
+- I intentionally did **not** also enforce contract §3 ("new contracts ship with ≥1 active pillar or explicit review-only"). The brief specs exactly two assertions (field present + values subset); §4 says backlog tagging defaults to `review` and "is cleanup, not blocking," so a stricter "must have an active pillar" check would wrongly fail honest `review`-only tags. Left as a possible future tightening for *new* contracts only.

--- a/docs/quirks/enforcement-lint.md
+++ b/docs/quirks/enforcement-lint.md
@@ -12,6 +12,8 @@ Edge cases and judgement calls hit while making ADR-104 / `docs/contracts/contra
 
 My 107 added test rows all pass. I did **not** touch these — out of scope, and they predate this branch. Flagging so nobody blames the enforcement-lint PR for a red audit file.
 
+**Correction-wave update:** these no longer reproduce. `npx vitest run test/audits/contracts.test.ts` on this branch is fully green (708 passed, 0 failed) — the registry-data gap (#546) and the rate-limit timing flake were resolved upstream and merged in before this branch's base. Left here as history; nothing to fix.
+
 ## Tag-honesty judgement calls
 
 The backlog pass picks a pillar from each contract's nature. Where I could have over-claimed, I deliberately didn't:
@@ -22,7 +24,7 @@ The backlog pass picks a pillar from each contract's nature. Where I could have 
 
 - **`package-split` → `[review]`.** Its body claims the substrate/installer boundary is "held by a directory boundary + lint rules." I could not find that boundary lint in `contracts.test.ts` (it may be an eslint rule elsewhere, or aspirational). Didn't claim `lint` on the strength of a body sentence I couldn't verify.
 
-- **`comms-voice` → `[review]`** even though a `Comms-voice contract` describe block exists. That block only lints the file's own frontmatter shape and a canary phrase — not the substantive "forward-looking framing" rule, which is a human/LLM judgement. So `review` is the honest home for the rule itself.
+- **`comms-voice` → `[lint, review]`** (corrected from an earlier `[review]`). The `Comms-voice contract` describe block fails the build on structural violations — frontmatter shape, the `governs` list covering the four artifact classes, and the canary phrase. That is the lint pillar active, exactly like every other contract carrying a structural describe block. The substantive "forward-looking framing" rule stays a human/LLM call (`review`), but tagging the file `[review]`-only hid a surface that CI does enforce, which is the opposite of what the §2 tag is for. So `[lint, review]` matches the calibration of the other lint-backed contracts.
 
 - **`canvas-layout`, `hosted-storage` → `[review]`.** `canvas-layout` is behavioral UI determinism (ELK layout, 750ms batch, never auto-reflow) — would need a browser e2e to mechanize, which isn't there. `hosted-storage` describes a Postgres backend that isn't built yet. Both are honest `review` (the default for "genuinely unmechanizable / not built").
 

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -13188,3 +13188,63 @@ describe('ADR-075 — OBSERVED-tier live e2e against Brief', () => {
     expect(indexBody).toMatch(/ADR-075/)
   })
 })
+
+// ──────────────────────────────────────────────────────────────────────────
+// Contract enforcement tags (ADR-104 / docs/contracts/contract-enforcement.md)
+// ──────────────────────────────────────────────────────────────────────────
+//
+// The enforcement model only works if the tag is actually there. §2 says every
+// per-topic contract names which pillar(s) hold it via an `enforcement:`
+// frontmatter field; §3 says a new contract ships with one. This is the lint
+// pillar holding that rule: walk docs/contracts/, fail on any per-topic
+// contract missing the field, and reject pillar values outside the known set.
+// Without it the field is a convention an author can forget and CI stays green.
+describe('Contract enforcement tags (ADR-104)', () => {
+  const CONTRACTS_DIR = join(__dirname, '../../../../docs/contracts')
+  const VALID_PILLARS = ['lint', 'breaker', 'policy', 'review']
+
+  // Per-topic contracts only: every .md under docs/contracts/ except the
+  // PreToolUse hook helpers (_*) and any index file. The real index is
+  // docs/contracts.md a directory up, so it never lands here; the contracts.md
+  // guard is belt-and-suspenders in case one is ever co-located by mistake.
+  const contractFiles = readdirSync(CONTRACTS_DIR).filter(
+    (f) => f.endsWith('.md') && !f.startsWith('_') && f !== 'contracts.md',
+  )
+
+  // Read the enforcement list out of the frontmatter block only — the body can
+  // use the word freely. Same awk-grade parsing the hook does; pulling in a yaml
+  // dep just to read one field would over-spec a format that's stayed simple.
+  function parseEnforcement(src: string): string[] | null {
+    const fm = src.match(/^---\n([\s\S]*?)\n---/)
+    if (!fm) return null
+    const line = fm[1].match(/^enforcement:\s*\[([^\]]*)\]/m)
+    if (!line) return null
+    return line[1]
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+  }
+
+  it('finds per-topic contracts to check', () => {
+    // Guards against a path/glob regression quietly turning the suite green by
+    // matching nothing.
+    expect(contractFiles.length).toBeGreaterThan(0)
+  })
+
+  it.each(contractFiles)('%s carries a non-empty enforcement: tag', (file) => {
+    const src = readFileSync(join(CONTRACTS_DIR, file), 'utf8')
+    const enforcement = parseEnforcement(src)
+    expect(
+      enforcement,
+      `${file} is missing an enforcement: frontmatter field (ADR-104 §2 — every contract names its pillar(s))`,
+    ).not.toBeNull()
+    expect(enforcement!.length, `${file} has an empty enforcement: list`).toBeGreaterThan(0)
+  })
+
+  it.each(contractFiles)('%s enforcement values are a subset of [lint, breaker, policy, review]', (file) => {
+    const src = readFileSync(join(CONTRACTS_DIR, file), 'utf8')
+    const enforcement = parseEnforcement(src) ?? []
+    const unknown = enforcement.filter((p) => !VALID_PILLARS.includes(p))
+    expect(unknown, `${file} names unknown enforcement pillar(s): ${unknown.join(', ')}`).toEqual([])
+  })
+})


### PR DESCRIPTION
ADR-104 and `docs/contracts/contract-enforcement.md` say every per-topic contract carries an `enforcement:` tag naming which pillar(s) hold it (lint / breaker / policy / review). That was prose only, so a new contract could ship untagged without anyone noticing.

This adds the lint pillar the contract asks for. `packages/core/test/audits/contracts.test.ts` now walks `docs/contracts/`, skips the hook helpers and the index, and fails on any contract missing the field or naming a pillar outside the known set. Each contract is its own `it.each` row, so a gap names the offending file.

It also does the §4 backlog pass: the 42 contracts that predate the model get an honest tag picked from their nature — `lint` where contracts.test.ts already asserts the substantive rule, `breaker` for the live Brief e2e, `review` where the rule is a human judgement or the surface isn't built yet. Frontmatter only; no contract bodies changed.

A few honesty calls (why some lint-able-looking contracts are tagged `review`, why nothing is tagged `policy` yet, and two pre-existing red tests in the audit file that predate this branch) are written up in `docs/quirks/enforcement-lint.md`.

Refs #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)