### PR TITLE
Give terraform and Dockerfiles enough signal to answer infra topology

### DIFF
--- a/docs/contracts/static-extraction.md
+++ b/docs/contracts/static-extraction.md
@@ -96,7 +96,7 @@ Other extensions are skipped silently by `walkSourceFiles` per `IGNORED_DIRS` an
 | `databases/*`        | DatabaseNode + CONNECTS_TO                     | ❌ — #140      |
 | `configs.ts`         | ConfigNode + CONFIGURED_BY                     | ❌ — #140      |
 | `calls/{aws,grpc,http,kafka,redis,supabase}.ts` | CALLS / PUBLISHES_TO / CONSUMES_FROM | ✅          |
-| `infra/{docker-compose,dockerfile,k8s,terraform}.ts` | InfraNode + DEPENDS_ON / RUNS_ON | ❌ — #140 |
+| `infra/{docker-compose,dockerfile,k8s,terraform}.ts` | InfraNode + DEPENDS_ON / RUNS_ON / CONNECTS_TO | ✅ (evidence populated) |
 
 New producers under `calls/` for source-level DB connections (`new pg.Pool(...)`) and inter-service imports land under issue #141. They follow the same interface, same evidence shape, same idempotency.
 

--- a/packages/core/src/extract/infra/dockerfile.ts
+++ b/packages/core/src/extract/infra/dockerfile.ts
@@ -8,23 +8,49 @@ import { recordExtractionError } from '../errors.js'
 import { makeInfraNode } from './shared.js'
 import { ensureFileNode, toPosix } from '../calls/shared.js'
 
