### PR TITLE
Scope the bare-run readiness gate to the started project

### DIFF
--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -314,10 +314,11 @@ export async function applyInstallersOver(
       if (gaps.length > 0) {
         const svcName = path.basename(svc.dir)
         const list = gaps.join(', ')
-        const verb = gaps.length === 1 ? 'this library' : 'these libraries'
+        const subject = gaps.length === 1 ? 'this library' : 'these libraries'
+        const aux = gaps.length === 1 ? "isn't" : "aren't"
         console.warn(
           `neat: calls to ${list} won't be observed by default in ${svcName}.\n` +
-            `  ${verb} aren't in the default instrumentation set, so they produce no OBSERVED edges.\n` +
+            `  ${subject} ${aux} in the default instrumentation set, so they produce no OBSERVED edges.\n` +
             `  Run \`neat list-uninstrumented\` to review them, then \`neat extend\` to capture them.`,
         )
       }
@@ -442,29 +443,27 @@ async function probeProjectHealth(
   })
 }
 
-// Resolve the project-status set the wait loop branches on. Prefers the
-// daemon-wide /health response when it carries the list; otherwise reads
-// the registry directly and probes each project's per-project /health.
-// The fallback handles the case where the daemon-wide /health hasn't
-// landed in this branch's main yet.
+// Resolve the status of the one project this run just started — and only that
+// project (ADR-096: the orchestrator spawns a daemon scoped to a single
+// project, so readiness is a single-project question). A broken or stale
+// sibling sitting in the machine registry must never gate this run; it
+// belongs to a different daemon and would otherwise poison an otherwise-healthy
+// start. Prefers the daemon-wide /health entry for the project when one is
+// carried (the legacy multi-project shape); otherwise probes that project's
+// per-project /health directly. The registry is not consulted — siblings are
+// out of scope by construction.
 async function snapshotProjectStatus(
   restPort: number,
+  project: string,
   body: DaemonHealthResponse,
 ): Promise<Array<{ name: string; status: 'bootstrapping' | 'active' | 'broken' }>> {
   if (body.projects && body.projects.length > 0) {
-    return body.projects.map((p) => ({
-      name: p.name,
-      status: p.status ?? 'active',
-    }))
+    const mine = body.projects.filter((p) => p.name === project)
+    if (mine.length > 0) {
+      return mine.map((p) => ({ name: p.name, status: p.status ?? 'active' }))
+    }
   }
-  const entries = await listProjects().catch(() => [])
-  if (entries.length === 0) return []
-  return Promise.all(
-    entries.map(async (entry) => ({
-      name: entry.name,
-      status: await probeProjectHealth(restPort, entry.name),
-    })),
-  )
+  return [{ name: project, status: await probeProjectHealth(restPort, project) }]
 }
 
 interface DaemonReadyResult {
@@ -473,13 +472,17 @@ interface DaemonReadyResult {
   stillBootstrapping: string[]
 }
 
-async function waitForDaemonReady(restPort: number, timeoutMs: number): Promise<DaemonReadyResult> {
+async function waitForDaemonReady(
+  restPort: number,
+  project: string,
+  timeoutMs: number,
+): Promise<DaemonReadyResult> {
   const deadline = Date.now() + timeoutMs
   let lastBootstrapping: string[] = []
   while (Date.now() < deadline) {
     const body = await fetchDaemonHealth(restPort)
     if (body !== null) {
-      const projects = await snapshotProjectStatus(restPort, body)
+      const projects = await snapshotProjectStatus(restPort, project, body)
       const bootstrapping = projects
         .filter((p) => p.status === 'bootstrapping')
         .map((p) => p.name)
@@ -500,7 +503,7 @@ async function waitForDaemonReady(restPort: number, timeoutMs: number): Promise<
     await new Promise((r) => setTimeout(r, PROBE_INTERVAL_MS))
   }
   const final = await fetchDaemonHealth(restPort)
-  const projects = final ? await snapshotProjectStatus(restPort, final) : []
+  const projects = final ? await snapshotProjectStatus(restPort, project, final) : []
   return {
     ready: false,
     brokenProjects: projects.filter((p) => p.status === 'broken').map((p) => p.name),
@@ -680,6 +683,18 @@ async function healthIsForProject(restPort: number, project: string): Promise<bo
 // the matching-vs-not-mine decision directly.
 export function healthIsForProjectForTest(restPort: number, project: string): Promise<boolean> {
   return healthIsForProject(restPort, project)
+}
+
+// Test seam for the readiness wait (one-command-cli contract §1 / ADR-096).
+// The integration suite drives a fake single-project daemon against this to
+// prove the gate scopes to the just-started project and never blocks on a
+// broken sibling sitting in the registry.
+export function waitForDaemonReadyForTest(
+  restPort: number,
+  project: string,
+  timeoutMs: number,
+): Promise<DaemonReadyResult> {
+  return waitForDaemonReady(restPort, project, timeoutMs)
 }
 
 // Spawn the daemon as a child process the orchestrator drives. Returns the
@@ -971,7 +986,7 @@ export async function runOrchestrator(opts: OrchestratorOptions): Promise<Orches
             projectPath: opts.scanPath,
             ports: allocated,
           })
-          const ready = await waitForDaemonReady(allocated.rest, timeoutMs)
+          const ready = await waitForDaemonReady(allocated.rest, currentProjectName, timeoutMs)
           result.steps.daemon = ready.ready ? 'spawned' : 'timed-out'
           if (!ready.ready) {
             console.error(`neat: daemon did not become ready within ${timeoutMs}ms`)

--- a/packages/core/test/orchestrator-readiness.test.ts
+++ b/packages/core/test/orchestrator-readiness.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import type { AddressInfo } from 'node:net'
+
+// One-command-cli contract §1 / ADR-096 — the bare-run readiness gate is a
+// single-project question. The orchestrator spawns a daemon scoped to the one
+// project it just started, so the wait must resolve on that project alone. A
+// broken or stale sibling sitting in the machine registry (here: a
+// "recoverable" entry pointing at a deleted temp path) belongs to a different
+// daemon and must not gate this run — the harvest bug was exactly that, where
+// any broken sibling timed the whole start out at 60s.
+//
+// The fake daemon below answers /health in the single-project shape (top-level
+// `project`, no `projects` array), returns 200 for the started project's
+// per-project /health, and 503 for everyone else. If the gate ever probes the
+// sibling again it would read 503 forever and never go ready.
+
+interface FakeDaemon {
+  port: number
+  startedProject: string
+  probedPaths: string[]
+  close: () => Promise<void>
+}
+
+async function startFakeDaemon(startedProject: string): Promise<FakeDaemon> {
+  const probedPaths: string[] = []
+  const server = http.createServer((req, res) => {
+    const url = req.url ?? ''
+    probedPaths.push(url)
+    if (url === '/health') {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ ok: true, project: startedProject }))
+      return
+    }
+    if (url === `/projects/${encodeURIComponent(startedProject)}/health`) {
+      res.writeHead(200)
+      res.end()
+      return
+    }
+    // Any other project — including a broken sibling — never comes ready.
+    res.writeHead(503)
+    res.end()
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const port = (server.address() as AddressInfo).port
+  return {
+    port,
+    startedProject,
+    probedPaths,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  }
+}
+
+describe('orchestrator readiness gate scopes to the started project (ADR-096)', () => {
+  const cleanups: Array<() => Promise<void>> = []
+  let savedHome: string | undefined
+
+  afterEach(async () => {
+    for (const c of cleanups.splice(0)) await c().catch(() => {})
+    if (savedHome === undefined) delete process.env.NEAT_HOME
+    else process.env.NEAT_HOME = savedHome
+  })
+
+  it('resolves on the healthy just-started project and never probes a broken sibling', async () => {
+    savedHome = process.env.NEAT_HOME
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-readiness-home-'))
+    process.env.NEAT_HOME = home
+    cleanups.push(() => fs.rm(home, { recursive: true, force: true }))
+
+    // A healthy project we "just started", and a broken sibling whose path was
+    // deleted — the exact poison shape from the run-#2 harvest.
+    const { addProject, setStatus } = await import('../src/registry.js')
+    const started = 'harvest-app'
+    const startedDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-readiness-started-'))
+    cleanups.push(() => fs.rm(startedDir, { recursive: true, force: true }))
+    await addProject({ name: started, path: startedDir, languages: ['javascript'] })
+
+    const sibling = 'recoverable'
+    const siblingDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-readiness-sibling-'))
+    await addProject({ name: sibling, path: siblingDir, languages: ['javascript'] })
+    await setStatus(sibling, 'broken')
+    // Delete the sibling's path — a stale registry entry pointing at nothing.
+    await fs.rm(siblingDir, { recursive: true, force: true })
+
+    const daemon = await startFakeDaemon(started)
+    cleanups.push(daemon.close)
+
+    const { waitForDaemonReadyForTest } = await import('../src/orchestrator.js')
+    const start = Date.now()
+    const result = await waitForDaemonReadyForTest(daemon.port, started, 5_000)
+    const elapsed = Date.now() - start
+
+    expect(result.ready).toBe(true)
+    expect(result.stillBootstrapping).toEqual([])
+    // Resolved on the first probe — nowhere near the timeout.
+    expect(elapsed).toBeLessThan(2_000)
+    // The broken sibling was never consulted; the gate is scoped.
+    expect(daemon.probedPaths.some((p) => p.includes(sibling))).toBe(false)
+  })
+})


### PR DESCRIPTION
Two fixes in `packages/core/src/orchestrator.ts`, both harvested from a breaker-campaign run.

## J — readiness gate over-waits on broken siblings

`neat .` could exit 1 with `daemon did not become ready within 60000ms / still bootstrapping: recoverable, harvest-app` even though this project's daemon was already up and serving. The readiness wait fell back to reading the whole machine registry and probing every registered project's per-project `/health`. A stale or broken sibling — here a `recoverable` entry pointing at a deleted temp path — never comes ready, so it poisoned every new run.

Under ADR-096 the orchestrator spawns a daemon scoped to the single project it just started, so readiness is a single-project question. `snapshotProjectStatus` now takes that project name and reports only its status — it reads the daemon-wide `/health` entry for the project when one is carried, otherwise probes that project's per-project `/health` directly. The registry is no longer consulted, so a broken sibling can't gate an otherwise-healthy start. The gate still gates; it's just scoped to the project the run owns, which is what the daemon and one-command-cli contracts describe.

## M — grammar nit

The singular branch of the uninstrumented-library warning read `this library aren't in the default instrumentation set`. Now `this library isn't`.

## Test

`packages/core/test/orchestrator-readiness.test.ts` stands up a fake single-project daemon, registers a healthy just-started project plus a broken sibling whose path was deleted, and asserts the readiness wait resolves on the started project well inside the timeout and never probes the sibling.

Full `@neat.is/core` suite is green (47 files, 1123 passing).

Refs #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)