### PR TITLE
Let root-cause use recorded incidents, and make those incidents specific

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -421,18 +421,22 @@ function registerRoutes(scope: FastifyInstance, ctx: RouteContext): void {
     if (!proj.graph.hasNode(nodeId)) {
       return reply.code(404).send({ error: 'node not found', id: nodeId })
     }
-    let errorEvent: ErrorEvent | undefined
+    // Load the incident store so root-cause can localize an in-process failure
+    // that never crossed a graph edge (#584). When errorId is supplied the
+    // named incident colours the reason; the full set is the fallback the graph
+    // walk consults when no edge carried an incompatibility.
     const epath = errorsPathFor(proj)
-    if (req.query.errorId && epath) {
-      const events = await readErrorEvents(epath)
-      errorEvent = events.find((e) => e.id === req.query.errorId)
+    const incidents = epath ? await readErrorEvents(epath) : []
+    let errorEvent: ErrorEvent | undefined
+    if (req.query.errorId) {
+      errorEvent = incidents.find((e) => e.id === req.query.errorId)
       if (!errorEvent) {
         return reply
           .code(404)
           .send({ error: 'error event not found', id: req.query.errorId })
       }
     }
-    const result = getRootCause(proj.graph, nodeId, errorEvent)
+    const result = getRootCause(proj.graph, nodeId, errorEvent, incidents)
     if (!result) return reply.code(404).send({ error: 'no root cause found', id: nodeId })
     return result
   })

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -189,6 +189,34 @@ function httpResponseStatus(span: ParsedSpan): number | undefined {
   return undefined
 }
 
+// HTTP method/route off a span, across the OTel semconv rename (modern
+// `http.request.method` / legacy `http.method`; `http.route` is the matched
+// template, with `http.target` / `url.path` as the concrete-path fallback).
+function httpMethod(span: ParsedSpan): string | undefined {
+  return pickAttr(span, 'http.request.method', 'http.method')
+}
+
+function httpRoute(span: ParsedSpan): string | undefined {
+  return pickAttr(span, 'http.route', 'http.target', 'url.path')
+}
+
+// A human incident line built from the HTTP context a server span carries even
+// when no exception event was recorded — an Express error handler that answers
+// 500 cleanly leaves `span.exception` empty but still carries the route and
+// status. "500 on GET /users/:id" reads better than the literal 'unknown
+// error'. Returns undefined when the span has no usable HTTP context, so a
+// non-HTTP failure still falls back to 'unknown error'.
+function httpFailureMessage(span: ParsedSpan): string | undefined {
+  const status = httpResponseStatus(span)
+  const route = httpRoute(span)
+  const method = httpMethod(span)
+  const where = route ? `${method ? `${method} ` : ''}${route}` : undefined
+  if (status !== undefined && where) return `${status} on ${where}`
+  if (status !== undefined) return `HTTP ${status}`
+  if (where) return `error on ${where}`
+  return undefined
+}
+
 // In-flight 4xx burst against one (source, peer) pair. Lives on IngestContext so
 // it survives across spans without leaking into module state shared by every
 // project. firstTs/lastTs are the span timestamps (ADR-033 — span time, not
@@ -865,20 +893,36 @@ async function appendErrorEvent(ctx: IngestContext, ev: ErrorEvent): Promise<voi
   await fs.appendFile(ctx.errorsPath, JSON.stringify(ev) + '\n', 'utf8')
 }
 
+// Resolve the incident's affectedNode. When the span carries a `code.filepath`
+// call site, the incident attributes to the FileNode the failure surfaced in —
+// the same file grain OBSERVED CALLS edges land on (file-awareness.md §4) —
+// resolving a compiled `dist/...js` frame through its disk-adjacent source map
+// when one is present. Without a call site it stays at the originating service,
+// the honest fallback (§2). No graph access is needed: the file id is built
+// from the span's own `code.*` and `service` attributes, so the receiver can
+// attribute at file grain before the graph has caught up. The file node may not
+// yet be materialised, but querying the service still surfaces the incident, and
+// the recorded file:line is real evidence either way (§6 — never fabricated).
+function incidentAffectedNode(span: ParsedSpan): string {
+  const callSite = callSiteFromSpan(span)
+  if (callSite) return fileId(span.service, callSite.relPath)
+  return serviceId(span.service, span.env)
+}
+
 // Build the minimal ErrorEvent the receiver writes synchronously before
