### PR TITLE
Stop the ingest path from polluting a project's graph

### DIFF
--- a/docs/contracts/otel-ingest.md
+++ b/docs/contracts/otel-ingest.md
@@ -125,6 +125,18 @@ Record shape:
 
 A rate-limited stderr warning rides alongside, keyed by `service_name` on the same 60s interval as the broken-project warning so OTel-exporter retries don't flood the console.
 
+## Single-project service-ownership scoping (amended — refs #339)
+
+Single-project mode (ADR-096) binds the bare `/v1/traces` route to the one project the daemon hosts. The OTLP port it binds is shared, though: the OS-default endpoint is `localhost:4318`, so a sibling service belonging to a *different* project that exports with default settings reaches this daemon too. Delivering those spans straight to the slot mints the sibling's `ServiceNode` and incidents into this project's graph — cross-project contamination.
+
+The routing layer scopes delivery to the project's owned services. A span is owned when:
+
+- it carries no `service.name` — an SDK misconfig in this project's own app; `handleSpan` routes it to `service:unidentified` (refs #374), or
+- its `service.name` matches the project name the way the multi-project router matches (exact / token-prefix / token-contained, so `brief` owns `brief-api` and `brief-worker`), or
+- a `ServiceNode` with that name already lives in the project's graph — statically extracted, or observed-and-adopted on an earlier owned span.
+
+A span owned by none of those is foreign. It quarantines to the unrouted ledger (same record shape and rate-limited warning as above) instead of merging. The trade is deliberate and bounds the blast radius the other direction from §unrouted-spans: a brand-new service of *this* project that NEAT can't read statically and whose name doesn't echo the project name has its first spans quarantined until an extraction round registers it. That gap is small and self-healing; a whole sibling project bleeding into the graph is neither. ADR-096's per-project OTLP-port isolation remains the primary defense — this scoping covers the shared-port fallback.
+
 ## Authority
 
 Owned by `ingest.ts` per ADR-030. Receiver shape lives in `otel.ts` / `otel-grpc.ts`; mutation logic lives in `ingest.ts`. No other module mutates the graph through the OTel ingest path. The unrouted-span logging lives in `daemon.ts` because the routing layer owns the "is there a slot to deliver to?" decision.

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -52,7 +52,7 @@ import {
   buildUnroutedSpanRecord,
   unroutedErrorsPath,
 } from './unrouted.js'
-import type { RegistryEntry } from '@neat.is/types'
+import { NodeType, type RegistryEntry, type ServiceNode } from '@neat.is/types'
 
 // ── Per-project daemon self-description (ADR-096 / project-daemon contract) ──
 //
@@ -374,6 +374,49 @@ function isTokenContained(needle: string, haystack: string): boolean {
   if (!haystack.includes(needle)) return false
   const tokens = haystack.split(/[-_]/)
   return tokens.includes(needle)
+}
+
+// Does this span's `service.name` belong to the single project this daemon
+// hosts? Single-project mode (ADR-096) binds the bare `/v1/traces` route to one
+// project, but the OS-default OTLP endpoint (`localhost:4318`) is shared: a
+// sibling service from a *different* project that exports with default settings
+// lands here too. Merging its spans would mint that service's ServiceNode +
+// incidents into this project's graph — cross-project contamination. We scope
+// delivery to the project's owned services and quarantine the rest.
+//
+// A span is owned when:
+//   - it carries no `service.name` (SDK misconfig in this project's own app;
+//     handleSpan routes it to `service:unidentified`, refs #374), or
+//   - its `service.name` matches the project name the same way the multi-
+//     project router matches (exact / token-prefix / token-contained — covers
+//     the monorepo case where `brief` owns `brief-api`, `brief-worker`), or
+//   - a ServiceNode with that name already exists in the project's graph
+//     (statically extracted, or observed-and-adopted on an earlier span).
+//
+// Everything else is foreign and gets quarantined to the unrouted ledger rather
+// than merged. The trade is deliberate: a brand-new service of this project that
+// NEAT can't statically read and whose name doesn't echo the project name has
+// its first spans quarantined until extraction registers it — a far smaller
+// failure than an entire sibling project bleeding into this graph.
+function serviceNameMatchesProject(serviceName: string, project: string): boolean {
+  if (serviceName === project) return true
+  if (isTokenPrefix(project, serviceName)) return true
+  if (isTokenContained(project, serviceName)) return true
+  return false
+}
+
+function spanBelongsToSingleProject(
+  graph: NeatGraph,
+  project: string,
+  serviceName: string | undefined,
+): boolean {
+  if (!serviceName) return true
+  if (serviceNameMatchesProject(serviceName, project)) return true
+  return graph.someNode(
+    (_id, attrs) =>
+      attrs.type === NodeType.ServiceNode &&
+      (attrs as ServiceNode).name === serviceName,
+  )
 }
 
 async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
