### PR TITLE
Sharpen observed-dependencies and close the REST/MCP query-surface gaps

### DIFF
--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -36,6 +36,7 @@ Bare arrays from REST endpoints are a contract violation. Why: an object can gro
 | `GET /graph/node/:id` | single node by id | `{ node: GraphNode }` |
 | `GET /graph/edges/:id` | inbound + outbound edges from a node | `{ inbound: GraphEdge[], outbound: GraphEdge[] }` |
 | `GET /graph/dependencies/:nodeId?depth=N` | transitive outbound walk (default 3, max 10) | `TransitiveDependenciesResult` |
+| `GET /graph/observed-dependencies/:nodeId` | OBSERVED-only runtime deps, file-grained — for a ServiceNode, the OBSERVED edges of the files it owns too (the call-site processor lands them on files, not the service). Names REST parity for the MCP `get_observed_dependencies` tool | `ObservedDependenciesResult` |
 | `GET /graph/blast-radius/:nodeId?depth=N` | BFS outbound (default 10, max 20) | `BlastRadiusResult` |
 | `GET /graph/root-cause/:nodeId` | getRootCause result | `RootCauseResult` |
 | `GET /graph/diff?against=path` | snapshot diff | `GraphDiffResult` |
@@ -43,6 +44,7 @@ Bare arrays from REST endpoints are a contract violation. Why: an object can gro
 | `GET /search?q=...&limit=N` | semantic search via ADR-025 embedder chain | `{ query, provider, matches: SearchMatch[] }` |
 | `GET /incidents?limit=N` | recent ErrorEvents | `{ count, total, events: ErrorEvent[] }` |
 | `GET /incidents/:nodeId` | recent ErrorEvents filtered to a node | `{ count, total, events: ErrorEvent[] }` |
+| `GET /graph/incident-history/:nodeId` | same handler as `/incidents/:nodeId`, under the graph-query name that mirrors the MCP `get_incident_history` tool | `{ count, total, events: ErrorEvent[] }` |
 | `GET /stale-events?limit=N&edgeType=X` | recent STALE transitions | `{ count, total, events: StaleEvent[] }` |
 | `GET /policies` | parsed `policy.json` | `{ version, policies: Policy[] }` |
 | `GET /policies/violations?severity=X&policyId=X` | current violations, filterable | `{ violations: PolicyViolation[] }` |

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -35,6 +35,7 @@ import { extractFromDirectory } from './extract.js'
 import { readErrorEvents, readStaleEvents } from './ingest.js'
 import {
   getBlastRadius,
+  getObservedDependencies,
   getRootCause,
   getTransitiveDependencies,
   TRANSITIVE_DEPENDENCIES_DEFAULT_DEPTH,
@@ -307,6 +308,24 @@ function registerRoutes(scope: FastifyInstance, ctx: RouteContext): void {
     return getTransitiveDependencies(proj.graph, nodeId, depth)
   })
 
+  // Observed-only dependencies (issue #578). The runtime CALLS a node makes,
+  // file-grained — and, for a ServiceNode, the OBSERVED edges of the files it
+  // owns, since the call-site processor lands them on files, not the service
+  // root. REST parity for the MCP get_observed_dependencies tool (issue #593);
+  // the CLI observed-dependencies verb reads it too.
+  scope.get<{ Params: { project?: string; nodeId: string } }>(
+    '/graph/observed-dependencies/:nodeId',
+    async (req, reply) => {
+      const proj = resolveProject(registry, req, reply, ctx.bootstrap, ctx.singleProject)
+      if (!proj) return
+      const { nodeId } = req.params
+      if (!proj.graph.hasNode(nodeId)) {
+        return reply.code(404).send({ error: 'node not found', id: nodeId })
+      }
+      return getObservedDependencies(proj.graph, nodeId)
+    },
+  )
+
   // Divergence query — the thesis surface (ADR-060). Read-only, derived,
   // dual-mounted via registerRoutes. Query params filter the result set;
   // body shape is DivergenceResult.
@@ -391,24 +410,36 @@ function registerRoutes(scope: FastifyInstance, ctx: RouteContext): void {
     return { count: sliced.length, total, events: sliced }
   })
 
