### PR TITLE
Probe the daemon's real bind interface when allocating ports

### DIFF
--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -489,7 +489,7 @@ function portFromListenAddress(address: string, fallback: number): number {
   return fallback
 }
 
-function resolveHost(opts: DaemonOptions, authTokenSet: boolean): string {
+export function resolveHost(opts: DaemonOptions, authTokenSet: boolean): string {
   if (opts.host && opts.host.length > 0) return opts.host
   const env = process.env.HOST
   if (env && env.length > 0) return env
@@ -803,7 +803,13 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
             : undefined,
       })
       restAddress = await restApp.listen({ port: restPort, host })
-      console.log(`neatd: REST listening on ${restAddress}`)
+      // Fastify reports a 0.0.0.0 bind back as http://127.0.0.1:port, so the
+      // raw listen address hides a wildcard bind behind a loopback URL. Log the
+      // host we actually asked for so the line matches what the port allocator
+      // probed (the orchestrator threads this same host into its free check).
+      console.log(
+        `neatd: REST listening on http://${host}:${portFromListenAddress(restAddress, restPort)}`,
+      )
     } catch (err) {
       // Roll back anything we started so far before surfacing the error.
       for (const slot of slots.values()) {

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -34,7 +34,7 @@ import { ensureNeatOutIgnored } from './gitignore.js'
 import { saveGraphToDisk } from './persist.js'
 import { pathsForProject } from './projects.js'
 import { addProject, listProjects, ProjectNameCollisionError, setStatus } from './registry.js'
-import { readDaemonRecord, type DaemonPorts } from './daemon.js'
+import { readDaemonRecord, resolveHost, type DaemonPorts } from './daemon.js'
 import { printBanner } from './banner.js'
 import {
   isEmptyPlan,
@@ -521,12 +521,18 @@ async function waitForDaemonReady(restPort: number, timeoutMs: number): Promise<
 // surface.
 export const NEAT_PORTS = [8080, 4318, 6328] as const
 
-export async function isPortFree(port: number): Promise<boolean> {
+// Probe `host` so the availability answer reflects the interface the daemon
+// will actually bind. The daemon binds 0.0.0.0 on the authenticated path
+// (resolveHost) and 127.0.0.1 otherwise; probing loopback while the daemon
+// binds the wildcard reads a wildcard-held port as free, hands it to the
+// spawn, and the daemon dies on EADDRINUSE before it can write daemon.json —
+// the silent "daemon.json timeout" (#574). Check host must equal bind host.
+export async function isPortFree(port: number, host = '127.0.0.1'): Promise<boolean> {
   return new Promise((resolve) => {
     const server = net.createServer()
     server.once('error', () => resolve(false))
     server.once('listening', () => server.close(() => resolve(true)))
-    server.listen(port, '127.0.0.1')
+    server.listen(port, host)
   })
 }
 
@@ -570,10 +576,11 @@ const PORT_STRIDE = 1
 
 export interface AllocatedPorts extends DaemonPorts {}
 
-// True when all three ports of a candidate triple are free.
-async function tripleFree(ports: AllocatedPorts): Promise<boolean> {
+// True when all three ports of a candidate triple are free on `host` — the
+// interface the daemon will bind (see isPortFree).
+async function tripleFree(ports: AllocatedPorts, host = '127.0.0.1'): Promise<boolean> {
   for (const p of [ports.rest, ports.otlp, ports.web]) {
-    if (!(await isPortFree(p))) return false
+    if (!(await isPortFree(p, host))) return false
   }
   return true
 }
@@ -584,7 +591,7 @@ async function tripleFree(ports: AllocatedPorts): Promise<boolean> {
 // search window is free — a genuinely saturated environment. Reuse of a
 // project's persisted ports is the caller's decision (it has the /health
 // identity result); this only finds fresh free ports.
-export async function allocatePorts(): Promise<AllocatedPorts | null> {
+export async function allocatePorts(host = '127.0.0.1'): Promise<AllocatedPorts | null> {
   const [baseRest, baseOtlp, baseWeb] = NEAT_PORTS
   for (let i = 0; i < PORT_ALLOCATION_ATTEMPTS; i++) {
     const candidate: AllocatedPorts = {
@@ -592,7 +599,7 @@ export async function allocatePorts(): Promise<AllocatedPorts | null> {
       otlp: baseOtlp + i * PORT_STRIDE,
       web: baseWeb + i * PORT_STRIDE,
     }
-    if (await tripleFree(candidate)) return candidate
+    if (await tripleFree(candidate, host)) return candidate
   }
   return null
 }
@@ -914,6 +921,15 @@ export async function runOrchestrator(opts: OrchestratorOptions): Promise<Orches
   // port must report THIS project to count as ours (a sibling project's
   // daemon on a port we'd otherwise reuse is correctly seen as not-mine).
   const timeoutMs = opts.daemonReadyTimeoutMs ?? DEFAULT_DAEMON_READY_TIMEOUT_MS
+  // The interface the spawned daemon will bind — 0.0.0.0 on the authenticated
+  // path, 127.0.0.1 otherwise. resolveHost is the single source of that
+  // decision (the daemon calls it too), so the free-port probe below checks the
+  // exact interface the bind will use; a wildcard-held port must read as taken
+  // on the token path or the spawn collides on EADDRINUSE (#574).
+  const bindHost = resolveHost(
+    {},
+    typeof process.env.NEAT_AUTH_TOKEN === 'string' && process.env.NEAT_AUTH_TOKEN.length > 0,
+  )
   // Ports the project used last time (its daemon.json), if any — reuse keeps
   // the instrumented app's exporter endpoint stable across restarts (§3).
   const persistedPorts = await persistedPortsFor(opts.scanPath)
@@ -931,10 +947,14 @@ export async function runOrchestrator(opts: OrchestratorOptions): Promise<Orches
     // is free (the prior daemon is gone, so we take its ports back and the
     // app's endpoint stays put); otherwise allocate a fresh free triple,
     // stepping past the canonical set when a sibling project holds it.
-    if (persistedPorts && (await isPortFree(persistedPorts.rest)) && (await tripleFree(persistedPorts))) {
+    if (
+      persistedPorts &&
+      (await isPortFree(persistedPorts.rest, bindHost)) &&
+      (await tripleFree(persistedPorts, bindHost))
+    ) {
       allocated = persistedPorts
     } else {
-      allocated = await allocatePorts()
+      allocated = await allocatePorts(bindHost)
     }
     if (!allocated) {
       // The search window is saturated — surface the canonical REST port as the

--- a/packages/core/test/port-bind-host.test.ts
+++ b/packages/core/test/port-bind-host.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import net from 'node:net'
+import { isPortFree } from '../src/orchestrator.js'
+import { resolveHost } from '../src/daemon.js'
+
+// #574 — the port allocator must probe the same interface the daemon binds.
+//
+// On the authenticated path the daemon binds 0.0.0.0 (resolveHost). The
+// allocator used to probe loopback unconditionally, so a port already held on
+// the wildcard interface by a sibling daemon read as free, got handed to the
+// spawn, and the new daemon then died on EADDRINUSE binding 0.0.0.0 — before
+// it could write daemon.json, surfacing only as a silent "daemon.json
+// timeout". The fix threads the resolved bind host into the free-port check so
+// the interface probed always equals the interface the daemon will bind.
+
+function hold(host: string): Promise<net.Server> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.once('error', reject)
+    server.listen(0, host, () => resolve(server))
+  })
+}
+
+function portOf(server: net.Server): number {
+  const addr = server.address()
+  if (addr && typeof addr === 'object') return addr.port
+  throw new Error('expected a bound TCP port')
+}
+
+describe('port allocator bind-host probe (#574)', () => {
+  const held: net.Server[] = []
+  const savedHost = process.env.HOST
+
+  afterEach(async () => {
+    await Promise.all(
+      held.splice(0).map((s) => new Promise<void>((resolve) => s.close(() => resolve()))),
+    )
+    if (savedHost === undefined) delete process.env.HOST
+    else process.env.HOST = savedHost
+  })
+
+  it('reads a wildcard-held port as taken when probing the token bind host', async () => {
+    const server = await hold('0.0.0.0')
+    held.push(server)
+    const port = portOf(server)
+    // The token path binds 0.0.0.0; probing that interface catches the holder
+    // so the allocator steps past it instead of handing over a doomed port.
+    expect(await isPortFree(port, '0.0.0.0')).toBe(false)
+  })
+
+  it('probes loopback by default — the no-token bind host', async () => {
+    const server = await hold('127.0.0.1')
+    held.push(server)
+    const port = portOf(server)
+    expect(await isPortFree(port, '127.0.0.1')).toBe(false)
+    // No host argument falls back to loopback, matching resolveHost's no-token
+    // default, so the same loopback-held port still reads as taken.
+    expect(await isPortFree(port)).toBe(false)
+  })
+
+  it('takes its probe host from resolveHost, so token state decides the interface', () => {
+    delete process.env.HOST
+    // resolveHost is the single source of the bind decision the orchestrator
+    // feeds into the probe: token → 0.0.0.0, no token → loopback.
+    expect(resolveHost({}, true)).toBe('0.0.0.0')
+    expect(resolveHost({}, false)).toBe('127.0.0.1')
+  })
+})


### PR DESCRIPTION
## What

The port allocator decided a port was free by probing `127.0.0.1`, but on the authenticated path the daemon binds `0.0.0.0` — `resolveHost` returns the wildcard whenever `NEAT_AUTH_TOKEN` is set. When a sibling daemon was already holding a port on the wildcard interface, the loopback probe reported it free (a specific-address bind slips in beside a wildcard one), the allocator handed that port to the spawn, and the new daemon then died on `EADDRINUSE` binding `0.0.0.0` — before it reached `writeDaemonRecord`. All the operator saw was a silent "daemon.json timeout".

## Fix

Thread the resolved bind host through `isPortFree`, `tripleFree`, and `allocatePorts` so the interface checked always equals the interface the daemon will bind. The host comes straight from `resolveHost`, the single source of the token → `0.0.0.0` / no-token → `127.0.0.1` decision the daemon itself uses, so the probe and the bind can't drift.

Also fixed the REST listen log: Fastify reports a `0.0.0.0` bind back as `http://127.0.0.1:port`, so the line was claiming loopback while actually binding the wildcard. It now prints the host we asked for.

## Test

`packages/core/test/port-bind-host.test.ts` holds a port on the wildcard interface and asserts the allocator's check sees it as taken on the token bind host, that the no-token path still probes loopback by default, and that the probe host is taken from `resolveHost` (token state decides the interface). `npx turbo test --filter=@neat.is/core` is green (1125 passing).

Refs #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)