### PR TITLE
Follow the failing CALLS chain when root-causing an entry service

### DIFF
--- a/docs/contracts/get-root-cause.md
+++ b/docs/contracts/get-root-cause.md
@@ -33,7 +33,21 @@ Issue #123.
 
 `longestIncomingWalk` — DFS backward from origin to depth 5. `ROOT_CAUSE_MAX_DEPTH = 5` is a hardcoded contract value.
 
-The longest path produced becomes the candidate; the first incompatibility found along it is the root cause. If no incompatibility is found, `getRootCause` returns null.
+The longest path produced becomes the candidate; the first incompatibility found along it is the root cause. If no incompatibility is found, the walk yields no shape match and `getRootCause` moves to the localization steps below.
+
+## Cross-service localization — follow the failing CALLS chain (#589)
+
+An entry service surfaces a failure that actually originates downstream. Nothing calls the entry service, so `longestIncomingWalk` is empty and the incoming shapes find nothing — yet the service's own OBSERVED CALLS edge to the callee carries the failure (`signal.errorCount > 0`). Naive incident matching would self-attribute the caller's CLIENT-side 500 to the entry service and even name a route the entry service never serves.
+
+So for a `ServiceNode` origin, before consulting the incident store against the origin itself, `getRootCause` follows the **outbound** failing CALLS chain to the real culprit:
+
+- A CALLS edge counts as failing when `signal.errorCount > 0`. The chain steps to the callee at the other end of the dominant failing edge (most recorded errors, then highest `PROV_RANK`, then target id — deterministic).
+- The caller's CALLS edge may be anchored on a FileNode the service `CONTAINS` (file-awareness §4), not the service node itself; both the service and the files it owns are considered as edge sources.
+- The chain walks at most `ROOT_CAUSE_MAX_DEPTH` hops, skipping FrontierNode callees and already-visited services. The deepest still-failing callee — the service whose own downstream calls are clean — is the culprit whose handler actually threw.
+- The culprit is then localized through the incident store exactly like the in-process case below (its handler `file:line` / `http.route`), and the failing CALLS edges become the leading hops of `traversalPath` (origin → … → culprit → handler file). Each hop's `provenance` enters `edgeProvenances` in order; the localizing incident hop is `OBSERVED`.
+- When the culprit has no recorded incident, the result still names the culprit service (never the caller) with a reason derived from the failing edge that reached it.
+
+Cross-service confidence cascades over the failing CALLS edges and the incident hop, so it sits below an edge-walked compat result. When no outbound call is failing the failure is in-process here and `getRootCause` falls through to the incident store against the origin (#584).
 
 ## Reason
 

--- a/packages/core/src/traverse.ts
+++ b/packages/core/src/traverse.ts
@@ -408,13 +408,25 @@ export function getRootCause(
     }
   }
 
-  // No graph edge carried an incompatibility — but a service can fail in
-  // process (a 500 thrown inside its own handler) without that failure ever
-  // crossing an edge, so the walk above sees a healthy-looking node. The
-  // recorded incident store is the OBSERVED evidence the graph can't carry:
-  // it localizes the failure to the file:line / route the failing span
-  // captured. Consulting it here keeps root-cause useful for the in-process
-  // case instead of reporting "healthy" over a pile of recorded 500s (#584).
+  // A service surfacing a failure may be the entry point of a cross-service
+  // 500 that actually originates downstream. Nothing calls the entry service,
+  // so the incoming walk above is empty — but its own OBSERVED CALLS edge to
+  // the callee carries the failure. Follow that outbound failing CALLS chain to
+  // the real culprit's handler before self-attributing the caller's mislabelled
+  // CLIENT span (#589). Only null-returns here when no downstream call is
+  // failing, i.e. the failure is in process at the origin.
+  if (origin.type === NodeType.ServiceNode) {
+    const crossService = crossServiceRootCause(graph, errorNodeId, incidents, errorEvent)
+    if (crossService) return crossService
+  }
+
+  // No graph edge carried an incompatibility and no downstream call is failing —
+  // but a service can fail in process (a 500 thrown inside its own handler)
+  // without that failure ever crossing an edge, so the walk above sees a
+  // healthy-looking node. The recorded incident store is the OBSERVED evidence
+  // the graph can't carry: it localizes the failure to the file:line / route the
+  // failing span captured. Consulting it here keeps root-cause useful for the
+  // in-process case instead of reporting "healthy" over a pile of 500s (#584).
   return rootCauseFromIncidents(errorNodeId, incidents, errorEvent)
 }
 
