### PR TITLE
Keep the trace stitcher off structural edges

### DIFF
--- a/docs/contracts/trace-stitcher.md
+++ b/docs/contracts/trace-stitcher.md
@@ -1,6 +1,6 @@
 ---
 name: trace-stitcher
-description: stitchTrace fires only on ERROR spans, walks EXTRACTED outbound edges to depth 2, produces INFERRED edges with confidence 0.6, skips hops where an OBSERVED twin already exists.
+description: stitchTrace fires only on ERROR spans, walks EXTRACTED outbound dependency edges (CALLS / CONNECTS_TO / DEPENDS_ON only) to depth 2, produces INFERRED edges with confidence 0.6, skips hops where an OBSERVED twin already exists, and never touches structural edges (CONTAINS / IMPORTS / CONFIGURED_BY / RUNS_ON).
 governs:
   - "packages/core/src/ingest.ts"
 adr: [ADR-034, ADR-027, ADR-029, ADR-030]
@@ -29,6 +29,27 @@ The BFS walks `graph.outboundEdges(node)` and considers only edges where `proven
 - INFERRED edges are the stitcher's own output — no recursion.
 - FRONTIER edges represent unknown territory and are excluded per Rule 3 of `docs/contracts.md`.
 - STALE edges represent decayed observation — not inferable from a fresh error.
+
+## Dependency-edge-type allowlist (binding)
+
+Provenance is not the only gate. The stitcher considers an EXTRACTED edge only when its `type` is one of the **runtime dependency** types the ADR-014 case is about:
+
+```ts
+CALLS | CONNECTS_TO | DEPENDS_ON
+```
+
+These are the edges an error actually propagates along: a service calling a service, a service connecting to a datastore, a declared runtime dependency. An error span means the erroring service was exercising these relationships right now, so inferring an INFERRED bridge for the ones OTel couldn't instrument is honest.
+
+Structural edge types are **never** stitched — not their INFERRED twins, and the BFS does not recurse through them:
+
+- `CONTAINS` — a service owns a file (file-awareness.md §2). Static ownership, not a runtime call. A 500 in one request says nothing new about which files the service contains.
+- `IMPORTS` — one file imports another (ADR-092). Compile-time module structure, not traffic.
+- `CONFIGURED_BY` — a node's config provenance (ConfigNode existence, ADR-016). Not a dependency the error travels through.
+- `RUNS_ON` — deployment placement. Structural, not a runtime call.
+
+The trust signal is the point (PROVENANCE.md): an unrelated request 500-ing must never mint a low-confidence INFERRED twin of a hard EXTRACTED containment or import edge, because a consumer query (`/graph/dependencies`, `/graph/blast-radius`) would then surface the INFERRED twin (conf ~0.6, ranked above EXTRACTED by `PROV_RANK`) in place of the ground-truth structural edge (0.85). Structural facts are learned by static extraction and stay EXTRACTED until static extraction says otherwise; the stitcher does not get a vote on them.
+
+`PUBLISHES_TO` / `CONSUMES_FROM` are not in the allowlist today — the stitcher's demonstrated case (ADR-014, the uninstrumented `pg` driver) is synchronous request-path dependency. Adding a messaging edge type to the allowlist requires an ADR amendment, same as any other contract value here.
 
 ## OBSERVED-twin skip rule
 
@@ -67,5 +88,6 @@ The stitcher only writes edges. It never creates nodes; it never modifies existi
 - A live test asserting `STITCH_MAX_DEPTH` is enforced (depth-3 EXTRACTED chain produces edges only at depth 1 and 2).
 - An `it.todo` keyed to the OBSERVED-twin-skip refinement.
 - An idempotency test (calling `stitchTrace` twice produces identical edge state).
+- A live test asserting an error span from a service with outbound EXTRACTED `CONTAINS` / `IMPORTS` / `CONFIGURED_BY` edges produces no INFERRED twins of those, while a genuine EXTRACTED `CONNECTS_TO` to an uninstrumented backend still gets its INFERRED bridge.
 
 Full rationale and historical context: [ADR-034](../decisions.md#adr-034--trace-stitcher-contract).

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -608,6 +608,21 @@ function makeInferredEdgeId(type: EdgeTypeValue, source: string, target: string)
 const INFERRED_CONFIDENCE = 0.6
 const STITCH_MAX_DEPTH = 2
 
+// The trace stitcher only reasons about runtime *dependency* edges — the ones an
+// error actually propagates along (a service calling a service, connecting to a
+// datastore, a declared runtime dependency). Structural edges (CONTAINS a file,
+// IMPORTS a module, CONFIGURED_BY a ConfigNode, RUNS_ON a host) are static facts
+// learned by extraction; a 500 says nothing new about them. Minting an INFERRED
+// twin of a structural EXTRACTED edge would corrupt the trust signal — the twin
+// (conf 0.6) outranks the ground-truth EXTRACTED edge (0.85) under PROV_RANK, so
+// consumer queries would surface the inference in place of the hard fact
+// (docs/contracts/trace-stitcher.md — dependency-edge-type allowlist).
+const STITCH_EDGE_TYPES = new Set<EdgeTypeValue>([
+  EdgeType.CALLS,
+  EdgeType.CONNECTS_TO,
+  EdgeType.DEPENDS_ON,
+])
+
 // OTLP-wire SpanKind values. The receiver decodes the raw wire integer onto
 // `ParsedSpan.kind` (otel.ts), and the wire enum is offset by one from the
 // `@opentelemetry/api` SpanKind the SDK uses in-process — UNSPECIFIED 0,
@@ -910,6 +925,12 @@ function stitchTrace(graph: NeatGraph, sourceServiceId: string, ts: string): voi
     for (const edgeId of outbound) {
       const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
       if (edge.provenance !== Provenance.EXTRACTED) continue
+
+      // Only runtime dependency edges get stitched. Structural edges (CONTAINS /
+      // IMPORTS / CONFIGURED_BY / RUNS_ON) are never mirrored into INFERRED twins
+      // and the BFS does not recurse through them — an error propagates along
+      // dependencies, not static containment (trace-stitcher.md allowlist).
+      if (!STITCH_EDGE_TYPES.has(edge.type)) continue
 
       // OBSERVED twin already covers this hop with ground truth — no inference
       // needed (ADR-034). Stomping it with INFERRED erases the gap NEAT exists

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os'
 import { MultiDirectedGraph } from 'graphology'
 import {
   EdgeType,
+  type EdgeTypeValue,
   type ErrorEvent,
   fileId,
   type GraphEdge,
@@ -898,6 +899,76 @@ describe('stitchTrace', () => {
     ).toBe(true)
     expect(
       graph.hasEdge(`${EdgeType.CONNECTS_TO}:INFERRED:service:service-b->database:payments-db`),
+    ).toBe(true)
+  })
+
+  it('never mints INFERRED twins of structural edges, but still bridges an uninstrumented dependency', () => {
+    const graph = newGraph()
+    graph.addNode('service:api', {
+      id: 'service:api',
+      type: NodeType.ServiceNode,
+      name: 'api',
+      language: 'javascript',
+    })
+    graph.addNode('file:api/handler.ts', {
+      id: 'file:api/handler.ts',
+      type: NodeType.FileNode,
+      name: 'handler.ts',
+    })
+    graph.addNode('file:api/util.ts', {
+      id: 'file:api/util.ts',
+      type: NodeType.FileNode,
+      name: 'util.ts',
+    })
+    graph.addNode('config:api/.env', {
+      id: 'config:api/.env',
+      type: NodeType.ConfigNode,
+      name: '.env',
+    })
+    graph.addNode('database:orders-db', {
+      id: 'database:orders-db',
+      type: NodeType.DatabaseNode,
+      name: 'orders-db',
+    })
+
+    // Structural EXTRACTED edges out of the erroring service — must NOT be stitched.
+    const structural: [EdgeTypeValue, string, string][] = [
+      [EdgeType.CONTAINS, 'service:api', 'file:api/handler.ts'],
+      [EdgeType.IMPORTS, 'service:api', 'file:api/util.ts'],
+      [EdgeType.CONFIGURED_BY, 'service:api', 'config:api/.env'],
+    ]
+    for (const [type, source, target] of structural) {
+      const id = `${type}:${source}->${target}`
+      graph.addEdgeWithKey(id, source, target, {
+        id,
+        source,
+        target,
+        type,
+        provenance: Provenance.EXTRACTED,
+      })
+    }
+
+    // A genuine runtime dependency on an uninstrumented backend — SHOULD bridge.
+    graph.addEdgeWithKey(
+      'CONNECTS_TO:service:api->database:orders-db',
+      'service:api',
+      'database:orders-db',
+      {
+        id: 'CONNECTS_TO:service:api->database:orders-db',
+        source: 'service:api',
+        target: 'database:orders-db',
+        type: EdgeType.CONNECTS_TO,
+        provenance: Provenance.EXTRACTED,
+      },
+    )
+
+    stitchTrace(graph, 'service:api', '2026-05-01T00:00:00.000Z')
+
+    for (const [type, source, target] of structural) {
+      expect(graph.hasEdge(`${type}:INFERRED:${source}->${target}`)).toBe(false)
+    }
+    expect(
+      graph.hasEdge('CONNECTS_TO:INFERRED:service:api->database:orders-db'),
     ).toBe(true)
   })
 


### PR DESCRIPTION
`stitchTrace()` fires on error spans and walks outbound EXTRACTED edges to depth 2, minting an INFERRED twin for each so traversal can prefer the inferred bridge over a bare static edge. The loop filtered on provenance but not edge type, so it also twinned structural edges — CONTAINS, IMPORTS, CONFIGURED_BY. Because INFERRED outranks EXTRACTED under `PROV_RANK`, any 500 could make `/graph/dependencies` and `/graph/blast-radius` surface a 0.6-confidence guess in place of the 0.85 ground-truth containment or import fact. An unrelated request erroring should never downgrade a static structural edge.

This gates the stitcher on a dependency-edge-type allowlist — CALLS / CONNECTS_TO / DEPENDS_ON, the runtime edges the ADR-014 case is about. Structural edges are neither twinned nor recursed through. A genuine EXTRACTED CONNECTS_TO to an uninstrumented backend still gets its INFERRED bridge, unchanged.

The trace-stitcher contract is amended first to lock the allowlist and the structural-edge exclusion; the code follows it. New live test in `ingest.test.ts`: an error span from a service with outbound EXTRACTED CONTAINS / IMPORTS / CONFIGURED_BY produces no INFERRED twins of those, while a CONNECTS_TO to an uninstrumented backend still bridges.

ingest and contracts-audit suites are green. The other core test failures in this worktree (extraction / tree-sitter / api) pre-exist on the base commit and are unrelated.

Refs #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)