### PR TITLE
Record a service's declared DB target so host-mismatch can fire

### DIFF
--- a/packages/core/src/extract/databases/index.ts
+++ b/packages/core/src/extract/databases/index.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import type {
   CompatibleDriver,
+  ConfigNode,
   DatabaseNode,
   GraphEdge,
   GraphNode,
@@ -10,6 +11,7 @@ import {
   EdgeType,
   NodeType,
   Provenance,
+  configId,
   databaseId,
   confidenceForExtracted,
 } from '@neat.is/types'
@@ -24,7 +26,12 @@ import {
   nodeEngineConstraints,
   packageConflicts,
 } from '../../compat.js'
-import { cleanVersion, makeEdgeId, type DiscoveredService } from '../shared.js'
+import {
+  cleanVersion,
+  isConfigFile,
+  makeEdgeId,
+  type DiscoveredService,
+} from '../shared.js'
 import { ensureFileNode, toPosix } from '../calls/shared.js'
 import { dbConfigYamlParser } from './db-config-yaml.js'
 import { dotenvParser } from './dotenv.js'
@@ -256,6 +263,58 @@ export async function addDatabasesAndCompat(
       }
     }
 
+    // Service-level declared DB target. When a service declares exactly one DB
+    // connection in config — a `postgres://…` string in .env, a db-config.yaml,
+    // a prisma/drizzle/knex datasource — record where it's pointed on the
+    // ServiceNode as `dbConnectionTarget` (host[:port]) and link the service to
+    // the config that declared it with an EXTRACTED CONFIGURED_BY edge. This is
+    // the service-grained declared intent the host-mismatch divergence compares
+    // against the service-grained OBSERVED CONNECTS_TO (file-awareness §7 —
+    // compare at the shared grain; a DB OTel span carries no call site, so the
+    // comparison is service-level). Without this, `declaredHostFor` reads an
+    // unpopulated field and host-mismatch never fires.
+    //
+    // We hold to a *single* declared target: with two or more distinct hosts
+    // the single-target model is ambiguous and would flag every observed host
+    // but one as a false mismatch, so we decline rather than guess.
+    if (allConfigs.length === 1) {
+      const primary = allConfigs[0]!
+      service.node.dbConnectionTarget = primary.port
+        ? `${primary.host}:${primary.port}`
+        : primary.host
+
+      // Link to the config file that declared the connection. Mirror configs.ts's
+      // ConfigNode id (Phase 3 runs after this and is idempotent on the node);
+      // the CONFIGURED_BY edge is service-grained here, matching the grain of
+      // the declared target it backs.
+      const relPath = path.relative(scanPath, primary.sourceFile)
+      const cfgId = configId(relPath)
+      if (!graph.hasNode(cfgId)) {
+        const cfgNode: ConfigNode = {
+          id: cfgId,
+          type: NodeType.ConfigNode,
+          name: path.basename(primary.sourceFile),
+          path: relPath,
+          fileType: isConfigFile(path.basename(primary.sourceFile)).fileType || 'config',
+        }
+        graph.addNode(cfgId, cfgNode)
+        nodesAdded++
+      }
+      const cfgEdge: GraphEdge = {
+        id: makeEdgeId(service.node.id, cfgId, EdgeType.CONFIGURED_BY),
+        source: service.node.id,
+        target: cfgId,
+        type: EdgeType.CONFIGURED_BY,
+        provenance: Provenance.EXTRACTED,
+        confidence: confidenceForExtracted('structural'),
+        evidence: { file: toPosix(relPath) },
+      }
+      if (!graph.hasEdge(cfgEdge.id)) {
+        graph.addEdgeWithKey(cfgEdge.id, cfgEdge.source, cfgEdge.target, cfgEdge)
+        edgesAdded++
+      }
+    }
+
     // Run all kinds of incompat checks even for services with no db connection
     // — node-engine / package-conflict / deprecated-api don't depend on db.
     attachIncompatibilities(service, allConfigs)
@@ -275,6 +334,12 @@ export async function addDatabasesAndCompat(
       // graph reporting a problem the new manifest no longer has.
       if (!service.node.incompatibilities || service.node.incompatibilities.length === 0) {
         delete (updated as { incompatibilities?: unknown }).incompatibilities
+      }
+      // Same stale-survivor guard for the declared DB target: if this pass found
+      // no single declared connection, a value left on `current` from a prior
+      // extract would otherwise survive the spread.
+      if (!service.node.dbConnectionTarget) {
+        delete (updated as { dbConnectionTarget?: unknown }).dbConnectionTarget
       }
       graph.replaceNodeAttributes(service.node.id, updated as unknown as GraphNode)
     }

