### PR TITLE
Only report missing-observed for runtime-observable edges

### DIFF
--- a/packages/core/src/divergences.ts
+++ b/packages/core/src/divergences.ts
@@ -15,6 +15,7 @@ import type {
   Divergence,
   DivergenceResult,
   DivergenceType,
+  EdgeTypeValue,
   GraphEdge,
   GraphNode,
   ServiceNode,
@@ -135,6 +136,26 @@ function gradedConfidence(edge: GraphEdge): number {
   return clampConfidence(confidenceForEdge(edge))
 }
 
+// Edge types production can actually emit as OBSERVED traffic — the CALLS
+// family plus cross-service and connection edges. `missing-observed` only
+// makes sense for these: an EXTRACTED edge of one of these types with no
+// OBSERVED twin is a real "code declares it, production never ran it" finding.
+//
+// Structural / static-only edge types (IMPORTS, CONFIGURED_BY, CONTAINS,
+// DEPENDS_ON, RUNS_ON) have no runtime span behind them, so there is never an
+// OBSERVED twin to be "missing" — measuring their tiers would report every
+// import and every config wire as a missing-observed divergence, which is
+// noise, not signal. Keep this an allowlist (not a denylist) so a new
+// structural edge type stays out of the missing-observed surface by default
+// until it is deliberately added here (divergence-query.md — the five locked
+// types compare CALLS-family edges at the shared grain).
+const OBSERVABLE_EDGE_TYPES: ReadonlySet<EdgeTypeValue> = new Set([
+  EdgeType.CALLS,
+  EdgeType.CONNECTS_TO,
+  EdgeType.PUBLISHES_TO,
+  EdgeType.CONSUMES_FROM,
+])
+
 function detectMissingDivergences(
   graph: NeatGraph,
   bucket: EdgeBucket,
@@ -147,7 +168,7 @@ function detectMissingDivergences(
   // Divergence compares CALLS-family edges at the shared grain (§7).
   if (bucket.type === EdgeType.CONTAINS) return out
 
-  if (bucket.extracted && !bucket.observed) {
+  if (bucket.extracted && !bucket.observed && OBSERVABLE_EDGE_TYPES.has(bucket.type)) {
     // Skip when the would-be target is a FrontierNode — those represent
     // unresolved span peers, not real entities we expect OBSERVED traffic
     // to. The coexistence contract is between EXTRACTED and OBSERVED on

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -8390,6 +8390,83 @@ describe('Divergence query (ADR-060)', () => {
     expect(hit!.confidence).toBe(0.5)
   })
 
+  it('computeDivergences does not report missing-observed for structural, never-observable edges (IMPORTS / CONFIGURED_BY)', async () => {
+    const { computeDivergences } = await import('../../src/divergences.js')
+    const { extractedEdgeId } = await import('@neat.is/types')
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+
+    // Two files within a service, statically importing one another, and a
+    // config the service is wired to. None of these are runtime-observable, so
+    // OTel never mints an OBSERVED twin — they must not surface as
+    // missing-observed divergences.
+    g.addNode('file:a/src/index.js', {
+      id: 'file:a/src/index.js',
+      type: NodeType.FileNode,
+      name: 'index.js',
+      language: 'javascript',
+    })
+    g.addNode('file:a/src/users.js', {
+      id: 'file:a/src/users.js',
+      type: NodeType.FileNode,
+      name: 'users.js',
+      language: 'javascript',
+    })
+    g.addNode('service:a', {
+      id: 'service:a',
+      type: NodeType.ServiceNode,
+      name: 'a',
+      language: 'javascript',
+    })
+    g.addNode('config:a/.env', {
+      id: 'config:a/.env',
+      type: NodeType.ConfigNode,
+      name: '.env',
+    })
+
+    const importsId = extractedEdgeId('file:a/src/index.js', 'file:a/src/users.js', EdgeType.IMPORTS)
+    g.addEdgeWithKey(importsId, 'file:a/src/index.js', 'file:a/src/users.js', {
+      id: importsId,
+      source: 'file:a/src/index.js',
+      target: 'file:a/src/users.js',
+      type: EdgeType.IMPORTS,
+      provenance: Provenance.EXTRACTED,
+      evidence: { file: 'a/src/index.js', line: 1, snippet: "require('./users')" },
+    })
+    const configuredId = extractedEdgeId('service:a', 'config:a/.env', EdgeType.CONFIGURED_BY)
+    g.addEdgeWithKey(configuredId, 'service:a', 'config:a/.env', {
+      id: configuredId,
+      source: 'service:a',
+      target: 'config:a/.env',
+      type: EdgeType.CONFIGURED_BY,
+      provenance: Provenance.EXTRACTED,
+      evidence: { file: 'a/.env' },
+    })
+
+    const result = computeDivergences(g)
+    const structural = result.divergences.filter(
+      (d) =>
+        d.type === 'missing-observed' &&
+        (d.edgeType === EdgeType.IMPORTS || d.edgeType === EdgeType.CONFIGURED_BY),
+    )
+    expect(structural).toEqual([])
+
+    // A real EXTRACTED CALLS edge with no OBSERVED twin still fires — the
+    // precision fix narrows the surface, it does not silence it.
+    g.addNode('service:b', {
+      id: 'service:b',
+      type: NodeType.ServiceNode,
+      name: 'b',
+      language: 'javascript',
+    })
+    g.addEdgeWithKey(extractedCallEdge.id, 'service:a', 'service:b', extractedCallEdge)
+    const withCall = computeDivergences(g)
+    expect(
+      withCall.divergences.some(
+        (d) => d.type === 'missing-observed' && d.edgeType === EdgeType.CALLS,
+      ),
+    ).toBe(true)
+  })
+
   it('computeDivergences detects missing-extracted: OBSERVED edge without EXTRACTED counterpart (ADR-060 #5)', async () => {
     const { computeDivergences } = await import('../../src/divergences.js')
     const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })


### PR DESCRIPTION
`get_divergences` was reporting structural, never-observable edge types as `missing-observed` divergences. Imports and config wiring carry no runtime span, so there's never an OBSERVED twin for them to be "missing" — but `detectMissingDivergences` only excluded `CONTAINS`, so `IMPORTS` and `CONFIGURED_BY` (and `DEPENDS_ON` / `RUNS_ON`) fell through into the missing-observed branch and fired in every project. In a breaker run that was 13 false positives against 2 real findings, with nonsensical advice like "check feature flags that gate the call" attached to a plain import.

This gates the missing-observed branch on an explicit allowlist of runtime-observable edge types — the CALLS family plus the cross-service and connection edges (`CALLS`, `CONNECTS_TO`, `PUBLISHES_TO`, `CONSUMES_FROM`). An allowlist rather than a denylist means a new structural edge type stays out of the surface by default instead of quietly reintroducing the flood. This stays inside `divergence-query.md`'s five locked types — it sharpens `missing-observed`, it doesn't add a type.

`missing-extracted` is untouched: it only fires when an OBSERVED edge exists, which structural types never get. A real EXTRACTED `CALLS` edge with no OBSERVED twin still surfaces as before.

A new test in the ADR-060 block asserts that a graph with `IMPORTS` and `CONFIGURED_BY` edges and no OBSERVED produces no missing-observed findings for them, while a real EXTRACTED `CALLS` edge still does. Full `@neat.is/core` suite is green (1123 passing).

Refs #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)