### PR TITLE
Make worker and queue app shapes engage, or say why they can't

### DIFF
--- a/docs/contracts/sdk-install.md
+++ b/docs/contracts/sdk-install.md
@@ -44,10 +44,11 @@ The Node installer resolves a service's entry point in this order:
 3. **Entry parsed from `pkg.scripts.start`** (ADR-070) — tokenise the script, skip recognised launchers (`node`, `ts-node`, `tsx`, `ts-node-dev`, `nodemon`, `npx`, `pnpm`, `yarn`, `npm`, `cross-env`, `dotenv`, `--`) and flag tokens (start with `-`) and env-var assignments (`FOO=bar`), then return the first remaining token that names a file inside the package. Chained shells (`a && b`) or pipes cause the tokeniser to bail and the heuristic falls through.
 4. **Entry parsed from `pkg.scripts.dev`** (ADR-070) — same tokeniser. Captures `tsx watch src/index.ts`, `ts-node-dev src/server.ts`, etc.
 5. **`src/index.{ts,tsx,js,mjs,cjs}`** (ADR-070) — first match, in that extension order.
-6. **`src/server.{...}` / `src/main.{...}` / `src/app.{...}`** (ADR-070) — each pattern probed in turn, same extension order. Covers conventional Node web-service layouts.
-7. **`index.{ts,tsx,js,mjs,cjs}`** at the package root — the original ADR-069 §3 fallback.
+6. **`src/server.{...}` / `src/main.{...}` / `src/app.{...}` / `src/worker.{...}`** (ADR-070 + #570) — each pattern probed in turn, same extension order. Covers conventional Node web-service and background-worker layouts.
+7. **`server.{...}` / `app.{...}` / `main.{...}` / `worker.{...}`** at the package root (#545 + #570) — a runnable app or queue worker commonly keeps its entry at the repo root under a conventional name with no `scripts.start` and a stale `pkg.main`. Probed just before the root-`index` fallback so it's the last resort after the manifest/script/src signals but still keeps the app from silently dropping out of instrumentation.
+8. **`index.{ts,tsx,js,mjs,cjs}`** at the package root — the original ADR-069 §3 fallback.
 
-Packages with no resolvable entry across all seven steps are **lib-only** and skipped. The apply summary logs each skip with reason `lib-only` so the user can see coverage.
+Packages with no resolvable entry across all eight steps are **lib-only** and skipped. The apply summary logs each skip with reason `lib-only` so the user can see coverage. A lib-only package that nonetheless declares a web-framework or background-worker dependency (`appFrameworkDependencies`) is almost certainly a missed app entry, not a real library — the orchestrator names the matched dependency and the recovery path loudly (#545 #570) instead of folding it into the silent `lib-only N` tally.
 
 ## ESM/CJS + TS/JS dispatch (ADR-069 §1, §3)
 

--- a/docs/quirks/engine-honesty.md
+++ b/docs/quirks/engine-honesty.md
@@ -76,7 +76,9 @@ only — a maintainer-scope decision, same boundary #547 drew).
    `require('node:fs')` block). It predates this work and is unrelated to it;
    `turbo lint` passes (0 errors). Not touched to avoid scope creep.
 
-7. **`looksLikeWebApp` kept as a thin alias.** It's now implemented over
-   `appFrameworkDependencies` and no longer imported by the orchestrator, but
-   left exported for back-compat. It's technically an unused export now; safe to
-   remove in a later cleanup if nothing external depends on it.
+7. **`looksLikeWebApp` removed.** The orchestrator switched to
+   `appFrameworkDependencies` (the richer form that names what it found), which
+   left `looksLikeWebApp` as a thin alias imported by nothing — not the
+   orchestrator, not the installer index, not the tests. It was dead code this
+   change created, so it's gone rather than left as a back-compat stub; the
+   contract already references `appFrameworkDependencies` as the signal.

--- a/docs/quirks/engine-honesty.md
+++ b/docs/quirks/engine-honesty.md
@@ -1,0 +1,82 @@
+# Engine honesty (issue #570) — quirks and edge cases
+
+Notes from the sprint that made worker/queue app shapes engage-or-loudly-warn,
+building on PR #547. Read this if you're carrying the work forward or cleaning up.
+
+## What this PR does and deliberately does not do
+
+It closes the install-time half of "never a silent zero" for the four named
+shapes:
+
+- **bare node `server.js`** — engages (already covered by #547's root-entry
+  resolution; now has an explicit no-false-warning test).
+- **sqlite3 / better-sqlite3 CRUD server** — engages (http/fastify bundled) and
+  the in-process driver gap is named (#546's warning), including the raw-http
+  leaf case with no web framework.
+- **bullmq worker** — `worker.js` / `src/worker.ts` now resolve, so it engages;
+  the bullmq job-span gap is named. If no entry resolves at all, the lib-only
+  branch now warns loudly instead of staying silent.
+- **lib-only package** — a genuine library stays quiet; a lib-only package that
+  declares a web- or worker-framework dep gets the loud "no entry point" line.
+
+It does **not** add instrumentation for sqlite3 / bullmq (detection + guidance
+only — a maintainer-scope decision, same boundary #547 drew).
+
+## Quirks I hit
+
+1. **Worktree resolves the registry to the parent repo's stale dist.** This
+   worktree has no `node_modules` of its own; `@neat.is/instrumentation-registry`
+   resolves up to the parent checkout's workspace package
+   (`packages/instrumentation-registry/dist/index.cjs`). That dist was stale —
+   its source carried `sqlite3` (added in #547) but the built `index.cjs` did
+   not, so `resolve('sqlite3', …)` returned `null` and the *pre-existing* #546
+   registry tests failed locally too. Fix was a force-rebuild of the parent's
+   registry dist (`turbo build --filter=@neat.is/instrumentation-registry
+   --force`); it's a build-artifact refresh, not a source change. CI is
+   unaffected — a fresh install links the branch's own source. This is the same
+   "shared node_modules / stale dist hides cross-package state" class already
+   noted in the repo's env quirks.
+
+2. **The sdk-install contract's entry-resolution list was already stale before
+   I touched it.** #547 inserted the root-level `server`/`app`/`main` step but
+   never updated `docs/contracts/sdk-install.md`, which still listed 7 steps
+   ending at root `index.*`. I updated it to the real order (now 8 steps,
+   including #570's `worker` addition) so code and contract agree again. Flagging
+   the prior drift rather than silently absorbing it.
+
+3. **Worker/queue app-framework signal lives in code, not the registry.** The
+   `WORKER_FRAMEWORK_DEPS` list sits alongside #547's `WEB_FRAMEWORK_DEPS` in
+   `javascript.ts`, not in `registry.json`. I considered a `role`/category field
+   on registry entries, but the instrumentation-registry contract treats the
+   schema as stable-from-launch with a closed coverage enum, and this is an
+   app-shape heuristic ("is this a runnable app whose entry we missed?"), not
+   instrumentation coverage. The registry stays the single source of truth for
+   *what is observed*; this only answers *is this an app*. Kept it next to the
+   existing precedent.
+
+4. **"Traffic flowed but zero OBSERVED edges" is not built here.** Issue #546's
+   third bullet — a live leaf service receiving traffic should be
+   distinguishable from a dead one — is a runtime/daemon-side check (inbound
+   SERVER spans seen, no outbound edges formed), not an install-time fact. This
+   PR covers the install-time signal ("this library won't be observed"); the
+   "service is live but produced no edges" signal needs the daemon's view of the
+   OBSERVED layer and is out of scope. Built the buildable part, logged the rest
+   here per the honesty guardrail.
+
+5. **A lib-only package with a `gap` DB driver but no app-framework dep stays
+   quiet.** A CLI/helper depending on `better-sqlite3` with no resolvable entry
+   is genuinely ambiguous — it could be a real library. Only web/worker
+   app-framework deps flip a lib-only classification into a loud warning, to keep
+   the signal high and avoid nagging genuine libraries. If a concrete user story
+   shows DB-only lib-only packages are usually missed apps, widen the signal
+   then.
+
+6. **Pre-existing lint warning left as-is.** `orchestrator.ts` carries an
+   "Unused eslint-disable directive" warning in `spawnDaemonDetached` (the
+   `require('node:fs')` block). It predates this work and is unrelated to it;
+   `turbo lint` passes (0 errors). Not touched to avoid scope creep.
+
+7. **`looksLikeWebApp` kept as a thin alias.** It's now implemented over
+   `appFrameworkDependencies` and no longer imported by the orchestrator, but
+   left exported for back-compat. It's technically an unused export now; safe to
+   remove in a later cleanup if nothing external depends on it.

--- a/packages/core/src/installers/javascript.ts
+++ b/packages/core/src/installers/javascript.ts
@@ -384,14 +384,6 @@ export function appFrameworkDependencies(pkg: PackageJsonShape): string[] {
   return APP_FRAMEWORK_DEPS.filter((name) => name in deps)
 }
 
-// True when the package declares a web- or worker-framework dependency — the
-// signal that a lib-only classification is more likely a missed app entry than
-// a real library. Retained for the existing call sites; `appFrameworkDependencies`
-// is the richer form the orchestrator uses to name what it found.
-export function looksLikeWebApp(pkg: PackageJsonShape): boolean {
-  return appFrameworkDependencies(pkg).length > 0
-}
-
 // Issue #546 — libraries whose calls aren't observed by the default
 // auto-instrumentation set. Resolved through the instrumentation registry (the
 // single source of truth, contract §3) rather than a hardcoded list: a

--- a/packages/core/src/installers/javascript.ts
+++ b/packages/core/src/installers/javascript.ts
@@ -348,12 +348,48 @@ const WEB_FRAMEWORK_DEPS = [
   'micro',
 ] as const
 
-// True when the package declares a web-framework dependency — the signal that
-// a lib-only classification is more likely a missed app entry than a real
-// library.
-export function looksLikeWebApp(pkg: PackageJsonShape): boolean {
+// Issue #570 — background-worker / queue-consumer signals. A package that
+// pulls jobs off a queue or consumes a message bus is a runnable process, not
+// a pure library: a lib-only classification on one of these is a missed entry
+// just like a web framework, so it earns the same loud warning instead of a
+// silent `lib-only N`. These sit alongside WEB_FRAMEWORK_DEPS rather than in
+// the registry because they're an app-shape heuristic, not instrumentation
+// coverage — the registry stays the single source of truth for what is/isn't
+// observed (uninstrumentedLibraries below), and these only answer "is this a
+// runnable app whose entry we failed to find?".
+const WORKER_FRAMEWORK_DEPS = [
+  'bullmq',
+  'bull',
+  'bee-queue',
+  'agenda',
+  'kafkajs',
+  'amqplib',
+  'amqp-connection-manager',
+  'nats',
+  'node-resque',
+  'pg-boss',
+  'graphile-worker',
+] as const
+
+// Every dependency family that marks a package as a runnable application
+// (inbound web framework or background worker) rather than a library.
+const APP_FRAMEWORK_DEPS = [...WEB_FRAMEWORK_DEPS, ...WORKER_FRAMEWORK_DEPS] as const
+
+// The application-framework dependencies a package declares — the names the
+// orchestrator puts in its warning so a lib-only-but-app-shaped package gets a
+// specific recovery line ("depends on bullmq but neat couldn't resolve an
+// entry") instead of a silent tally bump.
+export function appFrameworkDependencies(pkg: PackageJsonShape): string[] {
   const deps = allDeps(pkg)
-  return WEB_FRAMEWORK_DEPS.some((name) => name in deps)
+  return APP_FRAMEWORK_DEPS.filter((name) => name in deps)
+}
+
+// True when the package declares a web- or worker-framework dependency — the
+// signal that a lib-only classification is more likely a missed app entry than
+// a real library. Retained for the existing call sites; `appFrameworkDependencies`
+// is the richer form the orchestrator uses to name what it found.
+export function looksLikeWebApp(pkg: PackageJsonShape): boolean {
+  return appFrameworkDependencies(pkg).length > 0
 }
 
 // Issue #546 — libraries whose calls aren't observed by the default
@@ -472,9 +508,10 @@ async function isTypeScriptProject(serviceDir: string): Promise<boolean> {
   return exists(path.join(serviceDir, 'tsconfig.json'))
 }
 
-// ADR-069 §2 + ADR-070 + issue #545 — entry resolution: pkg.main → pkg.bin →
-// scripts.start → scripts.dev → src/index.* → src/{server,main,app}.* →
-// root {server,app,main}.* → root index.*. `pkg.main` is only accepted when
+// ADR-069 §2 + ADR-070 + issue #545 #570 — entry resolution: pkg.main →
+// pkg.bin → scripts.start → scripts.dev → src/index.* →
+// src/{server,main,app,worker}.* → root {server,app,main,worker}.* →
+// root index.*. `pkg.main` is only accepted when
 // the file it names actually exists; a stale `main` (e.g. `dist/index.js` that
 // hasn't been built, or a leftover that was deleted) falls through to the rest
 // of the chain rather than marking the package lib-only. Returns the absolute
@@ -483,17 +520,22 @@ async function isTypeScriptProject(serviceDir: string): Promise<boolean> {
 const INDEX_EXTENSIONS = ['.ts', '.tsx', '.js', '.mjs', '.cjs']
 const INDEX_CANDIDATES = INDEX_EXTENSIONS.map((ext) => `index${ext}`)
 const SRC_INDEX_CANDIDATES = INDEX_EXTENSIONS.map((ext) => `src/index${ext}`)
-const SRC_NAMED_CANDIDATES = ['server', 'main', 'app'].flatMap((name) =>
+// `worker` joins the named set (issue #570) — a background-queue worker
+// (bullmq, kafkajs, …) is a runnable process whose entry conventionally lives
+// in `worker.{js,ts}`, never under `index`. Without it the worker fell to
+// lib-only and its runtime layer silently never engaged.
+const SRC_NAMED_CANDIDATES = ['server', 'main', 'app', 'worker'].flatMap((name) =>
   INDEX_EXTENSIONS.map((ext) => `src/${name}${ext}`),
 )
-// Issue #545 — a runnable app commonly keeps its entry at the repo root under
-// a conventional name (`server.js`, `app.js`, `main.js`) with no `scripts.start`
-// and a `pkg.main` that points at a build output that doesn't exist yet. Those
-// shapes resolved to lib-only before — the runtime layer never engaged. Root
-// named candidates sit just before the `index.*` root fallback so they're the
-// last resort after the manifest/script/src signals, but still keep the app
-// from silently dropping out of instrumentation.
-const ROOT_NAMED_CANDIDATES = ['server', 'app', 'main'].flatMap((name) =>
+// Issue #545 / #570 — a runnable app commonly keeps its entry at the repo root
+// under a conventional name (`server.js`, `app.js`, `main.js`, or `worker.js`
+// for a queue consumer) with no `scripts.start` and a `pkg.main` that points at
+// a build output that doesn't exist yet. Those shapes resolved to lib-only
+// before — the runtime layer never engaged. Root named candidates sit just
+// before the `index.*` root fallback so they're the last resort after the
+// manifest/script/src signals, but still keep the app from silently dropping
+// out of instrumentation.
+const ROOT_NAMED_CANDIDATES = ['server', 'app', 'main', 'worker'].flatMap((name) =>
   INDEX_EXTENSIONS.map((ext) => `${name}${ext}`),
 )
 
@@ -593,13 +635,13 @@ export async function resolveEntry(
     const candidate = path.join(serviceDir, rel)
     if (await exists(candidate)) return candidate
   }
-  // 6) src/server.*, src/main.*, src/app.* — ADR-070.
+  // 6) src/server.*, src/main.*, src/app.*, src/worker.* — ADR-070 + #570.
   for (const rel of SRC_NAMED_CANDIDATES) {
     const candidate = path.join(serviceDir, rel)
     if (await exists(candidate)) return candidate
   }
-  // 7) root server.*, app.*, main.* — issue #545. Common for a runnable app
-  // whose entry sits at the repo root rather than under src/.
+  // 7) root server.*, app.*, main.*, worker.* — issue #545 / #570. Common for
+  // a runnable app or queue worker whose entry sits at the repo root.
   for (const rel of ROOT_NAMED_CANDIDATES) {
     const candidate = path.join(serviceDir, rel)
     if (await exists(candidate)) return candidate

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -41,7 +41,7 @@ import {
   pickInstaller,
   type InstallPlan,
 } from './installers/index.js'
-import { looksLikeWebApp, uninstrumentedLibraries } from './installers/javascript.js'
+import { appFrameworkDependencies, uninstrumentedLibraries } from './installers/javascript.js'
 import {
   detectPackageManager,
   runPackageManagerInstall,
@@ -223,16 +223,20 @@ export async function applyInstallersOver(
     } else if (outcome.outcome === 'already-instrumented') already++
     else if (outcome.outcome === 'lib-only') {
       libOnly++
-      // Issue #545 — a lib-only package that carries a web-framework dependency
-      // is almost certainly a runnable app whose entry the installer couldn't
-      // find, not a true library. Left in the `lib-only N` tally it's silent;
-      // the runtime layer never engages and the user has no idea why. Name it
-      // loudly with the recovery path.
-      if (svc.pkg && looksLikeWebApp(svc.pkg)) {
+      // Issue #545 / #570 — a lib-only package that carries a web-framework or
+      // background-worker dependency is almost certainly a runnable app whose
+      // entry the installer couldn't find, not a true library. Left in the
+      // `lib-only N` tally it's silent; the runtime layer never engages and the
+      // user has no idea why. Name the dependency we found and the recovery path
+      // loudly. A genuine library with no app signal stays quiet — there's
+      // nothing for its runtime layer to engage.
+      const appDeps = svc.pkg ? appFrameworkDependencies(svc.pkg) : []
+      if (appDeps.length > 0) {
         const svcName = path.basename(svc.dir)
+        const list = appDeps.join(', ')
         console.warn(
           `neat: runtime layer won't engage for ${svcName}: no entry point found.\n` +
-            `  ${svc.dir} depends on a web framework but neat couldn't resolve an entry to instrument.\n` +
+            `  ${svc.dir} depends on ${list} — a runnable app — but neat couldn't resolve an entry to instrument.\n` +
             `  Add a "start" script to package.json, or point neat at the entry file directly.`,
         )
       }

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -4293,7 +4293,7 @@ describe('SDK install — apply-side (ADR-069)', () => {
   })
 })
 
-describe('Runtime layer fails loud, never silent (#545 #546)', () => {
+describe('Runtime layer fails loud, never silent (#545 #546 #570)', () => {
   async function makeService(
     pkg: Record<string, unknown>,
     files: Record<string, string> = {},
@@ -4401,6 +4401,143 @@ describe('Runtime layer fails loud, never silent (#545 #546)', () => {
       expect(entry).not.toBeNull()
       expect(entry!.coverage).toBe('gap')
     }
+  })
+
+  // ── Engine honesty (#570): the four real-app shapes each engage or warn ──
+
+  it('a bare node server.js engages — instruments, no false won\'t-engage warning (#570)', async () => {
+    const { discoverServices } = await import('../../src/extract/services.js')
+    const { applyInstallersOver } = await import('../../src/orchestrator.js')
+    // Stale main, empty scripts, entry at root server.js — the #545 shape, but
+    // here with no DB so the only honest outcome is a clean instrument.
+    const { dir, cleanup } = await makeService(
+      { name: 'bare-server', main: 'dist/index.js', scripts: {} },
+      { 'server.js': "require('http').createServer().listen(0)\n" },
+    )
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const services = await discoverServices(dir)
+      const tally = await applyInstallersOver(services, 'proj', stubInstall)
+      expect(tally.instrumented).toBe(1)
+      expect(tally.libOnly).toBe(0)
+      const joined = warn.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(joined).not.toContain("won't engage")
+    } finally {
+      warn.mockRestore()
+      await cleanup()
+    }
+  })
+
+  it('a bare node + sqlite3 leaf server engages and names sqlite3 (#570 / #546)', async () => {
+    const { discoverServices } = await import('../../src/extract/services.js')
+    const { applyInstallersOver } = await import('../../src/orchestrator.js')
+    // No web framework at all — raw http + sqlite3. It instruments (http is
+    // bundled) but its only I/O is the in-process sqlite3 driver, so the
+    // OBSERVED layer would be empty. That must be named, never silent.
+    const { dir, cleanup } = await makeService(
+      { name: 'sqlite-leaf', main: 'dist/index.js', scripts: {}, dependencies: { sqlite3: '^5.1.0' } },
+      { 'server.js': "require('http').createServer().listen(0)\n" },
+    )
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const services = await discoverServices(dir)
+      const tally = await applyInstallersOver(services, 'proj', stubInstall)
+      expect(tally.instrumented).toBe(1)
+      const joined = warn.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(joined).toContain('sqlite3')
+      expect(joined).toContain("won't be observed by default")
+    } finally {
+      warn.mockRestore()
+      await cleanup()
+    }
+  })
+
+  it('a bullmq worker.js engages and names the bullmq gap (#570)', async () => {
+    const { discoverServices } = await import('../../src/extract/services.js')
+    const { applyInstallersOver } = await import('../../src/orchestrator.js')
+    // The canonical worker shape: entry at root worker.js (now in the
+    // resolution chain), bullmq as the job runtime. It instruments — bullmq's
+    // redis traffic is observable — but bullmq's own job spans are a gap, so
+    // the user is told.
+    const { dir, cleanup } = await makeService(
+      { name: 'jobs', main: 'dist/index.js', scripts: {}, dependencies: { bullmq: '^5.0.0' } },
+      { 'worker.js': "console.log('working')\n" },
+    )
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const services = await discoverServices(dir)
+      const tally = await applyInstallersOver(services, 'proj', stubInstall)
+      expect(tally.instrumented).toBe(1)
+      expect(tally.libOnly).toBe(0)
+      const joined = warn.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(joined).toContain('bullmq')
+      expect(joined).toContain("won't be observed by default")
+    } finally {
+      warn.mockRestore()
+      await cleanup()
+    }
+  })
+
+  it('a bullmq worker with no resolvable entry warns loudly, naming bullmq (#570)', async () => {
+    const { discoverServices } = await import('../../src/extract/services.js')
+    const { applyInstallersOver } = await import('../../src/orchestrator.js')
+    // No entry file anywhere, stale main, empty scripts — lib-only. But it
+    // depends on bullmq, so it's a worker whose entry we missed, not a library.
+    // Pre-#570 this fell into the silent `lib-only N` tally.
+    const { dir, cleanup } = await makeService({
+      name: 'headless-worker',
+      main: 'dist/index.js',
+      scripts: {},
+      dependencies: { bullmq: '^5.0.0' },
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const services = await discoverServices(dir)
+      const tally = await applyInstallersOver(services, 'proj', stubInstall)
+      expect(tally.libOnly).toBe(1)
+      const joined = warn.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(joined).toContain("runtime layer won't engage")
+      expect(joined).toContain('no entry point found')
+      expect(joined).toContain('bullmq')
+    } finally {
+      warn.mockRestore()
+      await cleanup()
+    }
+  })
+
+  it('resolveEntry picks up root worker.js and src/worker.ts (#570)', async () => {
+    const { resolveEntry } = await import('../../src/installers/javascript.js')
+    const os2 = await import('node:os')
+    const fs2 = await import('node:fs/promises')
+    const path2 = await import('node:path')
+    for (const rel of ['worker.js', 'src/worker.ts']) {
+      const base = await fs2.mkdtemp(path2.join(os2.tmpdir(), 'neat-worker-'))
+      const dir = await fs2.realpath(base)
+      try {
+        const full = path2.join(dir, rel)
+        await fs2.mkdir(path2.dirname(full), { recursive: true })
+        await fs2.writeFile(full, '\n')
+        const entry = await resolveEntry(dir, { name: 'w', main: 'dist/index.js', scripts: {} })
+        expect(entry).toBe(full)
+      } finally {
+        await fs2.rm(dir, { recursive: true, force: true })
+      }
+    }
+  })
+
+  it('appFrameworkDependencies names web and worker frameworks, ignores plain libs (#570)', async () => {
+    const { appFrameworkDependencies } = await import('../../src/installers/javascript.js')
+    expect(appFrameworkDependencies({ dependencies: { fastify: '^4', bullmq: '^5' } }).sort()).toEqual(
+      ['bullmq', 'fastify'],
+    )
+    expect(appFrameworkDependencies({ dependencies: { lodash: '^4', sqlite3: '^5' } })).toEqual([])
+  })
+
+  it('the registry classifies bullmq as a coverage gap (#570)', async () => {
+    const { resolve } = await import('@neat.is/instrumentation-registry')
+    const entry = resolve('bullmq', '5.0.0')
+    expect(entry).not.toBeNull()
+    expect(entry!.coverage).toBe('gap')
   })
 })
 


### PR DESCRIPTION
Refs #570

Building on #547. That PR got the runtime layer engaging on more app shapes and naming the ones it couldn't reach, but two holes in the same #545/#546 class were left, both around background workers — the shape #546 explicitly calls out.

## The holes

A bullmq / kafkajs / queue-consumer worker is a runnable process, not a library, but it slipped through both ways:

- Its entry usually lives in `worker.js` or `src/worker.ts`, which entry resolution never tried. A worker with a stale `pkg.main` and no `start` script resolved to lib-only and never got instrumented — its runtime layer silently never engaged.
- When it did land lib-only, the loud warning only fired for web frameworks. A worker carrying `bullmq` folded into the quiet `lib-only N` tally with no signal at all — a silent zero.

## What changed

- `worker` joins the named entry-resolution candidates at both the `src/` and root tiers, so the common worker shape engages and its redis/db driver traffic shows up in OBSERVED.
- The lib-only warning now keys off web **and** worker frameworks and names the dependency it found: `depends on bullmq — a runnable app — but neat couldn't resolve an entry to instrument`, with the recovery path. A genuine library with no app signal still stays quiet.
- The worker-framework signal (`WORKER_FRAMEWORK_DEPS`) sits next to #547's `WEB_FRAMEWORK_DEPS` as an app-shape heuristic. The registry stays the single source of truth for what's actually observed — `bullmq` is already a `gap`, so an instrumented worker still gets the #546 "won't be observed" line for its job spans.
- Updated `sdk-install.md`'s entry-resolution order, which had drifted from the code since #547 added the root `server`/`app`/`main` step.

Detection and guidance only — nothing is auto-added to the instrumentation set; that stays a maintainer-scope decision.

## Tests

All four named shapes, end to end (each engages or warns loudly, never a silent zero):

- a bare node `server.js` instruments with no false won't-engage warning
- a raw-http + sqlite3 leaf server instruments and names the sqlite3 gap
- a bullmq `worker.js` instruments and names the bullmq gap
- a headless bullmq worker (no resolvable entry) warns loudly, naming bullmq
- `resolveEntry` resolves root `worker.js` and `src/worker.ts`
- `appFrameworkDependencies` names web + worker frameworks, ignores plain libs

`npx vitest run` is green across the core package (998 passed). Quirks and the one out-of-scope piece (a daemon-side "traffic flowed but zero edges" signal) are written up in `docs/quirks/engine-honesty.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)