### PR TITLE
Fuse OBSERVED and EXTRACTED FileNodes for the same source file

### DIFF
--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -459,6 +459,53 @@ function callSiteFromSpan(
   }
 }
 
+// Reconcile a runtime-derived relPath onto the service-relative path the
+// extractor already minted, so OBSERVED and EXTRACTED FileNodes for the same
+// source file fuse into ONE node instead of two disjoint subgraphs
+// (file-awareness.md §4 — ingest joins the runtime path against the service
+// root to land the edge on a FileNode).
+//
+// relPathForRuntimeFile anchors the absolute `code.filepath` against scanPath /
+// repoPath. When that anchor can't be found — no scanPath wired, or the span
+// was emitted from a service whose absolute root differs from the daemon's
+// checkout (a container image rooted at `/app`, a relocated clone) — the
+// leftover relPath still carries the unanchored leading segments
+// (`app/src/foo.ts`, `Users/me/repo/src/foo.ts`) and forks a parallel FileNode
+// keyed off the absolute path. That splits the graph: the OBSERVED layer never
+// lands on the EXTRACTED `src/foo.ts` node, and divergence/traversal see two
+// half-graphs for one file.
+//
+// The extractor's FileNode paths are ground truth for which service-relative
+// paths exist. Recover the right one by matching the longest EXTRACTED (non-
+// OTel) FileNode path that is a trailing segment-suffix of the runtime relPath.
+// A match means the runtime path is the same file the extractor parsed, just
+// carrying extra leading directories the anchor couldn't strip — reuse the
+// extractor's path so both layers key the same node. No match means the file is
+// genuinely OTel-only; the honest runtime path stands (never fabricated, §6).
+function reconcileObservedRelPath(
+  graph: NeatGraph,
+  serviceName: string,
+  relPath: string,
+): string {
+  // Already lands on a known node (the anchor resolved cleanly, or a prior span
+  // created this node) — fused, nothing to recover.
+  if (graph.hasNode(fileId(serviceName, relPath))) return relPath
+  let best: string | null = null
+  graph.forEachNode((_id, attrs) => {
+    const a = attrs as FileNode & { type?: string }
+    if (a.type !== NodeType.FileNode || a.service !== serviceName) return
+    // Only fuse onto a statically-known file. An existing OTel-only node would
+    // already have matched the hasNode short-circuit above.
+    if (a.discoveredVia === 'otel') return
+    const p = a.path
+    if (!p) return
+    if ((relPath === p || relPath.endsWith(`/${p}`)) && (!best || p.length > best.length)) {
+      best = p
+    }
+  })
+  return best ?? relPath
+}
+
 // Ensure the FileNode for an observed call site and the owning service's
 // OBSERVED `CONTAINS` edge both exist, returning the FileNode id so the caller
 // can originate the relationship from it (file-awareness.md §1–2 + §4). The
