### PR TITLE
Stability patches: daemon ports, OTLP ingest, graph fusion, and extraction

### DIFF
--- a/docs/contracts/otel-ingest.md
+++ b/docs/contracts/otel-ingest.md
@@ -125,6 +125,18 @@ Record shape:
 
 A rate-limited stderr warning rides alongside, keyed by `service_name` on the same 60s interval as the broken-project warning so OTel-exporter retries don't flood the console.
 
+## Single-project service-ownership scoping (amended — refs #339)
+
+Single-project mode (ADR-096) binds the bare `/v1/traces` route to the one project the daemon hosts. The OTLP port it binds is shared, though: the OS-default endpoint is `localhost:4318`, so a sibling service belonging to a *different* project that exports with default settings reaches this daemon too. Delivering those spans straight to the slot mints the sibling's `ServiceNode` and incidents into this project's graph — cross-project contamination.
+
+The routing layer scopes delivery to the project's owned services. A span is owned when:
+
+- it carries no `service.name` — an SDK misconfig in this project's own app; `handleSpan` routes it to `service:unidentified` (refs #374), or
+- its `service.name` matches the project name the way the multi-project router matches (exact / token-prefix / token-contained, so `brief` owns `brief-api` and `brief-worker`), or
+- a `ServiceNode` with that name already lives in the project's graph — statically extracted, or observed-and-adopted on an earlier owned span.
+
+A span owned by none of those is foreign. It quarantines to the unrouted ledger (same record shape and rate-limited warning as above) instead of merging. The trade is deliberate and bounds the blast radius the other direction from §unrouted-spans: a brand-new service of *this* project that NEAT can't read statically and whose name doesn't echo the project name has its first spans quarantined until an extraction round registers it. That gap is small and self-healing; a whole sibling project bleeding into the graph is neither. ADR-096's per-project OTLP-port isolation remains the primary defense — this scoping covers the shared-port fallback.
+
 ## Authority
 
 Owned by `ingest.ts` per ADR-030. Receiver shape lives in `otel.ts` / `otel-grpc.ts`; mutation logic lives in `ingest.ts`. No other module mutates the graph through the OTel ingest path. The unrouted-span logging lives in `daemon.ts` because the routing layer owns the "is there a slot to deliver to?" decision.

--- a/packages/core/proto/opentelemetry/proto/trace/v1/trace.proto
+++ b/packages/core/proto/opentelemetry/proto/trace/v1/trace.proto
@@ -70,13 +70,19 @@ message Span {
     string trace_state = 3;
     repeated opentelemetry.proto.common.v1.KeyValue attributes = 4;
     uint32 dropped_attributes_count = 5;
-    uint32 flags = 6;
+    // fixed32 (wire type 5), per the upstream OTel proto. A uint32 here makes
+    // protobufjs read the on-wire fixed32 as a varint and misalign the buffer.
+    fixed32 flags = 6;
   }
 
   repeated Link links = 13;
   uint32 dropped_links_count = 14;
   Status status = 15;
-  uint32 flags = 16;
+  // fixed32 (wire type 5), per the upstream OTel proto. The W3C trace flags
+  // live in the low 8 bits; real SDK exporters set the sampled bit, so this
+  // field arrives on the wire as a 4-byte fixed32. Typing it uint32 made
+  // protobufjs decode it as a varint and overrun the rest of the message.
+  fixed32 flags = 16;
 }
 
 message Status {

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -421,18 +421,22 @@ function registerRoutes(scope: FastifyInstance, ctx: RouteContext): void {
     if (!proj.graph.hasNode(nodeId)) {
       return reply.code(404).send({ error: 'node not found', id: nodeId })
     }
-    let errorEvent: ErrorEvent | undefined
+    // Load the incident store so root-cause can localize an in-process failure
+    // that never crossed a graph edge (#584). When errorId is supplied the
+    // named incident colours the reason; the full set is the fallback the graph
+    // walk consults when no edge carried an incompatibility.
     const epath = errorsPathFor(proj)
-    if (req.query.errorId && epath) {
-      const events = await readErrorEvents(epath)
-      errorEvent = events.find((e) => e.id === req.query.errorId)
+    const incidents = epath ? await readErrorEvents(epath) : []
+    let errorEvent: ErrorEvent | undefined
+    if (req.query.errorId) {
+      errorEvent = incidents.find((e) => e.id === req.query.errorId)
       if (!errorEvent) {
         return reply
           .code(404)
           .send({ error: 'error event not found', id: req.query.errorId })
       }
     }
-    const result = getRootCause(proj.graph, nodeId, errorEvent)
+    const result = getRootCause(proj.graph, nodeId, errorEvent, incidents)
     if (!result) return reply.code(404).send({ error: 'no root cause found', id: nodeId })
     return result
   })

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -52,7 +52,7 @@ import {
   buildUnroutedSpanRecord,
   unroutedErrorsPath,
 } from './unrouted.js'
-import type { RegistryEntry } from '@neat.is/types'
+import { NodeType, type RegistryEntry, type ServiceNode } from '@neat.is/types'
 
 // ── Per-project daemon self-description (ADR-096 / project-daemon contract) ──
 //
@@ -374,6 +374,49 @@ function isTokenContained(needle: string, haystack: string): boolean {
   if (!haystack.includes(needle)) return false
   const tokens = haystack.split(/[-_]/)
   return tokens.includes(needle)
+}
+
+// Does this span's `service.name` belong to the single project this daemon
+// hosts? Single-project mode (ADR-096) binds the bare `/v1/traces` route to one
+// project, but the OS-default OTLP endpoint (`localhost:4318`) is shared: a
+// sibling service from a *different* project that exports with default settings
+// lands here too. Merging its spans would mint that service's ServiceNode +
+// incidents into this project's graph — cross-project contamination. We scope
+// delivery to the project's owned services and quarantine the rest.
+//
+// A span is owned when:
+//   - it carries no `service.name` (SDK misconfig in this project's own app;
+//     handleSpan routes it to `service:unidentified`, refs #374), or
+//   - its `service.name` matches the project name the same way the multi-
+//     project router matches (exact / token-prefix / token-contained — covers
+//     the monorepo case where `brief` owns `brief-api`, `brief-worker`), or
+//   - a ServiceNode with that name already exists in the project's graph
+//     (statically extracted, or observed-and-adopted on an earlier span).
+//
+// Everything else is foreign and gets quarantined to the unrouted ledger rather
+// than merged. The trade is deliberate: a brand-new service of this project that
+// NEAT can't statically read and whose name doesn't echo the project name has
+// its first spans quarantined until extraction registers it — a far smaller
+// failure than an entire sibling project bleeding into this graph.
+function serviceNameMatchesProject(serviceName: string, project: string): boolean {
+  if (serviceName === project) return true
+  if (isTokenPrefix(project, serviceName)) return true
+  if (isTokenContained(project, serviceName)) return true
+  return false
+}
+
+function spanBelongsToSingleProject(
+  graph: NeatGraph,
+  project: string,
+  serviceName: string | undefined,
+): boolean {
+  if (!serviceName) return true
+  if (serviceNameMatchesProject(serviceName, project)) return true
+  return graph.someNode(
+    (_id, attrs) =>
+      attrs.type === NodeType.ServiceNode &&
+      (attrs as ServiceNode).name === serviceName,
+  )
 }
 
 async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
@@ -853,6 +896,14 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
         }
         if (!slot || slot.status !== 'active') {
           warnDroppedSpan(singleProject, slot?.errorReason ?? 'unknown')
+          return null
+        }
+        // Scope to this project's owned services — quarantine a sibling
+        // project's spans that reached our shared OTLP port instead of merging
+        // them (cross-project contamination). The unrouted ledger records what
+        // we dropped so it isn't silently dark.
+        if (!spanBelongsToSingleProject(slot.graph, singleProject, serviceName)) {
+          await recordUnroutedSpan(serviceName, traceId)
           return null
         }
         return slot

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -489,7 +489,7 @@ function portFromListenAddress(address: string, fallback: number): number {
   return fallback
 }
 
-function resolveHost(opts: DaemonOptions, authTokenSet: boolean): string {
+export function resolveHost(opts: DaemonOptions, authTokenSet: boolean): string {
   if (opts.host && opts.host.length > 0) return opts.host
   const env = process.env.HOST
   if (env && env.length > 0) return env
@@ -803,7 +803,13 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
             : undefined,
       })
       restAddress = await restApp.listen({ port: restPort, host })