@@ -432,15 +444,28 @@ function incidentMatchesNode(ev: ErrorEvent, nodeId: string): boolean {
   return ev.affectedNode === nodeId || ev.service === nodeId.replace(/^service:/, '')
 }
 
-// Build a root-cause result from the recorded incident store when the graph
-// walk found nothing. Picks the most recent incident affecting the node and
-// localizes the failure to the file:line / route it captured. Returns null when
-// no incident touches the node — the honest "nothing to say" answer.
-function rootCauseFromIncidents(
+// A failure localized to a node through the incident store: which node carries
+// the cause, the human reason, the file the failure surfaced in (when the
+// incident captured a `code.*` call site), and the derived fix.
+interface IncidentLocalization {
+  rootCauseNode: string
+  rootCauseReason: string
+  // The FileNode the failure surfaced in, present only when the incident
+  // localized to a file grain. Callers walk node → file as a single OBSERVED
+  // hop when this is set.
+  fileNode?: string
+  fixRecommendation?: string
+}
+
+// Pick the most recent incident affecting `nodeId` and localize the failure to
+// the file:line / route it captured. Returns null when no incident touches the
+// node. Shared by the in-process fallback and the cross-service chain (#589) so
+// both describe a culprit's handler the same way.
+function localizeFromIncidents(
   nodeId: string,
   incidents: ErrorEvent[] | undefined,
   errorEvent: ErrorEvent | undefined,
-): RootCauseResult | null {
+): IncidentLocalization | null {
   const pool = incidents && incidents.length > 0 ? incidents : errorEvent ? [errorEvent] : []
   const relevant = pool.filter((ev) => incidentMatchesNode(ev, nodeId))
   if (relevant.length === 0) return null
@@ -460,14 +485,11 @@ function rootCauseFromIncidents(
   const rootCauseReason = `${reasonParts.join(' — ')}${tail}`
 
   // When the incident localized to a file (affectedNode is a file id), name
-  // that file as the root cause and walk the queried node → file as a single
-  // OBSERVED hop. The "edge" is the captured runtime attribution; OBSERVED is
-  // honest because the file came from a real `code.*` on the failing span.
-  // Otherwise the cause sits on the queried node itself (service grain).
+  // that file as the root cause. The "edge" the caller walks is the captured
+  // runtime attribution; OBSERVED is honest because the file came from a real
+  // `code.*` on the failing span. Otherwise the cause sits on the node itself.
   const localizesToFile = latest.affectedNode !== nodeId && latest.affectedNode.startsWith('file:')
-  const rootCauseNode = localizesToFile ? latest.affectedNode : nodeId
-  const traversalPath = localizesToFile ? [nodeId, latest.affectedNode] : [nodeId]
-  const edgeProvenances = localizesToFile ? [Provenance.OBSERVED] : []
+  const fileNode = localizesToFile ? latest.affectedNode : undefined
 
   const fixRecommendation = location
     ? `Inspect ${location}${route ? ` handling ${route}` : ''}`
@@ -475,13 +497,186 @@ function rootCauseFromIncidents(
       ? `Inspect ${latest.service}'s handler for ${route}`
       : undefined
 
-  return RootCauseResultSchema.parse({
-    rootCauseNode,
+  return {
+    rootCauseNode: fileNode ?? nodeId,
     rootCauseReason,
+    ...(fileNode ? { fileNode } : {}),
+    ...(fixRecommendation ? { fixRecommendation } : {}),
+  }
+}
+
+// Build a root-cause result from the recorded incident store when the graph
+// walk found nothing. Localizes the failure to the queried node itself (or the
+// file it surfaced in). Returns null when no incident touches the node — the
+// honest "nothing to say" answer.
+function rootCauseFromIncidents(
+  nodeId: string,
+  incidents: ErrorEvent[] | undefined,
+  errorEvent: ErrorEvent | undefined,
+): RootCauseResult | null {
+  const loc = localizeFromIncidents(nodeId, incidents, errorEvent)
+  if (!loc) return null
+
+  const traversalPath = loc.fileNode ? [nodeId, loc.fileNode] : [nodeId]
+  const edgeProvenances = loc.fileNode ? [Provenance.OBSERVED] : []
+
+  return RootCauseResultSchema.parse({
+    rootCauseNode: loc.rootCauseNode,
+    rootCauseReason: loc.rootCauseReason,
     traversalPath,
     edgeProvenances,
     confidence: INCIDENT_ROOT_CAUSE_CONFIDENCE,
-    ...(fixRecommendation ? { fixRecommendation } : {}),
+    ...(loc.fixRecommendation ? { fixRecommendation: loc.fixRecommendation } : {}),
+  })
+}
+
+// A CALLS edge counts as failing when its OBSERVED signal recorded at least one
+// error. This is the signal the cross-service chain follows: the caller's call
+// to the callee returned a 5xx (#589).
+function isFailingCallEdge(e: GraphEdge): boolean {
+  return e.type === EdgeType.CALLS && (e.signal?.errorCount ?? 0) > 0
+}
+
+// Every node id that can originate an outbound CALLS edge on a service's behalf:
+// the service itself, plus each FileNode it CONTAINS. A file-first graph anchors
+// the caller's CALLS edge on the call-site file (file-awareness.md §4), so an
+// entry service's failing call may hang off one of its files, not the bare
+// service node.
+function callSourcesForService(graph: NeatGraph, serviceId: string): string[] {
+  const ids = [serviceId]
+  for (const edgeId of graph.outboundEdges(serviceId)) {
+    const e = graph.getEdgeAttributes(edgeId) as GraphEdge
+    if (e.type !== EdgeType.CONTAINS) continue
+    const tgt = graph.getNodeAttributes(e.target) as GraphNode
+    if (tgt.type === NodeType.FileNode) ids.push(e.target)
+  }
+  return ids
+}
+
+// Did edge `e` to service `id` beat the current best failing call? Most recorded
+// errors win; ties break on PROV_RANK, then target id — deterministic.
+function failingCallDominates(
+  e: GraphEdge,
+  id: string,
+  curEdge: GraphEdge,
+  curId: string,
+): boolean {
+  const ec = e.signal?.errorCount ?? 0
+  const cc = curEdge.signal?.errorCount ?? 0
+  if (ec !== cc) return ec > cc
+  if (PROV_RANK[e.provenance] !== PROV_RANK[curEdge.provenance]) {
+    return PROV_RANK[e.provenance] > PROV_RANK[curEdge.provenance]
+  }
+  return id < curId
+}
+
+// The dominant failing outbound CALLS from a service: among the service's own
+// edges and those of the files it owns, the failing CALLS edge to another
+// service with the most recorded errors. Returns the next-hop service id and the
+// edge, or null when no downstream call is failing — meaning the failure is in
+// process here, not relayed from deeper.
+function dominantFailingCall(
+  graph: NeatGraph,
+  serviceId: string,
+  visited: Set<string>,
+): { nextService: string; edge: GraphEdge } | null {
+  let best: { nextService: string; edge: GraphEdge } | null = null
+  for (const src of callSourcesForService(graph, serviceId)) {
+    for (const edgeId of graph.outboundEdges(src)) {
+      const e = graph.getEdgeAttributes(edgeId) as GraphEdge
+      if (!isFailingCallEdge(e)) continue
+      if (isFrontierNode(graph, e.target)) continue
+      const owner = resolveOwningService(graph, e.target)
+      if (!owner || visited.has(owner.id)) continue
+      if (!best || failingCallDominates(e, owner.id, best.edge, best.nextService)) {
+        best = { nextService: owner.id, edge: e }
+      }
+    }
+  }
+  return best
+}
+
+// Walk the failing CALLS chain outbound from an entry service to the deepest
+// still-failing callee — the service whose own downstream calls are clean and
+// whose handler therefore threw (#589). Returns the path of service ids, the
+// failing edges along it, and the culprit, or null when nothing downstream is
+// failing.
+function followFailingCallChain(
+  graph: NeatGraph,
+  originServiceId: string,
+  maxDepth: number,
+): { path: string[]; edges: GraphEdge[]; culprit: string } | null {
+  const path = [originServiceId]
+  const edges: GraphEdge[] = []
+  const visited = new Set<string>([originServiceId])
+  let current = originServiceId
+
+  for (let depth = 0; depth < maxDepth; depth++) {
+    const hop = dominantFailingCall(graph, current, visited)
+    if (!hop) break
+    path.push(hop.nextService)
+    edges.push(hop.edge)
+    visited.add(hop.nextService)
+    current = hop.nextService
+  }
+
+  if (edges.length === 0) return null
+  return { path, edges, culprit: current }
+}
+
+// Localize a cross-service failure (#589). An entry ServiceNode surfaces a 500
+// that originates downstream: follow the failing CALLS chain to the culprit and
+// describe its handler, never the caller's mis-attributed CLIENT span. Returns
+// null when no outbound call is failing — the failure is in process here and the
+// caller falls through to the origin's own incident store.
+function crossServiceRootCause(
+  graph: NeatGraph,
+  originId: string,
+  incidents: ErrorEvent[] | undefined,
+  errorEvent: ErrorEvent | undefined,
+): RootCauseResult | null {
+  const chain = followFailingCallChain(graph, originId, ROOT_CAUSE_MAX_DEPTH)
+  if (!chain) return null
+
+  const culprit = chain.culprit
+  const path = [...chain.path]
+  const edgeProvenances = chain.edges.map((e) => e.provenance)
+
+  // Cross-service confidence cascades over the failing CALLS edges and the
+  // incident-localization hop, so it lands below an edge-walked compat result.
+  const baseConfidence = confidenceFromMix(chain.edges)
+  const confidence = Math.max(0, Math.min(1, baseConfidence * INCIDENT_ROOT_CAUSE_CONFIDENCE))
+
+  const loc = localizeFromIncidents(culprit, incidents, errorEvent)
+  if (loc) {
+    let rootCauseNode = culprit
+    if (loc.fileNode) {
+      path.push(loc.fileNode)
+      edgeProvenances.push(Provenance.OBSERVED)
+      rootCauseNode = loc.fileNode
+    }
+    return RootCauseResultSchema.parse({
+      rootCauseNode,
+      rootCauseReason: loc.rootCauseReason,
+      traversalPath: path,
+      edgeProvenances,
+      confidence,
+      ...(loc.fixRecommendation ? { fixRecommendation: loc.fixRecommendation } : {}),
+    })
+  }
+
+  // No recorded incident for the culprit — still better than blaming the caller.
+  // Name the culprit service and read the reason off the failing edge.
+  const lastEdge = chain.edges[chain.edges.length - 1]!
+  const errs = lastEdge.signal?.errorCount ?? 0
+  const culpritName = culprit.replace(/^service:/, '')
+  return RootCauseResultSchema.parse({
+    rootCauseNode: culprit,
+    rootCauseReason: `${culpritName} is failing downstream calls (${errs} observed error${errs === 1 ? '' : 's'})`,
+    traversalPath: path,
+    edgeProvenances,
+    confidence,
+    fixRecommendation: `Inspect ${culpritName}'s failing handler`,
   })
 }
 

--- a/packages/core/test/traverse.test.ts
+++ b/packages/core/test/traverse.test.ts
@@ -362,6 +362,120 @@ describe('getRootCause — incident-localized fallback (#584)', () => {
   })
 })
 
+// Cross-service root-cause (#589): service-a is the entry service surfacing a
+// 502. It calls service-b, whose /charge handler throws the 500. Nothing calls
+// service-a, so the incoming walk is empty and naive incident matching would
+// blame service-a's own CLIENT span for a route it never serves. Root-cause
+// must follow the OBSERVED failing CALLS edge outbound to service-b's handler.
+describe('getRootCause — cross-service failing CALLS chain (#589)', () => {
+  function twoServiceGraph(): NeatGraph {
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:service-a', {
+      id: 'service:service-a',
+      type: NodeType.ServiceNode,
+      name: 'service-a',
+      language: 'javascript',
+    })
+    g.addNode('service:service-b', {
+      id: 'service:service-b',
+      type: NodeType.ServiceNode,
+      name: 'service-b',
+      language: 'javascript',
+    })
+    // service-a --CALLS--> service-b, observed with recorded errors on the call.
+    addEdge(g, {
+      id: 'CALLS:OBSERVED:service:service-a->service:service-b',
+      source: 'service:service-a',
+      target: 'service:service-b',
+      type: EdgeType.CALLS,
+      provenance: Provenance.OBSERVED,
+      signal: { spanCount: 40, errorCount: 12, lastObservedAgeMs: 0 },
+    })
+    return g
+  }
+
+  // The 500 the downstream handler threw, recorded against service-b's /charge.
+  function chargeIncident(overrides: Partial<ErrorEvent> = {}): ErrorEvent {
+    return {
+      id: 'trace-c:span-c',
+      timestamp: '2026-06-30T12:00:00.000Z',
+      service: 'service-b',
+      traceId: 'trace-c',
+      spanId: 'span-c',
+      errorMessage: '500 on POST /charge',
+      affectedNode: 'file:service-b:src/charge.js',
+      attributes: {
+        'code.filepath': 'src/charge.js',
+        'code.lineno': 47,
+        'http.route': '/charge',
+      },
+      httpStatusCode: 500,
+      ...overrides,
+    }
+  }
+
+  it('localizes the downstream culprit handler, not the calling entry service', () => {
+    const g = twoServiceGraph()
+    const result = getRootCause(g, 'service:service-a', undefined, [chargeIncident()])
+
+    expect(result).not.toBeNull()
+    // The root cause is service-b's handler file, reached by crossing the
+    // failing CALLS edge — never the caller service-a.
+    expect(result!.rootCauseNode).toBe('file:service-b:src/charge.js')
+    expect(result!.rootCauseNode).not.toBe('service:service-a')
+    expect(result!.traversalPath).toEqual([
+      'service:service-a',
+      'service:service-b',
+      'file:service-b:src/charge.js',
+    ])
+    // The CALLS hop is OBSERVED, and so is the incident-localization hop.
+    expect(result!.edgeProvenances).toEqual([Provenance.OBSERVED, Provenance.OBSERVED])
+    expect(result!.rootCauseReason).toContain('service-b')
+    expect(result!.rootCauseReason).toContain('/charge')
+    // /charge belongs to service-b: the reason must not misattribute it to a-.
+    expect(result!.rootCauseReason).not.toMatch(/service-a/)
+    expect(result!.fixRecommendation).toContain('src/charge.js:47')
+  })
+
+  it('answers correctly when service-b is queried directly (the data was always there)', () => {
+    const g = twoServiceGraph()
+    const result = getRootCause(g, 'service:service-b', undefined, [chargeIncident()])
+    expect(result).not.toBeNull()
+    expect(result!.rootCauseNode).toBe('file:service-b:src/charge.js')
+  })
+
+  it('names the culprit service even when it has no recorded incident', () => {
+    const g = twoServiceGraph()
+    const result = getRootCause(g, 'service:service-a', undefined, [])
+    expect(result).not.toBeNull()
+    expect(result!.rootCauseNode).toBe('service:service-b')
+    expect(result!.rootCauseReason).toContain('service-b')
+    expect(result!.traversalPath).toEqual(['service:service-a', 'service:service-b'])
+  })
+
+  it('stays in-process (falls through to the origin) when no outbound call is failing', () => {
+    const g = twoServiceGraph()
+    // Clear the error signal so the outbound call is clean; the origin owns the
+    // failure and the incident store localizes it against service-a.
+    g.setEdgeAttribute(
+      'CALLS:OBSERVED:service:service-a->service:service-b',
+      'signal',
+      { spanCount: 40, errorCount: 0, lastObservedAgeMs: 0 },
+    )
+    const result = getRootCause(g, 'service:service-a', undefined, [
+      chargeIncident({
+        id: 'trace-a:span-a',
+        service: 'service-a',
+        affectedNode: 'service:service-a',
+        attributes: undefined,
+        errorMessage: 'in-process boom',
+      }),
+    ])
+    expect(result).not.toBeNull()
+    expect(result!.rootCauseNode).toBe('service:service-a')
+  })
+})
+
 // File-first graph (file-awareness.md §1–2, #392): relationships originate from
 // files, the service owns them through CONTAINS. service-a's index.js calls
 // service-b, service-b's db.js connects to the db, and service-b declares the


### PR DESCRIPTION
Cross-service root-cause was returning a confidently wrong answer from the symptom side. Ask why an entry service is 500ing and it blamed the entry service itself — plus a route the entry service doesn't even serve. Root: `getRootCause` only walked *incoming* edges via `longestIncomingWalk`; for an entry service nothing calls it, so the walk came up empty and the incident fallback self-attributed the caller's client-side 500. It never crossed the OBSERVED CALLS edge to the downstream culprit.

Now, for a `ServiceNode` origin, before consulting the origin's own incidents, root-cause follows the **outbound** failing CALLS chain (`signal.errorCount > 0`) to the deepest still-failing callee — the service whose own downstream calls are clean and whose handler therefore threw. That culprit is localized through the incident store the same way the in-process case is (handler `file:line` / `http.route`), and the failing CALLS edges become the leading hops of the traversal path. When the culprit has no recorded incident we still name it, never the caller.

The CALLS-edge source may be a FileNode the service `CONTAINS` (file-first graph), so both the service and its files are considered as edge sources. Chain steps are deterministic: most recorded errors, then `PROV_RANK`, then target id. FrontierNode and already-visited callees are skipped; the chain is depth-bounded at `ROOT_CAUSE_MAX_DEPTH`.

Contract `docs/contracts/get-root-cause.md` gets the new "Cross-service localization" section first, then the code.

New test: a 2-service graph, A→B where B's `/charge` handler throws — `root-cause(A)` localizes `file:service-b:src/charge.js`, not service-a. Sibling cases cover querying B directly, a culprit with no recorded incident, and the in-process fall-through when no outbound call is failing.

Full `@neat.is/core` suite green (1149 passed), including the contracts audit.

Refs #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)