-// replying (ADR-033 §Error events, amended). affectedNode resolves to the
-// originating service because graph state isn't available at this point —
-// the queued handleSpan path may reach a more precise target later, but the
-// durable record is what the receiver writes here.
+// replying (ADR-033 §Error events, amended). affectedNode attributes to the
+// FileNode when the span carries a `code.filepath` call site, else to the
+// originating service (incidentAffectedNode above).
 //
 // errorMessage reads from the exception event's `exception.message` (OTel
 // semconv) so the incident surface shows the actual thrown error string.
-// When the span carries no exception event the field falls back to the
-// literal 'unknown error' rather than `span.name` — OTel HTTP server
-// instrumentation routinely populates `span.name` with the HTTP method,
-// which produces incidents that read 'GET' or 'POST' instead of the
-// underlying failure. `span.status.message` is intentionally out of the
-// chain for the same reason.
+// When the span carries no exception event the field falls back to the HTTP
+// context the span still holds — "500 on GET /users/:id" (httpFailureMessage)
+// — and only then to the literal 'unknown error'. `span.name` is never in the
+// chain: OTel HTTP server instrumentation routinely populates it with the HTTP
+// method, which produces incidents that read 'GET' or 'POST' instead of the
+// underlying failure. `span.status.message` is intentionally out for the same
+// reason.
 // Span attributes pass through verbatim so consumers can read source
 // attribution (`code.filepath`, `code.lineno`, `code.function`) and other
 // SDK-emitted context without ingest enumerating every key it cares about.
@@ -907,13 +951,13 @@ export function buildErrorEventForReceiver(span: ParsedSpan): ErrorEvent | null 
     service: span.service,
     traceId: span.traceId,
     spanId: span.spanId,
-    errorMessage: span.exception?.message ?? 'unknown error',
+    errorMessage: span.exception?.message ?? httpFailureMessage(span) ?? 'unknown error',
     ...(span.exception?.type ? { exceptionType: span.exception.type } : {}),
     ...(span.exception?.stacktrace
       ? { exceptionStacktrace: span.exception.stacktrace }
       : {}),
     ...(Object.keys(attrs).length > 0 ? { attributes: attrs } : {}),
-    affectedNode: serviceId(span.service, span.env),
+    affectedNode: incidentAffectedNode(span),
   }
 }
 
@@ -1208,7 +1252,7 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
         service: span.service,
         traceId: span.traceId,
         spanId: span.spanId,