-// Pull the first non-`scratch` `FROM` line out of a Dockerfile, ignoring
-// multi-stage `as` aliases. Returns the image including tag (e.g. `node:20`,
-// `python:3.11-slim`). Multi-stage builds report the *runtime* image — the
-// last FROM that isn't aliasing a previous stage.
-function runtimeImage(content: string): string | null {
-  const lines = content.split('\n')
-  let last: string | null = null
-  for (const raw of lines) {
+interface DockerfileFacts {
+  image: string | null
+  // Ports declared with `EXPOSE`, in declaration order, deduped. Each one is a
+  // network endpoint the container listens on — the structural answer to "what
+  // is this service reachable at".
+  ports: number[]
+  // The trimmed `ENTRYPOINT` / `CMD` line that names the process the container
+  // runs. Carried as edge evidence so the entrypoint is queryable instead of
+  // being a silent fact only the Dockerfile knows.
+  entrypoint: string | null
+}
+
+// Read the runtime-shaping instructions out of a Dockerfile in one pass:
+//
+//   - FROM   → the runtime image. Multi-stage builds report the *runtime* image
+//              (the last FROM that isn't `scratch` / a stage alias).
+//   - EXPOSE → the ports the container listens on (`EXPOSE 8080 9090`,
+//              `EXPOSE 8080/tcp`).
+//   - CMD / ENTRYPOINT → the process the container runs. ENTRYPOINT wins when
+//              both are present, matching Docker's precedence.
+function readDockerfile(content: string): DockerfileFacts {
+  let image: string | null = null
+  const ports: number[] = []
+  let cmd: string | null = null
+  let entrypoint: string | null = null
+  for (const raw of content.split('\n')) {
     const line = raw.trim()
     if (!line || line.startsWith('#')) continue
-    if (!/^from\s+/i.test(line)) continue
-    const tokens = line.split(/\s+/)
-    const image = tokens[1]
-    if (!image || image.toLowerCase() === 'scratch') continue
-    last = image
+    if (/^from\s+/i.test(line)) {
+      const candidate = line.split(/\s+/)[1]
+      if (candidate && candidate.toLowerCase() !== 'scratch') image = candidate
+    } else if (/^expose\s+/i.test(line)) {
+      for (const token of line.split(/\s+/).slice(1)) {
+        const port = Number.parseInt(token.split('/')[0]!, 10)
+        if (Number.isInteger(port) && !ports.includes(port)) ports.push(port)
+      }
+    } else if (/^entrypoint\s+/i.test(line)) {
+      entrypoint = line
+    } else if (/^cmd\s+/i.test(line)) {
+      cmd = line
+    }
   }
-  return last
+  return { image, ports, entrypoint: entrypoint ?? cmd }
 }
 
 // For each ServiceNode that has a Dockerfile in its dir, emit a
@@ -52,18 +78,22 @@ export async function addDockerfileRuntimes(
       )
       continue
     }
-    const image = runtimeImage(content)
-    if (!image) continue
+    const facts = readDockerfile(content)
+    if (!facts.image) continue
 
-    const node = makeInfraNode('container-image', image)
+    const node = makeInfraNode('container-image', facts.image)
     if (!graph.hasNode(node.id)) {
       graph.addNode(node.id, node)
       nodesAdded++
     }
 
     // file-awareness §1 — the Dockerfile IS the file that declares the runtime;
-    // anchor the RUNS_ON edge on a FileNode for it, not on the service.
+    // anchor the infra edges on a FileNode for it, not on the service. The file
+    // node is service-scoped, so two services that both `FROM node:20` keep
+    // distinct entrypoints and exposed ports instead of colliding on the shared
+    // image node.
     const relDockerfile = toPosix(path.relative(service.dir, dockerfilePath))
+    const evidenceFile = toPosix(path.relative(scanPath, dockerfilePath))
     const { fileNodeId, nodesAdded: fn, edgesAdded: fe } = ensureFileNode(
       graph,
       service.pkg.name,
@@ -72,6 +102,10 @@ export async function addDockerfileRuntimes(
     )
     nodesAdded += fn
     edgesAdded += fe
+
+    // RUNS_ON carries the runtime image, and — when the Dockerfile declares one
+    // — the entrypoint/CMD line as evidence.snippet, so the process the
+    // container runs is queryable instead of a silent fact.
     const edgeId = makeEdgeId(fileNodeId, node.id, EdgeType.RUNS_ON)
     if (!graph.hasEdge(edgeId)) {
       const edge: GraphEdge = {
@@ -82,10 +116,36 @@ export async function addDockerfileRuntimes(
         provenance: Provenance.EXTRACTED,
         confidence: confidenceForExtracted('structural'),
         evidence: {
-          file: toPosix(path.relative(scanPath, dockerfilePath)),
+          file: evidenceFile,
+          ...(facts.entrypoint ? { snippet: facts.entrypoint.slice(0, 120) } : {}),
         },
       }
       graph.addEdgeWithKey(edgeId, edge.source, edge.target, edge)
+      edgesAdded++
+    }
+
+    // Each EXPOSE port becomes an `infra:port:<n>` node the Dockerfile
+    // CONNECTS_TO — the structural answer to "what is this service reachable
+    // at". Without this, a declared listener is a fact only the Dockerfile
+    // knows; with it, the port is a first-class node the topology can reach.
+    for (const port of facts.ports) {
+      const portNode = makeInfraNode('port', String(port))
+      if (!graph.hasNode(portNode.id)) {
+        graph.addNode(portNode.id, portNode)
+        nodesAdded++
+      }
+      const portEdgeId = makeEdgeId(fileNodeId, portNode.id, EdgeType.CONNECTS_TO)
+      if (graph.hasEdge(portEdgeId)) continue
+      const portEdge: GraphEdge = {
+        id: portEdgeId,
+        source: fileNodeId,
+        target: portNode.id,
+        type: EdgeType.CONNECTS_TO,
+        provenance: Provenance.EXTRACTED,
+        confidence: confidenceForExtracted('structural'),
+        evidence: { file: evidenceFile, snippet: `EXPOSE ${port}` },
+      }
+      graph.addEdgeWithKey(portEdgeId, portEdge.source, portEdge.target, portEdge)
       edgesAdded++
     }
   }

--- a/packages/core/src/extract/infra/terraform.ts
+++ b/packages/core/src/extract/infra/terraform.ts
@@ -1,14 +1,32 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import type { GraphEdge } from '@neat.is/types'
+import { EdgeType, Provenance, confidenceForExtracted } from '@neat.is/types'
 import type { NeatGraph } from '../../graph.js'
-import { IGNORED_DIRS, isPythonVenvDir } from '../shared.js'
+import { IGNORED_DIRS, isPythonVenvDir, makeEdgeId } from '../shared.js'
+import { toPosix } from '../calls/shared.js'
 import { makeInfraNode } from './shared.js'
 
-// Light pass: catalogue `resource "aws_*" "name"` blocks in any *.tf file.
-// We don't interpret references — a real Terraform backend would resolve
-// those — but the resource-type/name pair is enough to register the node so
-// later cross-references can hang off it.
+// Light pass: catalogue `resource "aws_*" "name"` blocks in any *.tf file and
+// wire the references between them. We don't run a real Terraform backend, but
+// the body of every resource block names the other resources it consumes
+// (`aws_db_instance.main.endpoint`, `${aws_security_group.db.id}`, …). Those
+// `<type>.<name>` references are the structural fact that turns an edgeless
+// catalogue into a topology: a resource nothing points at is declared-but-unused,
+// a resource something points at is in use. Without this, an RDS instance the
+// app server depends on looks identical to a forgotten S3 bucket.
 const RESOURCE_RE = /resource\s+"(aws_[A-Za-z0-9_]+)"\s+"([A-Za-z0-9_-]+)"/g
+// A reference to another declared resource. The negative look-behind keeps us
+// from matching the tail of a longer identifier (`my_aws_thing.x`).
+const REFERENCE_RE = /(?<![\w.])(aws_[A-Za-z0-9_]+)\.([A-Za-z0-9_-]+)/g
+
+interface TfResource {
+  type: string
+  name: string
+  nodeId: string
+  body: string
+  bodyOffset: number
+}
 
 async function walkTfFiles(start: string, depth = 0, max = 5): Promise<string[]> {
   if (depth > max) return []
@@ -27,25 +45,101 @@ async function walkTfFiles(start: string, depth = 0, max = 5): Promise<string[]>
   return out
 }
 
+// Find the index just past the `}` that closes the block whose opening `{`
+// sits at or after `from`. Returns the body span (exclusive of the braces).
+// Balanced-brace scan — good enough for HCL, which doesn't put bare braces in
+// string literals often enough to matter for a reference catalogue.
+function blockBody(content: string, from: number): { body: string; offset: number } | null {
+  const open = content.indexOf('{', from)
+  if (open === -1) return null
+  let depth = 0
+  for (let i = open; i < content.length; i++) {
+    const ch = content[i]
+    if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) return { body: content.slice(open + 1, i), offset: open + 1 }
+    }
+  }
+  return null
+}
+
+function lineAt(content: string, index: number): number {
+  let line = 1
+  for (let i = 0; i < index && i < content.length; i++) {
+    if (content[i] === '\n') line++
+  }
+  return line
+}
+
 export async function addTerraformResources(
   graph: NeatGraph,
   scanPath: string,
 ): Promise<{ nodesAdded: number; edgesAdded: number }> {
   let nodesAdded = 0
+  let edgesAdded = 0
   const files = await walkTfFiles(scanPath)
   for (const file of files) {
     const content = await fs.readFile(file, 'utf8')
+    const evidenceFile = toPosix(path.relative(scanPath, file))
+
+    // First pass: register every resource as a node and remember its body so
+    // the second pass can resolve references against the set of declared names.
+    const resources: TfResource[] = []
+    const byKey = new Map<string, TfResource>()
     RESOURCE_RE.lastIndex = 0
     let m: RegExpExecArray | null
     while ((m = RESOURCE_RE.exec(content)) !== null) {
-      const kind = m[1]!
+      const type = m[1]!
       const name = m[2]!
-      const node = makeInfraNode(kind, name, 'aws')
+      const node = makeInfraNode(type, name, 'aws')
       if (!graph.hasNode(node.id)) {
         graph.addNode(node.id, node)
         nodesAdded++
       }
+      const span = blockBody(content, RESOURCE_RE.lastIndex)
+      const resource: TfResource = {
+        type,
+        name,
+        nodeId: node.id,
+        body: span?.body ?? '',
+        bodyOffset: span?.offset ?? RESOURCE_RE.lastIndex,
+      }
+      resources.push(resource)
+      byKey.set(`${type}.${name}`, resource)
+    }
+
+    // Second pass: a `<type>.<name>` reference inside a resource body that
+    // names another declared resource becomes a DEPENDS_ON edge from the
+    // referencing resource to the one it consumes. Structural tier (ADR-066) —
+    // the HCL literally says it depends on it.
+    for (const resource of resources) {
+      const seen = new Set<string>()
+      REFERENCE_RE.lastIndex = 0
+      let ref: RegExpExecArray | null
+      while ((ref = REFERENCE_RE.exec(resource.body)) !== null) {
+        const key = `${ref[1]!}.${ref[2]!}`
+        if (key === `${resource.type}.${resource.name}`) continue
+        const target = byKey.get(key)
+        if (!target) continue
+        if (seen.has(target.nodeId)) continue
+        seen.add(target.nodeId)
+        const edgeId = makeEdgeId(resource.nodeId, target.nodeId, EdgeType.DEPENDS_ON)
+        if (graph.hasEdge(edgeId)) continue
+        const line = lineAt(content, resource.bodyOffset + ref.index)
+        const edge: GraphEdge = {
+          id: edgeId,
+          source: resource.nodeId,
+          target: target.nodeId,
+          type: EdgeType.DEPENDS_ON,
+          provenance: Provenance.EXTRACTED,
+          confidence: confidenceForExtracted('structural'),
+          evidence: { file: evidenceFile, line, snippet: key },
+        }
+        graph.addEdgeWithKey(edgeId, edge.source, edge.target, edge)
+        edgesAdded++
+      }
     }
   }
-  return { nodesAdded, edgesAdded: 0 }
+  return { nodesAdded, edgesAdded }
 }

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -203,7 +203,10 @@ describe('REST API (fastify.inject)', () => {
     // distance 2 (via Dockerfile FileNode); service-b at distance 2 (via
     // index.js); service-b's files (db-config.yaml, Dockerfile, index.js,
     // otel.js) at distance 3; its ConfigNode and payments-db at distance 4.
-    expect(body.totalAffected).toBe(11)
+    // Each Dockerfile's EXPOSE also hangs an infra:port node off its FileNode:
+    // port:3000 for service-a (distance 2) and port:3001 for service-b
+    // (distance 4).
+    expect(body.totalAffected).toBe(13)
     // path + confidence land per ADR-038 §affectedNodes payload. Property-style
     // assertions so this test doesn't pin every BFS path detail — the contract
     // tests in contracts.test.ts pin the per-node invariants tightly.
@@ -226,6 +229,8 @@ describe('REST API (fastify.inject)', () => {
       'file:service-b:index.js',
       'file:service-b:otel.js',
       'infra:container-image:node:20-bookworm-slim',
+      'infra:port:3000',
+      'infra:port:3001',
       'service:service-b',
     ])
   })