-      console.log(`neatd: REST listening on ${restAddress}`)
+      // Fastify reports a 0.0.0.0 bind back as http://127.0.0.1:port, so the
+      // raw listen address hides a wildcard bind behind a loopback URL. Log the
+      // host we actually asked for so the line matches what the port allocator
+      // probed (the orchestrator threads this same host into its free check).
+      console.log(
+        `neatd: REST listening on http://${host}:${portFromListenAddress(restAddress, restPort)}`,
+      )
     } catch (err) {
       // Roll back anything we started so far before surfacing the error.
       for (const slot of slots.values()) {

--- a/packages/core/src/divergences.ts
+++ b/packages/core/src/divergences.ts
@@ -15,6 +15,7 @@ import type {
   Divergence,
   DivergenceResult,
   DivergenceType,
+  EdgeTypeValue,
   GraphEdge,
   GraphNode,
   ServiceNode,
@@ -135,6 +136,26 @@ function gradedConfidence(edge: GraphEdge): number {
   return clampConfidence(confidenceForEdge(edge))
 }
 
+// Edge types production can actually emit as OBSERVED traffic — the CALLS
+// family plus cross-service and connection edges. `missing-observed` only
+// makes sense for these: an EXTRACTED edge of one of these types with no
+// OBSERVED twin is a real "code declares it, production never ran it" finding.
+//
+// Structural / static-only edge types (IMPORTS, CONFIGURED_BY, CONTAINS,
+// DEPENDS_ON, RUNS_ON) have no runtime span behind them, so there is never an
+// OBSERVED twin to be "missing" — measuring their tiers would report every
+// import and every config wire as a missing-observed divergence, which is
+// noise, not signal. Keep this an allowlist (not a denylist) so a new
+// structural edge type stays out of the missing-observed surface by default
+// until it is deliberately added here (divergence-query.md — the five locked
+// types compare CALLS-family edges at the shared grain).
+const OBSERVABLE_EDGE_TYPES: ReadonlySet<EdgeTypeValue> = new Set([
+  EdgeType.CALLS,
+  EdgeType.CONNECTS_TO,
+  EdgeType.PUBLISHES_TO,
+  EdgeType.CONSUMES_FROM,
+])
+
 function detectMissingDivergences(
   graph: NeatGraph,
   bucket: EdgeBucket,
@@ -147,7 +168,7 @@ function detectMissingDivergences(
   // Divergence compares CALLS-family edges at the shared grain (§7).
   if (bucket.type === EdgeType.CONTAINS) return out
 
-  if (bucket.extracted && !bucket.observed) {
+  if (bucket.extracted && !bucket.observed && OBSERVABLE_EDGE_TYPES.has(bucket.type)) {
     // Skip when the would-be target is a FrontierNode — those represent
     // unresolved span peers, not real entities we expect OBSERVED traffic
     // to. The coexistence contract is between EXTRACTED and OBSERVED on

--- a/packages/core/src/extract/calls/shared.ts
+++ b/packages/core/src/extract/calls/shared.ts
@@ -10,7 +10,12 @@ import {
   fileId,
 } from '@neat.is/types'
 import type { NeatGraph } from '../../graph.js'
-import { IGNORED_DIRS, SERVICE_FILE_EXTENSIONS, isPythonVenvDir } from '../shared.js'
+import {
+  IGNORED_DIRS,
+  SERVICE_FILE_EXTENSIONS,
+  isNeatAuthoredSourceFile,
+  isPythonVenvDir,
+} from '../shared.js'
 
 export interface SourceFile {
   path: string
@@ -42,7 +47,13 @@ export async function walkSourceFiles(dir: string): Promise<string[]> {
         if (IGNORED_DIRS.has(entry.name)) continue
         if (await isPythonVenvDir(full)) continue
         await walk(full)
-      } else if (entry.isFile() && SERVICE_FILE_EXTENSIONS.has(path.extname(entry.name))) {
+      } else if (
+        entry.isFile() &&
+        SERVICE_FILE_EXTENSIONS.has(path.extname(entry.name)) &&
+        // Skip NEAT's own generated `otel-init.*` bootstrap — extracting it
+        // would attribute our instrumentation imports to the user's service.
+        !isNeatAuthoredSourceFile(entry.name)
+      ) {
         out.push(full)
       }
     }

--- a/packages/core/src/extract/databases/index.ts
+++ b/packages/core/src/extract/databases/index.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import type {
   CompatibleDriver,
+  ConfigNode,
   DatabaseNode,
   GraphEdge,
   GraphNode,
@@ -10,6 +11,7 @@ import {
   EdgeType,
   NodeType,
   Provenance,
+  configId,
   databaseId,
   confidenceForExtracted,
 } from '@neat.is/types'
@@ -24,7 +26,12 @@ import {
   nodeEngineConstraints,
   packageConflicts,
 } from '../../compat.js'
-import { cleanVersion, makeEdgeId, type DiscoveredService } from '../shared.js'
+import {
+  cleanVersion,
+  isConfigFile,
+  makeEdgeId,
+  type DiscoveredService,
+} from '../shared.js'
 import { ensureFileNode, toPosix } from '../calls/shared.js'
 import { dbConfigYamlParser } from './db-config-yaml.js'
 import { dotenvParser } from './dotenv.js'
@@ -256,6 +263,58 @@ export async function addDatabasesAndCompat(
       }
     }
 
+    // Service-level declared DB target. When a service declares exactly one DB
+    // connection in config — a `postgres://…` string in .env, a db-config.yaml,
+    // a prisma/drizzle/knex datasource — record where it's pointed on the
+    // ServiceNode as `dbConnectionTarget` (host[:port]) and link the service to
+    // the config that declared it with an EXTRACTED CONFIGURED_BY edge. This is
+    // the service-grained declared intent the host-mismatch divergence compares
+    // against the service-grained OBSERVED CONNECTS_TO (file-awareness §7 —
+    // compare at the shared grain; a DB OTel span carries no call site, so the
+    // comparison is service-level). Without this, `declaredHostFor` reads an
+    // unpopulated field and host-mismatch never fires.
+    //
+    // We hold to a *single* declared target: with two or more distinct hosts
+    // the single-target model is ambiguous and would flag every observed host
+    // but one as a false mismatch, so we decline rather than guess.
+    if (allConfigs.length === 1) {
+      const primary = allConfigs[0]!
+      service.node.dbConnectionTarget = primary.port
+        ? `${primary.host}:${primary.port}`
+        : primary.host
+
+      // Link to the config file that declared the connection. Mirror configs.ts's
+      // ConfigNode id (Phase 3 runs after this and is idempotent on the node);
+      // the CONFIGURED_BY edge is service-grained here, matching the grain of
+      // the declared target it backs.
+      const relPath = path.relative(scanPath, primary.sourceFile)
+      const cfgId = configId(relPath)
+      if (!graph.hasNode(cfgId)) {
+        const cfgNode: ConfigNode = {
+          id: cfgId,
+          type: NodeType.ConfigNode,
+          name: path.basename(primary.sourceFile),
+          path: relPath,
+          fileType: isConfigFile(path.basename(primary.sourceFile)).fileType || 'config',
+        }
+        graph.addNode(cfgId, cfgNode)
+        nodesAdded++
+      }
+      const cfgEdge: GraphEdge = {
+        id: makeEdgeId(service.node.id, cfgId, EdgeType.CONFIGURED_BY),
+        source: service.node.id,
+        target: cfgId,
+        type: EdgeType.CONFIGURED_BY,
+        provenance: Provenance.EXTRACTED,
+        confidence: confidenceForExtracted('structural'),
+        evidence: { file: toPosix(relPath) },
+      }
+      if (!graph.hasEdge(cfgEdge.id)) {
+        graph.addEdgeWithKey(cfgEdge.id, cfgEdge.source, cfgEdge.target, cfgEdge)
+        edgesAdded++
+      }
+    }
+
     // Run all kinds of incompat checks even for services with no db connection
     // — node-engine / package-conflict / deprecated-api don't depend on db.
     attachIncompatibilities(service, allConfigs)
@@ -275,6 +334,12 @@ export async function addDatabasesAndCompat(
       // graph reporting a problem the new manifest no longer has.
       if (!service.node.incompatibilities || service.node.incompatibilities.length === 0) {
         delete (updated as { incompatibilities?: unknown }).incompatibilities
+      }
+      // Same stale-survivor guard for the declared DB target: if this pass found
+      // no single declared connection, a value left on `current` from a prior
+      // extract would otherwise survive the spread.
+      if (!service.node.dbConnectionTarget) {
+        delete (updated as { dbConnectionTarget?: unknown }).dbConnectionTarget
       }
       graph.replaceNodeAttributes(service.node.id, updated as unknown as GraphNode)
     }

--- a/packages/core/src/extract/imports.ts
+++ b/packages/core/src/extract/imports.ts
@@ -114,19 +114,45 @@ function collectJsImports(node: Parser.SyntaxNode, out: RawImport[]): void {
 interface RawPyImport {
   modulePath: string // dotted path with the leading dots stripped, e.g. 'utils.auth'
   level: number // count of leading dots; 0 = absolute import
+  names: string[] // the imported names after `import` — each may be a submodule
   line: number
   snippet: string
 }
 
-// Walks the AST for `from X import ...` / `from .X import ...`. Bare `import
-// X` statements name modules without resolving to a single file (`import
-// os.path` doesn't tell us which file in `os` got used), so Phase 2 limits
-// itself to the `from`-form per the resolution rules in the contract.
+// Collects the imported names from the tail of a `from`-import — the part
+// after the `import` keyword. Pushes each `name` (and the original name of an
+// `as`-aliased import); descends into a parenthesised list so `from app import
+// (config, db)` reads the same as the unparenthesised form. A wildcard `*`
+// has no name and is left for the module-file fallback in resolution.
+function collectImportedNames(node: Parser.SyntaxNode, out: string[]): void {
+  if (node.type === 'aliased_import') {
+    const nameNode = node.childForFieldName('name')
+    if (nameNode) out.push(nameNode.text)
+    return
+  }
+  if (node.type === 'dotted_name') {
+    out.push(node.text)
+    return
+  }
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i)
+    if (child) collectImportedNames(child, out)
+  }
+}
+
+// Walks the AST for `from X import a, b` / `from .X import a`. Bare `import X`
+// statements name modules without resolving to a single file (`import os.path`
+// doesn't tell us which file in `os` got used), so Phase 2 limits itself to
+// the `from`-form per the resolution rules in the contract. The imported names
+// matter: `from app import config` names the `config` submodule, not a symbol
+// on `app/__init__.py`, so resolution keys on them (see resolvePyImport).
 function collectPyImports(node: Parser.SyntaxNode, out: RawPyImport[]): void {
   if (node.type === 'import_from_statement') {
     let level = 0
     let modulePath = ''
+    const names: string[] = []
     let pastFrom = false
+    let pastImport = false
 
     for (let i = 0; i < node.childCount; i++) {
       const child = node.child(i)
@@ -135,33 +161,38 @@ function collectPyImports(node: Parser.SyntaxNode, out: RawPyImport[]): void {
         if (child.type === 'from') pastFrom = true
         continue
       }
-      if (child.type === 'import') break
-
-      if (child.type === 'relative_import') {
-        for (let j = 0; j < child.childCount; j++) {
-          const rc = child.child(j)
-          if (!rc) continue
-          // tree-sitter-python groups every leading dot into a single
-          // import_prefix node — `..` parses as one import_prefix with two
-          // `.` children, not two import_prefix nodes. Count the `.` tokens,
-          // not the prefix nodes, or multi-dot imports under-count `level`
-          // and resolve onto the wrong (sometimes self) target (#457).
-          if (rc.type === 'import_prefix') {
-            for (let k = 0; k < rc.childCount; k++) {
-              if (rc.child(k)?.type === '.') level++
-            }
-          } else if (rc.type === 'dotted_name') modulePath = rc.text
+      if (!pastImport) {
+        if (child.type === 'import') {
+          pastImport = true
+          continue
         }
-        break
+        // The `from`-module spec, before the `import` keyword.
+        if (child.type === 'relative_import') {
+          for (let j = 0; j < child.childCount; j++) {
+            const rc = child.child(j)
+            if (!rc) continue
+            // tree-sitter-python groups every leading dot into a single
+            // import_prefix node — `..` parses as one import_prefix with two
+            // `.` children, not two import_prefix nodes. Count the `.` tokens,
+            // not the prefix nodes, or multi-dot imports under-count `level`
+            // and resolve onto the wrong (sometimes self) target (#457).
+            if (rc.type === 'import_prefix') {
+              for (let k = 0; k < rc.childCount; k++) {
+                if (rc.child(k)?.type === '.') level++
+              }
+            } else if (rc.type === 'dotted_name') modulePath = rc.text
+          }
+        } else if (child.type === 'dotted_name') {
+          modulePath = child.text
+        }
+        continue
       }
-      if (child.type === 'dotted_name') {
-        modulePath = child.text
-        break
-      }
+      // Past the `import` keyword — the imported names.
+      collectImportedNames(child, names)
     }
 
     if (level > 0 || modulePath) {
-      out.push({ modulePath, level, line: node.startPosition.row + 1, snippet: clipSnippet(node.text) })
+      out.push({ modulePath, level, names, line: node.startPosition.row + 1, snippet: clipSnippet(node.text) })
     }
   }
 
@@ -319,17 +350,23 @@ async function resolveJsImport(
   return null
 }
 
-// Resolves a Python `from`-import to a service-relative posix path.
-// Relative imports (level > 0) walk up from the importing module's directory;
-// absolute imports match against the service source tree directly.
+// Resolves a Python `from`-import to the service-relative posix paths it
+// touches — one per imported module. Relative imports (level > 0) walk up from
+// the importing module's directory; absolute imports match against the service
+// source tree directly.
+//
+// `from app import config` names the `config` *submodule* (app/config.py), not
+// a symbol re-exported by app/__init__.py. Resolving the whole statement onto
+// the package's __init__.py was wrong: every intra-package import collapsed
+// onto one target and the per-(source,target) edge dedup then made the second
+// such dependency invisible. So we key on each imported name, resolving it to
+// its own module file, and fall back to the package/module file only for names
+// that aren't submodules (plain symbols, or a `*` wildcard).
 async function resolvePyImport(
   imp: RawPyImport,
   importerPath: string,
   serviceDir: string,
-): Promise<string | null> {
-  if (!imp.modulePath) return null // bare `from . import x` names a package, not a file
-
-  const relPath = imp.modulePath.split('.').join('/')
+): Promise<string[]> {
   let baseDir: string
   if (imp.level > 0) {
     baseDir = path.dirname(importerPath)
@@ -338,13 +375,43 @@ async function resolvePyImport(
     baseDir = serviceDir
   }
 
-  const candidates = [path.join(baseDir, `${relPath}.py`), path.join(baseDir, relPath, '__init__.py')]
-  for (const candidate of candidates) {
-    if (isWithinServiceDir(candidate, serviceDir) && (await fileExists(candidate))) {
-      return toPosix(path.relative(serviceDir, candidate))
+  // The on-disk base of the `from`-module. `from app import x` → app/ ;
+  // `from . import x` → the importer's own package directory (modulePath empty).
+  const moduleBase = imp.modulePath
+    ? path.join(baseDir, imp.modulePath.split('.').join('/'))
+    : baseDir
+
+  const resolved = new Set<string>()
+  let needModuleFile = imp.names.length === 0 // wildcard / unparsed → the module itself
+
+  for (const name of imp.names) {
+    const submoduleFile = path.join(moduleBase, `${name}.py`)
+    const subpackageInit = path.join(moduleBase, name, '__init__.py')
+    if (isWithinServiceDir(submoduleFile, serviceDir) && (await fileExists(submoduleFile))) {
+      resolved.add(toPosix(path.relative(serviceDir, submoduleFile)))
+    } else if (isWithinServiceDir(subpackageInit, serviceDir) && (await fileExists(subpackageInit))) {
+      resolved.add(toPosix(path.relative(serviceDir, subpackageInit)))
+    } else {
+      // Not a submodule — the name is a symbol defined in the module itself.
+      needModuleFile = true
     }
   }
-  return null
+
+  if (needModuleFile) {
+    // An empty modulePath (`from . import x`) has no module file of its own —
+    // the package is the directory, so only its __init__.py applies.
+    const moduleFileCandidates = imp.modulePath
+      ? [`${moduleBase}.py`, path.join(moduleBase, '__init__.py')]
+      : [path.join(moduleBase, '__init__.py')]
+    for (const candidate of moduleFileCandidates) {
+      if (isWithinServiceDir(candidate, serviceDir) && (await fileExists(candidate))) {
+        resolved.add(toPosix(path.relative(serviceDir, candidate)))
+        break
+      }
+    }
+  }
+
+  return [...resolved]
 }
 
 // ── edge emission ──────────────────────────────────────────────────────────
@@ -413,17 +480,18 @@ export async function addImports(
           continue
         }
         for (const imp of pyImports) {
-          const resolved = await resolvePyImport(imp, file.path, service.dir)
-          if (!resolved) continue
-          edgesAdded += emitImportEdge(
-            graph,
-            service.pkg.name,
-            importerFileId,
-            relFile,
-            resolved,
-            imp.line,
-            imp.snippet,
-          )
+          const resolvedPaths = await resolvePyImport(imp, file.path, service.dir)
+          for (const resolved of resolvedPaths) {
+            edgesAdded += emitImportEdge(
+              graph,
+              service.pkg.name,
+              importerFileId,
+              relFile,
+              resolved,
+              imp.line,
+              imp.snippet,
+            )
+          }
         }
         continue
       }

--- a/packages/core/src/extract/shared.ts
+++ b/packages/core/src/extract/shared.ts
@@ -73,9 +73,31 @@ export function isConfigFile(name: string): { match: boolean; fileType: string }
   // not runtime config.
   if (name === '.env' || name.startsWith('.env.')) {
     if (isEnvTemplateFile(name)) return { match: false, fileType: '' }
+    // NEAT writes `.env.neat` itself during `--apply` (ADR-069 §4). Ingesting
+    // it would record our own instrumentation env as if it were the user's
+    // declared config — self-pollution. Skip it the same way the template
+    // filter skips onboarding docs.
+    if (isNeatAuthoredEnvFile(name)) return { match: false, fileType: '' }
     return { match: true, fileType: 'env' }
   }
   return { match: false, fileType: '' }
+}
+
+// NEAT-authored artifacts the installer drops into the user's tree during
+// `--apply` (ADR-069). Extraction skips them: they're our own runtime hooks,
+// not first-party config or source. Ingesting them pollutes the graph with
+// NEAT's instrumentation as though the user had written it.
+//
+//   `.env.neat`         — per-package env carrying `OTEL_SERVICE_NAME`.
+//   `otel-init.{ext}`   — generated SDK bootstrap (js/cjs/mjs/ts), including
+//                         the framework variants (`src/otel-init.*`,
+//                         `server/plugins/otel-init.*`) — basename is stable.
+export function isNeatAuthoredEnvFile(name: string): boolean {
+  return name === '.env.neat'
+}
+
+export function isNeatAuthoredSourceFile(name: string): boolean {
+  return /^otel-init\.(?:js|cjs|mjs|ts|tsx)$/i.test(name)
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -189,6 +189,34 @@ function httpResponseStatus(span: ParsedSpan): number | undefined {
   return undefined
 }
 
+// HTTP method/route off a span, across the OTel semconv rename (modern
+// `http.request.method` / legacy `http.method`; `http.route` is the matched
+// template, with `http.target` / `url.path` as the concrete-path fallback).
+function httpMethod(span: ParsedSpan): string | undefined {
+  return pickAttr(span, 'http.request.method', 'http.method')
+}
+
+function httpRoute(span: ParsedSpan): string | undefined {
+  return pickAttr(span, 'http.route', 'http.target', 'url.path')
+}
+
+// A human incident line built from the HTTP context a server span carries even
+// when no exception event was recorded — an Express error handler that answers
+// 500 cleanly leaves `span.exception` empty but still carries the route and
+// status. "500 on GET /users/:id" reads better than the literal 'unknown
+// error'. Returns undefined when the span has no usable HTTP context, so a
+// non-HTTP failure still falls back to 'unknown error'.
+function httpFailureMessage(span: ParsedSpan): string | undefined {
+  const status = httpResponseStatus(span)
+  const route = httpRoute(span)
+  const method = httpMethod(span)
+  const where = route ? `${method ? `${method} ` : ''}${route}` : undefined
+  if (status !== undefined && where) return `${status} on ${where}`
+  if (status !== undefined) return `HTTP ${status}`
+  if (where) return `error on ${where}`
+  return undefined
+}
+
 // In-flight 4xx burst against one (source, peer) pair. Lives on IngestContext so
 // it survives across spans without leaking into module state shared by every
 // project. firstTs/lastTs are the span timestamps (ADR-033 — span time, not
@@ -865,20 +893,36 @@ async function appendErrorEvent(ctx: IngestContext, ev: ErrorEvent): Promise<voi
   await fs.appendFile(ctx.errorsPath, JSON.stringify(ev) + '\n', 'utf8')
 }
 
+// Resolve the incident's affectedNode. When the span carries a `code.filepath`
+// call site, the incident attributes to the FileNode the failure surfaced in —
+// the same file grain OBSERVED CALLS edges land on (file-awareness.md §4) —
+// resolving a compiled `dist/...js` frame through its disk-adjacent source map
+// when one is present. Without a call site it stays at the originating service,
+// the honest fallback (§2). No graph access is needed: the file id is built
+// from the span's own `code.*` and `service` attributes, so the receiver can
+// attribute at file grain before the graph has caught up. The file node may not
+// yet be materialised, but querying the service still surfaces the incident, and
+// the recorded file:line is real evidence either way (§6 — never fabricated).
+function incidentAffectedNode(span: ParsedSpan): string {
+  const callSite = callSiteFromSpan(span)
+  if (callSite) return fileId(span.service, callSite.relPath)
+  return serviceId(span.service, span.env)
+}
+
 // Build the minimal ErrorEvent the receiver writes synchronously before
-// replying (ADR-033 §Error events, amended). affectedNode resolves to the
-// originating service because graph state isn't available at this point —
-// the queued handleSpan path may reach a more precise target later, but the
-// durable record is what the receiver writes here.
+// replying (ADR-033 §Error events, amended). affectedNode attributes to the
+// FileNode when the span carries a `code.filepath` call site, else to the
+// originating service (incidentAffectedNode above).
 //
 // errorMessage reads from the exception event's `exception.message` (OTel
 // semconv) so the incident surface shows the actual thrown error string.
-// When the span carries no exception event the field falls back to the
-// literal 'unknown error' rather than `span.name` — OTel HTTP server
-// instrumentation routinely populates `span.name` with the HTTP method,
-// which produces incidents that read 'GET' or 'POST' instead of the
-// underlying failure. `span.status.message` is intentionally out of the
-// chain for the same reason.
+// When the span carries no exception event the field falls back to the HTTP
+// context the span still holds — "500 on GET /users/:id" (httpFailureMessage)
+// — and only then to the literal 'unknown error'. `span.name` is never in the
+// chain: OTel HTTP server instrumentation routinely populates it with the HTTP
+// method, which produces incidents that read 'GET' or 'POST' instead of the
+// underlying failure. `span.status.message` is intentionally out for the same
+// reason.
 // Span attributes pass through verbatim so consumers can read source
 // attribution (`code.filepath`, `code.lineno`, `code.function`) and other
 // SDK-emitted context without ingest enumerating every key it cares about.
@@ -907,13 +951,13 @@ export function buildErrorEventForReceiver(span: ParsedSpan): ErrorEvent | null 
     service: span.service,
     traceId: span.traceId,
     spanId: span.spanId,
-    errorMessage: span.exception?.message ?? 'unknown error',
+    errorMessage: span.exception?.message ?? httpFailureMessage(span) ?? 'unknown error',
     ...(span.exception?.type ? { exceptionType: span.exception.type } : {}),
     ...(span.exception?.stacktrace
       ? { exceptionStacktrace: span.exception.stacktrace }
       : {}),
     ...(Object.keys(attrs).length > 0 ? { attributes: attrs } : {}),
-    affectedNode: serviceId(span.service, span.env),
+    affectedNode: incidentAffectedNode(span),
   }
 }
 
@@ -1208,7 +1252,7 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
         service: span.service,
         traceId: span.traceId,
         spanId: span.spanId,
-        errorMessage: span.exception?.message ?? 'unknown error',
+        errorMessage: span.exception?.message ?? httpFailureMessage(span) ?? 'unknown error',
         ...(span.exception?.type ? { exceptionType: span.exception.type } : {}),
         ...(span.exception?.stacktrace
           ? { exceptionStacktrace: span.exception.stacktrace }

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -1517,14 +1517,43 @@ export function startStalenessLoop(
 export async function readErrorEvents(errorsPath: string): Promise<ErrorEvent[]> {
   try {
     const raw = await fs.readFile(errorsPath, 'utf8')
-    return raw
+    const events = raw
       .split('\n')
       .filter((line) => line.length > 0)
       .map((line) => JSON.parse(line) as ErrorEvent)
+    return dedupeIncidents(events)
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
     throw err
   }
+}
+
+// Make the incident surface idempotent on `(traceId, spanId)`. The ndjson
+// sidecar is append-only (persistence contract), so a re-delivered span — OTel
+// BatchSpanProcessor retries, or a receiver + handler both writing one POST —
+// leaves duplicate lines on disk. An incident is one event per `(traceId,
+// spanId)`; collapsing on read keeps the count honest without rewriting the
+// append-only file. The deterministic incident `id` already encodes the pair
+// (`${traceId}:${spanId}`); we dedupe on it directly, falling back to the raw
+// pair for any record that predates the id. Records that carry neither (extract
+// parse-failure rows, `source: 'extract'`) pass through untouched — they aren't
+// span incidents. First write wins so the original timestamp is preserved.
+function dedupeIncidents(events: ErrorEvent[]): ErrorEvent[] {
+  const seen = new Set<string>()
+  const out: ErrorEvent[] = []
+  for (const ev of events) {
+    const key =
+      ev.id ??
+      (ev.traceId && ev.spanId ? `${ev.traceId}:${ev.spanId}` : undefined)
+    if (key === undefined) {
+      out.push(ev)
+      continue
+    }
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(ev)
+  }
+  return out
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -459,6 +459,53 @@ function callSiteFromSpan(
   }
 }
 
+// Reconcile a runtime-derived relPath onto the service-relative path the
+// extractor already minted, so OBSERVED and EXTRACTED FileNodes for the same
+// source file fuse into ONE node instead of two disjoint subgraphs
+// (file-awareness.md §4 — ingest joins the runtime path against the service
+// root to land the edge on a FileNode).
+//
+// relPathForRuntimeFile anchors the absolute `code.filepath` against scanPath /
+// repoPath. When that anchor can't be found — no scanPath wired, or the span
+// was emitted from a service whose absolute root differs from the daemon's
+// checkout (a container image rooted at `/app`, a relocated clone) — the
+// leftover relPath still carries the unanchored leading segments
+// (`app/src/foo.ts`, `Users/me/repo/src/foo.ts`) and forks a parallel FileNode
+// keyed off the absolute path. That splits the graph: the OBSERVED layer never
+// lands on the EXTRACTED `src/foo.ts` node, and divergence/traversal see two
+// half-graphs for one file.
+//
+// The extractor's FileNode paths are ground truth for which service-relative
+// paths exist. Recover the right one by matching the longest EXTRACTED (non-
+// OTel) FileNode path that is a trailing segment-suffix of the runtime relPath.
+// A match means the runtime path is the same file the extractor parsed, just
+// carrying extra leading directories the anchor couldn't strip — reuse the
+// extractor's path so both layers key the same node. No match means the file is
+// genuinely OTel-only; the honest runtime path stands (never fabricated, §6).
+function reconcileObservedRelPath(
+  graph: NeatGraph,
+  serviceName: string,
+  relPath: string,
+): string {
+  // Already lands on a known node (the anchor resolved cleanly, or a prior span
+  // created this node) — fused, nothing to recover.
+  if (graph.hasNode(fileId(serviceName, relPath))) return relPath
+  let best: string | null = null
+  graph.forEachNode((_id, attrs) => {
+    const a = attrs as FileNode & { type?: string }
+    if (a.type !== NodeType.FileNode || a.service !== serviceName) return
+    // Only fuse onto a statically-known file. An existing OTel-only node would
+    // already have matched the hasNode short-circuit above.
+    if (a.discoveredVia === 'otel') return
+    const p = a.path
+    if (!p) return
+    if ((relPath === p || relPath.endsWith(`/${p}`)) && (!best || p.length > best.length)) {
+      best = p
+    }
+  })
+  return best ?? relPath
+}
+
 // Ensure the FileNode for an observed call site and the owning service's
 // OBSERVED `CONTAINS` edge both exist, returning the FileNode id so the caller
 // can originate the relationship from it (file-awareness.md §1–2 + §4). The
@@ -472,14 +519,15 @@ function ensureObservedFileNode(
   serviceNodeId: string,
   callSite: CallSite,
 ): string {
-  const fileNodeId = fileId(serviceName, callSite.relPath)
+  const relPath = reconcileObservedRelPath(graph, serviceName, callSite.relPath)
+  const fileNodeId = fileId(serviceName, relPath)
   if (!graph.hasNode(fileNodeId)) {
-    const language = languageForExt(callSite.relPath)
+    const language = languageForExt(relPath)
     const node: FileNode = {
       id: fileNodeId,
       type: NodeType.FileNode,
       service: serviceName,
-      path: callSite.relPath,
+      path: relPath,
       ...(language ? { language } : {}),
       ...(callSite.originalRelPath ? { originalPath: callSite.originalRelPath } : {}),
       discoveredVia: 'otel',

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -34,7 +34,7 @@ import { ensureNeatOutIgnored } from './gitignore.js'
 import { saveGraphToDisk } from './persist.js'
 import { pathsForProject } from './projects.js'
 import { addProject, listProjects, ProjectNameCollisionError, setStatus } from './registry.js'
-import { readDaemonRecord, type DaemonPorts } from './daemon.js'
+import { readDaemonRecord, resolveHost, type DaemonPorts } from './daemon.js'
 import { printBanner } from './banner.js'
 import {
   isEmptyPlan,
@@ -521,12 +521,18 @@ async function waitForDaemonReady(restPort: number, timeoutMs: number): Promise<
 // surface.
 export const NEAT_PORTS = [8080, 4318, 6328] as const
 
-export async function isPortFree(port: number): Promise<boolean> {
+// Probe `host` so the availability answer reflects the interface the daemon
+// will actually bind. The daemon binds 0.0.0.0 on the authenticated path
+// (resolveHost) and 127.0.0.1 otherwise; probing loopback while the daemon
+// binds the wildcard reads a wildcard-held port as free, hands it to the
+// spawn, and the daemon dies on EADDRINUSE before it can write daemon.json —
+// the silent "daemon.json timeout" (#574). Check host must equal bind host.
+export async function isPortFree(port: number, host = '127.0.0.1'): Promise<boolean> {
   return new Promise((resolve) => {
     const server = net.createServer()
     server.once('error', () => resolve(false))
     server.once('listening', () => server.close(() => resolve(true)))
-    server.listen(port, '127.0.0.1')
+    server.listen(port, host)
   })
 }
 
@@ -570,10 +576,11 @@ const PORT_STRIDE = 1
 
 export interface AllocatedPorts extends DaemonPorts {}
 
-// True when all three ports of a candidate triple are free.
-async function tripleFree(ports: AllocatedPorts): Promise<boolean> {
+// True when all three ports of a candidate triple are free on `host` — the
+// interface the daemon will bind (see isPortFree).
+async function tripleFree(ports: AllocatedPorts, host = '127.0.0.1'): Promise<boolean> {
   for (const p of [ports.rest, ports.otlp, ports.web]) {
-    if (!(await isPortFree(p))) return false
+    if (!(await isPortFree(p, host))) return false
   }
   return true
 }
@@ -584,7 +591,7 @@ async function tripleFree(ports: AllocatedPorts): Promise<boolean> {
 // search window is free — a genuinely saturated environment. Reuse of a
 // project's persisted ports is the caller's decision (it has the /health
 // identity result); this only finds fresh free ports.
-export async function allocatePorts(): Promise<AllocatedPorts | null> {
+export async function allocatePorts(host = '127.0.0.1'): Promise<AllocatedPorts | null> {
   const [baseRest, baseOtlp, baseWeb] = NEAT_PORTS
   for (let i = 0; i < PORT_ALLOCATION_ATTEMPTS; i++) {
     const candidate: AllocatedPorts = {
@@ -592,7 +599,7 @@ export async function allocatePorts(): Promise<AllocatedPorts | null> {
       otlp: baseOtlp + i * PORT_STRIDE,
       web: baseWeb + i * PORT_STRIDE,
     }
-    if (await tripleFree(candidate)) return candidate
+    if (await tripleFree(candidate, host)) return candidate
   }
   return null
 }
@@ -914,6 +921,15 @@ export async function runOrchestrator(opts: OrchestratorOptions): Promise<Orches
   // port must report THIS project to count as ours (a sibling project's
   // daemon on a port we'd otherwise reuse is correctly seen as not-mine).
   const timeoutMs = opts.daemonReadyTimeoutMs ?? DEFAULT_DAEMON_READY_TIMEOUT_MS
+  // The interface the spawned daemon will bind — 0.0.0.0 on the authenticated
+  // path, 127.0.0.1 otherwise. resolveHost is the single source of that
+  // decision (the daemon calls it too), so the free-port probe below checks the
+  // exact interface the bind will use; a wildcard-held port must read as taken
+  // on the token path or the spawn collides on EADDRINUSE (#574).
+  const bindHost = resolveHost(
+    {},
+    typeof process.env.NEAT_AUTH_TOKEN === 'string' && process.env.NEAT_AUTH_TOKEN.length > 0,
+  )
   // Ports the project used last time (its daemon.json), if any — reuse keeps
   // the instrumented app's exporter endpoint stable across restarts (§3).
   const persistedPorts = await persistedPortsFor(opts.scanPath)
@@ -931,10 +947,14 @@ export async function runOrchestrator(opts: OrchestratorOptions): Promise<Orches
     // is free (the prior daemon is gone, so we take its ports back and the
     // app's endpoint stays put); otherwise allocate a fresh free triple,
     // stepping past the canonical set when a sibling project holds it.
-    if (persistedPorts && (await isPortFree(persistedPorts.rest)) && (await tripleFree(persistedPorts))) {
+    if (
+      persistedPorts &&
+      (await isPortFree(persistedPorts.rest, bindHost)) &&
+      (await tripleFree(persistedPorts, bindHost))
+    ) {
       allocated = persistedPorts
     } else {
-      allocated = await allocatePorts()
+      allocated = await allocatePorts(bindHost)
     }
     if (!allocated) {
       // The search window is saturated — surface the canonical REST port as the

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -314,10 +314,11 @@ export async function applyInstallersOver(
       if (gaps.length > 0) {
         const svcName = path.basename(svc.dir)
         const list = gaps.join(', ')
-        const verb = gaps.length === 1 ? 'this library' : 'these libraries'
+        const subject = gaps.length === 1 ? 'this library' : 'these libraries'
+        const aux = gaps.length === 1 ? "isn't" : "aren't"
         console.warn(
           `neat: calls to ${list} won't be observed by default in ${svcName}.\n` +
-            `  ${verb} aren't in the default instrumentation set, so they produce no OBSERVED edges.\n` +
+            `  ${subject} ${aux} in the default instrumentation set, so they produce no OBSERVED edges.\n` +
             `  Run \`neat list-uninstrumented\` to review them, then \`neat extend\` to capture them.`,
         )
       }
@@ -442,29 +443,27 @@ async function probeProjectHealth(
   })
 }
 
-// Resolve the project-status set the wait loop branches on. Prefers the
-// daemon-wide /health response when it carries the list; otherwise reads
-// the registry directly and probes each project's per-project /health.
-// The fallback handles the case where the daemon-wide /health hasn't
-// landed in this branch's main yet.
+// Resolve the status of the one project this run just started — and only that
+// project (ADR-096: the orchestrator spawns a daemon scoped to a single
+// project, so readiness is a single-project question). A broken or stale
+// sibling sitting in the machine registry must never gate this run; it
+// belongs to a different daemon and would otherwise poison an otherwise-healthy
+// start. Prefers the daemon-wide /health entry for the project when one is
+// carried (the legacy multi-project shape); otherwise probes that project's
+// per-project /health directly. The registry is not consulted — siblings are
+// out of scope by construction.
 async function snapshotProjectStatus(
   restPort: number,
+  project: string,
   body: DaemonHealthResponse,
 ): Promise<Array<{ name: string; status: 'bootstrapping' | 'active' | 'broken' }>> {
   if (body.projects && body.projects.length > 0) {
-    return body.projects.map((p) => ({
-      name: p.name,
-      status: p.status ?? 'active',
-    }))
+    const mine = body.projects.filter((p) => p.name === project)
+    if (mine.length > 0) {
+      return mine.map((p) => ({ name: p.name, status: p.status ?? 'active' }))
+    }
   }
-  const entries = await listProjects().catch(() => [])
-  if (entries.length === 0) return []
-  return Promise.all(
-    entries.map(async (entry) => ({
-      name: entry.name,
-      status: await probeProjectHealth(restPort, entry.name),
-    })),
-  )
+  return [{ name: project, status: await probeProjectHealth(restPort, project) }]
 }
 
 interface DaemonReadyResult {
@@ -473,13 +472,17 @@ interface DaemonReadyResult {
   stillBootstrapping: string[]
 }
 
-async function waitForDaemonReady(restPort: number, timeoutMs: number): Promise<DaemonReadyResult> {
+async function waitForDaemonReady(
+  restPort: number,
+  project: string,
+  timeoutMs: number,
+): Promise<DaemonReadyResult> {
   const deadline = Date.now() + timeoutMs
   let lastBootstrapping: string[] = []
   while (Date.now() < deadline) {
     const body = await fetchDaemonHealth(restPort)
     if (body !== null) {
-      const projects = await snapshotProjectStatus(restPort, body)
+      const projects = await snapshotProjectStatus(restPort, project, body)
       const bootstrapping = projects
         .filter((p) => p.status === 'bootstrapping')
         .map((p) => p.name)
@@ -500,7 +503,7 @@ async function waitForDaemonReady(restPort: number, timeoutMs: number): Promise<
     await new Promise((r) => setTimeout(r, PROBE_INTERVAL_MS))
   }
   const final = await fetchDaemonHealth(restPort)
-  const projects = final ? await snapshotProjectStatus(restPort, final) : []
+  const projects = final ? await snapshotProjectStatus(restPort, project, final) : []
   return {
     ready: false,
     brokenProjects: projects.filter((p) => p.status === 'broken').map((p) => p.name),
@@ -680,6 +683,18 @@ async function healthIsForProject(restPort: number, project: string): Promise<bo
 // the matching-vs-not-mine decision directly.
 export function healthIsForProjectForTest(restPort: number, project: string): Promise<boolean> {
   return healthIsForProject(restPort, project)
+}
+
+// Test seam for the readiness wait (one-command-cli contract §1 / ADR-096).
+// The integration suite drives a fake single-project daemon against this to
+// prove the gate scopes to the just-started project and never blocks on a
+// broken sibling sitting in the registry.
+export function waitForDaemonReadyForTest(
+  restPort: number,
+  project: string,
+  timeoutMs: number,
+): Promise<DaemonReadyResult> {
+  return waitForDaemonReady(restPort, project, timeoutMs)
 }
 
 // Spawn the daemon as a child process the orchestrator drives. Returns the
@@ -971,7 +986,7 @@ export async function runOrchestrator(opts: OrchestratorOptions): Promise<Orches
             projectPath: opts.scanPath,
             ports: allocated,
           })
-          const ready = await waitForDaemonReady(allocated.rest, timeoutMs)
+          const ready = await waitForDaemonReady(allocated.rest, currentProjectName, timeoutMs)
           result.steps.daemon = ready.ready ? 'spawned' : 'timed-out'
           if (!ready.ready) {
             console.error(`neat: daemon did not become ready within ${timeoutMs}ms`)

--- a/packages/core/src/traverse.ts
+++ b/packages/core/src/traverse.ts
@@ -15,6 +15,7 @@ import {
   EdgeType,
   NodeType,
   PROV_RANK,
+  Provenance,
   RootCauseResultSchema,
   TransitiveDependenciesResultSchema,
 } from '@neat.is/types'
@@ -379,30 +380,108 @@ export function getRootCause(
   graph: NeatGraph,
   errorNodeId: string,
   errorEvent?: ErrorEvent,
+  incidents?: ErrorEvent[],
 ): RootCauseResult | null {
   if (!graph.hasNode(errorNodeId)) return null
   const origin = graph.getNodeAttributes(errorNodeId) as GraphNode
   const shape = rootCauseShapes[origin.type]
-  if (!shape) return null
 
-  const walk = longestIncomingWalk(graph, errorNodeId, ROOT_CAUSE_MAX_DEPTH)
-  const match = shape(graph, origin, walk)
-  if (!match) return null
+  if (shape) {
+    const walk = longestIncomingWalk(graph, errorNodeId, ROOT_CAUSE_MAX_DEPTH)
+    const match = shape(graph, origin, walk)
+    if (match) {
+      const reason = errorEvent
+        ? `${match.rootCauseReason} (observed error: ${errorEvent.errorMessage})`
+        : match.rootCauseReason
 
-  const reason = errorEvent
-    ? `${match.rootCauseReason} (observed error: ${errorEvent.errorMessage})`
-    : match.rootCauseReason
+      // Schema-validate before return (ADR-036, #139). A drift in the result
+      // shape becomes a runtime throw at the call site rather than a silently
+      // malformed payload reaching MCP / REST consumers.
+      return RootCauseResultSchema.parse({
+        rootCauseNode: match.rootCauseNode,
+        rootCauseReason: reason,
+        traversalPath: walk.path,
+        edgeProvenances: walk.edges.map((e) => e.provenance),
+        confidence: confidenceFromMix(walk.edges),
+        fixRecommendation: match.fixRecommendation,
+      })
+    }
+  }
 
-  // Schema-validate before return (ADR-036, #139). A drift in the result
-  // shape becomes a runtime throw at the call site rather than a silently
-  // malformed payload reaching MCP / REST consumers.
+  // No graph edge carried an incompatibility — but a service can fail in
+  // process (a 500 thrown inside its own handler) without that failure ever
+  // crossing an edge, so the walk above sees a healthy-looking node. The
+  // recorded incident store is the OBSERVED evidence the graph can't carry:
+  // it localizes the failure to the file:line / route the failing span
+  // captured. Consulting it here keeps root-cause useful for the in-process
+  // case instead of reporting "healthy" over a pile of recorded 500s (#584).
+  return rootCauseFromIncidents(errorNodeId, incidents, errorEvent)
+}
+
+// OBSERVED-grade confidence for an incident-localized cause. The incident is a
+// real captured runtime fact (where the failure surfaced), but it names the
+// surface, not a proven upstream incompatibility — so it sits below an
+// edge-walked compat result yet well above an EXTRACTED guess.
+const INCIDENT_ROOT_CAUSE_CONFIDENCE = 0.6
+
+// Match an incident to the queried node the same way the REST incident-history
+// read does (api.ts): an exact affectedNode hit, or a service match when the
+// node is the service the incident was recorded against. A file-grained
+// affectedNode (file:<svc>:<path>) still matches the owning service this way.
+function incidentMatchesNode(ev: ErrorEvent, nodeId: string): boolean {
+  return ev.affectedNode === nodeId || ev.service === nodeId.replace(/^service:/, '')
+}
+
+// Build a root-cause result from the recorded incident store when the graph
+// walk found nothing. Picks the most recent incident affecting the node and
+// localizes the failure to the file:line / route it captured. Returns null when
+// no incident touches the node — the honest "nothing to say" answer.
+function rootCauseFromIncidents(
+  nodeId: string,
+  incidents: ErrorEvent[] | undefined,
+  errorEvent: ErrorEvent | undefined,
+): RootCauseResult | null {
+  const pool = incidents && incidents.length > 0 ? incidents : errorEvent ? [errorEvent] : []
+  const relevant = pool.filter((ev) => incidentMatchesNode(ev, nodeId))
+  if (relevant.length === 0) return null
+
+  // Most recent incident is the representative; ISO timestamps sort lexically.
+  const latest = [...relevant].sort((a, b) => b.timestamp.localeCompare(a.timestamp))[0]!
+  const attrs = latest.attributes ?? {}
+  const filepath = typeof attrs['code.filepath'] === 'string' ? attrs['code.filepath'] : undefined
+  const lineno = typeof attrs['code.lineno'] === 'number' ? attrs['code.lineno'] : undefined
+  const route = typeof attrs['http.route'] === 'string' ? attrs['http.route'] : undefined
+  const location = filepath ? `${filepath}${lineno !== undefined ? `:${lineno}` : ''}` : undefined
+
+  const count = relevant.length
+  const tail = count > 1 ? ` (${count} recorded incidents)` : ' (1 recorded incident)'
+  const reasonParts = [`${latest.service}: ${latest.errorMessage}`]
+  if (location) reasonParts.push(`surfaced at ${location}`)
+  const rootCauseReason = `${reasonParts.join(' — ')}${tail}`
+
+  // When the incident localized to a file (affectedNode is a file id), name
+  // that file as the root cause and walk the queried node → file as a single
+  // OBSERVED hop. The "edge" is the captured runtime attribution; OBSERVED is
+  // honest because the file came from a real `code.*` on the failing span.
+  // Otherwise the cause sits on the queried node itself (service grain).
+  const localizesToFile = latest.affectedNode !== nodeId && latest.affectedNode.startsWith('file:')
+  const rootCauseNode = localizesToFile ? latest.affectedNode : nodeId
+  const traversalPath = localizesToFile ? [nodeId, latest.affectedNode] : [nodeId]
+  const edgeProvenances = localizesToFile ? [Provenance.OBSERVED] : []
+
+  const fixRecommendation = location
+    ? `Inspect ${location}${route ? ` handling ${route}` : ''}`
+    : route
+      ? `Inspect ${latest.service}'s handler for ${route}`
+      : undefined
+
   return RootCauseResultSchema.parse({
-    rootCauseNode: match.rootCauseNode,
-    rootCauseReason: reason,
-    traversalPath: walk.path,
-    edgeProvenances: walk.edges.map((e) => e.provenance),
-    confidence: confidenceFromMix(walk.edges),
-    fixRecommendation: match.fixRecommendation,
+    rootCauseNode,
+    rootCauseReason,
+    traversalPath,
+    edgeProvenances,
+    confidence: INCIDENT_ROOT_CAUSE_CONFIDENCE,
+    ...(fixRecommendation ? { fixRecommendation } : {}),
   })
 }
 

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -196,15 +196,14 @@ describe('REST API (fastify.inject)', () => {
     expect(body.origin).toBe('service:service-a')
     // File-first — databases/dockerfile/configs extractors now all anchor edges
     // on FileNodes. Phase 1 file enumeration (ADR-092, file-awareness.md §1)
-    // now gives every source file a FileNode unconditionally, so service-a
-    // CONTAINS four files at distance 1 (index.js, Dockerfile, .env.neat, and
-    // otel.js — previously invisible because no call pattern fired from it);
-    // infra:container-image is at distance 2 (via Dockerfile FileNode);
-    // service-b at distance 2 (via index.js); service-b's five files
-    // (db-config.yaml, Dockerfile, .env.neat, index.js, and otel.js — the
-    // latter two previously invisible for the same reason) at distance 3;
-    // their ConfigNodes and payments-db at distance 4.
-    expect(body.totalAffected).toBe(15)
+    // gives every source file a FileNode unconditionally, so service-a CONTAINS
+    // three files at distance 1 (index.js, Dockerfile, and otel.js). The
+    // NEAT-authored `.env.neat` is excluded from extraction (self-pollution),
+    // so it never lands as a FileNode/ConfigNode. infra:container-image is at
+    // distance 2 (via Dockerfile FileNode); service-b at distance 2 (via
+    // index.js); service-b's files (db-config.yaml, Dockerfile, index.js,
+    // otel.js) at distance 3; its ConfigNode and payments-db at distance 4.
+    expect(body.totalAffected).toBe(11)
     // path + confidence land per ADR-038 §affectedNodes payload. Property-style
     // assertions so this test doesn't pin every BFS path detail — the contract
     // tests in contracts.test.ts pin the per-node invariants tightly.
@@ -217,15 +216,11 @@ describe('REST API (fastify.inject)', () => {
     }
     const ids = body.affectedNodes.map((n: { nodeId: string }) => n.nodeId).sort()
     expect(ids).toEqual([
-      'config:service-a/.env.neat',
-      'config:service-b/.env.neat',
       'config:service-b/db-config.yaml',
       'database:payments-db',
-      'file:service-a:.env.neat',
       'file:service-a:Dockerfile',
       'file:service-a:index.js',
       'file:service-a:otel.js',
-      'file:service-b:.env.neat',
       'file:service-b:Dockerfile',
       'file:service-b:db-config.yaml',
       'file:service-b:index.js',
@@ -264,15 +259,14 @@ describe('REST API (fastify.inject)', () => {
     })
     expect(res.statusCode).toBe(200)
     const body = res.json()
-    // File-first — at distance 1 service-a reaches all four of its own
-    // FileNodes via CONTAINS (.env.neat, Dockerfile, index.js, and — newly
-    // visible since Phase 1 file enumeration gives every source file a
-    // FileNode unconditionally (ADR-092, file-awareness.md §1) — otel.js).
-    // The container-image and service-b both sit at distance 2, so depth=1
-    // doesn't reach them.
-    expect(body.totalAffected).toBe(4)
+    // File-first — at distance 1 service-a reaches its own FileNodes via
+    // CONTAINS (Dockerfile, index.js, and otel.js — every source file gets a
+    // FileNode unconditionally per Phase 1 file enumeration, ADR-092,
+    // file-awareness.md §1). The NEAT-authored `.env.neat` is excluded from
+    // extraction (self-pollution), so it isn't among them. The container-image
+    // and service-b both sit at distance 2, so depth=1 doesn't reach them.
+    expect(body.totalAffected).toBe(3)
     expect(body.affectedNodes.map((n: { nodeId: string }) => n.nodeId).sort()).toEqual([
-      'file:service-a:.env.neat',
       'file:service-a:Dockerfile',
       'file:service-a:index.js',
       'file:service-a:otel.js',

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -8390,6 +8390,83 @@ describe('Divergence query (ADR-060)', () => {
     expect(hit!.confidence).toBe(0.5)
   })
 
+  it('computeDivergences does not report missing-observed for structural, never-observable edges (IMPORTS / CONFIGURED_BY)', async () => {
+    const { computeDivergences } = await import('../../src/divergences.js')
+    const { extractedEdgeId } = await import('@neat.is/types')
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+
+    // Two files within a service, statically importing one another, and a
+    // config the service is wired to. None of these are runtime-observable, so
+    // OTel never mints an OBSERVED twin — they must not surface as
+    // missing-observed divergences.
+    g.addNode('file:a/src/index.js', {
+      id: 'file:a/src/index.js',
+      type: NodeType.FileNode,
+      name: 'index.js',
+      language: 'javascript',
+    })
+    g.addNode('file:a/src/users.js', {
+      id: 'file:a/src/users.js',
+      type: NodeType.FileNode,
+      name: 'users.js',
+      language: 'javascript',
+    })
+    g.addNode('service:a', {
+      id: 'service:a',
+      type: NodeType.ServiceNode,
+      name: 'a',
+      language: 'javascript',
+    })
+    g.addNode('config:a/.env', {
+      id: 'config:a/.env',
+      type: NodeType.ConfigNode,
+      name: '.env',
+    })
+
+    const importsId = extractedEdgeId('file:a/src/index.js', 'file:a/src/users.js', EdgeType.IMPORTS)
+    g.addEdgeWithKey(importsId, 'file:a/src/index.js', 'file:a/src/users.js', {
+      id: importsId,
+      source: 'file:a/src/index.js',
+      target: 'file:a/src/users.js',
+      type: EdgeType.IMPORTS,
+      provenance: Provenance.EXTRACTED,
+      evidence: { file: 'a/src/index.js', line: 1, snippet: "require('./users')" },
+    })
+    const configuredId = extractedEdgeId('service:a', 'config:a/.env', EdgeType.CONFIGURED_BY)
+    g.addEdgeWithKey(configuredId, 'service:a', 'config:a/.env', {
+      id: configuredId,
+      source: 'service:a',
+      target: 'config:a/.env',
+      type: EdgeType.CONFIGURED_BY,
+      provenance: Provenance.EXTRACTED,
+      evidence: { file: 'a/.env' },
+    })
+
+    const result = computeDivergences(g)
+    const structural = result.divergences.filter(
+      (d) =>
+        d.type === 'missing-observed' &&
+        (d.edgeType === EdgeType.IMPORTS || d.edgeType === EdgeType.CONFIGURED_BY),
+    )
+    expect(structural).toEqual([])
+
+    // A real EXTRACTED CALLS edge with no OBSERVED twin still fires — the
+    // precision fix narrows the surface, it does not silence it.
+    g.addNode('service:b', {
+      id: 'service:b',
+      type: NodeType.ServiceNode,
+      name: 'b',
+      language: 'javascript',
+    })
+    g.addEdgeWithKey(extractedCallEdge.id, 'service:a', 'service:b', extractedCallEdge)
+    const withCall = computeDivergences(g)
+    expect(
+      withCall.divergences.some(
+        (d) => d.type === 'missing-observed' && d.edgeType === EdgeType.CALLS,
+      ),
+    ).toBe(true)
+  })
+
   it('computeDivergences detects missing-extracted: OBSERVED edge without EXTRACTED counterpart (ADR-060 #5)', async () => {
     const { computeDivergences } = await import('../../src/divergences.js')
     const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })

--- a/packages/core/test/db-connection-target.test.ts
+++ b/packages/core/test/db-connection-target.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import { computeDivergences } from '../src/divergences.js'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  databaseId,
+  type DatabaseNode,
+  type GraphEdge,
+  type ServiceNode,
+} from '@neat.is/types'
+
+// A plain DB connection string in config is the most common shape there is.
+// Before #586 the extractor parsed it into a DatabaseNode but never recorded
+// where the service was pointed (`dbConnectionTarget`) nor a service-level
+// CONFIGURED_BY edge, so the `host-mismatch` divergence could never fire.
+describe('declared DB connection target (#586)', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    resetGraph()
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-dbtarget-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  async function writeService(): Promise<void> {
+    const svc = path.join(dir, 'svc')
+    await fs.mkdir(svc, { recursive: true })
+    await fs.writeFile(
+      path.join(svc, 'package.json'),
+      JSON.stringify({ name: 'orders', version: '1.0.0', dependencies: { pg: '8.11.0' } }),
+    )
+    await fs.writeFile(
+      path.join(svc, '.env'),
+      'DATABASE_URL=postgres://user:pw@host.x:5432/orders\n',
+    )
+  }
+
+  it('parses a postgres:// connection string into a DatabaseNode plus a declared target on the service', async () => {
+    await writeService()
+    const graph = getGraph()
+    await extractFromDirectory(graph, dir)
+
+    const dbId = databaseId('host.x')
+    expect(graph.hasNode(dbId)).toBe(true)
+    const db = graph.getNodeAttributes(dbId) as DatabaseNode
+    expect(db.engine).toBe('postgresql')
+    expect(db.host).toBe('host.x')
+    expect(db.port).toBe(5432)
+
+    const svc = graph.getNodeAttributes('service:orders') as ServiceNode
+    expect(svc.dbConnectionTarget).toBe('host.x:5432')
+
+    // A service-grained EXTRACTED CONFIGURED_BY edge backs the declared target
+    // so the host-mismatch detector's gate is satisfiable.
+    const configuredBy = graph
+      .outboundEdges('service:orders')
+      .map((e) => graph.getEdgeAttributes(e) as GraphEdge)
+      .filter(
+        (e) =>
+          e.type === EdgeType.CONFIGURED_BY && e.provenance === Provenance.EXTRACTED,
+      )
+    expect(configuredBy).toHaveLength(1)
+    expect(configuredBy[0]!.evidence?.file).toMatch(/\.env$/)
+  })
+
+  it('surfaces host-mismatch when production connects to a different host than config declares', async () => {
+    await writeService()
+    const graph = getGraph()
+    await extractFromDirectory(graph, dir)
+
+    // Production was OBSERVED connecting to host.y, not the declared host.x.
+    const observedDbId = databaseId('host.y')
+    graph.addNode(observedDbId, {
+      id: observedDbId,
+      type: NodeType.DatabaseNode,
+      name: 'host.y',
+      engine: 'postgresql',
+      engineVersion: 'unknown',
+      compatibleDrivers: [],
+      host: 'host.y',
+      discoveredVia: 'otel',
+    } as DatabaseNode)
+    const obsEdge = `${EdgeType.CONNECTS_TO}:OBSERVED:service:orders->${observedDbId}`
+    graph.addEdgeWithKey(obsEdge, 'service:orders', observedDbId, {
+      id: obsEdge,
+      source: 'service:orders',
+      target: observedDbId,
+      type: EdgeType.CONNECTS_TO,
+      provenance: Provenance.OBSERVED,
+    })
+
+    const result = computeDivergences(graph)
+    const hit = result.divergences.find((d) => d.type === 'host-mismatch')
+    expect(hit).toBeDefined()
+    if (hit?.type === 'host-mismatch') {
+      expect(hit.extractedHost).toBe('host.x')
+      expect(hit.observedHost).toBe('host.y')
+    }
+  })
+})

--- a/packages/core/test/fixtures/imports/py-service/app/config.py
+++ b/packages/core/test/fixtures/imports/py-service/app/config.py
@@ -1,0 +1,1 @@
+DATABASE_URL = "postgres://localhost/app"

--- a/packages/core/test/fixtures/imports/py-service/app/db.py
+++ b/packages/core/test/fixtures/imports/py-service/app/db.py
@@ -1,0 +1,5 @@
+from app import config
+
+
+def connect():
+    return config.DATABASE_URL

--- a/packages/core/test/fixtures/imports/py-service/app/registry.py
+++ b/packages/core/test/fixtures/imports/py-service/app/registry.py
@@ -1,0 +1,7 @@
+from app import config
+from app import db
+
+
+def boot():
+    db.connect()
+    return config.DATABASE_URL

--- a/packages/core/test/imports.test.ts
+++ b/packages/core/test/imports.test.ts
@@ -90,6 +90,43 @@ describe('import graph extraction (ADR-092, file-awareness.md §10)', () => {
     expect(result.extractionErrors).toBe(0)
   })
 
+  it('resolves `from PKG import NAME` to the submodule file, one edge per name', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    // app/registry.py does `from app import config` and `from app import db`.
+    // Each names a submodule (app/config.py, app/db.py), not a symbol on
+    // app/__init__.py. Resolving both onto __init__.py collapsed them into a
+    // single edge — the second dependency went invisible to dedup.
+    const configEdge =
+      'IMPORTS:file:fixture-imports-py-service:app/registry.py->file:fixture-imports-py-service:app/config.py'
+    const dbEdge =
+      'IMPORTS:file:fixture-imports-py-service:app/registry.py->file:fixture-imports-py-service:app/db.py'
+
+    expect(graph.hasEdge(configEdge)).toBe(true)
+    expect(graph.hasEdge(dbEdge)).toBe(true)
+
+    // Nothing should land on the package __init__.py — config/db are submodules.
+    expect(
+      graph.hasEdge(
+        'IMPORTS:file:fixture-imports-py-service:app/registry.py->file:fixture-imports-py-service:app/__init__.py',
+      ),
+    ).toBe(false)
+
+    const edge = graph.getEdgeAttributes(configEdge) as GraphEdge
+    expect(edge.provenance).toBe('EXTRACTED')
+    expect(edge.evidence?.file).toBe('app/registry.py')
+    expect(edge.evidence?.snippet).toContain('config')
+
+    // app/db.py imports config too, so blast-radius/dependencies see config.py
+    // as a real upstream — not a zero-edge orphan.
+    expect(
+      graph.hasEdge(
+        'IMPORTS:file:fixture-imports-py-service:app/db.py->file:fixture-imports-py-service:app/config.py',
+      ),
+    ).toBe(true)
+  })
+
   it('is idempotent across repeated passes', async () => {
     const graph = getGraph()
     const first = await extractFromDirectory(graph, FIXTURES)

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -342,6 +342,30 @@ describe('handleSpan', () => {
     } as ErrorEvent)
   })
 
+  it('dedupes a re-delivered span to one incident on (traceId, spanId)', async () => {
+    // OTel BatchSpanProcessor retries deliver the same span more than once, and
+    // a daemon's receiver + handler can each write one POST. The append-only
+    // ndjson keeps both lines; the incident surface must still count one.
+    const span = dbSpan({
+      statusCode: 2,
+      exception: { message: 'connection reset' },
+    })
+    await handleSpan(ctx, span)
+    await handleSpan(ctx, span)
+
+    // Two lines on disk — the sidecar is append-only.
+    const raw = await fs.readFile(ctx.errorsPath, 'utf8')
+    expect(raw.split('\n').filter((l) => l.length > 0)).toHaveLength(2)
+
+    // One incident at the surface.
+    const events = await readErrorEvents(ctx.errorsPath)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      traceId: 'trace-1',
+      spanId: 'span-b',
+    } as ErrorEvent)
+  })
+
   it('preserves span attributes on the ErrorEvent (ADR-068 follow-up)', async () => {
     await handleSpan(
       ctx,

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -12,6 +12,7 @@ import {
   Provenance,
 } from '@neat.is/types'
 import {
+  buildErrorEventForReceiver,
   handleSpan,
   markStaleEdges,
   promoteFrontierNodes,
@@ -408,6 +409,64 @@ describe('handleSpan', () => {
   it('does not log an ErrorEvent for a successful span', async () => {
     await handleSpan(ctx, clientHttpSpan())
     expect(await readErrorEvents(ctx.errorsPath)).toEqual([])
+  })
+})
+
+// The durable incident the daemon receiver writes (buildErrorEventForReceiver).
+// An Express error handler that answers 500 cleanly leaves the span with no
+// exception event but with the HTTP context and a `code.filepath` call site —
+// the record must read those, not collapse to 'unknown error' on the bare
+// service (#584).
+describe('buildErrorEventForReceiver — file-grain + HTTP-context fallback (#584)', () => {
+  function serverErrorSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
+    return {
+      service: 'harvest-api',
+      traceId: 'trace-7',
+      spanId: 'span-7',
+      name: 'GET /users/:id',
+      kind: 2, // SERVER
+      startTimeUnixNano: '0',
+      endTimeUnixNano: '0',
+      durationNanos: 0n,
+      env: 'unknown',
+      startTimeIso: '2026-06-30T12:00:00.000Z',
+      attributes: {
+        'http.request.method': 'GET',
+        'http.route': '/users/:id',
+        'http.response.status_code': 500,
+        'code.filepath': 'src/index.js',
+        'code.lineno': 22,
+      },
+      statusCode: 2,
+      ...overrides,
+    }
+  }
+
+  it('attributes to the file node and builds a message from the route + status', () => {
+    const ev = buildErrorEventForReceiver(serverErrorSpan())
+    expect(ev).not.toBeNull()
+    expect(ev!.errorMessage).toBe('500 on GET /users/:id')
+    expect(ev!.affectedNode).toBe('file:harvest-api:src/index.js')
+    expect(ev!.attributes!['code.filepath']).toBe('src/index.js')
+    expect(ev!.attributes!['code.lineno']).toBe(22)
+    expect(ev!.attributes!['http.route']).toBe('/users/:id')
+  })
+
+  it('prefers a real exception message when the span carries one', () => {
+    const ev = buildErrorEventForReceiver(
+      serverErrorSpan({ exception: { message: 'TypeError: cannot read id of undefined' } }),
+    )
+    expect(ev!.errorMessage).toBe('TypeError: cannot read id of undefined')
+    // File grain still applies.
+    expect(ev!.affectedNode).toBe('file:harvest-api:src/index.js')
+  })
+
+  it('falls back to the originating service and `unknown error` with no HTTP/code context', () => {
+    const ev = buildErrorEventForReceiver(
+      serverErrorSpan({ attributes: { 'db.system': 'postgresql' } }),
+    )
+    expect(ev!.errorMessage).toBe('unknown error')
+    expect(ev!.affectedNode).toBe('service:harvest-api')
   })
 })
 

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -6,11 +6,13 @@ import { MultiDirectedGraph } from 'graphology'
 import {
   EdgeType,
   type ErrorEvent,
+  fileId,
   type GraphEdge,
   type GraphNode,
   NodeType,
   Provenance,
 } from '@neat.is/types'
+import { ensureFileNode } from '../src/extract/calls/shared.js'
 import {
   handleSpan,
   markStaleEdges,
@@ -1229,5 +1231,106 @@ describe('handleSpan parent-fallback call site (issue #536)', () => {
       if ((attrs as { type: string }).type === NodeType.FileNode) fileNodeCount++
     })
     expect(fileNodeCount).toBe(0)
+  })
+})
+
+// The thesis: EXTRACTED (static) and OBSERVED (runtime) FileNodes for the SAME
+// source file must fuse into ONE node, so the graph is a single fused model
+// rather than two disjoint subgraphs. A real OTel SpanProcessor stamps an
+// ABSOLUTE `code.filepath` (the Lambda task root, a container image rooted at
+// /app, a relocated clone) — when that prefix can't be anchored against the
+// daemon's scan root, the runtime path used to fork a parallel FileNode keyed
+// off the absolute path, and the OBSERVED layer never landed on the EXTRACTED
+// `src/...` node. handleSpan reconciles the runtime path onto the extractor's
+// service-relative path so both layers key the same node (file-awareness.md §4).
+describe('EXTRACTED and OBSERVED FileNodes fuse for the same source file', () => {
+  let tmpDir: string
+  let ctx: IngestContext
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-fuse-'))
+    ctx = { graph: newGraph(), errorsPath: path.join(tmpDir, 'errors.ndjson') }
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('lands an OBSERVED span with an absolute code.filepath on the EXTRACTED FileNode (one fused node, not two)', async () => {
+    // Static extraction minted the FileNode at the service-relative path.
+    const staticFileId = fileId('service-a', 'src/client.ts')
+    ensureFileNode(ctx.graph, 'service-a', 'service:service-a', 'src/client.ts')
+    expect(ctx.graph.getNodeAttributes(staticFileId)).toMatchObject({
+      discoveredVia: 'static',
+      path: 'src/client.ts',
+    })
+
+    // A runtime span for the SAME file, carrying the absolute path the
+    // SpanProcessor captured. No scanPath is wired (the multi-tenant / ad-hoc
+    // surface), and the prefix `/var/task` is the deployed root, not the
+    // daemon's checkout — so the path can't be anchored the cheap way.
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        attributes: {
+          'server.address': 'service-b',
+          'code.filepath': '/var/task/src/client.ts',
+          'code.lineno': 42,
+        },
+      }),
+    )
+
+    // Exactly ONE FileNode exists, and it is the EXTRACTED one — the OBSERVED
+    // layer fused onto it rather than forking an absolute-path twin.
+    const fileNodeIds: string[] = []
+    ctx.graph.forEachNode((id, attrs) => {
+      if ((attrs as { type: string }).type === NodeType.FileNode) fileNodeIds.push(id)
+    })
+    expect(fileNodeIds).toEqual([staticFileId])
+    // The absolute-derived id the bug used to mint is absent.
+    expect(ctx.graph.hasNode('file:service-a:var/task/src/client.ts')).toBe(false)
+
+    // The fused node carries BOTH layers: the EXTRACTED CONTAINS edge from
+    // static analysis and the OBSERVED CALLS edge from runtime both hang off
+    // the one node id — a single fused model a divergence/traversal query reads.
+    const observedCallsId = `${EdgeType.CALLS}:OBSERVED:${staticFileId}->service:service-b`
+    expect(ctx.graph.hasEdge(observedCallsId)).toBe(true)
+    expect((ctx.graph.getEdgeAttributes(observedCallsId) as GraphEdge).source).toBe(staticFileId)
+
+    const provenancesTouchingFile = new Set<string>()
+    ctx.graph.forEachEdge((_id, attrs) => {
+      const e = attrs as GraphEdge
+      if (e.source === staticFileId || e.target === staticFileId) {
+        provenancesTouchingFile.add(e.provenance)
+      }
+    })
+    expect(provenancesTouchingFile.has(Provenance.EXTRACTED)).toBe(true)
+    expect(provenancesTouchingFile.has(Provenance.OBSERVED)).toBe(true)
+  })
+
+  it('keeps a genuinely OTel-only file honest — no false fusion onto an unrelated extracted file', async () => {
+    ensureFileNode(ctx.graph, 'service-a', 'service:service-a', 'src/client.ts')
+
+    // A file the extractor never parsed. It must NOT collapse onto src/client.ts.
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        attributes: {
+          'server.address': 'service-b',
+          'code.filepath': '/var/task/src/uninstrumented.ts',
+          'code.lineno': 7,
+        },
+      }),
+    )
+
+    const fileNodeIds: string[] = []
+    ctx.graph.forEachNode((id, attrs) => {
+      if ((attrs as { type: string }).type === NodeType.FileNode) fileNodeIds.push(id)
+    })
+    expect(fileNodeIds).toContain(fileId('service-a', 'src/client.ts'))
+    expect(fileNodeIds.length).toBe(2)
+    // The honest runtime path stands; evidence is never fabricated onto the
+    // wrong static node.
+    expect(fileNodeIds.some((id) => id.endsWith('src/uninstrumented.ts'))).toBe(true)
   })
 })

--- a/packages/core/test/orchestrator-readiness.test.ts
+++ b/packages/core/test/orchestrator-readiness.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import type { AddressInfo } from 'node:net'
+
+// One-command-cli contract §1 / ADR-096 — the bare-run readiness gate is a
+// single-project question. The orchestrator spawns a daemon scoped to the one
+// project it just started, so the wait must resolve on that project alone. A
+// broken or stale sibling sitting in the machine registry (here: a
+// "recoverable" entry pointing at a deleted temp path) belongs to a different
+// daemon and must not gate this run — the harvest bug was exactly that, where
+// any broken sibling timed the whole start out at 60s.
+//
+// The fake daemon below answers /health in the single-project shape (top-level
+// `project`, no `projects` array), returns 200 for the started project's
+// per-project /health, and 503 for everyone else. If the gate ever probes the
+// sibling again it would read 503 forever and never go ready.
+
+interface FakeDaemon {
+  port: number
+  startedProject: string
+  probedPaths: string[]
+  close: () => Promise<void>
+}
+
+async function startFakeDaemon(startedProject: string): Promise<FakeDaemon> {
+  const probedPaths: string[] = []
+  const server = http.createServer((req, res) => {
+    const url = req.url ?? ''
+    probedPaths.push(url)
+    if (url === '/health') {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ ok: true, project: startedProject }))
+      return
+    }
+    if (url === `/projects/${encodeURIComponent(startedProject)}/health`) {
+      res.writeHead(200)
+      res.end()
+      return
+    }
+    // Any other project — including a broken sibling — never comes ready.
+    res.writeHead(503)
+    res.end()
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const port = (server.address() as AddressInfo).port
+  return {
+    port,
+    startedProject,
+    probedPaths,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  }
+}
+
+describe('orchestrator readiness gate scopes to the started project (ADR-096)', () => {
+  const cleanups: Array<() => Promise<void>> = []
+  let savedHome: string | undefined
+
+  afterEach(async () => {
+    for (const c of cleanups.splice(0)) await c().catch(() => {})
+    if (savedHome === undefined) delete process.env.NEAT_HOME
+    else process.env.NEAT_HOME = savedHome
+  })
+
+  it('resolves on the healthy just-started project and never probes a broken sibling', async () => {
+    savedHome = process.env.NEAT_HOME
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-readiness-home-'))
+    process.env.NEAT_HOME = home
+    cleanups.push(() => fs.rm(home, { recursive: true, force: true }))
+
+    // A healthy project we "just started", and a broken sibling whose path was
+    // deleted — the exact poison shape from the run-#2 harvest.
+    const { addProject, setStatus } = await import('../src/registry.js')
+    const started = 'harvest-app'
+    const startedDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-readiness-started-'))
+    cleanups.push(() => fs.rm(startedDir, { recursive: true, force: true }))
+    await addProject({ name: started, path: startedDir, languages: ['javascript'] })
+
+    const sibling = 'recoverable'
+    const siblingDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-readiness-sibling-'))
+    await addProject({ name: sibling, path: siblingDir, languages: ['javascript'] })
+    await setStatus(sibling, 'broken')
+    // Delete the sibling's path — a stale registry entry pointing at nothing.
+    await fs.rm(siblingDir, { recursive: true, force: true })
+
+    const daemon = await startFakeDaemon(started)
+    cleanups.push(daemon.close)
+
+    const { waitForDaemonReadyForTest } = await import('../src/orchestrator.js')
+    const start = Date.now()
+    const result = await waitForDaemonReadyForTest(daemon.port, started, 5_000)
+    const elapsed = Date.now() - start
+
+    expect(result.ready).toBe(true)
+    expect(result.stillBootstrapping).toEqual([])
+    // Resolved on the first probe — nowhere near the timeout.
+    expect(elapsed).toBeLessThan(2_000)
+    // The broken sibling was never consulted; the gate is scoped.
+    expect(daemon.probedPaths.some((p) => p.includes(sibling))).toBe(false)
+  })
+})

--- a/packages/core/test/otel-protobuf-flags.test.ts
+++ b/packages/core/test/otel-protobuf-flags.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import path from 'node:path'
+import os from 'node:os'
+import { promises as fs } from 'node:fs'
+import protobuf from 'protobufjs'
+import { MultiDirectedGraph } from 'graphology'
+import {
+  EdgeType,
+  type GraphEdge,
+  type GraphNode,
+  NodeType,
+  Provenance,
+} from '@neat.is/types'
+import { buildOtelReceiver, type ParsedSpan } from '../src/otel.js'
+import { handleSpan, type IngestContext } from '../src/ingest.js'
+import type { NeatGraph } from '../src/graph.js'
+
+// Real OTel SDK exporters set the W3C sampled bit, so every sampled span
+// carries `flags` on the wire as a fixed32 (wire type 5, 4 bytes) and the
+// timestamps as fixed64. The bundled proto used to type `flags` as uint32,
+// which made protobufjs read the 4-byte fixed32 as a varint and overrun the
+// rest of the buffer — every sampled span 400'd with "index out of range" and
+// the OBSERVED layer stayed dark for the default Python/JS http/protobuf
+// exporters. The hand-built JS-SDK fixture missed it because those spans left
+// `flags` at the proto3 default (0, omitted). This encodes the exact wire shape
+// — fixed32 flags + fixed64 timestamps — and asserts it decodes to a span and
+// mints an OBSERVED edge.
+
+// Canonical OTel field types: flags is fixed32, the timestamps fixed64. This
+// matches what the real SDK serializes, so the bytes below are the same shape
+// the production exporter puts on the wire (the receiver's own bundled proto is
+// what does the decoding under test).
+const CANONICAL_PROTO = `
+syntax = "proto3";
+package neat.test.otlp;
+message AnyValue { string string_value = 1; }
+message KeyValue { string key = 1; AnyValue value = 2; }
+message Resource { repeated KeyValue attributes = 1; }
+message Span {
+  bytes trace_id = 1;
+  bytes span_id = 2;
+  string trace_state = 3;
+  bytes parent_span_id = 4;
+  string name = 5;
+  int32 kind = 6;
+  fixed64 start_time_unix_nano = 7;
+  fixed64 end_time_unix_nano = 8;
+  repeated KeyValue attributes = 9;
+  Status status = 15;
+  fixed32 flags = 16;
+}
+message Status { string message = 2; int32 code = 3; }
+message ScopeSpans { repeated Span spans = 2; }
+message ResourceSpans { Resource resource = 1; repeated ScopeSpans scope_spans = 2; }
+message ExportTraceServiceRequest { repeated ResourceSpans resource_spans = 1; }
+`
+
+function encodeSampledSpanRequest(): Buffer {
+  const root = protobuf.parse(CANONICAL_PROTO, { keepCase: true }).root
+  const Req = root.lookupType('neat.test.otlp.ExportTraceServiceRequest')
+  // Strings, not native bigint — protobufjs's fixed64 writer parses Long
+  // values from strings but coerces an unrecognised bigint to 0.
+  const startNanos = '1717761600123000000'
+  const endNanos = '1717761600148000000'
+  const msg = Req.create({
+    resource_spans: [
+      {
+        resource: {
+          attributes: [
+            { key: 'service.name', value: { string_value: 'svc-flags-fixed32' } },
+          ],
+        },
+        scope_spans: [
+          {
+            spans: [
+              {
+                trace_id: Buffer.alloc(16, 0xab),
+                span_id: Buffer.alloc(8, 0xcd),
+                name: 'GET /downstream',
+                kind: 3, // CLIENT
+                start_time_unix_nano: startNanos,
+                end_time_unix_nano: endNanos,
+                // The W3C sampled bit. Non-zero is what forces flags onto the
+                // wire as a fixed32 — the exact byte that used to 400.
+                flags: 1,
+                attributes: [
+                  { key: 'server.address', value: { string_value: 'svc-flags-peer' } },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })
+  return Buffer.from(Req.encode(msg).finish())
+}
+
+function newGraph(): NeatGraph {
+  const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+  g.addNode('service:svc-flags-fixed32', {
+    id: 'service:svc-flags-fixed32',
+    type: NodeType.ServiceNode,
+    name: 'svc-flags-fixed32',
+    language: 'javascript',
+  })
+  g.addNode('service:svc-flags-peer', {
+    id: 'service:svc-flags-peer',
+    type: NodeType.ServiceNode,
+    name: 'svc-flags-peer',
+    language: 'javascript',
+  })
+  return g
+}
+
+describe('http/protobuf — sampled span with fixed32 flags decodes and mints an edge', () => {
+  let tmpDir: string
+  let ctx: IngestContext
+  let collected: ParsedSpan[]
+  let receiver: Awaited<ReturnType<typeof buildOtelReceiver>>
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-flags-fixed32-'))
+    ctx = { graph: newGraph(), errorsPath: path.join(tmpDir, 'errors.ndjson') }
+    collected = []
+    receiver = await buildOtelReceiver({
+      onSpan: async (span) => {
+        collected.push(span)
+        await handleSpan(ctx, span)
+      },
+    })
+  })
+
+  afterEach(async () => {
+    await receiver.close()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns 200, decodes the span, and mints the OBSERVED CALLS edge', async () => {
+    const payload = encodeSampledSpanRequest()
+    const res = await receiver.inject({
+      method: 'POST',
+      url: '/v1/traces',
+      headers: { 'content-type': 'application/x-protobuf' },
+      payload,
+    })
+    expect(res.statusCode).toBe(200)
+
+    await receiver.flushPending()
+
+    expect(collected).toHaveLength(1)
+    const parsed = collected[0]
+    expect(parsed.service).toBe('svc-flags-fixed32')
+    expect(parsed.traceId).toBe('ab'.repeat(16))
+    expect(parsed.spanId).toBe('cd'.repeat(8))
+    expect(parsed.kind).toBe(3)
+    // fixed64 timestamps survived the decode intact.
+    expect(parsed.startTimeUnixNano).toBe('1717761600123000000')
+    expect(parsed.durationNanos).toBe(25_000_000n)
+    expect(parsed.attributes['server.address']).toBe('svc-flags-peer')
+
+    const edgeId = `${EdgeType.CALLS}:OBSERVED:service:svc-flags-fixed32->service:svc-flags-peer`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+  })
+})

--- a/packages/core/test/port-bind-host.test.ts
+++ b/packages/core/test/port-bind-host.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import net from 'node:net'
+import { isPortFree } from '../src/orchestrator.js'
+import { resolveHost } from '../src/daemon.js'
+
+// #574 — the port allocator must probe the same interface the daemon binds.
+//
+// On the authenticated path the daemon binds 0.0.0.0 (resolveHost). The
+// allocator used to probe loopback unconditionally, so a port already held on
+// the wildcard interface by a sibling daemon read as free, got handed to the
+// spawn, and the new daemon then died on EADDRINUSE binding 0.0.0.0 — before
+// it could write daemon.json, surfacing only as a silent "daemon.json
+// timeout". The fix threads the resolved bind host into the free-port check so
+// the interface probed always equals the interface the daemon will bind.
+
+function hold(host: string): Promise<net.Server> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.once('error', reject)
+    server.listen(0, host, () => resolve(server))
+  })
+}
+
+function portOf(server: net.Server): number {
+  const addr = server.address()
+  if (addr && typeof addr === 'object') return addr.port
+  throw new Error('expected a bound TCP port')
+}
+
+describe('port allocator bind-host probe (#574)', () => {
+  const held: net.Server[] = []
+  const savedHost = process.env.HOST
+
+  afterEach(async () => {
+    await Promise.all(
+      held.splice(0).map((s) => new Promise<void>((resolve) => s.close(() => resolve()))),
+    )
+    if (savedHost === undefined) delete process.env.HOST
+    else process.env.HOST = savedHost
+  })
+
+  it('reads a wildcard-held port as taken when probing the token bind host', async () => {
+    const server = await hold('0.0.0.0')
+    held.push(server)
+    const port = portOf(server)
+    // The token path binds 0.0.0.0; probing that interface catches the holder
+    // so the allocator steps past it instead of handing over a doomed port.
+    expect(await isPortFree(port, '0.0.0.0')).toBe(false)
+  })
+
+  it('probes loopback by default — the no-token bind host', async () => {
+    const server = await hold('127.0.0.1')
+    held.push(server)
+    const port = portOf(server)
+    expect(await isPortFree(port, '127.0.0.1')).toBe(false)
+    // No host argument falls back to loopback, matching resolveHost's no-token
+    // default, so the same loopback-held port still reads as taken.
+    expect(await isPortFree(port)).toBe(false)
+  })
+
+  it('takes its probe host from resolveHost, so token state decides the interface', () => {
+    delete process.env.HOST
+    // resolveHost is the single source of the bind decision the orchestrator
+    // feeds into the probe: token → 0.0.0.0, no token → loopback.
+    expect(resolveHost({}, true)).toBe('0.0.0.0')
+    expect(resolveHost({}, false)).toBe('127.0.0.1')
+  })
+})

--- a/packages/core/test/project-daemon.test.ts
+++ b/packages/core/test/project-daemon.test.ts
@@ -270,6 +270,60 @@ describe('per-project daemon — §1 spans land in the right graph, none drop (A
     expect(await fileExists(path.join(sandbox.home, 'errors.ndjson'))).toBe(false)
   })
 
+  it('single-project mode quarantines a sibling project\'s span instead of merging it (refs #339)', async () => {
+    const sandbox = await setupSandbox(['own-svc'])
+    pending.push(sandbox.cleanup)
+    const { startDaemon } = await import('../src/daemon.js')
+    const ownPath = sandbox.projectPaths.get('own-svc')!
+
+    const daemon = await startDaemon({
+      project: 'own-svc',
+      projectPath: ownPath,
+      restPort: 0,
+      otlpPort: 0,
+    })
+    pending.push(daemon.stop)
+    await daemon.initialBootstrap
+    const endpoint = `${daemon.otlpAddress}/v1/traces`
+
+    // A foreign service's exporter found this daemon's shared OTLP port (the
+    // OS-default 4318 analogue). Its service.name belongs to no part of this
+    // project — neither the project name nor any extracted ServiceNode.
+    const foreignRes = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: clientSpanBody('foreign-svc', 'foreign-frontier.example.test', '4444444444444444'),
+    })
+    expect(foreignRes.status).toBe(200) // OTLP spec — always 200.
+
+    // This project's own span, posted after, lands normally.
+    const ownRes = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: clientSpanBody('own-svc', 'own-frontier.example.test', '5555555555555555'),
+    })
+    expect(ownRes.status).toBe(200)
+
+    const slot = daemon.slots.get('own-svc')!
+    const ownLanded = await waitFor(
+      () => [...slot.graph.nodes()].some((id) => id.includes('own-frontier.example.test')),
+      10_000,
+    )
+    expect(ownLanded, 'own span minted a node in own graph').toBe(true)
+
+    // The foreign span never merged: neither its peer host nor its service node
+    // appear in this project's graph.
+    expect([...slot.graph.nodes()].some((id) => id.includes('foreign-frontier.example.test'))).toBe(false)
+    expect([...slot.graph.nodes()].some((id) => id.includes('foreign-svc'))).toBe(false)
+
+    // It quarantined to the home-level unrouted ledger rather than going dark.
+    const quarantined = await waitFor(
+      () => fileExists(path.join(sandbox.home, 'errors.ndjson')),
+      10_000,
+    )
+    expect(quarantined, 'foreign span recorded to the unrouted ledger').toBe(true)
+  })
+
   it('ports are stable across a daemon restart — the persisted triple is reused', async () => {
     const sandbox = await setupSandbox(['restart-svc'])
     pending.push(sandbox.cleanup)

--- a/packages/core/test/self-pollution.test.ts
+++ b/packages/core/test/self-pollution.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import path from 'node:path'
+import os from 'node:os'
+import { promises as fs } from 'node:fs'
+
+// NEAT's `--apply` writes `.env.neat` and `otel-init.{ext}` into the user's
+// tree (ADR-069). Extraction must skip both — ingesting them records NEAT's own
+// instrumentation as if the user had declared it (self-pollution). This mirrors
+// the existing `.env.template` exclusion in the static-extraction contract.
+
+describe('self-pollution: NEAT-authored files are excluded from extraction', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-self-pollution-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('walkConfigFiles skips .env.neat but keeps a real .env', async () => {
+    await fs.writeFile(path.join(dir, '.env'), 'DATABASE_URL=postgres://x\n')
+    await fs.writeFile(path.join(dir, '.env.neat'), 'OTEL_SERVICE_NAME=app\n')
+
+    const { walkConfigFiles } = await import('../src/extract/configs.js')
+    const files = (await walkConfigFiles(dir)).map((p) => path.basename(p))
+
+    expect(files).toContain('.env')
+    expect(files).not.toContain('.env.neat')
+  })
+
+  it('walkSourceFiles skips the generated otel-init but keeps real source', async () => {
+    await fs.writeFile(path.join(dir, 'index.js'), 'console.log("app")\n')
+    await fs.writeFile(path.join(dir, 'otel-init.cjs'), 'require("@neat.is/otel")\n')
+    await fs.writeFile(path.join(dir, 'otel-init.ts'), 'import "@neat.is/otel"\n')
+
+    const { walkSourceFiles } = await import('../src/extract/calls/shared.js')
+    const files = (await walkSourceFiles(dir)).map((p) => path.basename(p))
+
+    expect(files).toContain('index.js')
+    expect(files).not.toContain('otel-init.cjs')
+    expect(files).not.toContain('otel-init.ts')
+  })
+
+  it('predicates classify NEAT-authored artifacts directly', async () => {
+    const { isNeatAuthoredEnvFile, isNeatAuthoredSourceFile, isConfigFile } =
+      await import('../src/extract/shared.js')
+
+    expect(isNeatAuthoredEnvFile('.env.neat')).toBe(true)
+    expect(isNeatAuthoredEnvFile('.env')).toBe(false)
+    expect(isNeatAuthoredEnvFile('.env.local')).toBe(false)
+
+    expect(isNeatAuthoredSourceFile('otel-init.cjs')).toBe(true)
+    expect(isNeatAuthoredSourceFile('otel-init.mjs')).toBe(true)
+    expect(isNeatAuthoredSourceFile('otel-init.js')).toBe(true)
+    expect(isNeatAuthoredSourceFile('otel-init.ts')).toBe(true)
+    expect(isNeatAuthoredSourceFile('index.js')).toBe(false)
+    expect(isNeatAuthoredSourceFile('my-otel-init.js')).toBe(false)
+
+    // isConfigFile delegates — .env.neat is not config, a real env file is.
+    expect(isConfigFile('.env.neat').match).toBe(false)
+    expect(isConfigFile('.env').match).toBe(true)
+    expect(isConfigFile('.env.local').match).toBe(true)
+  })
+})

--- a/packages/core/test/traverse.test.ts
+++ b/packages/core/test/traverse.test.ts
@@ -275,6 +275,93 @@ describe('getRootCause', () => {
   })
 })
 
+// Incident-localized root cause (#584): a service can fail in process — a 500
+// thrown inside its own handler — without the failure ever crossing a graph
+// edge, so the edge walk reports nothing. getRootCause then consults the
+// recorded incident store, which localizes the failure to the file:line / route
+// the failing span captured.
+describe('getRootCause — incident-localized fallback (#584)', () => {
+  function harvestGraph(): NeatGraph {
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:harvest-api', {
+      id: 'service:harvest-api',
+      type: NodeType.ServiceNode,
+      name: 'harvest-api',
+      language: 'javascript',
+    })
+    return g
+  }
+
+  function incident(overrides: Partial<ErrorEvent> = {}): ErrorEvent {
+    return {
+      id: 'trace-x:span-x',
+      timestamp: '2026-06-30T12:00:00.000Z',
+      service: 'harvest-api',
+      traceId: 'trace-x',
+      spanId: 'span-x',
+      errorMessage: '500 on GET /users/:id',
+      affectedNode: 'file:harvest-api:src/index.js',
+      attributes: {
+        'code.filepath': 'src/index.js',
+        'code.lineno': 22,
+        'http.route': '/users/:id',
+      },
+      httpStatusCode: 500,
+      ...overrides,
+    }
+  }
+
+  it('localizes a service with recorded incidents instead of reporting healthy', () => {
+    const g = harvestGraph()
+    const incidents = [incident(), incident({ id: 'trace-y:span-y', timestamp: '2026-06-30T11:00:00.000Z' })]
+
+    const result = getRootCause(g, 'service:harvest-api', undefined, incidents)
+    expect(result).not.toBeNull()
+    // Names the file the failure surfaced in, walked from the queried service
+    // as a single OBSERVED hop.
+    expect(result!.rootCauseNode).toBe('file:harvest-api:src/index.js')
+    expect(result!.traversalPath).toEqual([
+      'service:harvest-api',
+      'file:harvest-api:src/index.js',
+    ])
+    expect(result!.edgeProvenances).toEqual([Provenance.OBSERVED])
+    expect(result!.rootCauseReason).toContain('500 on GET /users/:id')
+    expect(result!.rootCauseReason).toContain('src/index.js:22')
+    expect(result!.rootCauseReason).toContain('2 recorded incidents')
+    expect(result!.fixRecommendation).toContain('src/index.js:22')
+    expect(result!.fixRecommendation).toContain('/users/:id')
+  })
+
+  it('matches incidents to the service by service name when affectedNode is file-grained', () => {
+    const g = harvestGraph()
+    // Querying the service must still surface a file-grained incident — the
+    // service-name match mirrors the REST incident-history read.
+    const result = getRootCause(g, 'service:harvest-api', undefined, [incident()])
+    expect(result).not.toBeNull()
+    expect(result!.confidence).toBeGreaterThan(0)
+    expect(result!.confidence).toBeLessThan(1)
+  })
+
+  it('falls back to service grain when the incident carries no call site', () => {
+    const g = harvestGraph()
+    const result = getRootCause(g, 'service:harvest-api', undefined, [
+      incident({ affectedNode: 'service:harvest-api', attributes: undefined }),
+    ])
+    expect(result).not.toBeNull()
+    expect(result!.rootCauseNode).toBe('service:harvest-api')
+    expect(result!.traversalPath).toEqual(['service:harvest-api'])
+    expect(result!.edgeProvenances).toEqual([])
+  })
+
+  it('returns null when no incident touches the queried node', () => {
+    const g = harvestGraph()
+    const result = getRootCause(g, 'service:harvest-api', undefined, [
+      incident({ service: 'other-svc', affectedNode: 'service:other-svc' }),
+    ])
+    expect(result).toBeNull()
+  })
+})
+
 // File-first graph (file-awareness.md §1–2, #392): relationships originate from
 // files, the service owns them through CONTAINS. service-a's index.js calls
 // service-b, service-b's db.js connects to the db, and service-b declares the


### PR DESCRIPTION
A batch of stability patches across NEAT's runtime path and the graph it produces, drawn from running NEAT against a spread of real backend shapes.

**Daemon & ports**
- The port allocator probes the same interface the daemon binds (wildcard on the authenticated path), so the daemon comes up reliably when other processes hold nearby ports.
- The bare-run readiness gate scopes to the project being started, so an unrelated registered project can't hold it up.

**OTLP ingest**
- The trace receiver decodes the full OpenTelemetry SDK wire format, including sampled spans (the `fixed32` flags field), so telemetry from standard exporters lands.
- Spans are scoped to their owning project, and incidents are recorded once per `(traceId, spanId)`.

**Graph fusion**
- Static and runtime views of the same source file resolve to one node, so EXTRACTED and OBSERVED edges share a graph even when a deployment's paths differ from the checkout (container, serverless, relocated clone).

**Divergence & root-cause**
- Divergence considers only runtime-observable edge types, so structural imports and config wiring stay out of the results.
- Root-cause draws on the incident store to localize in-process failures to file and route.
- A service's declared database target is extracted, so a declared-vs-observed host divergence can surface.

**Extraction**
- Python `from pkg import module` resolves to the module file rather than the package root.
- NEAT's own generated files (`.env.neat`, otel-init) stay out of the extracted graph.

Refs #574 #581 #582 #584 #586 #598 #599 #602 #604