-        errorMessage: span.exception?.message ?? 'unknown error',
+        errorMessage: span.exception?.message ?? httpFailureMessage(span) ?? 'unknown error',
         ...(span.exception?.type ? { exceptionType: span.exception.type } : {}),
         ...(span.exception?.stacktrace
           ? { exceptionStacktrace: span.exception.stacktrace }

--- a/packages/core/src/traverse.ts
+++ b/packages/core/src/traverse.ts
@@ -15,6 +15,7 @@ import {
   EdgeType,
   NodeType,
   PROV_RANK,
+  Provenance,
   RootCauseResultSchema,
   TransitiveDependenciesResultSchema,
 } from '@neat.is/types'
@@ -379,30 +380,108 @@ export function getRootCause(
   graph: NeatGraph,
   errorNodeId: string,
   errorEvent?: ErrorEvent,
+  incidents?: ErrorEvent[],
 ): RootCauseResult | null {
   if (!graph.hasNode(errorNodeId)) return null
   const origin = graph.getNodeAttributes(errorNodeId) as GraphNode
   const shape = rootCauseShapes[origin.type]
-  if (!shape) return null
 
-  const walk = longestIncomingWalk(graph, errorNodeId, ROOT_CAUSE_MAX_DEPTH)
-  const match = shape(graph, origin, walk)
-  if (!match) return null
+  if (shape) {
+    const walk = longestIncomingWalk(graph, errorNodeId, ROOT_CAUSE_MAX_DEPTH)
+    const match = shape(graph, origin, walk)
+    if (match) {
+      const reason = errorEvent
+        ? `${match.rootCauseReason} (observed error: ${errorEvent.errorMessage})`
+        : match.rootCauseReason
 
-  const reason = errorEvent
-    ? `${match.rootCauseReason} (observed error: ${errorEvent.errorMessage})`
-    : match.rootCauseReason
+      // Schema-validate before return (ADR-036, #139). A drift in the result
+      // shape becomes a runtime throw at the call site rather than a silently
+      // malformed payload reaching MCP / REST consumers.
+      return RootCauseResultSchema.parse({
+        rootCauseNode: match.rootCauseNode,
+        rootCauseReason: reason,
+        traversalPath: walk.path,
+        edgeProvenances: walk.edges.map((e) => e.provenance),
+        confidence: confidenceFromMix(walk.edges),
+        fixRecommendation: match.fixRecommendation,
+      })
+    }
+  }
 
-  // Schema-validate before return (ADR-036, #139). A drift in the result
-  // shape becomes a runtime throw at the call site rather than a silently
-  // malformed payload reaching MCP / REST consumers.
+  // No graph edge carried an incompatibility — but a service can fail in
+  // process (a 500 thrown inside its own handler) without that failure ever
+  // crossing an edge, so the walk above sees a healthy-looking node. The
+  // recorded incident store is the OBSERVED evidence the graph can't carry:
+  // it localizes the failure to the file:line / route the failing span
+  // captured. Consulting it here keeps root-cause useful for the in-process
+  // case instead of reporting "healthy" over a pile of recorded 500s (#584).
+  return rootCauseFromIncidents(errorNodeId, incidents, errorEvent)
+}
+
+// OBSERVED-grade confidence for an incident-localized cause. The incident is a
+// real captured runtime fact (where the failure surfaced), but it names the
+// surface, not a proven upstream incompatibility — so it sits below an
+// edge-walked compat result yet well above an EXTRACTED guess.
+const INCIDENT_ROOT_CAUSE_CONFIDENCE = 0.6
+
+// Match an incident to the queried node the same way the REST incident-history
+// read does (api.ts): an exact affectedNode hit, or a service match when the
+// node is the service the incident was recorded against. A file-grained
+// affectedNode (file:<svc>:<path>) still matches the owning service this way.
+function incidentMatchesNode(ev: ErrorEvent, nodeId: string): boolean {
+  return ev.affectedNode === nodeId || ev.service === nodeId.replace(/^service:/, '')
+}
+
+// Build a root-cause result from the recorded incident store when the graph
+// walk found nothing. Picks the most recent incident affecting the node and
+// localizes the failure to the file:line / route it captured. Returns null when
+// no incident touches the node — the honest "nothing to say" answer.
+function rootCauseFromIncidents(
+  nodeId: string,
+  incidents: ErrorEvent[] | undefined,
+  errorEvent: ErrorEvent | undefined,
+): RootCauseResult | null {
+  const pool = incidents && incidents.length > 0 ? incidents : errorEvent ? [errorEvent] : []
+  const relevant = pool.filter((ev) => incidentMatchesNode(ev, nodeId))
+  if (relevant.length === 0) return null
+
+  // Most recent incident is the representative; ISO timestamps sort lexically.
+  const latest = [...relevant].sort((a, b) => b.timestamp.localeCompare(a.timestamp))[0]!
+  const attrs = latest.attributes ?? {}
+  const filepath = typeof attrs['code.filepath'] === 'string' ? attrs['code.filepath'] : undefined
+  const lineno = typeof attrs['code.lineno'] === 'number' ? attrs['code.lineno'] : undefined
+  const route = typeof attrs['http.route'] === 'string' ? attrs['http.route'] : undefined
+  const location = filepath ? `${filepath}${lineno !== undefined ? `:${lineno}` : ''}` : undefined
+
+  const count = relevant.length
+  const tail = count > 1 ? ` (${count} recorded incidents)` : ' (1 recorded incident)'
+  const reasonParts = [`${latest.service}: ${latest.errorMessage}`]
+  if (location) reasonParts.push(`surfaced at ${location}`)
+  const rootCauseReason = `${reasonParts.join(' — ')}${tail}`
+
+  // When the incident localized to a file (affectedNode is a file id), name
+  // that file as the root cause and walk the queried node → file as a single
+  // OBSERVED hop. The "edge" is the captured runtime attribution; OBSERVED is
+  // honest because the file came from a real `code.*` on the failing span.
+  // Otherwise the cause sits on the queried node itself (service grain).
+  const localizesToFile = latest.affectedNode !== nodeId && latest.affectedNode.startsWith('file:')
+  const rootCauseNode = localizesToFile ? latest.affectedNode : nodeId
+  const traversalPath = localizesToFile ? [nodeId, latest.affectedNode] : [nodeId]
+  const edgeProvenances = localizesToFile ? [Provenance.OBSERVED] : []
+
+  const fixRecommendation = location
+    ? `Inspect ${location}${route ? ` handling ${route}` : ''}`
+    : route
+      ? `Inspect ${latest.service}'s handler for ${route}`
+      : undefined
+
   return RootCauseResultSchema.parse({
-    rootCauseNode: match.rootCauseNode,
-    rootCauseReason: reason,
-    traversalPath: walk.path,
-    edgeProvenances: walk.edges.map((e) => e.provenance),
-    confidence: confidenceFromMix(walk.edges),
-    fixRecommendation: match.fixRecommendation,
+    rootCauseNode,
+    rootCauseReason,
+    traversalPath,
+    edgeProvenances,
+    confidence: INCIDENT_ROOT_CAUSE_CONFIDENCE,
+    ...(fixRecommendation ? { fixRecommendation } : {}),
   })
 }
 

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -12,6 +12,7 @@ import {
   Provenance,
 } from '@neat.is/types'
 import {
+  buildErrorEventForReceiver,
   handleSpan,
   markStaleEdges,
   promoteFrontierNodes,
@@ -408,6 +409,64 @@ describe('handleSpan', () => {
   it('does not log an ErrorEvent for a successful span', async () => {
     await handleSpan(ctx, clientHttpSpan())
     expect(await readErrorEvents(ctx.errorsPath)).toEqual([])
+  })
+})
+
+// The durable incident the daemon receiver writes (buildErrorEventForReceiver).
+// An Express error handler that answers 500 cleanly leaves the span with no
+// exception event but with the HTTP context and a `code.filepath` call site —
+// the record must read those, not collapse to 'unknown error' on the bare
+// service (#584).
+describe('buildErrorEventForReceiver — file-grain + HTTP-context fallback (#584)', () => {
+  function serverErrorSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
+    return {
+      service: 'harvest-api',
+      traceId: 'trace-7',
+      spanId: 'span-7',
+      name: 'GET /users/:id',
+      kind: 2, // SERVER
+      startTimeUnixNano: '0',
+      endTimeUnixNano: '0',
+      durationNanos: 0n,
+      env: 'unknown',
+      startTimeIso: '2026-06-30T12:00:00.000Z',
+      attributes: {
+        'http.request.method': 'GET',
+        'http.route': '/users/:id',
+        'http.response.status_code': 500,
+        'code.filepath': 'src/index.js',
+        'code.lineno': 22,
+      },
+      statusCode: 2,
+      ...overrides,
+    }
+  }
+
+  it('attributes to the file node and builds a message from the route + status', () => {
+    const ev = buildErrorEventForReceiver(serverErrorSpan())
+    expect(ev).not.toBeNull()
+    expect(ev!.errorMessage).toBe('500 on GET /users/:id')
+    expect(ev!.affectedNode).toBe('file:harvest-api:src/index.js')
+    expect(ev!.attributes!['code.filepath']).toBe('src/index.js')
+    expect(ev!.attributes!['code.lineno']).toBe(22)
+    expect(ev!.attributes!['http.route']).toBe('/users/:id')
+  })
+
+  it('prefers a real exception message when the span carries one', () => {
+    const ev = buildErrorEventForReceiver(
+      serverErrorSpan({ exception: { message: 'TypeError: cannot read id of undefined' } }),
+    )
+    expect(ev!.errorMessage).toBe('TypeError: cannot read id of undefined')
+    // File grain still applies.
+    expect(ev!.affectedNode).toBe('file:harvest-api:src/index.js')
+  })
+
+  it('falls back to the originating service and `unknown error` with no HTTP/code context', () => {
+    const ev = buildErrorEventForReceiver(
+      serverErrorSpan({ attributes: { 'db.system': 'postgresql' } }),
+    )
+    expect(ev!.errorMessage).toBe('unknown error')
+    expect(ev!.affectedNode).toBe('service:harvest-api')
   })
 })
 

--- a/packages/core/test/traverse.test.ts
+++ b/packages/core/test/traverse.test.ts
@@ -275,6 +275,93 @@ describe('getRootCause', () => {
   })
 })
 