+  // One handler, two paths: `/incidents/:nodeId` is the original REST name and
+  // `/graph/incident-history/:nodeId` mirrors the MCP get_incident_history tool
+  // so the two surfaces answer under matching names (issue #593).
+  const incidentHistoryHandler = async (
+    req: FastifyRequest<{ Params: { project?: string; nodeId: string } }>,
+    reply: FastifyReply,
+  ): Promise<{ count: number; total: number; events: ErrorEvent[] } | undefined> => {
+    const proj = resolveProject(registry, req, reply, ctx.bootstrap, ctx.singleProject)
+    if (!proj) return
+    const { nodeId } = req.params
+    if (!proj.graph.hasNode(nodeId)) {
+      reply.code(404).send({ error: 'node not found', id: nodeId })
+      return
+    }
+    const epath = errorsPathFor(proj)
+    if (!epath) return { count: 0, total: 0, events: [] }
+    const events = await readErrorEvents(epath)
+    const filtered = events.filter(
+      (e) =>
+        e.affectedNode === nodeId || e.service === nodeId.replace(/^service:/, ''),
+    )
+    return { count: filtered.length, total: filtered.length, events: filtered }
+  }
   scope.get<{ Params: { project?: string; nodeId: string } }>(
     '/incidents/:nodeId',
-    async (req, reply) => {
-      const proj = resolveProject(registry, req, reply, ctx.bootstrap, ctx.singleProject)
-      if (!proj) return
-      const { nodeId } = req.params
-      if (!proj.graph.hasNode(nodeId)) {
-        return reply.code(404).send({ error: 'node not found', id: nodeId })
-      }
-      const epath = errorsPathFor(proj)
-      if (!epath) return { count: 0, total: 0, events: [] }
-      const events = await readErrorEvents(epath)
-      const filtered = events.filter(
-        (e) =>
-          e.affectedNode === nodeId || e.service === nodeId.replace(/^service:/, ''),
-      )
-      return { count: filtered.length, total: filtered.length, events: filtered }
-    },
+    incidentHistoryHandler,
+  )
+  scope.get<{ Params: { project?: string; nodeId: string } }>(
+    '/graph/incident-history/:nodeId',
+    incidentHistoryHandler,
   )
 
   scope.get<{

--- a/packages/core/src/cli-client.ts
+++ b/packages/core/src/cli-client.ts
@@ -21,6 +21,7 @@ import type {
   GraphEdge,
   GraphNode,
   HypotheticalAction,
+  ObservedDependenciesResult,
   PolicyViolation,
   RootCauseResult,
   TransitiveDependenciesResult,
@@ -300,9 +301,12 @@ export async function runDependencies(
   }
 }
 
-interface EdgesResponse {
-  inbound: GraphEdge[]
-  outbound: GraphEdge[]
+// Render one OBSERVED dependency. The edge is file-grained, so when its source
+// isn't the node we asked about (a service's owned file made the call) name the
+// originating file — that's the file-first answer, not a service rollup.
+function observedDepLine(nodeId: string, e: GraphEdge): string {
+  const via = e.source !== nodeId ? ` (via ${e.source})` : ''
+  return `  • ${e.target} — ${e.type}${via}${edgeMeta(e)}`
 }
 
 export async function runObservedDependencies(
@@ -310,20 +314,33 @@ export async function runObservedDependencies(
   input: DependenciesInput,
 ): Promise<VerbResult> {
   try {
-    const edges = await client.get<EdgesResponse>(
-      projectPath(input.project, `/graph/edges/${encodeURIComponent(input.nodeId)}`),
+    const result = await client.get<ObservedDependenciesResult>(
+      projectPath(
+        input.project,
+        `/graph/observed-dependencies/${encodeURIComponent(input.nodeId)}`,
+      ),
     )
-    const observed = edges.outbound.filter((e) => e.provenance === Provenance.OBSERVED)
-    if (observed.length === 0) {
-      const hasExtracted = edges.outbound.some((e) => e.provenance === Provenance.EXTRACTED)
-      const note = hasExtracted
+    if (result.dependencies.length === 0) {
+      // A pure receiver — hit at runtime but calling nothing downstream — is
+      // fully observed, so don't imply OTel is down. That note is honest only
+      // when nothing has been observed and static deps exist.
+      if (result.observed) {
+        return {
+          summary:
+            `${input.nodeId} makes no outbound runtime calls, but OTel has observed it ` +
+            `receiving traffic on ${result.inboundObservedCount} inbound call ` +
+            `path${result.inboundObservedCount === 1 ? '' : 's'} — it's a pure receiver.`,
+          provenance: Provenance.OBSERVED,
+        }
+      }
+      const note = result.hasExtractedOutbound
         ? ' Static (EXTRACTED) dependencies exist but no runtime traffic has been seen — is OTel running?'
         : ''
       return { summary: `No OBSERVED dependencies for ${input.nodeId}.${note}` }
     }
-    const blockLines = observed.map((e) => `  • ${e.target} — ${e.type}${edgeMeta(e)}`)
+    const blockLines = result.dependencies.map((e) => observedDepLine(input.nodeId, e))
     return {
-      summary: `${input.nodeId} has ${observed.length} runtime dependenc${observed.length === 1 ? 'y' : 'ies'} confirmed by OTel.`,
+      summary: `${input.nodeId} has ${result.dependencies.length} runtime dependenc${result.dependencies.length === 1 ? 'y' : 'ies'} confirmed by OTel.`,
       block: blockLines.join('\n'),
       provenance: Provenance.OBSERVED,
     }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1159,16 +1159,38 @@ export async function resolveProjectForVerb(
   )
 }
 
-// The daemon URL the CLI verbs talk to. `NEAT_API_URL` is the name the verbs
-// have always read, so it keeps precedence for existing users; `NEAT_CORE_URL`
-// is honored as an alias so a single env var works for both the CLI and the MCP
-// server (which names it `NEAT_CORE_URL`).
-function resolveDaemonUrl(): string {
-  return process.env.NEAT_API_URL ?? process.env.NEAT_CORE_URL ?? 'http://localhost:8080'
+// The daemon URL the CLI verbs talk to. Resolution mirrors the client-profiles
+// precedence (§3): an explicit env pin wins, then the requested project's own
+// per-project daemon (ADR-096 — one daemon per project, each on its own port),
+// then the loopback default. `NEAT_API_URL` is the name the verbs have always
+// read, so it keeps precedence for existing users; `NEAT_CORE_URL` is honored
+// as an alias so a single env var works for both the CLI and the MCP server.
+//
+// The project step is issue #579: with `--project foo` (or NEAT_PROJECT=foo)
+// but no env pin, the verb used to hit the loopback 8080 and append
+// `/projects/foo/...`, which lands on whatever daemon happens to own 8080 — a
+// different project's daemon, so it 404s. Under one-daemon-per-project the
+// project's REST port lives in its discovery record at `~/.neat/daemons/<foo>.json`;
+// resolving it there points the verb at the right daemon. A project that has no
+// discovery record falls through to loopback, unchanged.
+export async function resolveDaemonUrl(project?: string): Promise<string> {
+  const explicit = process.env.NEAT_API_URL ?? process.env.NEAT_CORE_URL
+  if (explicit) return explicit
+  if (project) {
+    const daemon = await findDaemonByProject(project)
+    if (daemon) return `http://localhost:${daemon.record.ports.rest}`
+  }
+  return 'http://localhost:8080'
 }
 
 export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<number> {
-  const baseUrl = resolveDaemonUrl()
+  // Resolve the URL against the requested project up front (issue #579). When
+  // the project comes from --project / NEAT_PROJECT it's known synchronously, so
+  // the client points at that project's daemon before the first call. A bare
+  // verb (no project named) resolves nothing here and keeps the loopback default
+  // — its project is discovered from /projects below (issue #500).
+  const requestedProject = resolveProjectFlag(parsed)
+  const baseUrl = await resolveDaemonUrl(requestedProject)
   // ADR-073 §3 — read the bearer once and thread it into the single client
   // every verb shares, so no verb path can reach a secured daemon without it.
   const client = createHttpClient(baseUrl, resolveAuthToken())
@@ -1351,7 +1373,7 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
       const detail = err.responseBody.length > 0 ? err.responseBody : err.message
       console.error(`neat ${cmd}: ${detail.trim()}`)
     } else if (err instanceof TransportError) {
-      console.error(`neat ${cmd}: ${err.message}. Is the daemon running? (NEAT_API_URL=${resolveDaemonUrl()})`)
+      console.error(`neat ${cmd}: ${err.message}. Is the daemon running? (endpoint=${baseUrl})`)
     } else {
       console.error(`neat ${cmd}: ${(err as Error).message}`)
     }

--- a/packages/core/src/traverse.ts
+++ b/packages/core/src/traverse.ts
@@ -5,6 +5,7 @@ import type {
   ErrorEvent,
   GraphEdge,
   GraphNode,
+  ObservedDependenciesResult,
   RootCauseResult,
   ServiceNode,
   TransitiveDependenciesResult,
@@ -14,6 +15,7 @@ import {
   BlastRadiusResultSchema,
   EdgeType,
   NodeType,
+  ObservedDependenciesResultSchema,
   PROV_RANK,
   Provenance,
   RootCauseResultSchema,
@@ -615,5 +617,99 @@ export function getTransitiveDependencies(
     depth,
     dependencies,
     total: dependencies.length,
+  })
+}
+
+// Observed-only dependencies (issue #578). "What does this node actually call at
+// runtime?" — its OBSERVED outbound edges, file-grained.
+//
+// The subtlety the previous edges-only query missed: the call-site processor
+// lands OBSERVED CALLS on the FileNode that made the call, not on the owning
+// ServiceNode (file-awareness §4). So a query that starts at a ServiceNode sees
+// only its structural `CONTAINS` edges and reports "no runtime traffic," while
+// the real dependency sits one hop away on a file it owns. When the origin is a
+// ServiceNode we therefore also read the OBSERVED outbound of the FileNodes it
+// `CONTAINS` and surface those file→target edges. This is not a service rollup
+// (file-awareness §3): the edges stay file-grained with the owning file as the
+// source; the service is only the grouping the query entered through.
+//
+// `observed` and `inboundObservedCount` separate two cases the old copy
+// conflated: a pure receiver — a node runtime hits but which calls nothing
+// downstream — has zero dependencies yet is plainly seen by OTel, so the caller
+// must not ask "is OTel running?" at it. That question is honest only when there
+// is no OBSERVED traffic at all and EXTRACTED outbound edges exist
+// (`hasExtractedOutbound`).
+export function getObservedDependencies(
+  graph: NeatGraph,
+  nodeId: string,
+): ObservedDependenciesResult {
+  if (!graph.hasNode(nodeId)) {
+    return ObservedDependenciesResultSchema.parse({
+      origin: nodeId,
+      dependencies: [],
+      observed: false,
+      inboundObservedCount: 0,
+      hasExtractedOutbound: false,
+    })
+  }
+
+  const attrs = graph.getNodeAttributes(nodeId) as GraphNode
+
+  // The origin plus, when it's a service, the files it owns — the set of nodes
+  // whose OBSERVED edges belong to "what this thing does at runtime."
+  const scope: string[] = [nodeId]
+  if (attrs.type === NodeType.ServiceNode) {
+    for (const edgeId of graph.outboundEdges(nodeId)) {
+      const e = graph.getEdgeAttributes(edgeId) as GraphEdge
+      if (e.type !== EdgeType.CONTAINS) continue
+      const owned = graph.getNodeAttributes(e.target) as GraphNode
+      if (owned.type === NodeType.FileNode) scope.push(e.target)
+    }
+  }
+
+  const dependencies: GraphEdge[] = []
+  const seenEdge = new Set<string>()
+  let hasExtractedOutbound = false
+  for (const src of scope) {
+    for (const edgeId of graph.outboundEdges(src)) {
+      const e = graph.getEdgeAttributes(edgeId) as GraphEdge
+      // CONTAINS is structural ownership, never a runtime dependency.
+      if (e.type === EdgeType.CONTAINS) continue
+      if (e.provenance === Provenance.OBSERVED) {
+        if (!seenEdge.has(e.id)) {
+          seenEdge.add(e.id)
+          dependencies.push(e)
+        }
+      } else if (e.provenance === Provenance.EXTRACTED) {
+        hasExtractedOutbound = true
+      }
+    }
+  }
+
+  // Was this node (or a file it owns) seen receiving traffic? Counting OBSERVED
+  // inbound edges is the pure-receiver signal — the "hit N times, calls nothing"
+  // shape that must read differently from "never observed."
+  let inboundObservedCount = 0
+  for (const tgt of scope) {
+    for (const edgeId of graph.inboundEdges(tgt)) {
+      const e = graph.getEdgeAttributes(edgeId) as GraphEdge
+      if (e.type === EdgeType.CONTAINS) continue
+      if (e.provenance === Provenance.OBSERVED) inboundObservedCount += 1
+    }
+  }
+
+  dependencies.sort(
+    (a, b) =>
+      a.target.localeCompare(b.target) ||
+      a.source.localeCompare(b.source) ||
+      a.id.localeCompare(b.id),
+  )
+
+  return ObservedDependenciesResultSchema.parse({
+    origin: nodeId,
+    dependencies,
+    observed: dependencies.length > 0 || inboundObservedCount > 0,
+    inboundObservedCount,
+    hasExtractedOutbound,
   })
 }

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -97,6 +97,30 @@ describe('REST API (fastify.inject)', () => {
     expect(body.outbound.length).toBeGreaterThanOrEqual(1)
   })
 
+  it('GET /graph/observed-dependencies/:nodeId returns the observed-deps shape (issue #578/#593)', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/graph/observed-dependencies/service:service-a',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.origin).toBe('service:service-a')
+    // The demo graph is static-only, so there are no OBSERVED deps — but the
+    // EXTRACTED CALLS to service-b is present, so the "is OTel running?" note is
+    // the honest one here.
+    expect(body.dependencies).toEqual([])
+    expect(body.observed).toBe(false)
+    expect(body.hasExtractedOutbound).toBe(true)
+  })
+
+  it('GET /graph/observed-dependencies/:nodeId returns 404 for an unknown node', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/graph/observed-dependencies/nope',
+    })
+    expect(res.statusCode).toBe(404)
+  })
+
   it('GET /incidents returns a wrapped empty list when no log is configured', async () => {
     const res = await app.inject({ method: 'GET', url: '/incidents' })
     expect(res.statusCode).toBe(200)
@@ -110,6 +134,21 @@ describe('REST API (fastify.inject)', () => {
     })
     expect(res.statusCode).toBe(200)
     expect(res.json()).toEqual({ count: 0, total: 0, events: [] })
+  })
+
+  it('GET /graph/incident-history/:nodeId mirrors /incidents/:nodeId (issue #593)', async () => {
+    const alias = await app.inject({
+      method: 'GET',
+      url: '/graph/incident-history/service:service-b',
+    })
+    expect(alias.statusCode).toBe(200)
+    expect(alias.json()).toEqual({ count: 0, total: 0, events: [] })
+
+    const unknown = await app.inject({
+      method: 'GET',
+      url: '/graph/incident-history/nope',
+    })
+    expect(unknown.statusCode).toBe(404)
   })
 
   it('GET /search?q=service-b finds the matching node', async () => {

--- a/packages/core/test/cli-daemon-url.test.ts
+++ b/packages/core/test/cli-daemon-url.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { daemonsDir, type DaemonRecord } from '../src/registry.js'
+import { resolveDaemonUrl } from '../src/cli.js'
+
+// Issue #579 — a query verb with --project <name> has to reach that project's
+// own daemon. Under one-daemon-per-project the REST port lives in the discovery
+// record at ~/.neat/daemons/<name>.json; resolveDaemonUrl reads it there instead
+// of blindly returning the loopback default.
+
+let home: string
+let prevHome: string | undefined
+let prevApi: string | undefined
+let prevCore: string | undefined
+
+beforeEach(async () => {
+  home = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-cli-url-home-'))
+  prevHome = process.env.NEAT_HOME
+  prevApi = process.env.NEAT_API_URL
+  prevCore = process.env.NEAT_CORE_URL
+  process.env.NEAT_HOME = home
+  delete process.env.NEAT_API_URL
+  delete process.env.NEAT_CORE_URL
+})
+
+afterEach(async () => {
+  restore('NEAT_HOME', prevHome)
+  restore('NEAT_API_URL', prevApi)
+  restore('NEAT_CORE_URL', prevCore)
+  await fs.rm(home, { recursive: true, force: true })
+})
+
+function restore(key: string, val: string | undefined): void {
+  if (val === undefined) delete process.env[key]
+  else process.env[key] = val
+}
+
+async function writeDaemonRecord(over: Partial<DaemonRecord> = {}): Promise<void> {
+  const record: DaemonRecord = {
+    project: 'harvest',
+    projectPath: '/tmp/harvest',
+    pid: 4242,
+    status: 'running',
+    ports: { rest: 8123, otlp: 4319, web: 6329 },
+    startedAt: '2026-06-27T00:00:00.000Z',
+    neatVersion: '0.4.19',
+    ...over,
+  }
+  const dir = daemonsDir()
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(path.join(dir, `${record.project}.json`), JSON.stringify(record, null, 2) + '\n', 'utf8')
+}
+
+describe('resolveDaemonUrl', () => {
+  it("resolves the requested project's daemon port from its discovery record", async () => {
+    await writeDaemonRecord()
+    expect(await resolveDaemonUrl('harvest')).toBe('http://localhost:8123')
+  })
+
+  it('falls back to loopback when the project has no discovery record', async () => {
+    expect(await resolveDaemonUrl('harvest')).toBe('http://localhost:8080')
+  })
+
+  it('falls back to loopback for a bare verb with no project', async () => {
+    await writeDaemonRecord()
+    expect(await resolveDaemonUrl(undefined)).toBe('http://localhost:8080')
+  })
+
+  it('lets an explicit NEAT_API_URL pin win over discovery', async () => {
+    await writeDaemonRecord()
+    process.env.NEAT_API_URL = 'http://hosted.example:9000'
+    expect(await resolveDaemonUrl('harvest')).toBe('http://hosted.example:9000')
+  })
+
+  it('honors NEAT_CORE_URL as the pin alias', async () => {
+    await writeDaemonRecord()
+    process.env.NEAT_CORE_URL = 'http://core.example:9100'
+    expect(await resolveDaemonUrl('harvest')).toBe('http://core.example:9100')
+  })
+})

--- a/packages/core/test/observed-dependencies.test.ts
+++ b/packages/core/test/observed-dependencies.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { MultiDirectedGraph } from 'graphology'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  type GraphEdge,
+  type GraphNode,
+} from '@neat.is/types'
+import type { NeatGraph } from '../src/graph.js'
+import { getObservedDependencies } from '../src/traverse.js'
+
+// Issue #578. The call-site processor lands OBSERVED CALLS on the FileNode that
+// made the call, not on the owning ServiceNode — so a service-level query has to
+// reach one hop through CONTAINS to surface the real runtime dependency, and it
+// has to tell "no outbound deps" apart from "never observed."
+
+function node(id: string, attrs: Omit<GraphNode, 'id'>): GraphNode {
+  return { ...attrs, id } as GraphNode
+}
+
+function newGraph(): NeatGraph {
+  return new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+}
+
+function addNode(g: NeatGraph, n: GraphNode): void {
+  g.addNode(n.id, n)
+}
+
+function addEdge(g: NeatGraph, e: GraphEdge): void {
+  g.addEdgeWithKey(e.id, e.source, e.target, e)
+}
+
+// A file-first harvest graph: harvest-api owns a file that calls harvest-ledger
+// at runtime; harvest-ledger is a pure receiver.
+function harvestGraph(): NeatGraph {
+  const g = newGraph()
+  addNode(g, node('service:harvest-api', { type: NodeType.ServiceNode, name: 'harvest-api', language: 'javascript' }))
+  addNode(g, node('service:harvest-ledger', { type: NodeType.ServiceNode, name: 'harvest-ledger', language: 'javascript' }))
+  addNode(g, node('file:harvest-api:src/pay.ts', { type: NodeType.FileNode, service: 'harvest-api', path: 'src/pay.ts', language: 'javascript' }))
+
+  // service ──CONTAINS──▶ file, OBSERVED structural ownership.
+  addEdge(g, {
+    id: 'CONTAINS:OBSERVED:service:harvest-api->file:harvest-api:src/pay.ts',
+    source: 'service:harvest-api',
+    target: 'file:harvest-api:src/pay.ts',
+    type: EdgeType.CONTAINS,
+    provenance: Provenance.OBSERVED,
+  })
+  // The real runtime dependency lives on the file, one hop from the service.
+  addEdge(g, {
+    id: 'CALLS:OBSERVED:file:harvest-api:src/pay.ts->service:harvest-ledger',
+    source: 'file:harvest-api:src/pay.ts',
+    target: 'service:harvest-ledger',
+    type: EdgeType.CALLS,
+    provenance: Provenance.OBSERVED,
+    signal: { spanCount: 44, errorCount: 0 },
+  })
+  return g
+}
+
+describe('getObservedDependencies', () => {
+  it('surfaces a service dependency that lives on an owned file (issue #578 H)', () => {
+    const g = harvestGraph()
+    const res = getObservedDependencies(g, 'service:harvest-api')
+    // The CONTAINS edge is not a runtime dependency; the file's CALLS is.
+    expect(res.dependencies).toHaveLength(1)
+    const dep = res.dependencies[0]!
+    expect(dep.target).toBe('service:harvest-ledger')
+    expect(dep.type).toBe(EdgeType.CALLS)
+    expect(dep.source).toBe('file:harvest-api:src/pay.ts')
+    expect(res.observed).toBe(true)
+  })
+
+  it('reads a pure receiver as observed, not OTel-down (issue #578 I)', () => {
+    const g = harvestGraph()
+    const res = getObservedDependencies(g, 'service:harvest-ledger')
+    // It calls nothing downstream, but it is hit at runtime.
+    expect(res.dependencies).toHaveLength(0)
+    expect(res.observed).toBe(true)
+    expect(res.inboundObservedCount).toBe(1)
+    expect(res.hasExtractedOutbound).toBe(false)
+  })
+
+  it('flags a genuinely unobserved node with static deps as the OTel-down case', () => {
+    const g = harvestGraph()
+    addNode(g, node('service:lonely', { type: NodeType.ServiceNode, name: 'lonely', language: 'javascript' }))
+    addEdge(g, {
+      id: 'CALLS:service:lonely->service:harvest-ledger',
+      source: 'service:lonely',
+      target: 'service:harvest-ledger',
+      type: EdgeType.CALLS,
+      provenance: Provenance.EXTRACTED,
+    })
+    const res = getObservedDependencies(g, 'service:lonely')
+    expect(res.dependencies).toHaveLength(0)
+    expect(res.observed).toBe(false)
+    expect(res.hasExtractedOutbound).toBe(true)
+  })
+
+  it('returns an empty, unobserved result for a missing node', () => {
+    const g = harvestGraph()
+    const res = getObservedDependencies(g, 'service:ghost')
+    expect(res.dependencies).toHaveLength(0)
+    expect(res.observed).toBe(false)
+    expect(res.inboundObservedCount).toBe(0)
+  })
+})

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -15,6 +15,7 @@ import type {
   GraphEdge,
   GraphNode,
   HypotheticalAction,
+  ObservedDependenciesResult,
   PolicyViolation,
   RootCauseResult,
   TransitiveDependenciesResult,
@@ -142,11 +143,6 @@ function formatBlastEntry(n: BlastRadiusAffectedNode): string {
   return `  • ${n.nodeId} (distance ${n.distance}, ${n.edgeProvenance})${tag}`
 }
 
-interface EdgesResponse {
-  inbound: GraphEdge[]
-  outbound: GraphEdge[]
-}
-
 export interface DependenciesInput {
   nodeId: string
   // BFS depth. Default 3; max 10. Direct-only consumers pass 1.
@@ -207,25 +203,46 @@ export async function getDependencies(
   }, `Node ${input.nodeId} not found in the graph.`)
 }
 
+// Render one OBSERVED dependency, file-grained. When the edge source isn't the
+// queried node — a service's owned file made the call — name that file, so the
+// answer stays file-first rather than a service rollup (file-awareness §3).
+function observedDepLine(nodeId: string, e: GraphEdge): string {
+  const via = e.source !== nodeId ? ` (via ${e.source})` : ''
+  return `  • ${e.target} — ${e.type}${via}${edgeMeta(e)}`
+}
+
 export async function getObservedDependencies(
   client: HttpClient,
   input: DependenciesInput,
 ): Promise<ToolResponse> {
   return withMissingNodeFallback(async () => {
-    const edges = await client.get<EdgesResponse>(
-      projectPath(input.project, `/graph/edges/${encodeURIComponent(input.nodeId)}`),
+    const result = await client.get<ObservedDependenciesResult>(
+      projectPath(
+        input.project,
+        `/graph/observed-dependencies/${encodeURIComponent(input.nodeId)}`,
+      ),
     )
-    const observed = edges.outbound.filter((e) => e.provenance === Provenance.OBSERVED)
-    if (observed.length === 0) {
-      const hasExtracted = edges.outbound.some((e) => e.provenance === Provenance.EXTRACTED)
-      const note = hasExtracted
+    if (result.dependencies.length === 0) {
+      // A pure receiver is fully observed — it just calls nothing downstream.
+      // Reporting "is OTel running?" at it would be wrong; that note is honest
+      // only when nothing has been observed at all and static deps exist.
+      if (result.observed) {
+        return formatToolResponse({
+          summary:
+            `${input.nodeId} makes no outbound runtime calls, but OTel has observed it ` +
+            `receiving traffic on ${result.inboundObservedCount} inbound call ` +
+            `path${result.inboundObservedCount === 1 ? '' : 's'} — it's a pure receiver.`,
+          provenance: Provenance.OBSERVED,
+        })
+      }
+      const note = result.hasExtractedOutbound
         ? ' Static (EXTRACTED) dependencies exist but no runtime traffic has been seen — is OTel running?'
         : ''
       return formatEmptyResponse(`No OBSERVED dependencies for ${input.nodeId}.${note}`)
     }
-    const blockLines = observed.map((e) => `  • ${e.target} — ${e.type}${edgeMeta(e)}`)
+    const blockLines = result.dependencies.map((e) => observedDepLine(input.nodeId, e))
     return formatToolResponse({
-      summary: `${input.nodeId} has ${observed.length} runtime dependenc${observed.length === 1 ? 'y' : 'ies'} confirmed by OTel.`,
+      summary: `${input.nodeId} has ${result.dependencies.length} runtime dependenc${result.dependencies.length === 1 ? 'y' : 'ies'} confirmed by OTel.`,
       block: blockLines.join('\n'),
       provenance: Provenance.OBSERVED,
     })

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -327,21 +327,14 @@ describe('getDependencies', () => {
 })
 
 describe('getObservedDependencies', () => {
-  it('filters to OBSERVED only and includes lastObserved + callCount', async () => {
-    const { client } = clientFor({
-      '/graph/edges/service:service-a': {
-        inbound: [],
-        outbound: [
+  it('reads /graph/observed-dependencies and reports the runtime deps', async () => {
+    const { client, capture } = clientFor({
+      '/graph/observed-dependencies/service:service-a': {
+        origin: 'service:service-a',
+        dependencies: [
           {
-            id: 'CALLS:service:service-a->service:service-b',
-            source: 'service:service-a',
-            target: 'service:service-b',
-            type: EdgeType.CALLS,
-            provenance: Provenance.EXTRACTED,
-          },
-          {
-            id: 'CALLS:OBSERVED:service:service-a->service:service-b',
-            source: 'service:service-a',
+            id: 'CALLS:OBSERVED:file:service-a:src/pay.ts->service:service-b',
+            source: 'file:service-a:src/pay.ts',
             target: 'service:service-b',
             type: EdgeType.CALLS,
             provenance: Provenance.OBSERVED,
@@ -350,33 +343,51 @@ describe('getObservedDependencies', () => {
             lastObserved: '2026-05-01T15:51:11.967Z',
           },
         ],
+        observed: true,
+        inboundObservedCount: 0,
+        hasExtractedOutbound: true,
       },
     })
     const res = await getObservedDependencies(client, { nodeId: 'service:service-a' })
     const text = res.content[0].text
+    expect(capture.paths[0]).toBe('/graph/observed-dependencies/service%3Aservice-a')
     expect(text).toContain('service:service-a has 1 runtime dependency confirmed by OTel')
     expect(text).toContain('service:service-b')
+    // The originating file is named so a service answer stays file-first.
+    expect(text).toContain('via file:service-a:src/pay.ts')
     expect(text).toContain('lastObserved=2026-05-01T15:51:11.967Z')
     expect(text).toMatch(/provenance: OBSERVED/)
   })
 
   it('explains the OTel-down case when only EXTRACTED edges exist', async () => {
     const { client } = clientFor({
-      '/graph/edges/service:service-a': {
-        inbound: [],
-        outbound: [
-          {
-            id: 'CALLS:service:service-a->service:service-b',
-            source: 'service:service-a',
-            target: 'service:service-b',
-            type: EdgeType.CALLS,
-            provenance: Provenance.EXTRACTED,
-          },
-        ],
+      '/graph/observed-dependencies/service:service-a': {
+        origin: 'service:service-a',
+        dependencies: [],
+        observed: false,
+        inboundObservedCount: 0,
+        hasExtractedOutbound: true,
       },
     })
     const res = await getObservedDependencies(client, { nodeId: 'service:service-a' })
     expect(res.content[0].text).toContain('OTel running')
+  })
+
+  it('calls a pure receiver a pure receiver, not an OTel-down case', async () => {
+    const { client } = clientFor({
+      '/graph/observed-dependencies/service:ledger': {
+        origin: 'service:ledger',
+        dependencies: [],
+        observed: true,
+        inboundObservedCount: 3,
+        hasExtractedOutbound: false,
+      },
+    })
+    const res = await getObservedDependencies(client, { nodeId: 'service:ledger' })
+    const text = res.content[0].text
+    expect(text).toContain('pure receiver')
+    expect(text).toContain('3 inbound call paths')
+    expect(text).not.toContain('OTel running')
   })
 })
 
@@ -645,7 +656,13 @@ describe('project routing', () => {
         totalAffected: 0,
         affectedNodes: [],
       },
-      '/projects/alpha/graph/edges/service:a': { inbound: [], outbound: [] },
+      '/projects/alpha/graph/observed-dependencies/service:a': {
+        origin: 'service:a',
+        dependencies: [],
+        observed: false,
+        inboundObservedCount: 0,
+        hasExtractedOutbound: false,
+      },
       '/projects/alpha/graph/dependencies/service:a?depth=3': {
         origin: 'service:a',
         depth: 3,

--- a/packages/types/src/results.ts
+++ b/packages/types/src/results.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { ProvenanceSchema, EdgeTypeSchema } from './edges.js'
+import { ProvenanceSchema, EdgeTypeSchema, GraphEdgeSchema } from './edges.js'
 
 export const RootCauseResultSchema = z.object({
   rootCauseNode: z.string(),
@@ -60,3 +60,34 @@ export const TransitiveDependenciesResultSchema = z.object({
   total: z.number().int().nonnegative(),
 })
 export type TransitiveDependenciesResult = z.infer<typeof TransitiveDependenciesResultSchema>
+
+// Observed-only dependencies (issue #578). "What does this node actually call
+// at runtime?" — the OBSERVED outbound edges, file-grained. When the queried
+// node is a ServiceNode the real runtime CALLS originate from the FileNodes it
+// owns (the call-site processor lands OBSERVED edges on files, not the service
+// root), so the query walks one hop through `service ──CONTAINS──▶ file` and
+// surfaces those file→target edges. This is not a service rollup
+// (file-awareness §3): the edges stay file-grained, with the owning file as the
+// edge source — the service is just the grouping we entered through.
+//
+// `observed` / `inboundObservedCount` separate "no outbound deps" from "never
+// observed": a pure receiver (hit at runtime but calls nothing downstream) has
+// zero dependencies yet is very much seen by OTel, so the consumer must not say
+// "is OTel running?" at it. `hasExtractedOutbound` gates that question to the
+// genuine no-runtime-traffic case.
+export const ObservedDependenciesResultSchema = z.object({
+  origin: z.string(),
+  // OBSERVED outbound edges (CALLS/CONNECTS_TO/etc.), file-grained. Structural
+  // CONTAINS ownership is never listed here — it is not a runtime dependency.
+  dependencies: z.array(GraphEdgeSchema),
+  // Did OTel see this node (or a file it owns) at all — as caller or callee?
+  // Distinguishes a pure receiver from a node runtime has never touched.
+  observed: z.boolean(),
+  // Count of OBSERVED inbound edges into the node (and its owned files). A
+  // non-zero count with zero dependencies is the pure-receiver signal.
+  inboundObservedCount: z.number().int().nonnegative(),
+  // Are there EXTRACTED outbound edges but no OBSERVED ones? Only then is
+  // "static deps exist but no runtime traffic — is OTel running?" the honest note.
+  hasExtractedOutbound: z.boolean(),
+})
+export type ObservedDependenciesResult = z.infer<typeof ObservedDependenciesResultSchema>


### PR DESCRIPTION
Three query-surface fixes from the breaker campaign, one PR.

## #578 — observed-dependencies granularity + pure-receiver messaging
The verb read a node's direct edges only. For a service that misses the real answer: the call-site processor lands OBSERVED CALLS on the *file* that made the call, not the owning service, so a service query saw only its structural CONTAINS edge and reported no runtime traffic while the dependency sat one hop away. `getObservedDependencies` (new, in `traverse.ts`) now walks that hop — for a ServiceNode it also reads the OBSERVED edges of the files it CONTAINS and surfaces them file-grained, naming the owning file as the source. No service rollup (file-awareness §3): the file stays the subject.

It also stopped conflating "calls nothing downstream" with "never observed." A pure receiver (hit at runtime, no outbound calls) was told "is OTel running?" — backwards. The result now carries `observed` and `inboundObservedCount`, so a pure receiver reads as one and the OTel-down note only fires when there's genuinely no runtime traffic and static deps exist.

## #593 — REST/MCP parity
`get_observed_dependencies` and `get_incident_history` had MCP tools but no REST routes, so both 404'd from the terminal. Added `GET /graph/observed-dependencies/:nodeId` and `GET /graph/incident-history/:nodeId` (the latter shares the `/incidents/:nodeId` handler). Both documented in the `rest-api.md` endpoint table.

## #579 — CLI query verbs reaching a non-default project's daemon
A verb run with `--project foo` hit loopback 8080 and appended `/projects/foo/...`, landing on the wrong daemon and 404ing. `resolveDaemonUrl` now resolves the requested project's own REST port from its discovery record at `~/.neat/daemons/<foo>.json`, falling through to loopback when there's no record, and an explicit `NEAT_API_URL` / `NEAT_CORE_URL` pin still wins.

## Tests
- `packages/core/test/observed-dependencies.test.ts` — service one-hop-through-CONTAINS, pure receiver, never-observed, missing node
- `packages/core/test/cli-daemon-url.test.ts` — discovery-record resolution, loopback fallback, env-pin precedence
- `packages/core/test/api.test.ts` — the two new REST routes
- `packages/mcp/test/tools.test.ts` — updated for the new endpoint + pure-receiver output

@neat.is/core, @neat.is/mcp, and @neat.is/types suites all green; lint clean.

Refs #578
Refs #593
Refs #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)