### PR TITLE
Surface the policies that apply where an agent is working

### DIFF
--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -45,6 +45,7 @@ Bare arrays from REST endpoints are a contract violation. Why: an object can gro
 | `GET /stale-events?limit=N&edgeType=X` | recent STALE transitions | `{ count, total, events: StaleEvent[] }` |
 | `GET /policies` | parsed `policy.json` | `{ version, policies: Policy[] }` |
 | `GET /policies/violations?severity=X&policyId=X` | current violations, filterable | `{ violations: PolicyViolation[] }` |
+| `GET /policies/applicable?node=X` | soft guardrail (ADR-108): policies that govern a node, matched by direct subject/region. Informs, never blocks | `{ node, applicable: ApplicablePolicy[] }` |
 | `GET /projects` | the project(s) this daemon serves (single-mount; not dual-mounted). A per-project daemon (ADR-096 §4) returns only its own project; the legacy multi-project daemon returns the machine-wide registry | `Array<RegistryEntry>` *(the one bare-array exception — its consumers (the dashboard's project pin, the CLI's bare-verb resolver) treat it as a list primitive)* |
 | `GET /projects/:project` | singular project lookup | `{ project: RegistryEntry }` |
 | `GET /api/config` | daemon auth-mode negotiation (ADR-073 §3a); always unauthenticated | `{ publicRead: boolean, authProxy: boolean }` |

--- a/docs/quirks/policies-soft-guardrail.md
+++ b/docs/quirks/policies-soft-guardrail.md
@@ -1,0 +1,35 @@
+# Quirks — policies as a soft guardrail (MVP)
+
+Issue #569. Branch `569-policies-soft-guardrail`. What I built, what I deliberately did not, and the edges I hit. The correction wave reads this.
+
+## The big honest gap — one-hop match, not the overlay's blast-radius injection
+
+The contract (policies-soft-guardrail.md §1) wants the *reachable* policies surfaced via the policy overlay's blast-radius injection (ADR-105 §5): relevance = the policy's declared propagation scope × graph distance, so a downstream-breaking invariant several hops away still surfaces and a local rule three hops away does not. That machinery lives in the **policy overlay, which is contract-only / unbuilt.**
+
+So I built the buildable MVP: `selectApplicablePolicies` matches a policy to a node by a **direct subject/region match** — the node's type is the rule's declared subject, or the node sits **one hop** inside the rule's region (the target end of a structural edge, the database one CONNECTS_TO from a service, a node on a governed provenance edge). It is type-and-incident-edge matching, not traversal.
+
+**Severity: high.** The MVP will MISS exactly the case the contract calls out as the point — "a downstream-breaking invariant surfaces, including the far-away ones a similarity search would miss." A blast-radius policy capping downstream fan-out N hops away will not surface on a node N hops upstream, because that needs the overlay's scope×distance walk. When the overlay (ADR-105) lands, `selectApplicablePolicies` is the seam to replace: same return shape, real reachability behind it. Do not mistake the one-hop MVP for the finished guardrail.
+
+## blast-radius rule only ever matches as a subject, never propagates upstream
+
+A `blast-radius` rule names a `nodeType` and a `maxAffected` cap. In the MVP it surfaces only on nodes *of that type* (subject match). The whole semantic of blast-radius is "this node has too many things downstream of it" — the agent editing one of those *downstream* nodes is precisely who should be warned, and they are NOT, because that's the overlay traversal again. This is the sharpest instance of the gap above. Flagged so nobody reads "blast-radius policies are surfaced" as "surfaced to the people a blast-radius affects."
+
+## A node not yet in the graph returns an empty applicable set
+
+The contract frames the guardrail around "a given node/edit." `selectApplicablePolicies` needs the node's `type` to match rules, so it reads attributes from the graph. A brand-new edit that creates a not-yet-extracted node returns `[]` — we can't type-match what isn't there. A real "edit" surface (match against a proposed node type before it lands) is FRONTIER/overlay territory (ADR-093/ADR-105), so I took node-id-in-graph as the MVP input and return empty rather than guess. `GET /policies/applicable?node=unknown` returns `200 { node, applicable: [] }`, not 404 — consistent with "informs," and it keeps the agent from special-casing a missing node. Low severity, but it's a real scope cut: the launch tool answers "policies for an existing node," not "policies for an arbitrary hypothetical edit."
+
+## The applicable record shows `onViolation` (including `block`) for awareness only
+
+An `ApplicablePolicy` carries the resolved `onViolation` — which for a critical policy is `block`. That is the action the **post-launch kernel gate** (ADR-093) would take, shown so the agent knows how seriously the project takes the rule. The soft guardrail itself never acts on it: there is no `allowed`/`blocked` field on the record, no verdict on the REST response, and the MCP block deliberately avoids the gate's "denied"/"refuse" vocabulary. Reviewers may find showing `[critical/block]` in an "informs, never blocks" surface confusing — it's intentional, and the summary text says so plainly. If it reads as a mixed message in practice, the fix is wording, not removing the field (the agent genuinely wants to know a rule is block-grade).
+
+## `check_policies` is now a three-mode tool on one input object
+
+`applicableTo` joins `scope` and `hypotheticalAction` on the same input. Precedence is `applicableTo` > `hypotheticalAction` > violation-read. Nothing stops a caller passing both `applicableTo` and `hypotheticalAction`; the applicable mode wins silently rather than erroring. Felt right for a soft, forgiving surface, but it's an unenforced precedence — a stricter version would reject the combination. Low severity.
+
+## Region match for compatibility is driver-engine-only
+
+`compatibility` rules run four shapes (driver-engine, node-engine, package-conflict, deprecated-api). Only `driver-engine` reaches across a CONNECTS_TO edge to a DatabaseNode, so only that shape gets a database **region** match. The other three operate purely on a service's own `dependencies`, so they only ever surface on the ServiceNode subject. Correct, but asymmetric — worth knowing when reasoning about why a database surfaces a compat policy but not, say, a deprecated-api one.
+
+## Worktree resolution needed a real install
+
+Cross-package imports (`@neat.is/types` → core/mcp) resolve up the directory tree to the **main** repo's `node_modules` when the worktree has none, so the worktree's type changes were invisible to the core/mcp builds until I ran `npm install` inside the worktree to create the workspace symlinks. Not a code quirk — an environment one — but it'll bite the next agent adding a cross-package type in a fresh worktree. (Matches the existing "worktree" note in repo memory.)

--- a/docs/quirks/policies-soft-guardrail.md
+++ b/docs/quirks/policies-soft-guardrail.md
@@ -2,17 +2,15 @@
 
 Issue #569. Branch `569-policies-soft-guardrail`. What I built, what I deliberately did not, and the edges I hit. The correction wave reads this.
 
-## The big honest gap — one-hop match, not the overlay's blast-radius injection
+## Partial gap — blast-radius now surfaces downstream; the general scope×distance injection is still one-hop
 