--- a/packages/core/test/fixtures/infra/dockerfile/api/Dockerfile
+++ b/packages/core/test/fixtures/infra/dockerfile/api/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:20
 WORKDIR /app
 COPY . .
+EXPOSE 8080
 CMD ["node", "index.js"]

--- a/packages/core/test/fixtures/infra/terraform-refs/main.tf
+++ b/packages/core/test/fixtures/infra/terraform-refs/main.tf
@@ -1,0 +1,23 @@
+resource "aws_db_instance" "main" {
+  identifier = "app-db"
+  engine     = "postgres"
+}
+
+resource "aws_security_group" "db" {
+  name = "app-db-sg"
+}
+
+# The app server references the RDS instance and its security group, so both
+# are in use — something in the topology points at them.
+resource "aws_instance" "app" {
+  ami                    = "ami-fixture"
+  instance_type          = "t3.micro"
+  vpc_security_group_ids = [aws_security_group.db.id]
+  user_data              = "DATABASE_URL=${aws_db_instance.main.endpoint}"
+}
+
+# Nothing references this bucket — it is declared-but-unused, and stays an
+# edgeless orphan so the two cases remain distinguishable.
+resource "aws_s3_bucket" "orphan" {
+  bucket = "fixture-orphan"
+}

--- a/packages/core/test/infra.test.ts
+++ b/packages/core/test/infra.test.ts
@@ -44,6 +44,26 @@ describe('infrastructure extraction', () => {
     expect(graph.hasEdge(edgeId)).toBe(true)
     const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
     expect(edge.type).toBe('RUNS_ON')
+    // CMD line rides along as evidence so the entrypoint is queryable.
+    expect(edge.evidence?.snippet).toContain('node')
+  })
+
+  it('Dockerfile: EXPOSE emits a port InfraNode + CONNECTS_TO edge', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'dockerfile'))
+
+    const portNodeId = 'infra:port:8080'
+    expect(graph.hasNode(portNodeId)).toBe(true)
+    const port = graph.getNodeAttributes(portNodeId) as InfraNode
+    expect(port.kind).toBe('port')
+
+    const fileNodeId = 'file:fixture-api:Dockerfile'
+    const portEdgeId = `CONNECTS_TO:${fileNodeId}->${portNodeId}`
+    expect(graph.hasEdge(portEdgeId)).toBe(true)
+    const portEdge = graph.getEdgeAttributes(portEdgeId) as GraphEdge
+    expect(portEdge.type).toBe('CONNECTS_TO')
+    expect(portEdge.provenance).toBe('EXTRACTED')
+    expect(portEdge.evidence?.file).toBe('api/Dockerfile')
   })
 
   it('terraform: catalogues aws_* resources as InfraNodes', async () => {
@@ -56,6 +76,34 @@ describe('infrastructure extraction', () => {
 
     const table = graph.getNodeAttributes('infra:aws_dynamodb_table:orders') as InfraNode
     expect(table.kind).toBe('aws_dynamodb_table')
+  })
+
+  it('terraform: a referenced RDS is a connected node; an unreferenced bucket stays orphan', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'terraform-refs'))
+
+    // The RDS instance and its security group are both referenced by the app
+    // server, so DEPENDS_ON edges connect them into the topology.
+    const rds = 'infra:aws_db_instance:main'
+    const app = 'infra:aws_instance:app'
+    expect(graph.hasNode(rds)).toBe(true)
+    expect(graph.hasNode(app)).toBe(true)
+
+    const dependsRds = `DEPENDS_ON:${app}->${rds}`
+    expect(graph.hasEdge(dependsRds)).toBe(true)
+    const edge = graph.getEdgeAttributes(dependsRds) as GraphEdge
+    expect(edge.provenance).toBe('EXTRACTED')
+    expect(edge.evidence?.snippet).toBe('aws_db_instance.main')
+    expect(graph.hasEdge(`DEPENDS_ON:${app}->infra:aws_security_group:db`)).toBe(true)
+
+    // The RDS is in use — something points at it.
+    expect(graph.inDegree(rds)).toBeGreaterThan(0)
+
+    // The unreferenced bucket has no edges at all — declared-but-unused stays
+    // distinguishable from in-use.
+    const orphan = 'infra:aws_s3_bucket:orphan'
+    expect(graph.hasNode(orphan)).toBe(true)
+    expect(graph.degree(orphan)).toBe(0)
   })
 
   it('k8s: catalogues Service + Deployment manifests as InfraNodes', async () => {


### PR DESCRIPTION
Infra extraction was near-absent: terraform resources landed as edgeless orphans (a declared-but-unused RDS looked identical to an in-use one), and a Dockerfile produced only a FROM edge — EXPOSE and CMD were facts only the file knew.

Terraform now reads each resource block's body and turns every `<type>.<name>` reference into a DEPENDS_ON edge to the resource it names. A resource something points at is in use; one nothing points at is declared-but-unused. The two cases are now distinguishable in the graph.

Dockerfiles now yield more than the runtime image. Each EXPOSE port becomes an `infra:port:<n>` node the Dockerfile's FileNode CONNECTS_TO — the structural answer to "what is this service reachable at" — and the CMD/ENTRYPOINT line rides along as evidence on the RUNS_ON edge so the entrypoint is queryable. The port edge anchors on the service-scoped Dockerfile FileNode, so two services that both `FROM node:20` keep distinct ports instead of colliding on the shared image node.

All EXTRACTED edges carry evidence and structural-tier confidence per the static-extraction contract; the contract's producer table is updated to list infra's CONNECTS_TO output.

Fixtures + tests added: a terraform RDS referenced by an app server produces a connected node while an unreferenced bucket stays edgeless, and a Dockerfile EXPOSE produces a port node + CONNECTS_TO edge.

Refs #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)