@@ -853,6 +896,14 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
         }
         if (!slot || slot.status !== 'active') {
           warnDroppedSpan(singleProject, slot?.errorReason ?? 'unknown')
+          return null
+        }
+        // Scope to this project's owned services — quarantine a sibling
+        // project's spans that reached our shared OTLP port instead of merging
+        // them (cross-project contamination). The unrouted ledger records what
+        // we dropped so it isn't silently dark.
+        if (!spanBelongsToSingleProject(slot.graph, singleProject, serviceName)) {
+          await recordUnroutedSpan(serviceName, traceId)
           return null
         }
         return slot

--- a/packages/core/src/extract/calls/shared.ts
+++ b/packages/core/src/extract/calls/shared.ts
@@ -10,7 +10,12 @@ import {
   fileId,
 } from '@neat.is/types'
 import type { NeatGraph } from '../../graph.js'
-import { IGNORED_DIRS, SERVICE_FILE_EXTENSIONS, isPythonVenvDir } from '../shared.js'
+import {
+  IGNORED_DIRS,
+  SERVICE_FILE_EXTENSIONS,
+  isNeatAuthoredSourceFile,
+  isPythonVenvDir,
+} from '../shared.js'
 
 export interface SourceFile {
   path: string
@@ -42,7 +47,13 @@ export async function walkSourceFiles(dir: string): Promise<string[]> {
         if (IGNORED_DIRS.has(entry.name)) continue
         if (await isPythonVenvDir(full)) continue
         await walk(full)
-      } else if (entry.isFile() && SERVICE_FILE_EXTENSIONS.has(path.extname(entry.name))) {
+      } else if (
+        entry.isFile() &&
+        SERVICE_FILE_EXTENSIONS.has(path.extname(entry.name)) &&
+        // Skip NEAT's own generated `otel-init.*` bootstrap — extracting it
+        // would attribute our instrumentation imports to the user's service.
+        !isNeatAuthoredSourceFile(entry.name)
+      ) {
         out.push(full)
       }
     }

--- a/packages/core/src/extract/shared.ts
+++ b/packages/core/src/extract/shared.ts
@@ -73,9 +73,31 @@ export function isConfigFile(name: string): { match: boolean; fileType: string }
   // not runtime config.
   if (name === '.env' || name.startsWith('.env.')) {
     if (isEnvTemplateFile(name)) return { match: false, fileType: '' }
+    // NEAT writes `.env.neat` itself during `--apply` (ADR-069 §4). Ingesting
+    // it would record our own instrumentation env as if it were the user's
+    // declared config — self-pollution. Skip it the same way the template
+    // filter skips onboarding docs.
+    if (isNeatAuthoredEnvFile(name)) return { match: false, fileType: '' }
     return { match: true, fileType: 'env' }
   }
   return { match: false, fileType: '' }