--- a/packages/core/test/db-connection-target.test.ts
+++ b/packages/core/test/db-connection-target.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import { computeDivergences } from '../src/divergences.js'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  databaseId,
+  type DatabaseNode,
+  type GraphEdge,
+  type ServiceNode,
+} from '@neat.is/types'
+
+// A plain DB connection string in config is the most common shape there is.
+// Before #586 the extractor parsed it into a DatabaseNode but never recorded
+// where the service was pointed (`dbConnectionTarget`) nor a service-level
+// CONFIGURED_BY edge, so the `host-mismatch` divergence could never fire.
+describe('declared DB connection target (#586)', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    resetGraph()
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-dbtarget-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  async function writeService(): Promise<void> {
+    const svc = path.join(dir, 'svc')
+    await fs.mkdir(svc, { recursive: true })
+    await fs.writeFile(
+      path.join(svc, 'package.json'),
+      JSON.stringify({ name: 'orders', version: '1.0.0', dependencies: { pg: '8.11.0' } }),
+    )
+    await fs.writeFile(
+      path.join(svc, '.env'),
+      'DATABASE_URL=postgres://user:pw@host.x:5432/orders\n',
+    )
+  }
+
+  it('parses a postgres:// connection string into a DatabaseNode plus a declared target on the service', async () => {
+    await writeService()
+    const graph = getGraph()
+    await extractFromDirectory(graph, dir)
+
+    const dbId = databaseId('host.x')
+    expect(graph.hasNode(dbId)).toBe(true)
+    const db = graph.getNodeAttributes(dbId) as DatabaseNode
+    expect(db.engine).toBe('postgresql')
+    expect(db.host).toBe('host.x')
+    expect(db.port).toBe(5432)
+
+    const svc = graph.getNodeAttributes('service:orders') as ServiceNode
+    expect(svc.dbConnectionTarget).toBe('host.x:5432')
+
+    // A service-grained EXTRACTED CONFIGURED_BY edge backs the declared target
+    // so the host-mismatch detector's gate is satisfiable.
+    const configuredBy = graph
+      .outboundEdges('service:orders')
+      .map((e) => graph.getEdgeAttributes(e) as GraphEdge)
+      .filter(
+        (e) =>
+          e.type === EdgeType.CONFIGURED_BY && e.provenance === Provenance.EXTRACTED,
+      )
+    expect(configuredBy).toHaveLength(1)
+    expect(configuredBy[0]!.evidence?.file).toMatch(/\.env$/)
+  })
+
+  it('surfaces host-mismatch when production connects to a different host than config declares', async () => {
+    await writeService()
+    const graph = getGraph()
+    await extractFromDirectory(graph, dir)
+
+    // Production was OBSERVED connecting to host.y, not the declared host.x.
+    const observedDbId = databaseId('host.y')
+    graph.addNode(observedDbId, {
+      id: observedDbId,
+      type: NodeType.DatabaseNode,
+      name: 'host.y',
+      engine: 'postgresql',
+      engineVersion: 'unknown',
+      compatibleDrivers: [],
+      host: 'host.y',
+      discoveredVia: 'otel',
+    } as DatabaseNode)
+    const obsEdge = `${EdgeType.CONNECTS_TO}:OBSERVED:service:orders->${observedDbId}`
+    graph.addEdgeWithKey(obsEdge, 'service:orders', observedDbId, {
+      id: obsEdge,
+      source: 'service:orders',
+      target: observedDbId,
+      type: EdgeType.CONNECTS_TO,
+      provenance: Provenance.OBSERVED,
+    })
+
+    const result = computeDivergences(graph)
+    const hit = result.divergences.find((d) => d.type === 'host-mismatch')
+    expect(hit).toBeDefined()
+    if (hit?.type === 'host-mismatch') {
+      expect(hit.extractedHost).toBe('host.x')
+      expect(hit.observedHost).toBe('host.y')
+    }
+  })
+})


### PR DESCRIPTION
## What

The databases producer parsed a DB connection string into a DatabaseNode but never recorded where the service was pointed. `ServiceNode.dbConnectionTarget` stayed empty and no service-level `CONFIGURED_BY` edge was emitted — and `detectHostMismatch` in `divergences.ts` reads exactly that field and gates on a service-outbound EXTRACTED `CONFIGURED_BY`. So `host-mismatch` was structurally unreachable for the most common shape: a service with a single DB connection declared in a `.env`, a `db-config.yaml`, or a prisma/drizzle/knex datasource, however far production drifted from it.

## Change

When a service declares exactly one DB connection, the producer now records `host[:port]` on the ServiceNode as `dbConnectionTarget` and links the service to the config that declared it with an EXTRACTED `CONFIGURED_BY` edge carrying `evidence.file`. That gives the detector both a target to compare and the static backing its gate needs.

We hold to a single declared target on purpose: with two or more distinct hosts the single-target model is ambiguous and would flag every observed host but one as a false mismatch, so we decline rather than guess. A stale-survivor guard clears the field on re-extract when the config no longer declares a single connection, mirroring the existing handling for `incompatibilities`.

Comparison stays at the service grain — which is where a DB OTel span lands, since it has no call site — matching file-awareness §7. The fix is contained to the databases producer; `divergences.ts` is untouched.

## Test

`packages/core/test/db-connection-target.test.ts`: a `postgres://user:pw@host.x:5432/orders` in `.env` yields a DatabaseNode for `host.x` (engine/port correct), a `dbConnectionTarget` of `host.x:5432`, and a service-level EXTRACTED `CONFIGURED_BY` edge; then an OBSERVED CONNECTS_TO to `host.y` surfaces a `host-mismatch` divergence with `extractedHost=host.x`, `observedHost=host.y`.

Full `@neat.is/core` suite green (1124 passed), lint clean.

Refs #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)