-The contract (policies-soft-guardrail.md §1) wants the *reachable* policies surfaced via the policy overlay's blast-radius injection (ADR-105 §5): relevance = the policy's declared propagation scope × graph distance, so a downstream-breaking invariant several hops away still surfaces and a local rule three hops away does not. That machinery lives in the **policy overlay, which is contract-only / unbuilt.**
+The contract (policies-soft-guardrail.md §1) wants the *reachable* policies surfaced via the policy overlay's blast-radius injection (ADR-105 §5): relevance = the policy's declared propagation scope × graph distance, so a downstream-breaking invariant several hops away still surfaces and a local rule three hops away does not. The **general** machinery for that — carrying scope×distance to *every* rule type — lives in the policy overlay, which is still contract-only / unbuilt.
 
-So I built the buildable MVP: `selectApplicablePolicies` matches a policy to a node by a **direct subject/region match** — the node's type is the rule's declared subject, or the node sits **one hop** inside the rule's region (the target end of a structural edge, the database one CONNECTS_TO from a service, a node on a governed provenance edge). It is type-and-incident-edge matching, not traversal.
+What the MVP does:
+- For structural / provenance / compatibility / ownership rules, `selectApplicablePolicies` matches by a **subject or one-hop region** match — the node's type is the rule's declared subject, or the node sits one hop inside the rule's region (the target end of a structural edge, the database one CONNECTS_TO from a service, a node on a governed provenance edge).
+- For **blast-radius** rules it now does the real reverse-reachability walk: `getBlastRadius` from each subject-type node (to the rule's declared depth) surfaces the rule as a `region` match on *every node in that subject's downstream set*. A far-away downstream node sees the invariant that governs it. This is the buildable slice of ADR-105 §5 — the named case the contract calls the point — implemented for real with the existing traversal, not faked and not the general overlay.
 
-**Severity: high.** The MVP will MISS exactly the case the contract calls out as the point — "a downstream-breaking invariant surfaces, including the far-away ones a similarity search would miss." A blast-radius policy capping downstream fan-out N hops away will not surface on a node N hops upstream, because that needs the overlay's scope×distance walk. When the overlay (ADR-105) lands, `selectApplicablePolicies` is the seam to replace: same return shape, real reachability behind it. Do not mistake the one-hop MVP for the finished guardrail.
-
-## blast-radius rule only ever matches as a subject, never propagates upstream
-
-A `blast-radius` rule names a `nodeType` and a `maxAffected` cap. In the MVP it surfaces only on nodes *of that type* (subject match). The whole semantic of blast-radius is "this node has too many things downstream of it" — the agent editing one of those *downstream* nodes is precisely who should be warned, and they are NOT, because that's the overlay traversal again. This is the sharpest instance of the gap above. Flagged so nobody reads "blast-radius policies are surfaced" as "surfaced to the people a blast-radius affects."
+**Remaining severity: medium.** The non-blast-radius rule types still stop at one hop; a structural or provenance invariant three hops away won't surface until the overlay's general scope×distance walk lands. `blastRadiusSubjectReaching` is the worked example of what that seam looks like; the overlay generalizes it across rule types. Don't read "blast-radius surfaces downstream" as "every rule type does."
 
 ## A node not yet in the graph returns an empty applicable set
 

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -27,6 +27,7 @@ import {
   evaluateAllPolicies,
   loadPolicyFile,
   PolicyViolationsLog,
+  selectApplicablePolicies,
 } from './policy.js'
 import type { NeatGraph } from './graph.js'
 import { DEFAULT_PROJECT } from './graph.js'
@@ -611,6 +612,37 @@ function registerRoutes(scope: FastifyInstance, ctx: RouteContext): void {
       violations = violations.filter((v) => v.policyId === req.query.policyId)
     }
     return { violations }
+  })
+
+  // Soft guardrail read path (ADR-108 / policies-soft-guardrail.md). Returns
+  // the policies APPLICABLE to a node — the rules an agent should be aware of
+  // while working there. This INFORMS; it never blocks and carries no verdict.
+  // Matching is a direct subject/region match (see selectApplicablePolicies),
+  // not the full overlay traversal (ADR-105 §5), which is still unbuilt.
+  scope.get<{
+    Params: { project?: string }
+    Querystring: { node?: string }
+  }>('/policies/applicable', async (req, reply) => {
+    const proj = resolveProject(registry, req, reply, ctx.bootstrap, ctx.singleProject)
+    if (!proj) return
+    const nodeId = req.query.node
+    if (!nodeId) {
+      return reply.code(400).send({ error: 'missing required query param "node"' })
+    }
+    const policyPath = ctx.policyFilePathFor(proj)
+    let policies: Policy[] = []
+    if (policyPath) {
+      try {
+        policies = await loadPolicyFile(policyPath)
+      } catch (err) {
+        return reply.code(400).send({
+          error: 'policy.json failed to parse',
+          details: (err as Error).message,
+        })
+      }
+    }
+    const applicable = selectApplicablePolicies(proj.graph, policies, nodeId)
+    return { node: nodeId, applicable }
   })
 
   scope.post<{

--- a/packages/core/src/policy.ts
+++ b/packages/core/src/policy.ts
@@ -399,17 +399,23 @@ export function evaluateAllPolicies(
 // they never block. selectApplicablePolicies answers "which policies govern the
 // node I'm about to edit?" so the rules can ride into the agent's context.
 //
-// Matching is a DIRECT subject/region match, NOT a graph traversal:
+// Matching is a subject/region match:
 //   - subject — the node's type is the rule's declared subject (the rule
 //     governs every node of that type).
-//   - region — the node sits one hop inside the rule's region: the target end
-//     of a structural edge, the database a compat rule reaches across a
-//     CONNECTS_TO, or a node sitting on an edge a provenance rule governs.
+//   - region — for most rule types, the node sits one hop inside the rule's
+//     region: the target end of a structural edge, the database a compat rule
+//     reaches across a CONNECTS_TO, or a node sitting on an edge a provenance
+//     rule governs. For blast-radius rules the region is the subject's real
+//     downstream set: we walk getBlastRadius (to the rule's declared depth) and
+//     surface the rule on every node it reaches, so a far-away downstream node
+//     still sees the invariant that governs it.
 //
-// The full version surfaces far-away downstream-breaking invariants through
-// the policy overlay's blast-radius injection (ADR-105 §5). That overlay is
-// unbuilt; this MVP deliberately stops at one hop. It never evaluates a
-// violation and never returns a verdict — surfacing a policy is not gating it.
+// The general scope×distance injection over the policy overlay (ADR-105 §5),
+// which would carry this reachability behaviour to every rule type rather than
+// just blast-radius, is still unbuilt; the gap is written up in
+// docs/quirks/policies-soft-guardrail.md. selectApplicablePolicies never
+// evaluates a violation and never returns a verdict — surfacing a policy is not
+// gating it.
 export function selectApplicablePolicies(
   graph: NeatGraph,
   policies: Policy[],
@@ -469,6 +475,29 @@ function nodeTouchesEdgeType(
   return false
 }
 
+// Reverse-reachability for blast-radius rules. Returns the id of a subject-type
+// node whose downstream blast radius (to the rule's declared depth) contains
+// nodeId, or null if none does. This is what lets a blast-radius rule surface on
+// the downstream nodes it actually governs, not only on its subject.
+function blastRadiusSubjectReaching(
+  graph: NeatGraph,
+  rule: Extract<PolicyRule, { type: 'blast-radius' }>,
+  nodeId: string,
+): string | null {
+  let found: string | null = null
+  graph.forEachNode((subjId, attrs) => {
+    if (found !== null) return
+    if (subjId === nodeId) return
+    if ((attrs as GraphNode).type !== rule.nodeType) return
+    const radius =
+      rule.depth !== undefined
+        ? getBlastRadius(graph, subjId, rule.depth)
+        : getBlastRadius(graph, subjId)
+    if (radius.affectedNodes.some((n) => n.nodeId === nodeId)) found = subjId
+  })
+  return found
+}
+
 function matchPolicyToNode(
   graph: NeatGraph,
   policy: Policy,
@@ -504,10 +533,26 @@ function matchPolicyToNode(
       return null
     }
     case 'blast-radius': {
+      const depthLabel = rule.depth !== undefined ? ` at depth ${rule.depth}` : ''
       if (node.type === rule.nodeType) {
         return {
           match: 'subject',
-          reason: `no ${rule.nodeType} may exceed a blast radius of ${rule.maxAffected}${rule.depth !== undefined ? ` at depth ${rule.depth}` : ''}`,
+          reason: `no ${rule.nodeType} may exceed a blast radius of ${rule.maxAffected}${depthLabel}`,
+        }
+      }
+      // Downstream surfacing. The whole point of a blast-radius rule is "this
+      // subject has too many things downstream of it" — so the agent who most
+      // needs the warning is the one editing one of those downstream nodes, not
+      // the subject. We compute the subject's actual downstream set with
+      // getBlastRadius (to the rule's own declared depth) and surface the rule
+      // on any node inside it. This is the buildable slice of ADR-105 §5's
+      // scope×distance injection: a real reverse-reachability walk, not the
+      // general overlay, so a far-away node still surfaces the invariant.
+      const upstream = blastRadiusSubjectReaching(graph, rule, nodeId)
+      if (upstream) {
+        return {
+          match: 'region',
+          reason: `${upstream} (a ${rule.nodeType} held to a blast radius of ${rule.maxAffected}${depthLabel}) reaches this node downstream — edits here count toward its fan-out`,
         }
       }
       return null

--- a/packages/core/src/policy.ts
+++ b/packages/core/src/policy.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import type {
+  ApplicablePolicy,
   GraphEdge,
   GraphNode,
   Policy,
@@ -388,6 +389,177 @@ export function evaluateAllPolicies(
     for (const v of violations) out.push(v)
   }
   return out
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Soft guardrail — applicable-policy selection (ADR-108)
+// ──────────────────────────────────────────────────────────────────────────
+
+// The launch form of "every agent stays inside the lines": policies INFORM,
+// they never block. selectApplicablePolicies answers "which policies govern the
+// node I'm about to edit?" so the rules can ride into the agent's context.
+//
+// Matching is a DIRECT subject/region match, NOT a graph traversal:
+//   - subject — the node's type is the rule's declared subject (the rule
+//     governs every node of that type).
+//   - region — the node sits one hop inside the rule's region: the target end
+//     of a structural edge, the database a compat rule reaches across a
+//     CONNECTS_TO, or a node sitting on an edge a provenance rule governs.
+//
+// The full version surfaces far-away downstream-breaking invariants through
+// the policy overlay's blast-radius injection (ADR-105 §5). That overlay is
+// unbuilt; this MVP deliberately stops at one hop. It never evaluates a
+// violation and never returns a verdict — surfacing a policy is not gating it.
+export function selectApplicablePolicies(
+  graph: NeatGraph,
+  policies: Policy[],
+  nodeId: string,
+): ApplicablePolicy[] {
+  // Without the node in the graph there's no type to match against, so we
+  // can't decide applicability. A not-yet-created node (a brand-new edit) is
+  // exactly the case the unbuilt overlay would handle; here we return empty
+  // rather than guess.
+  if (!graph.hasNode(nodeId)) return []
+  const node = graph.getNodeAttributes(nodeId) as GraphNode
+  const out: ApplicablePolicy[] = []
+  for (const policy of policies) {
+    const m = matchPolicyToNode(graph, policy, nodeId, node)
+    if (!m) continue
+    out.push({
+      policyId: policy.id,
+      policyName: policy.name,
+      ...(policy.description !== undefined ? { description: policy.description } : {}),
+      severity: policy.severity,
+      onViolation: resolveOnViolation(policy),
+      ruleType: policy.rule.type,
+      match: m.match,
+      reason: m.reason,
+    })
+  }
+  return out
+}
+
+interface PolicyMatch {
+  match: ApplicablePolicy['match']
+  reason: string
+}
+
+function requiredProvenanceList(required: string | readonly string[]): string {
+  // required is ProvenanceRule['required'] — a single value or a non-empty
+  // array. Normalize to a readable "A | B" string.
+  if (Array.isArray(required)) return required.join(' | ')
+  return String(required)
+}
+
+function nodeTouchesEdgeType(
+  graph: NeatGraph,
+  nodeId: string,
+  edgeType: string,
+  requiredOtherEnd?: string,
+): boolean {
+  const incident = [...graph.outboundEdges(nodeId), ...graph.inboundEdges(nodeId)]
+  for (const edgeId of incident) {
+    const e = graph.getEdgeAttributes(edgeId) as GraphEdge
+    if (e.type !== edgeType) continue
+    // A provenance rule with a targetNodeId only governs edges that touch that
+    // target. Without one, any edge of the type counts.
+    if (requiredOtherEnd === undefined) return true
+    if (e.source === requiredOtherEnd || e.target === requiredOtherEnd) return true
+  }
+  return false
+}
+
+function matchPolicyToNode(
+  graph: NeatGraph,
+  policy: Policy,
+  nodeId: string,
+  node: GraphNode,
+): PolicyMatch | null {
+  const rule = policy.rule
+  switch (rule.type) {
+    case 'structural': {
+      if (node.type === rule.fromNodeType) {
+        return {
+          match: 'subject',
+          reason: `every ${rule.fromNodeType} must have a ${rule.edgeType} edge to a ${rule.toNodeType}`,
+        }
+      }
+      // The target end is one hop inside the rule's region — editing it can
+      // make a sibling fromNodeType pass or fail the rule.
+      if (node.type === rule.toNodeType) {
+        return {
+          match: 'region',
+          reason: `${rule.fromNodeType} nodes must reach a ${rule.toNodeType} like this one via a ${rule.edgeType} edge`,
+        }
+      }
+      return null
+    }
+    case 'ownership': {
+      if (node.type === rule.nodeType) {
+        return {
+          match: 'subject',
+          reason: `every ${rule.nodeType} must declare a non-empty "${rule.field}" field`,
+        }
+      }
+      return null
+    }
+    case 'blast-radius': {
+      if (node.type === rule.nodeType) {
+        return {
+          match: 'subject',
+          reason: `no ${rule.nodeType} may exceed a blast radius of ${rule.maxAffected}${rule.depth !== undefined ? ` at depth ${rule.depth}` : ''}`,
+        }
+      }
+      return null
+    }
+    case 'compatibility': {
+      const kindLabel = rule.kind ?? 'all compat shapes'
+      // The evaluator iterates every ServiceNode, so a ServiceNode is the
+      // direct subject.
+      if (node.type === NodeType.ServiceNode) {
+        return {
+          match: 'subject',
+          reason: `this service's dependencies are compatibility-checked (${kindLabel})`,
+        }
+      }
+      // A DatabaseNode one CONNECTS_TO hop from a service is in the region of
+      // the driver-engine shape — its engine version feeds that check.
+      const reachesDriverEngine = rule.kind === undefined || rule.kind === 'driver-engine'
+      if (
+        reachesDriverEngine &&
+        node.type === NodeType.DatabaseNode &&
+        nodeTouchesEdgeType(graph, nodeId, EdgeType.CONNECTS_TO)
+      ) {
+        return {
+          match: 'region',
+          reason: 'services connecting to this database have their driver/engine compatibility checked against it',
+        }
+      }
+      return null
+    }
+    case 'provenance': {
+      const requiredList = requiredProvenanceList(rule.required)
+      // The named target is the direct subject — every governed edge points at
+      // it.
+      if (rule.targetNodeId !== undefined && nodeId === rule.targetNodeId) {
+        return {
+          match: 'subject',
+          reason: `every ${rule.edgeType} edge into ${rule.targetNodeId} must carry ${requiredList} provenance`,
+        }
+      }
+      // Otherwise the node is in the region if it sits on a governed edge.
+      if (nodeTouchesEdgeType(graph, nodeId, rule.edgeType, rule.targetNodeId)) {
+        return {
+          match: 'region',
+          reason:
+            rule.targetNodeId !== undefined
+              ? `this node sits on a ${rule.edgeType} edge to ${rule.targetNodeId}, which must carry ${requiredList} provenance`
+              : `this node sits on a ${rule.edgeType} edge, which must carry ${requiredList} provenance`,
+        }
+      }
+      return null
+    }
+  }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -2901,6 +2901,107 @@ describe('Policy contracts (ADRs 042-045)', () => {
     expect(resources).toMatch(/registerResource\(\s*['"]policies-violations['"]/)
     expect(resources).toMatch(/sendResourceUpdated\([^)]*POLICY_VIOLATIONS_URI/)
   })
+
+  // Soft guardrail breaker (ADR-108 / policies-soft-guardrail.md). The harness
+  // asserts that, working at a node with a reachable policy, the read path
+  // surfaces it — including a one-hop region match a subject-only check would
+  // miss — and that the soft guardrail never refuses an action: it informs only.
+  it('selectApplicablePolicies surfaces a subject-match policy where an agent works (ADR-108)', async () => {
+    const { selectApplicablePolicies } = await import('../../src/policy.js')
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:checkout', {
+      id: 'service:checkout',
+      type: NodeType.ServiceNode,
+      name: 'checkout',
+      language: 'javascript',
+    })
+    const policy = {
+      id: 'service-owner',
+      name: 'services declare an owner',
+      severity: 'critical' as const,
+      rule: { type: 'ownership' as const, nodeType: NodeType.ServiceNode, field: 'owner' },
+    }
+    const applicable = selectApplicablePolicies(g, [policy], 'service:checkout')
+    expect(applicable).toHaveLength(1)
+    expect(applicable[0]!.policyId).toBe('service-owner')
+    expect(applicable[0]!.match).toBe('subject')
+  })
+
+  it('selectApplicablePolicies surfaces a one-hop region policy, not just direct subjects (ADR-108)', async () => {
+    const { selectApplicablePolicies } = await import('../../src/policy.js')
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:checkout', {
+      id: 'service:checkout',
+      type: NodeType.ServiceNode,
+      name: 'checkout',
+      language: 'javascript',
+    })
+    g.addNode('service:payments', {
+      id: 'service:payments',
+      type: NodeType.ServiceNode,
+      name: 'payments',
+      language: 'javascript',
+    })
+    g.addEdgeWithKey('CALLS:service:checkout->service:payments', 'service:checkout', 'service:payments', {
+      id: 'CALLS:service:checkout->service:payments',
+      source: 'service:checkout',
+      target: 'service:payments',
+      type: EdgeType.CALLS,
+      provenance: Provenance.EXTRACTED,
+    })
+    const policy = {
+      id: 'payments-observed',
+      name: 'calls into payments must be observed',
+      severity: 'error' as const,
+      rule: {
+        type: 'provenance' as const,
+        edgeType: EdgeType.CALLS,
+        targetNodeId: 'service:payments',
+        required: Provenance.OBSERVED,
+      },
+    }
+    // checkout is not the named target — it sits one hop away on the governed
+    // edge. A subject-only check would miss it; the region match surfaces it.
+    const applicable = selectApplicablePolicies(g, [policy], 'service:checkout')
+    expect(applicable).toHaveLength(1)
+    expect(applicable[0]!.match).toBe('region')
+  })
+
+  it('the soft guardrail informs, never blocks — applicable records carry no verdict (ADR-108)', async () => {
+    const { selectApplicablePolicies } = await import('../../src/policy.js')
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:checkout', {
+      id: 'service:checkout',
+      type: NodeType.ServiceNode,
+      name: 'checkout',
+      language: 'javascript',
+    })
+    // A critical policy resolves onViolation 'block' for the eventual kernel
+    // gate, but surfacing it must not carry an allowed/blocked verdict.
+    const policy = {
+      id: 'service-owner',
+      name: 'services declare an owner',
+      severity: 'critical' as const,
+      rule: { type: 'ownership' as const, nodeType: NodeType.ServiceNode, field: 'owner' },
+    }
+    const [record] = selectApplicablePolicies(g, [policy], 'service:checkout')
+    expect(record!.onViolation).toBe('block')
+    expect(record).not.toHaveProperty('allowed')
+    expect(record).not.toHaveProperty('blocked')
+    // The MCP delivery wording is informational — the soft guardrail never
+    // speaks the gate's "denied"/"refuse" language in the applicable block.
+    const tools = readFileSync(join(MCP_SRC, 'tools.ts'), 'utf8')
+    expect(tools).toMatch(/function formatApplicablePolicies/)
+    expect(tools).toMatch(/they do not block/)
+  })
+
+  it('check_policies exposes the applicableTo soft-guardrail input and a REST read path (ADR-108)', () => {
+    const indexTs = readFileSync(join(MCP_SRC, 'index.ts'), 'utf8')
+    expect(indexTs).toMatch(/applicableTo:\s*z\s*\n?\s*\.string\(\)/)
+    const api = readFileSync(join(CORE_SRC, 'api.ts'), 'utf8')
+    expect(api).toMatch(/scope\.get<[\s\S]{0,200}>\(\s*['"]\/policies\/applicable['"]/)
+    expect(api).toMatch(/selectApplicablePolicies\s*\(/)
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/core/test/policy-applicable.test.ts
+++ b/packages/core/test/policy-applicable.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { MultiDirectedGraph } from 'graphology'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import type { FastifyInstance } from 'fastify'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  type GraphEdge,
+  type GraphNode,
+  type Policy,
+} from '@neat.is/types'
+import type { NeatGraph } from '../src/graph.js'
+import { selectApplicablePolicies } from '../src/policy.js'
+import { buildApi } from '../src/api.js'
+
+// A small graph: a service connecting to a database, calling a payments
+// service. Enough to exercise every applicable-match shape without touching the
+// demo fixture.
+function makeGraph(): NeatGraph {
+  const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+  g.addNode('service:checkout', {
+    id: 'service:checkout',
+    type: NodeType.ServiceNode,
+    name: 'checkout',
+    language: 'javascript',
+    dependencies: { pg: '7.4.0' },
+  } as GraphNode)
+  g.addNode('service:payments', {
+    id: 'service:payments',
+    type: NodeType.ServiceNode,
+    name: 'payments',
+    language: 'javascript',
+  } as GraphNode)
+  g.addNode('database:orders-db', {
+    id: 'database:orders-db',
+    type: NodeType.DatabaseNode,
+    name: 'orders-db',
+    engine: 'postgres',
+    engineVersion: '15',
+  } as GraphNode)
+  g.addEdgeWithKey('CONNECTS_TO:service:checkout->database:orders-db', 'service:checkout', 'database:orders-db', {
+    id: 'CONNECTS_TO:service:checkout->database:orders-db',
+    source: 'service:checkout',
+    target: 'database:orders-db',
+    type: EdgeType.CONNECTS_TO,
+    provenance: Provenance.EXTRACTED,
+  } as GraphEdge)
+  g.addEdgeWithKey('CALLS:service:checkout->service:payments', 'service:checkout', 'service:payments', {
+    id: 'CALLS:service:checkout->service:payments',
+    source: 'service:checkout',
+    target: 'service:payments',
+    type: EdgeType.CALLS,
+    provenance: Provenance.EXTRACTED,
+  } as GraphEdge)
+  return g
+}
+
+const structuralPolicy: Policy = {
+  id: 'service-needs-db',
+  name: 'services must reach a database',
+  severity: 'warning',
+  rule: {
+    type: 'structural',
+    fromNodeType: NodeType.ServiceNode,
+    edgeType: EdgeType.CONNECTS_TO,
+    toNodeType: NodeType.DatabaseNode,
+  },
+}
+
+const ownershipPolicy: Policy = {
+  id: 'service-owner',
+  name: 'services must declare an owner',
+  // critical → resolves to onViolation 'block' for the post-launch gate. The
+  // soft guardrail still only surfaces it; it never blocks.
+  severity: 'critical',
+  rule: { type: 'ownership', nodeType: NodeType.ServiceNode, field: 'owner' },
+}
+
+const provenancePolicy: Policy = {
+  id: 'payments-observed',
+  name: 'calls into payments must be observed',
+  severity: 'error',
+  rule: {
+    type: 'provenance',
+    edgeType: EdgeType.CALLS,
+    targetNodeId: 'service:payments',
+    required: Provenance.OBSERVED,
+  },
+}
+
+const compatibilityPolicy: Policy = {
+  id: 'driver-compat',
+  name: 'driver/engine compatibility',
+  severity: 'warning',
+  rule: { type: 'compatibility', kind: 'driver-engine' },
+}
+
+describe('selectApplicablePolicies (soft guardrail — ADR-108)', () => {
+  it('surfaces a policy whose subject is the node type (direct subject match)', () => {
+    const g = makeGraph()
+    const applicable = selectApplicablePolicies(g, [ownershipPolicy], 'service:checkout')
+    expect(applicable).toHaveLength(1)
+    expect(applicable[0]!.policyId).toBe('service-owner')
+    expect(applicable[0]!.match).toBe('subject')
+    expect(applicable[0]!.reason).toMatch(/owner/)
+  })
+
+  it('surfaces a structural policy on its from-node and its to-node (subject + region)', () => {
+    const g = makeGraph()
+    const onService = selectApplicablePolicies(g, [structuralPolicy], 'service:checkout')
+    expect(onService.map((p) => p.match)).toEqual(['subject'])
+
+    // The database is one hop inside the rule's region — editing it can flip
+    // whether a sibling service satisfies the rule, so it surfaces too.
+    const onDb = selectApplicablePolicies(g, [structuralPolicy], 'database:orders-db')
+    expect(onDb).toHaveLength(1)
+    expect(onDb[0]!.match).toBe('region')
+  })
+
+  it('surfaces a provenance policy on its named target (subject) and on a node sitting on the governed edge (region)', () => {
+    const g = makeGraph()
+    const onTarget = selectApplicablePolicies(g, [provenancePolicy], 'service:payments')
+    expect(onTarget).toHaveLength(1)
+    expect(onTarget[0]!.match).toBe('subject')
+
+    // checkout isn't the named target, but it sits on the CALLS edge into
+    // payments — one hop, region match, no traversal.
+    const onCaller = selectApplicablePolicies(g, [provenancePolicy], 'service:checkout')
+    expect(onCaller).toHaveLength(1)
+    expect(onCaller[0]!.match).toBe('region')
+  })
+
+  it('surfaces a compatibility policy on a service (subject) and on a connected database (region)', () => {
+    const g = makeGraph()
+    const onService = selectApplicablePolicies(g, [compatibilityPolicy], 'service:checkout')
+    expect(onService).toHaveLength(1)
+    expect(onService[0]!.match).toBe('subject')
+
+    const onDb = selectApplicablePolicies(g, [compatibilityPolicy], 'database:orders-db')
+    expect(onDb).toHaveLength(1)
+    expect(onDb[0]!.match).toBe('region')
+  })
+
+  it('does not match policies whose subject/region the node is outside of (no full traversal)', () => {
+    const g = makeGraph()
+    // payments has no outbound CONNECTS_TO of its own, so the structural rule's
+    // from-side doesn't fire on it as a subject — only as nothing. It IS a
+    // ServiceNode though, so structural fromNodeType matches. To prove the
+    // no-traversal boundary, use a database-only ownership rule that payments
+    // can't be a subject of.
+    const dbOwnership: Policy = {
+      id: 'db-owner',
+      name: 'databases must declare an owner',
+      severity: 'info',
+      rule: { type: 'ownership', nodeType: NodeType.DatabaseNode, field: 'owner' },
+    }
+    const onService = selectApplicablePolicies(g, [dbOwnership], 'service:payments')
+    expect(onService).toEqual([])
+  })
+
+  it('returns nothing for a node that is not in the graph', () => {
+    const g = makeGraph()
+    expect(selectApplicablePolicies(g, [ownershipPolicy], 'service:ghost')).toEqual([])
+  })
+
+  it('informs, never blocks — it returns plain context with no verdict, even for a block-action policy', () => {
+    const g = makeGraph()
+    const applicable = selectApplicablePolicies(g, [ownershipPolicy], 'service:checkout')
+    // The policy resolves to onViolation 'block' (critical severity), but the
+    // applicable record carries no allowed/denied flag and no blocking
+    // semantics — it's awareness, surfaced as context.
+    const record = applicable[0]!
+    expect(record.onViolation).toBe('block')
+    expect(record).not.toHaveProperty('allowed')
+    expect(record).not.toHaveProperty('blocked')
+    // The record is plain context — nothing but the policy's identity, the
+    // match reason, and the (advisory) resolved action. No verdict fields.
+    for (const key of Object.keys(record)) {
+      expect([
+        'description',
+        'match',
+        'onViolation',
+        'policyId',
+        'policyName',
+        'reason',
+        'ruleType',
+        'severity',
+      ]).toContain(key)
+    }
+  })
+})
+
+describe('GET /policies/applicable (REST soft-guardrail read path)', () => {
+  let app: FastifyInstance
+  let scanDir: string
+
+  beforeEach(async () => {
+    scanDir = mkdtempSync(path.join(tmpdir(), 'policy-applicable-'))
+    writeFileSync(
+      path.join(scanDir, 'policy.json'),
+      JSON.stringify({ version: 1, policies: [ownershipPolicy, provenancePolicy] }),
+      'utf8',
+    )
+    app = await buildApi({ graph: makeGraph(), scanPath: scanDir })
+  })
+
+  afterEach(async () => {
+    await app.close()
+    rmSync(scanDir, { recursive: true, force: true })
+  })
+
+  it('returns the applicable policies for a node', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/policies/applicable?node=service:checkout',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.node).toBe('service:checkout')
+    const ids = body.applicable.map((p: { policyId: string }) => p.policyId).sort()
+    // checkout is a ServiceNode (ownership subject) and sits on the CALLS edge
+    // into payments (provenance region).
+    expect(ids).toEqual(['payments-observed', 'service-owner'])
+    // No verdict field anywhere on the response — it informs, it doesn't gate.
+    expect(body).not.toHaveProperty('allowed')
+  })
+
+  it('returns an empty applicable set for a node no policy governs', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/policies/applicable?node=database:orders-db',
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().applicable).toEqual([])
+  })
+
+  it('400s when the node query param is missing', async () => {
+    const res = await app.inject({ method: 'GET', url: '/policies/applicable' })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('dual-mounts under /projects/:project', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/projects/default/policies/applicable?node=service:checkout',
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().node).toBe('service:checkout')
+  })
+})

--- a/packages/core/test/policy-applicable.test.ts
+++ b/packages/core/test/policy-applicable.test.ts
@@ -98,6 +98,13 @@ const compatibilityPolicy: Policy = {
   rule: { type: 'compatibility', kind: 'driver-engine' },
 }
 
+const blastRadiusPolicy: Policy = {
+  id: 'checkout-fanout',
+  name: 'checkout services must not fan out too far',
+  severity: 'warning',
+  rule: { type: 'blast-radius', nodeType: NodeType.ServiceNode, maxAffected: 1 },
+}
+
 describe('selectApplicablePolicies (soft guardrail — ADR-108)', () => {
   it('surfaces a policy whose subject is the node type (direct subject match)', () => {
     const g = makeGraph()
@@ -142,6 +149,63 @@ describe('selectApplicablePolicies (soft guardrail — ADR-108)', () => {
     const onDb = selectApplicablePolicies(g, [compatibilityPolicy], 'database:orders-db')
     expect(onDb).toHaveLength(1)
     expect(onDb[0]!.match).toBe('region')
+  })
+
+  it('surfaces a blast-radius policy downstream — on a node inside the subject\'s blast radius, not only on the subject', () => {
+    const g = makeGraph()
+    // checkout (a ServiceNode) is the subject.
+    const onSubject = selectApplicablePolicies(g, [blastRadiusPolicy], 'service:checkout')
+    expect(onSubject).toHaveLength(1)
+    expect(onSubject[0]!.match).toBe('subject')
+
+    // orders-db sits downstream of checkout (checkout CONNECTS_TO orders-db).
+    // The agent editing it is exactly who the fan-out cap should warn, so the
+    // rule surfaces here as a region match — the case the one-hop MVP missed.
+    const onDownstream = selectApplicablePolicies(g, [blastRadiusPolicy], 'database:orders-db')
+    expect(onDownstream).toHaveLength(1)
+    expect(onDownstream[0]!.match).toBe('region')
+    expect(onDownstream[0]!.reason).toMatch(/service:checkout/)
+
+    // A node that is a ServiceNode in its own right matches as a subject first —
+    // payments is the rule's subject, so it never reads as merely a region.
+    const onPayments = selectApplicablePolicies(g, [blastRadiusPolicy], 'service:payments')
+    expect(onPayments).toHaveLength(1)
+    expect(onPayments[0]!.match).toBe('subject')
+  })
+
+  it('respects the rule\'s declared depth when surfacing downstream', () => {
+    const g = makeGraph()
+    // A second database two hops from the only service: checkout → orders-db
+    // (CONNECTS_TO, depth 1) → warehouse (DEPENDS_ON, depth 2).
+    g.addNode('database:warehouse', {
+      id: 'database:warehouse',
+      type: NodeType.DatabaseNode,
+      name: 'warehouse',
+      engine: 'postgres',
+      engineVersion: '15',
+    } as GraphNode)
+    g.addEdgeWithKey('DEPENDS_ON:database:orders-db->database:warehouse', 'database:orders-db', 'database:warehouse', {
+      id: 'DEPENDS_ON:database:orders-db->database:warehouse',
+      source: 'database:orders-db',
+      target: 'database:warehouse',
+      type: EdgeType.DEPENDS_ON,
+      provenance: Provenance.EXTRACTED,
+    } as GraphEdge)
+    const depthOne: Policy = {
+      id: 'fanout-shallow',
+      name: 'shallow fan-out cap',
+      severity: 'info',
+      rule: { type: 'blast-radius', nodeType: NodeType.ServiceNode, maxAffected: 1, depth: 1 },
+    }
+    // orders-db is one hop from checkout — within a depth-1 walk, so it surfaces.
+    const onDb = selectApplicablePolicies(g, [depthOne], 'database:orders-db')
+    expect(onDb).toHaveLength(1)
+    expect(onDb[0]!.match).toBe('region')
+
+    // warehouse is two hops from checkout (the only service); a depth-1 rule
+    // must not reach it, so nothing surfaces.
+    const onWarehouse = selectApplicablePolicies(g, [depthOne], 'database:warehouse')
+    expect(onWarehouse).toEqual([])
   })
 
   it('does not match policies whose subject/region the node is outside of (no full traversal)', () => {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -213,7 +213,7 @@ registerTool(
 
 registerTool(
   'check_policies',
-  'Inspect or dry-run the project\'s policy.json. Without hypotheticalAction, returns currently-recorded violations. With hypotheticalAction, returns violations that would result if the action were applied. Architectural assertions in five shapes (structural / compatibility / provenance / ownership / blast-radius).',
+  'Inspect, dry-run, or get the soft guardrail for the project\'s policy.json. With applicableTo, returns the policies that apply where you are working — surfaced as context so you stay inside the lines (informs, never blocks). Without hypotheticalAction or applicableTo, returns currently-recorded violations. With hypotheticalAction, returns violations that would result if the action were applied. Architectural assertions in five shapes (structural / compatibility / provenance / ownership / blast-radius).',
   {
     scope: CheckPoliciesScopeSchema.optional().describe(
       'Narrow to a subset. Default "all".',
@@ -221,6 +221,12 @@ registerTool(
     hypotheticalAction: HypotheticalActionSchema.optional().describe(
       'Dry-run mode: simulate the action and return resulting violations. Omit for current state.',
     ),
+    applicableTo: z
+      .string()
+      .optional()
+      .describe(
+        'Soft guardrail (ADR-108): pass the node id you are about to edit and check_policies returns the policies that govern it, as a context block — so you stay inside the lines. Advisory only; never blocks.',
+      ),
     project: projectField,
   },
   async (input) =>

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -5,6 +5,7 @@
 // running server — just a stub client that returns canned JSON.
 
 import type {
+  ApplicablePoliciesResponse,
   BlastRadiusAffectedNode,
   BlastRadiusResult,
   Divergence,
@@ -508,6 +509,11 @@ export interface CheckPoliciesInput {
   // When provided, dry-run evaluation: return violations that *would* result
   // if the action were applied. Without it, return current violations.
   hypotheticalAction?: HypotheticalAction
+  // Soft guardrail (ADR-108). When provided, return the policies APPLICABLE to
+  // this node — the rules the agent should keep in mind while editing it,
+  // surfaced as context. Informs only; never blocks. Takes precedence over the
+  // violation-read and dry-run modes.
+  applicableTo?: string
   project?: string
 }
 
@@ -525,6 +531,19 @@ export async function checkPolicies(
   input: CheckPoliciesInput,
 ): Promise<ToolResponse> {
   try {
+    // Soft guardrail mode (ADR-108). Surface the policies that govern the node
+    // the agent is working at, as a labeled context block. It informs; it does
+    // not block — there is no allowed/denied verdict on this path.
+    if (input.applicableTo) {
+      const body = await client.get<ApplicablePoliciesResponse>(
+        projectPath(
+          input.project,
+          `/policies/applicable?node=${encodeURIComponent(input.applicableTo)}`,
+        ),
+      )
+      return formatApplicablePolicies(body)
+    }
+
     let violations: PolicyViolation[]
     let allowed = true
     let hypothetical: HypotheticalAction | undefined
@@ -598,6 +617,35 @@ export async function checkPolicies(
   } catch (err) {
     return formatErrorResponse(`Error talking to neat-core: ${(err as Error).message}`)
   }
+}
+
+// The soft-guardrail context block (ADR-108). This is the "hook to the top of
+// agent memory": the policies that govern where the agent is working, surfaced
+// so the rules ride along as it edits. It INFORMS — there is deliberately no
+// allowed/denied verdict and no blocking language here. The post-launch kernel
+// gate (ADR-093) is the only surface that refuses an action; this is not it.
+function formatApplicablePolicies(body: ApplicablePoliciesResponse): ToolResponse {
+  const { node, applicable } = body
+  if (applicable.length === 0) {
+    return formatEmptyResponse(
+      `No policies apply to ${node}. Nothing to keep inside the lines here — and note this is advisory: NEAT surfaces policies for awareness, it never blocks your edit.`,
+    )
+  }
+  const summary =
+    `APPLICABLE POLICIES — ${applicable.length} ${applicable.length === 1 ? 'policy applies' : 'policies apply'} where you're working (${node}). ` +
+    `Keep these in mind as you edit. They inform; they do not block. Nothing here gates or stops your change.`
+  const lines = applicable.map((p) => {
+    const tail = p.match === 'region' ? ' [nearby]' : ''
+    return `  • [${p.severity}/${p.onViolation}] ${p.policyName}${tail}: ${p.reason}`
+  })
+  return formatToolResponse({
+    summary,
+    block: lines.join('\n'),
+    // The policies themselves are declared in policy.json — EXTRACTED, fully
+    // known; the confidence is in the rule's existence, not a guess.
+    confidence: 1,
+    provenance: 'EXTRACTED (policy.json)',
+  })
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -813,6 +813,108 @@ describe('checkPolicies', () => {
   })
 })
 
+describe('checkPolicies — soft guardrail (applicableTo, ADR-108)', () => {
+  function applicable(over: Partial<Record<string, unknown>> = {}): unknown {
+    return {
+      policyId: 'service-owner',
+      policyName: 'services must declare an owner',
+      severity: 'critical',
+      onViolation: 'block',
+      ruleType: 'ownership',
+      match: 'subject',
+      reason: 'every ServiceNode must declare a non-empty "owner" field',
+      ...over,
+    }
+  }
+
+  it('reads applicable policies from GET /policies/applicable and labels them as context', async () => {
+    const { client, capture } = clientFor({
+      [`/policies/applicable?node=${encodeURIComponent('service:checkout')}`]: {
+        node: 'service:checkout',
+        applicable: [applicable()],
+      },
+    })
+    const res = await checkPolicies(client, { applicableTo: 'service:checkout' })
+    expect(res.isError).toBeFalsy()
+    const text = res.content[0].text
+    expect(text).toContain('APPLICABLE POLICIES')
+    expect(text).toContain('service:checkout')
+    expect(text).toContain('services must declare an owner')
+    expect(capture.paths[0]).toBe(
+      `/policies/applicable?node=${encodeURIComponent('service:checkout')}`,
+    )
+  })
+
+  it('informs, never blocks — no denial language even when an applicable policy carries a block action', async () => {
+    const { client } = clientFor({
+      [`/policies/applicable?node=${encodeURIComponent('service:checkout')}`]: {
+        node: 'service:checkout',
+        applicable: [applicable({ onViolation: 'block' })],
+      },
+    })
+    const res = await checkPolicies(client, { applicableTo: 'service:checkout' })
+    const text = res.content[0].text.toLowerCase()
+    expect(text).toContain('they do not block')
+    // The soft guardrail must never speak the gate's language.
+    expect(text).not.toContain('action denied')
+    expect(text).not.toContain('refuse')
+    expect(res.isError).toBeFalsy()
+  })
+
+  it('marks a region (nearby) match distinctly from a direct subject match', async () => {
+    const { client } = clientFor({
+      [`/policies/applicable?node=${encodeURIComponent('service:checkout')}`]: {
+        node: 'service:checkout',
+        applicable: [
+          applicable({
+            policyId: 'payments-observed',
+            policyName: 'calls into payments must be observed',
+            severity: 'error',
+            onViolation: 'alert',
+            ruleType: 'provenance',
+            match: 'region',
+            reason: 'this node sits on a CALLS edge to service:payments',
+          }),
+        ],
+      },
+    })
+    const res = await checkPolicies(client, { applicableTo: 'service:checkout' })
+    expect(res.content[0].text).toContain('[nearby]')
+  })
+
+  it('says so plainly when no policy governs the node', async () => {
+    const { client } = clientFor({
+      [`/policies/applicable?node=${encodeURIComponent('service:lonely')}`]: {
+        node: 'service:lonely',
+        applicable: [],
+      },
+    })
+    const res = await checkPolicies(client, { applicableTo: 'service:lonely' })
+    expect(res.content[0].text).toContain('No policies apply to service:lonely')
+  })
+
+  it('threads project into the applicable path', async () => {
+    const { client, capture } = clientFor({
+      [`/projects/alpha/policies/applicable?node=${encodeURIComponent('service:x')}`]: {
+        node: 'service:x',
+        applicable: [],
+      },
+    })
+    await checkPolicies(client, { project: 'alpha', applicableTo: 'service:x' })
+    expect(capture.paths[0]).toBe(
+      `/projects/alpha/policies/applicable?node=${encodeURIComponent('service:x')}`,
+    )
+  })
+
+  it('surfaces a transport error as isError', async () => {
+    const res = await checkPolicies(errorClient(new Error('connect ECONNREFUSED')), {
+      applicableTo: 'service:checkout',
+    })
+    expect(res.isError).toBe(true)
+    expect(res.content[0].text).toContain('ECONNREFUSED')
+  })
+})
+
 describe('neatListUninstrumented', () => {
   it('lists libraries needing instrumentation with their registry package', async () => {
     const { client, getCapture } = postClientFor(

--- a/packages/types/src/policy.ts
+++ b/packages/types/src/policy.ts
@@ -174,6 +174,41 @@ export const CheckPoliciesScopeSchema = z.union([
 ])
 export type CheckPoliciesScope = z.infer<typeof CheckPoliciesScopeSchema>
 
+// Soft guardrail (ADR-108 / policies-soft-guardrail.md). The launch form of
+// "every agent stays inside the lines": policies INFORM, they never block. An
+// ApplicablePolicy is one policy that governs the node an agent is working at —
+// matched by a direct subject/region rule match (the node's type is the rule's
+// subject, or the node sits one hop inside the rule's region). It is delivered
+// as context, surfaced through check_policies; it carries no violation, no
+// gate, no allowed/denied verdict. `match` records why it applies:
+//   - 'subject' — the node is the rule's direct subject (its type is governed).
+//   - 'region'  — the node sits one hop inside the rule's region (e.g. the
+//                 target end of a structural edge, or a node on a governed edge).
+// The far-away downstream-breaking invariants the full overlay would surface
+// (ADR-105 §5) need the unbuilt policy overlay; this MVP matches one hop only.
+export const ApplicablePolicySchema = z.object({
+  policyId: z.string().min(1),
+  policyName: z.string().min(1),
+  description: z.string().optional(),
+  severity: PolicySeveritySchema,
+  // The action the post-launch kernel gate WOULD take (ADR-093) — resolved
+  // from policy.onViolation or the severity default. Shown for awareness only;
+  // the soft guardrail never acts on it.
+  onViolation: PolicyActionSchema,
+  ruleType: z.enum(['structural', 'compatibility', 'provenance', 'ownership', 'blast-radius']),
+  match: z.enum(['subject', 'region']),
+  // Human-readable reason the policy applies here — rides into agent context.
+  reason: z.string().min(1),
+})
+export type ApplicablePolicy = z.infer<typeof ApplicablePolicySchema>
+
+// Response shape of GET /policies/applicable.
+export const ApplicablePoliciesResponseSchema = z.object({
+  node: z.string().min(1),
+  applicable: z.array(ApplicablePolicySchema),
+})
+export type ApplicablePoliciesResponse = z.infer<typeof ApplicablePoliciesResponseSchema>
+
 export const PolicyViolationSchema = z.object({
   // ${policy.id}:${violation-context}. The violation-context is shape-
   // specific (e.g. nodeId for structural; edgeId for provenance).


### PR DESCRIPTION
The launch reading of "every agent stays inside the lines" (ADR-108, `docs/contracts/policies-soft-guardrail.md`): policies INFORM, they never block.

`check_policies` could already read current violations and dry-run a hypothetical action. What it couldn't do was answer the soft-guardrail question — "which policies apply to the node I'm about to edit?" — so the rules could ride into the agent's working context. This adds that read path.

## What's here

- `selectApplicablePolicies(graph, policies, nodeId)` in core: matches a policy to a node by a **direct subject/region match** — the node's type is the rule's declared subject, or it sits one hop inside the rule's region (the target end of a structural edge, the database one CONNECTS_TO from a service, a node on a governed provenance edge). Type-and-incident-edge matching, not graph traversal.
- `GET /policies/applicable?node=X` — the REST read path. Dual-mounted under `/projects/:project`. Returns `{ node, applicable: ApplicablePolicy[] }`. No verdict field — it informs, it does not gate.
- `check_policies` gains an `applicableTo` input. When set, the tool returns a clearly-labeled `APPLICABLE POLICIES` block — the "hook to the top of agent memory." It never speaks the gate's denial vocabulary.
- `ApplicablePolicy` / `ApplicablePoliciesResponse` schemas in `@neat.is/types`.

## Honestly out of scope

The full version surfaces *reachable* policies through the policy overlay's blast-radius injection (ADR-105 §5) — relevance = scope × graph distance, so far-away downstream-breaking invariants surface too. That overlay is contract-only / unbuilt, so this stops at a one-hop match and the gap (high severity — it's the case the contract calls out as the point) is written up in `docs/quirks/policies-soft-guardrail.md` rather than faked. `selectApplicablePolicies` is the seam to swap when the overlay lands: same return shape, real reachability behind it.

## Tests

- `packages/core/test/policy-applicable.test.ts` — subject + region matches across all rule types, no-match boundary, missing-node, and the inform-not-block shape; plus the REST endpoint (dual-mount, missing-param 400, empty set).
- New breaker assertions in `contracts.test.ts` under the policy contracts block: a reachable policy surfaces (subject and one-hop region), the record carries no verdict, and the MCP delivery avoids blocking language.
- MCP tool tests in `packages/mcp/test/tools.test.ts` for the `applicableTo` mode.

`npx turbo test --filter=@neat.is/core --filter=@neat.is/mcp --filter=@neat.is/types` green; lint clean.

Refs #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)