+// Incident-localized root cause (#584): a service can fail in process — a 500
+// thrown inside its own handler — without the failure ever crossing a graph
+// edge, so the edge walk reports nothing. getRootCause then consults the
+// recorded incident store, which localizes the failure to the file:line / route
+// the failing span captured.
+describe('getRootCause — incident-localized fallback (#584)', () => {
+  function harvestGraph(): NeatGraph {
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:harvest-api', {
+      id: 'service:harvest-api',
+      type: NodeType.ServiceNode,
+      name: 'harvest-api',
+      language: 'javascript',
+    })
+    return g
+  }
+
+  function incident(overrides: Partial<ErrorEvent> = {}): ErrorEvent {
+    return {
+      id: 'trace-x:span-x',
+      timestamp: '2026-06-30T12:00:00.000Z',
+      service: 'harvest-api',
+      traceId: 'trace-x',
+      spanId: 'span-x',
+      errorMessage: '500 on GET /users/:id',
+      affectedNode: 'file:harvest-api:src/index.js',
+      attributes: {
+        'code.filepath': 'src/index.js',
+        'code.lineno': 22,
+        'http.route': '/users/:id',
+      },
+      httpStatusCode: 500,
+      ...overrides,
+    }
+  }
+
+  it('localizes a service with recorded incidents instead of reporting healthy', () => {
+    const g = harvestGraph()
+    const incidents = [incident(), incident({ id: 'trace-y:span-y', timestamp: '2026-06-30T11:00:00.000Z' })]
+
+    const result = getRootCause(g, 'service:harvest-api', undefined, incidents)
+    expect(result).not.toBeNull()
+    // Names the file the failure surfaced in, walked from the queried service
+    // as a single OBSERVED hop.
+    expect(result!.rootCauseNode).toBe('file:harvest-api:src/index.js')
+    expect(result!.traversalPath).toEqual([
+      'service:harvest-api',
+      'file:harvest-api:src/index.js',
+    ])
+    expect(result!.edgeProvenances).toEqual([Provenance.OBSERVED])
+    expect(result!.rootCauseReason).toContain('500 on GET /users/:id')
+    expect(result!.rootCauseReason).toContain('src/index.js:22')
+    expect(result!.rootCauseReason).toContain('2 recorded incidents')
+    expect(result!.fixRecommendation).toContain('src/index.js:22')
+    expect(result!.fixRecommendation).toContain('/users/:id')
+  })
+
+  it('matches incidents to the service by service name when affectedNode is file-grained', () => {
+    const g = harvestGraph()
+    // Querying the service must still surface a file-grained incident — the
+    // service-name match mirrors the REST incident-history read.
+    const result = getRootCause(g, 'service:harvest-api', undefined, [incident()])
+    expect(result).not.toBeNull()
+    expect(result!.confidence).toBeGreaterThan(0)
+    expect(result!.confidence).toBeLessThan(1)
+  })
+
+  it('falls back to service grain when the incident carries no call site', () => {
+    const g = harvestGraph()
+    const result = getRootCause(g, 'service:harvest-api', undefined, [
+      incident({ affectedNode: 'service:harvest-api', attributes: undefined }),
+    ])
+    expect(result).not.toBeNull()
+    expect(result!.rootCauseNode).toBe('service:harvest-api')
+    expect(result!.traversalPath).toEqual(['service:harvest-api'])
+    expect(result!.edgeProvenances).toEqual([])
+  })
+
+  it('returns null when no incident touches the queried node', () => {
+    const g = harvestGraph()
+    const result = getRootCause(g, 'service:harvest-api', undefined, [
+      incident({ service: 'other-svc', affectedNode: 'service:other-svc' }),
+    ])
+    expect(result).toBeNull()
+  })
+})
+
 // File-first graph (file-awareness.md §1–2, #392): relationships originate from
 // files, the service owns them through CONTAINS. service-a's index.js calls
 // service-b, service-b's db.js connects to the db, and service-b declares the