@@ -472,14 +519,15 @@ function ensureObservedFileNode(
   serviceNodeId: string,
   callSite: CallSite,
 ): string {
-  const fileNodeId = fileId(serviceName, callSite.relPath)
+  const relPath = reconcileObservedRelPath(graph, serviceName, callSite.relPath)
+  const fileNodeId = fileId(serviceName, relPath)
   if (!graph.hasNode(fileNodeId)) {
-    const language = languageForExt(callSite.relPath)
+    const language = languageForExt(relPath)
     const node: FileNode = {
       id: fileNodeId,
       type: NodeType.FileNode,
       service: serviceName,
-      path: callSite.relPath,
+      path: relPath,
       ...(language ? { language } : {}),
       ...(callSite.originalRelPath ? { originalPath: callSite.originalRelPath } : {}),
       discoveredVia: 'otel',

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -6,11 +6,13 @@ import { MultiDirectedGraph } from 'graphology'
 import {
   EdgeType,
   type ErrorEvent,
+  fileId,
   type GraphEdge,
   type GraphNode,
   NodeType,
   Provenance,
 } from '@neat.is/types'
+import { ensureFileNode } from '../src/extract/calls/shared.js'
 import {
   handleSpan,
   markStaleEdges,
@@ -1229,5 +1231,106 @@ describe('handleSpan parent-fallback call site (issue #536)', () => {
       if ((attrs as { type: string }).type === NodeType.FileNode) fileNodeCount++
     })
     expect(fileNodeCount).toBe(0)
+  })
+})
+
+// The thesis: EXTRACTED (static) and OBSERVED (runtime) FileNodes for the SAME
+// source file must fuse into ONE node, so the graph is a single fused model
+// rather than two disjoint subgraphs. A real OTel SpanProcessor stamps an
+// ABSOLUTE `code.filepath` (the Lambda task root, a container image rooted at
+// /app, a relocated clone) — when that prefix can't be anchored against the
+// daemon's scan root, the runtime path used to fork a parallel FileNode keyed
+// off the absolute path, and the OBSERVED layer never landed on the EXTRACTED
+// `src/...` node. handleSpan reconciles the runtime path onto the extractor's
+// service-relative path so both layers key the same node (file-awareness.md §4).
+describe('EXTRACTED and OBSERVED FileNodes fuse for the same source file', () => {
+  let tmpDir: string
+  let ctx: IngestContext
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-fuse-'))
+    ctx = { graph: newGraph(), errorsPath: path.join(tmpDir, 'errors.ndjson') }
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('lands an OBSERVED span with an absolute code.filepath on the EXTRACTED FileNode (one fused node, not two)', async () => {
+    // Static extraction minted the FileNode at the service-relative path.
+    const staticFileId = fileId('service-a', 'src/client.ts')
+    ensureFileNode(ctx.graph, 'service-a', 'service:service-a', 'src/client.ts')
+    expect(ctx.graph.getNodeAttributes(staticFileId)).toMatchObject({
+      discoveredVia: 'static',
+      path: 'src/client.ts',
+    })
+
+    // A runtime span for the SAME file, carrying the absolute path the
+    // SpanProcessor captured. No scanPath is wired (the multi-tenant / ad-hoc
+    // surface), and the prefix `/var/task` is the deployed root, not the
+    // daemon's checkout — so the path can't be anchored the cheap way.
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        attributes: {
+          'server.address': 'service-b',
+          'code.filepath': '/var/task/src/client.ts',
+          'code.lineno': 42,
+        },
+      }),
+    )
+
+    // Exactly ONE FileNode exists, and it is the EXTRACTED one — the OBSERVED
+    // layer fused onto it rather than forking an absolute-path twin.
+    const fileNodeIds: string[] = []
+    ctx.graph.forEachNode((id, attrs) => {
+      if ((attrs as { type: string }).type === NodeType.FileNode) fileNodeIds.push(id)
+    })
+    expect(fileNodeIds).toEqual([staticFileId])
+    // The absolute-derived id the bug used to mint is absent.
+    expect(ctx.graph.hasNode('file:service-a:var/task/src/client.ts')).toBe(false)
+
+    // The fused node carries BOTH layers: the EXTRACTED CONTAINS edge from
+    // static analysis and the OBSERVED CALLS edge from runtime both hang off
+    // the one node id — a single fused model a divergence/traversal query reads.
+    const observedCallsId = `${EdgeType.CALLS}:OBSERVED:${staticFileId}->service:service-b`
+    expect(ctx.graph.hasEdge(observedCallsId)).toBe(true)
+    expect((ctx.graph.getEdgeAttributes(observedCallsId) as GraphEdge).source).toBe(staticFileId)
+
+    const provenancesTouchingFile = new Set<string>()
+    ctx.graph.forEachEdge((_id, attrs) => {
+      const e = attrs as GraphEdge
+      if (e.source === staticFileId || e.target === staticFileId) {
+        provenancesTouchingFile.add(e.provenance)
+      }
+    })
+    expect(provenancesTouchingFile.has(Provenance.EXTRACTED)).toBe(true)
+    expect(provenancesTouchingFile.has(Provenance.OBSERVED)).toBe(true)
+  })
+
+  it('keeps a genuinely OTel-only file honest — no false fusion onto an unrelated extracted file', async () => {
+    ensureFileNode(ctx.graph, 'service-a', 'service:service-a', 'src/client.ts')
+
+    // A file the extractor never parsed. It must NOT collapse onto src/client.ts.
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        attributes: {
+          'server.address': 'service-b',
+          'code.filepath': '/var/task/src/uninstrumented.ts',
+          'code.lineno': 7,
+        },
+      }),
+    )
+
+    const fileNodeIds: string[] = []
+    ctx.graph.forEachNode((id, attrs) => {
+      if ((attrs as { type: string }).type === NodeType.FileNode) fileNodeIds.push(id)
+    })
+    expect(fileNodeIds).toContain(fileId('service-a', 'src/client.ts'))
+    expect(fileNodeIds.length).toBe(2)
+    // The honest runtime path stands; evidence is never fabricated onto the
+    // wrong static node.
+    expect(fileNodeIds.some((id) => id.endsWith('src/uninstrumented.ts'))).toBe(true)
   })
 })


### PR DESCRIPTION
A real OTel SpanProcessor stamps an **absolute** `code.filepath` on a span — the Lambda task root, a container image rooted at `/app`, a relocated clone. Ingest anchors that against the daemon's scan root (`scanPath` / the service `repoPath` segment) to recover the service-relative path the extractor keys its FileNodes on. When that anchor can't be found — no `scanPath` wired (the multi-tenant / ad-hoc surface), or the deployed root differs from the daemon's checkout — the leftover path kept its unanchored leading segments and forked a parallel FileNode keyed off the absolute path.

So the EXTRACTED `file:<svc>:src/foo.ts` and the OBSERVED `file:<svc>:var/task/src/foo.ts` were two disjoint nodes for one file. The runtime layer never landed on the static node, and the graph was two half-graphs instead of the one fused model the whole thing rests on — divergence and traversal over that file saw only one layer at a time.

The fix reconciles the runtime path onto the path the extractor already minted. When the runtime path doesn't already land on a known node, ingest matches the longest EXTRACTED (non-OTel) FileNode path that is a trailing segment-suffix of the runtime path and reuses it, so OBSERVED keys the same node id. A file the extractor never parsed has no match and keeps its honest runtime path — nothing fabricated (file-awareness.md §4 + §6). Ids still go through the `fileId` helper; this only feeds it the right normalized path.

The capstone test seeds an EXTRACTED FileNode, drives an OBSERVED span carrying that file's absolute `code.filepath` with no `scanPath`, and asserts one fused node (not two) carrying both EXTRACTED and OBSERVED edges — plus a sibling test that a genuinely OTel-only file does not false-fuse onto an unrelated static file. Full `@neat.is/core` suite (1124 tests incl. contract audits) is green.

Found during the breaker campaign (run #5-10 harvest).

Refs #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)