### PR TITLE
Decode real OTel spans by typing span flags as fixed32

### DIFF
--- a/packages/core/proto/opentelemetry/proto/trace/v1/trace.proto
+++ b/packages/core/proto/opentelemetry/proto/trace/v1/trace.proto
@@ -70,13 +70,19 @@ message Span {
     string trace_state = 3;
     repeated opentelemetry.proto.common.v1.KeyValue attributes = 4;
     uint32 dropped_attributes_count = 5;
-    uint32 flags = 6;
+    // fixed32 (wire type 5), per the upstream OTel proto. A uint32 here makes
+    // protobufjs read the on-wire fixed32 as a varint and misalign the buffer.
+    fixed32 flags = 6;
   }
 
   repeated Link links = 13;
   uint32 dropped_links_count = 14;
   Status status = 15;
-  uint32 flags = 16;
+  // fixed32 (wire type 5), per the upstream OTel proto. The W3C trace flags
+  // live in the low 8 bits; real SDK exporters set the sampled bit, so this
+  // field arrives on the wire as a 4-byte fixed32. Typing it uint32 made
+  // protobufjs decode it as a varint and overrun the rest of the message.
+  fixed32 flags = 16;
 }
 
 message Status {

--- a/packages/core/test/otel-protobuf-flags.test.ts
+++ b/packages/core/test/otel-protobuf-flags.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import path from 'node:path'
+import os from 'node:os'
+import { promises as fs } from 'node:fs'
+import protobuf from 'protobufjs'
+import { MultiDirectedGraph } from 'graphology'
+import {
+  EdgeType,
+  type GraphEdge,
+  type GraphNode,
+  NodeType,
+  Provenance,
+} from '@neat.is/types'
+import { buildOtelReceiver, type ParsedSpan } from '../src/otel.js'
+import { handleSpan, type IngestContext } from '../src/ingest.js'
+import type { NeatGraph } from '../src/graph.js'
+
+// Real OTel SDK exporters set the W3C sampled bit, so every sampled span
+// carries `flags` on the wire as a fixed32 (wire type 5, 4 bytes) and the
+// timestamps as fixed64. The bundled proto used to type `flags` as uint32,
+// which made protobufjs read the 4-byte fixed32 as a varint and overrun the
+// rest of the buffer — every sampled span 400'd with "index out of range" and
+// the OBSERVED layer stayed dark for the default Python/JS http/protobuf
+// exporters. The hand-built JS-SDK fixture missed it because those spans left
+// `flags` at the proto3 default (0, omitted). This encodes the exact wire shape
+// — fixed32 flags + fixed64 timestamps — and asserts it decodes to a span and
+// mints an OBSERVED edge.
+
+// Canonical OTel field types: flags is fixed32, the timestamps fixed64. This
+// matches what the real SDK serializes, so the bytes below are the same shape
+// the production exporter puts on the wire (the receiver's own bundled proto is
+// what does the decoding under test).
+const CANONICAL_PROTO = `
+syntax = "proto3";
+package neat.test.otlp;
+message AnyValue { string string_value = 1; }
+message KeyValue { string key = 1; AnyValue value = 2; }
+message Resource { repeated KeyValue attributes = 1; }
+message Span {
+  bytes trace_id = 1;
+  bytes span_id = 2;
+  string trace_state = 3;
+  bytes parent_span_id = 4;
+  string name = 5;
+  int32 kind = 6;
+  fixed64 start_time_unix_nano = 7;
+  fixed64 end_time_unix_nano = 8;
+  repeated KeyValue attributes = 9;
+  Status status = 15;
+  fixed32 flags = 16;
+}
+message Status { string message = 2; int32 code = 3; }
+message ScopeSpans { repeated Span spans = 2; }
+message ResourceSpans { Resource resource = 1; repeated ScopeSpans scope_spans = 2; }
+message ExportTraceServiceRequest { repeated ResourceSpans resource_spans = 1; }
+`
+
+function encodeSampledSpanRequest(): Buffer {
+  const root = protobuf.parse(CANONICAL_PROTO, { keepCase: true }).root
+  const Req = root.lookupType('neat.test.otlp.ExportTraceServiceRequest')
+  // Strings, not native bigint — protobufjs's fixed64 writer parses Long
+  // values from strings but coerces an unrecognised bigint to 0.
+  const startNanos = '1717761600123000000'
+  const endNanos = '1717761600148000000'
+  const msg = Req.create({
+    resource_spans: [
+      {
+        resource: {
+          attributes: [
+            { key: 'service.name', value: { string_value: 'svc-flags-fixed32' } },
+          ],
+        },
+        scope_spans: [
+          {
+            spans: [
+              {
+                trace_id: Buffer.alloc(16, 0xab),
+                span_id: Buffer.alloc(8, 0xcd),
+                name: 'GET /downstream',
+                kind: 3, // CLIENT
+                start_time_unix_nano: startNanos,
+                end_time_unix_nano: endNanos,
+                // The W3C sampled bit. Non-zero is what forces flags onto the
+                // wire as a fixed32 — the exact byte that used to 400.
+                flags: 1,
+                attributes: [
+                  { key: 'server.address', value: { string_value: 'svc-flags-peer' } },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })
+  return Buffer.from(Req.encode(msg).finish())
+}
+
+function newGraph(): NeatGraph {
+  const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+  g.addNode('service:svc-flags-fixed32', {
+    id: 'service:svc-flags-fixed32',
+    type: NodeType.ServiceNode,
+    name: 'svc-flags-fixed32',
+    language: 'javascript',
+  })
+  g.addNode('service:svc-flags-peer', {
+    id: 'service:svc-flags-peer',
+    type: NodeType.ServiceNode,
+    name: 'svc-flags-peer',
+    language: 'javascript',
+  })
+  return g
+}
+
+describe('http/protobuf — sampled span with fixed32 flags decodes and mints an edge', () => {
+  let tmpDir: string
+  let ctx: IngestContext
+  let collected: ParsedSpan[]
+  let receiver: Awaited<ReturnType<typeof buildOtelReceiver>>
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-flags-fixed32-'))
+    ctx = { graph: newGraph(), errorsPath: path.join(tmpDir, 'errors.ndjson') }
+    collected = []
+    receiver = await buildOtelReceiver({
+      onSpan: async (span) => {
+        collected.push(span)
+        await handleSpan(ctx, span)
+      },
+    })
+  })
+
+  afterEach(async () => {
+    await receiver.close()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns 200, decodes the span, and mints the OBSERVED CALLS edge', async () => {
+    const payload = encodeSampledSpanRequest()
+    const res = await receiver.inject({
+      method: 'POST',
+      url: '/v1/traces',
+      headers: { 'content-type': 'application/x-protobuf' },
+      payload,
+    })
+    expect(res.statusCode).toBe(200)
+
+    await receiver.flushPending()
+
+    expect(collected).toHaveLength(1)
+    const parsed = collected[0]
+    expect(parsed.service).toBe('svc-flags-fixed32')
+    expect(parsed.traceId).toBe('ab'.repeat(16))
+    expect(parsed.spanId).toBe('cd'.repeat(8))
+    expect(parsed.kind).toBe(3)
+    // fixed64 timestamps survived the decode intact.
+    expect(parsed.startTimeUnixNano).toBe('1717761600123000000')
+    expect(parsed.durationNanos).toBe(25_000_000n)
+    expect(parsed.attributes['server.address']).toBe('svc-flags-peer')
+
+    const edgeId = `${EdgeType.CALLS}:OBSERVED:service:svc-flags-fixed32->service:svc-flags-peer`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+  })
+})


### PR DESCRIPTION
The bundled OTel `trace.proto` typed `Span.flags` (field 16) and `Link.flags` (field 6) as `uint32`. The upstream OpenTelemetry proto types both as `fixed32`. Real SDK exporters (the Python http/protobuf default; the JS SDK with the sampled bit set) put `flags` on the wire as a 4-byte fixed32. With the field declared `uint32`, protobufjs read it as a varint, consumed the wrong number of bytes, and overran the message — so any sampled span came back as a 400 `protobuf decode failed: index out of range` and nothing reached the OBSERVED layer.

Spans that left `flags` at the proto3 default of 0 (field omitted) decoded fine, which is why the live JS-SDK e2e fixture passed and masked it.

The fix retypes both `flags` fields to `fixed32`, matching upstream. The added test encodes the exact wire shape a real exporter sends — fixed32 `flags` set to 1 plus fixed64 timestamps — feeds it through the receiver, and asserts it decodes to a span and mints the OBSERVED CALLS edge.

Full `@neat.is/core` suite is green (1123 passed).

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)