### PR DESCRIPTION
NEAT was recording 500 incidents for a service but couldn't do anything useful with them. Three coupled gaps on the in-process exception path — an Express error handler that answers 500 cleanly, so the failing span carries no exception event:

- **Root-cause ignored the incident store.** `root-cause service:harvest-api` reported "no root cause found / the node may be healthy" while NEAT held recorded 500s for that exact service, because `getRootCause` only walked graph edges and an in-process throw never crosses one. It now falls back to the incident store and localizes the failure to the `file:line` / route the failing span captured, walked from the queried service as a single OBSERVED hop.

- **Incidents were service-coarse.** The durable incident attributed to `service:<name>` even when the span carried `code.filepath` / `code.lineno` / `http.route`. It now lands on the FileNode — the same grain OBSERVED CALLS edges already use — resolving a `dist` frame through its source map when one is on disk, and falling back to the service honestly when there's no call site.

- **Every incident read "unknown error".** The message now falls back to the HTTP context the span still holds — "500 on GET /users/:id" — before the literal "unknown error".

Mutation authority is unchanged: `ingest.ts` still owns every incident write per the lifecycle contract. The root-cause fallback is a read-only consult — the REST handler does the file I/O and passes the events into the pure traversal, which never touches the graph.

Tests: a receiver incident with `code.filepath` + route attributes to file grain with a useful message (and still degrades to service + "unknown error" with no context); root-cause over a service with recorded incidents and no failing edge returns the incident-localized cause instead of null. Full `@neat.is/core` suite green (1129 passed), lint clean.

Refs #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)