+}
+
+// NEAT-authored artifacts the installer drops into the user's tree during
+// `--apply` (ADR-069). Extraction skips them: they're our own runtime hooks,
+// not first-party config or source. Ingesting them pollutes the graph with
+// NEAT's instrumentation as though the user had written it.
+//
+//   `.env.neat`         — per-package env carrying `OTEL_SERVICE_NAME`.
+//   `otel-init.{ext}`   — generated SDK bootstrap (js/cjs/mjs/ts), including
+//                         the framework variants (`src/otel-init.*`,
+//                         `server/plugins/otel-init.*`) — basename is stable.
+export function isNeatAuthoredEnvFile(name: string): boolean {
+  return name === '.env.neat'
+}
+
+export function isNeatAuthoredSourceFile(name: string): boolean {
+  return /^otel-init\.(?:js|cjs|mjs|ts|tsx)$/i.test(name)
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -1517,14 +1517,43 @@ export function startStalenessLoop(
 export async function readErrorEvents(errorsPath: string): Promise<ErrorEvent[]> {
   try {
     const raw = await fs.readFile(errorsPath, 'utf8')
-    return raw
+    const events = raw
       .split('\n')
       .filter((line) => line.length > 0)
       .map((line) => JSON.parse(line) as ErrorEvent)
+    return dedupeIncidents(events)
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
     throw err
   }
+}
+
+// Make the incident surface idempotent on `(traceId, spanId)`. The ndjson
+// sidecar is append-only (persistence contract), so a re-delivered span — OTel
+// BatchSpanProcessor retries, or a receiver + handler both writing one POST —
+// leaves duplicate lines on disk. An incident is one event per `(traceId,
+// spanId)`; collapsing on read keeps the count honest without rewriting the
+// append-only file. The deterministic incident `id` already encodes the pair
+// (`${traceId}:${spanId}`); we dedupe on it directly, falling back to the raw
+// pair for any record that predates the id. Records that carry neither (extract
+// parse-failure rows, `source: 'extract'`) pass through untouched — they aren't
+// span incidents. First write wins so the original timestamp is preserved.
+function dedupeIncidents(events: ErrorEvent[]): ErrorEvent[] {
+  const seen = new Set<string>()
+  const out: ErrorEvent[] = []
+  for (const ev of events) {
+    const key =
+      ev.id ??
+      (ev.traceId && ev.spanId ? `${ev.traceId}:${ev.spanId}` : undefined)
+    if (key === undefined) {
+      out.push(ev)
+      continue
+    }
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(ev)
+  }
+  return out
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -196,15 +196,14 @@ describe('REST API (fastify.inject)', () => {
     expect(body.origin).toBe('service:service-a')
     // File-first — databases/dockerfile/configs extractors now all anchor edges
     // on FileNodes. Phase 1 file enumeration (ADR-092, file-awareness.md §1)
-    // now gives every source file a FileNode unconditionally, so service-a
-    // CONTAINS four files at distance 1 (index.js, Dockerfile, .env.neat, and
-    // otel.js — previously invisible because no call pattern fired from it);
-    // infra:container-image is at distance 2 (via Dockerfile FileNode);
-    // service-b at distance 2 (via index.js); service-b's five files
-    // (db-config.yaml, Dockerfile, .env.neat, index.js, and otel.js — the
-    // latter two previously invisible for the same reason) at distance 3;
-    // their ConfigNodes and payments-db at distance 4.
-    expect(body.totalAffected).toBe(15)
+    // gives every source file a FileNode unconditionally, so service-a CONTAINS
+    // three files at distance 1 (index.js, Dockerfile, and otel.js). The
+    // NEAT-authored `.env.neat` is excluded from extraction (self-pollution),
+    // so it never lands as a FileNode/ConfigNode. infra:container-image is at
+    // distance 2 (via Dockerfile FileNode); service-b at distance 2 (via
+    // index.js); service-b's files (db-config.yaml, Dockerfile, index.js,
+    // otel.js) at distance 3; its ConfigNode and payments-db at distance 4.
+    expect(body.totalAffected).toBe(11)
     // path + confidence land per ADR-038 §affectedNodes payload. Property-style
     // assertions so this test doesn't pin every BFS path detail — the contract
     // tests in contracts.test.ts pin the per-node invariants tightly.
@@ -217,15 +216,11 @@ describe('REST API (fastify.inject)', () => {
     }
     const ids = body.affectedNodes.map((n: { nodeId: string }) => n.nodeId).sort()
     expect(ids).toEqual([
-      'config:service-a/.env.neat',
-      'config:service-b/.env.neat',
       'config:service-b/db-config.yaml',
       'database:payments-db',
-      'file:service-a:.env.neat',
       'file:service-a:Dockerfile',
       'file:service-a:index.js',
       'file:service-a:otel.js',
-      'file:service-b:.env.neat',
       'file:service-b:Dockerfile',
       'file:service-b:db-config.yaml',
       'file:service-b:index.js',
@@ -264,15 +259,14 @@ describe('REST API (fastify.inject)', () => {
     })
     expect(res.statusCode).toBe(200)
     const body = res.json()
-    // File-first — at distance 1 service-a reaches all four of its own
-    // FileNodes via CONTAINS (.env.neat, Dockerfile, index.js, and — newly
-    // visible since Phase 1 file enumeration gives every source file a
-    // FileNode unconditionally (ADR-092, file-awareness.md §1) — otel.js).
-    // The container-image and service-b both sit at distance 2, so depth=1
-    // doesn't reach them.
-    expect(body.totalAffected).toBe(4)
+    // File-first — at distance 1 service-a reaches its own FileNodes via
+    // CONTAINS (Dockerfile, index.js, and otel.js — every source file gets a
+    // FileNode unconditionally per Phase 1 file enumeration, ADR-092,
+    // file-awareness.md §1). The NEAT-authored `.env.neat` is excluded from
+    // extraction (self-pollution), so it isn't among them. The container-image
+    // and service-b both sit at distance 2, so depth=1 doesn't reach them.
+    expect(body.totalAffected).toBe(3)
     expect(body.affectedNodes.map((n: { nodeId: string }) => n.nodeId).sort()).toEqual([
-      'file:service-a:.env.neat',
       'file:service-a:Dockerfile',
       'file:service-a:index.js',
       'file:service-a:otel.js',

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -342,6 +342,30 @@ describe('handleSpan', () => {
     } as ErrorEvent)
   })
 
+  it('dedupes a re-delivered span to one incident on (traceId, spanId)', async () => {
+    // OTel BatchSpanProcessor retries deliver the same span more than once, and
+    // a daemon's receiver + handler can each write one POST. The append-only
+    // ndjson keeps both lines; the incident surface must still count one.
+    const span = dbSpan({
+      statusCode: 2,
+      exception: { message: 'connection reset' },
+    })
+    await handleSpan(ctx, span)
+    await handleSpan(ctx, span)
+
+    // Two lines on disk — the sidecar is append-only.
+    const raw = await fs.readFile(ctx.errorsPath, 'utf8')
+    expect(raw.split('\n').filter((l) => l.length > 0)).toHaveLength(2)
+
+    // One incident at the surface.
+    const events = await readErrorEvents(ctx.errorsPath)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      traceId: 'trace-1',
+      spanId: 'span-b',
+    } as ErrorEvent)
+  })
+
   it('preserves span attributes on the ErrorEvent (ADR-068 follow-up)', async () => {
     await handleSpan(
       ctx,

--- a/packages/core/test/project-daemon.test.ts
+++ b/packages/core/test/project-daemon.test.ts
@@ -270,6 +270,60 @@ describe('per-project daemon — §1 spans land in the right graph, none drop (A
     expect(await fileExists(path.join(sandbox.home, 'errors.ndjson'))).toBe(false)
   })
 
+  it('single-project mode quarantines a sibling project\'s span instead of merging it (refs #339)', async () => {
+    const sandbox = await setupSandbox(['own-svc'])
+    pending.push(sandbox.cleanup)
+    const { startDaemon } = await import('../src/daemon.js')
+    const ownPath = sandbox.projectPaths.get('own-svc')!
+
+    const daemon = await startDaemon({
+      project: 'own-svc',
+      projectPath: ownPath,
+      restPort: 0,
+      otlpPort: 0,
+    })
+    pending.push(daemon.stop)
+    await daemon.initialBootstrap
+    const endpoint = `${daemon.otlpAddress}/v1/traces`
+
+    // A foreign service's exporter found this daemon's shared OTLP port (the
+    // OS-default 4318 analogue). Its service.name belongs to no part of this
+    // project — neither the project name nor any extracted ServiceNode.
+    const foreignRes = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: clientSpanBody('foreign-svc', 'foreign-frontier.example.test', '4444444444444444'),
+    })
+    expect(foreignRes.status).toBe(200) // OTLP spec — always 200.
+
+    // This project's own span, posted after, lands normally.
+    const ownRes = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: clientSpanBody('own-svc', 'own-frontier.example.test', '5555555555555555'),
+    })
+    expect(ownRes.status).toBe(200)
+
+    const slot = daemon.slots.get('own-svc')!
+    const ownLanded = await waitFor(
+      () => [...slot.graph.nodes()].some((id) => id.includes('own-frontier.example.test')),
+      10_000,
+    )
+    expect(ownLanded, 'own span minted a node in own graph').toBe(true)
+
+    // The foreign span never merged: neither its peer host nor its service node
+    // appear in this project's graph.
+    expect([...slot.graph.nodes()].some((id) => id.includes('foreign-frontier.example.test'))).toBe(false)
+    expect([...slot.graph.nodes()].some((id) => id.includes('foreign-svc'))).toBe(false)
+
+    // It quarantined to the home-level unrouted ledger rather than going dark.
+    const quarantined = await waitFor(
+      () => fileExists(path.join(sandbox.home, 'errors.ndjson')),
+      10_000,
+    )
+    expect(quarantined, 'foreign span recorded to the unrouted ledger').toBe(true)
+  })
+
   it('ports are stable across a daemon restart — the persisted triple is reused', async () => {
     const sandbox = await setupSandbox(['restart-svc'])
     pending.push(sandbox.cleanup)

--- a/packages/core/test/self-pollution.test.ts
+++ b/packages/core/test/self-pollution.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import path from 'node:path'
+import os from 'node:os'
+import { promises as fs } from 'node:fs'
+
+// NEAT's `--apply` writes `.env.neat` and `otel-init.{ext}` into the user's
+// tree (ADR-069). Extraction must skip both — ingesting them records NEAT's own
+// instrumentation as if the user had declared it (self-pollution). This mirrors
+// the existing `.env.template` exclusion in the static-extraction contract.
+
+describe('self-pollution: NEAT-authored files are excluded from extraction', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-self-pollution-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('walkConfigFiles skips .env.neat but keeps a real .env', async () => {
+    await fs.writeFile(path.join(dir, '.env'), 'DATABASE_URL=postgres://x\n')
+    await fs.writeFile(path.join(dir, '.env.neat'), 'OTEL_SERVICE_NAME=app\n')
+
+    const { walkConfigFiles } = await import('../src/extract/configs.js')
+    const files = (await walkConfigFiles(dir)).map((p) => path.basename(p))
+
+    expect(files).toContain('.env')
+    expect(files).not.toContain('.env.neat')
+  })
+
+  it('walkSourceFiles skips the generated otel-init but keeps real source', async () => {
+    await fs.writeFile(path.join(dir, 'index.js'), 'console.log("app")\n')
+    await fs.writeFile(path.join(dir, 'otel-init.cjs'), 'require("@neat.is/otel")\n')
+    await fs.writeFile(path.join(dir, 'otel-init.ts'), 'import "@neat.is/otel"\n')
+
+    const { walkSourceFiles } = await import('../src/extract/calls/shared.js')
+    const files = (await walkSourceFiles(dir)).map((p) => path.basename(p))
+
+    expect(files).toContain('index.js')
+    expect(files).not.toContain('otel-init.cjs')
+    expect(files).not.toContain('otel-init.ts')
+  })
+
+  it('predicates classify NEAT-authored artifacts directly', async () => {
+    const { isNeatAuthoredEnvFile, isNeatAuthoredSourceFile, isConfigFile } =
+      await import('../src/extract/shared.js')
+
+    expect(isNeatAuthoredEnvFile('.env.neat')).toBe(true)
+    expect(isNeatAuthoredEnvFile('.env')).toBe(false)
+    expect(isNeatAuthoredEnvFile('.env.local')).toBe(false)
+
+    expect(isNeatAuthoredSourceFile('otel-init.cjs')).toBe(true)
+    expect(isNeatAuthoredSourceFile('otel-init.mjs')).toBe(true)
+    expect(isNeatAuthoredSourceFile('otel-init.js')).toBe(true)
+    expect(isNeatAuthoredSourceFile('otel-init.ts')).toBe(true)
+    expect(isNeatAuthoredSourceFile('index.js')).toBe(false)
+    expect(isNeatAuthoredSourceFile('my-otel-init.js')).toBe(false)
+
+    // isConfigFile delegates — .env.neat is not config, a real env file is.
+    expect(isConfigFile('.env.neat').match).toBe(false)
+    expect(isConfigFile('.env').match).toBe(true)
+    expect(isConfigFile('.env.local').match).toBe(true)
+  })
+})


### PR DESCRIPTION
Three bounded ingest/extraction hygiene fixes the breaker campaign surfaced (runs #5/#8/#9), all on the ingest/extract path.

**Self-pollution.** NEAT writes `.env.neat` and the generated `otel-init.*` bootstrap into the user's tree during `--apply` (ADR-069). Extraction was reading them back, so our own instrumentation landed in the graph as if the user had declared it. `isConfigFile`/`walkConfigFiles` now skip `.env.neat` and `walkSourceFiles` skips `otel-init.*`, mirroring the existing `.env.template` exclusion in the static-extraction contract.

**Cross-project span contamination.** Single-project mode (ADR-096) binds the bare `/v1/traces` route to one project, but the OS-default OTLP endpoint (`localhost:4318`) is shared — a sibling project's app exporting with defaults reached this daemon and merged its spans into this project's graph and `/incidents`. Delivery is now scoped to the project's owned services (project-name token match, or a ServiceNode already in the graph); a foreign span quarantines to the unrouted ledger instead of merging. ADR-096's per-project OTLP-port isolation stays the primary defense; this covers the shared-port fallback. The otel-ingest contract gains a section documenting the scoping and the deliberate trade-off.

**Incident dedup.** Incidents weren't deduped by `(traceId, spanId)`, so a re-delivered span (BatchSpanProcessor retries, or a receiver + handler double-write of one POST) multiplied the count. The ndjson sidecar stays append-only; `readErrorEvents` collapses on the deterministic incident id so the surface counts each incident once.

A focused test per fix:
- `test/self-pollution.test.ts` — `.env.neat` and `otel-init.*` excluded from extraction.
- `test/project-daemon.test.ts` — a foreign-service span quarantines, the project's own span lands.
- `test/ingest.test.ts` — a re-delivered span collapses to one incident.

The demo blast-radius assertions in `test/api.test.ts` drop the `.env.neat` nodes they no longer extract.

`npx vitest run` in `@neat.is/core`: 47 files, 1127 passed. Build + lint clean.

Refs #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)