### PR TITLE
Rebuild FileNodes on every watch re-extract

### DIFF
--- a/packages/core/src/watch.ts
+++ b/packages/core/src/watch.ts
@@ -8,6 +8,7 @@ import { assertBindAuthority, readAuthEnv } from './auth.js'
 import { ensureCompatLoaded } from './compat.js'
 import { discoverServices, addServiceNodes } from './extract/services.js'
 import { addServiceAliases } from './extract/aliases.js'
+import { addFiles } from './extract/files.js'
 import { addImports } from './extract/imports.js'
 import { addDatabasesAndCompat } from './extract/databases/index.js'
 import { addConfigNodes } from './extract/configs.js'
@@ -37,6 +38,7 @@ import { attachGraphToEventBus, emitNeatEvent } from './events.js'
 export type ExtractPhase =
   | 'services'
   | 'aliases'
+  | 'files'
   | 'imports'
   | 'databases'
   | 'configs'
@@ -46,6 +48,7 @@ export type ExtractPhase =
 const ALL_PHASES: ExtractPhase[] = [
   'services',
   'aliases',
+  'files',
   'imports',
   'databases',
   'configs',
@@ -63,10 +66,15 @@ const ALL_PHASES: ExtractPhase[] = [
 //   .env / *.env.* / prisma / knex / ormconfig → databases + configs
 //   docker-compose / Dockerfile / *.tf / k8s yaml → infra + aliases
 //     (compose labels and Dockerfile labels feed alias discovery)
-//   *.js / *.ts / *.tsx / *.py / *.jsx / *.mjs / *.cjs → imports + calls
+//   *.js / *.ts / *.tsx / *.py / *.jsx / *.mjs / *.cjs → files + imports + calls
 //     (a source edit can shift both its IMPORTS and CALLS edges; the shared
 //     evidence.file retirement mechanism — static-extraction.md §Ghost-edge
-//     cleanup — drops the stale ones from either producer before re-running)
+//     cleanup — drops the stale ones from either producer before re-running.
+//     The `files` phase re-enumerates FileNodes first: retiring an edited
+//     file's edges also drops its CONTAINS edge — whose evidence.file is the
+//     file itself — and can orphan the FileNode, so Phase 1 has to rebuild it
+//     before imports/calls originate edges from it, or addImports emits from a
+//     node that no longer exists.)
 //   *.yaml / *.yml that isn't compose → databases + configs (ORM yaml fallbacks)
 export function classifyChange(relPath: string): Set<ExtractPhase> {
   const phases = new Set<ExtractPhase>()
@@ -108,6 +116,7 @@ export function classifyChange(relPath: string): Set<ExtractPhase> {
   }
 
   if (/\.(?:js|jsx|mjs|cjs|ts|tsx|py)$/.test(base)) {
+    phases.add('files')
     phases.add('imports')
     phases.add('calls')
   }
@@ -156,6 +165,17 @@ export async function runExtractPhases(
   }
   if (phases.has('aliases')) {
     await addServiceAliases(graph, scanPath, services)
+  }
+  // Phase 1 — file enumeration runs before imports/calls (file-awareness.md §1).
+  // Both of those producers originate edges from FileNodes; a re-extract driven
+  // by a source edit has already retired that file's CONTAINS edge (its
+  // evidence.file is the file itself) and may have swept the now-orphaned
+  // FileNode, so rebuilding it here is what keeps addImports from emitting an
+  // edge off a missing node. Idempotent — an unchanged tree is a no-op.
+  if (phases.has('files')) {
+    const r = await addFiles(graph, services)
+    nodesAdded += r.nodesAdded
+    edgesAdded += r.edgesAdded
   }
   if (phases.has('imports')) {
     const r = await addImports(graph, services)

--- a/packages/core/test/watch.test.ts
+++ b/packages/core/test/watch.test.ts
@@ -1,8 +1,31 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, beforeEach } from 'vitest'
 import path from 'node:path'
-import { classifyChange } from '../src/watch.js'
+import { fileURLToPath } from 'node:url'
+import { classifyChange, runExtractPhases } from '../src/watch.js'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import { retireEdgesByFile } from '../src/extract/retire.js'
+import { NodeType, EdgeType } from '@neat.is/types'
+import type { GraphNode, GraphEdge } from '@neat.is/types'
 
 const sep = path.sep
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const TS_SERVICE = path.resolve(__dirname, 'fixtures', 'imports', 'ts-service')
+
+// Every FileNode should be owned by exactly one CONTAINS edge from its service.
+// A FileNode with no inbound CONTAINS is a corrupted snapshot — the file exists
+// on disk but the graph has orphaned it from its owner.
+function fileNodesWithoutContainer(graph: ReturnType<typeof getGraph>): string[] {
+  const orphans: string[] = []
+  graph.forEachNode((id, attrs) => {
+    if ((attrs as GraphNode).type !== NodeType.FileNode) return
+    const hasContainer = graph
+      .inboundEdges(id)
+      .some((e) => (graph.getEdgeAttributes(e) as GraphEdge).type === EdgeType.CONTAINS)
+    if (!hasContainer) orphans.push(id)
+  })
+  return orphans
+}
 
 describe('classifyChange', () => {
   it('routes package.json to services + aliases + databases', () => {
@@ -23,11 +46,11 @@ describe('classifyChange', () => {
     ])
   })
 
-  it('routes JS/TS/Python source to imports + calls', () => {
-    expect([...classifyChange(`src${sep}index.ts`)].sort()).toEqual(['calls', 'imports'])
-    expect([...classifyChange(`src${sep}index.js`)].sort()).toEqual(['calls', 'imports'])
-    expect([...classifyChange(`src${sep}page.tsx`)].sort()).toEqual(['calls', 'imports'])
-    expect([...classifyChange(`app${sep}main.py`)].sort()).toEqual(['calls', 'imports'])
+  it('routes JS/TS/Python source to files + imports + calls', () => {
+    expect([...classifyChange(`src${sep}index.ts`)].sort()).toEqual(['calls', 'files', 'imports'])
+    expect([...classifyChange(`src${sep}index.js`)].sort()).toEqual(['calls', 'files', 'imports'])
+    expect([...classifyChange(`src${sep}page.tsx`)].sort()).toEqual(['calls', 'files', 'imports'])
+    expect([...classifyChange(`app${sep}main.py`)].sort()).toEqual(['calls', 'files', 'imports'])
   })
 
   it('routes .env / prisma / knex / ormconfig to databases + configs', () => {
@@ -46,6 +69,7 @@ describe('classifyChange', () => {
       'calls',
       'configs',
       'databases',
+      'files',
       'imports',
     ])
     expect([...classifyChange(`ormconfig.json`)].sort()).toEqual(['configs', 'databases'])
@@ -81,5 +105,53 @@ describe('classifyChange', () => {
   it('case-insensitive for Dockerfile and friends', () => {
     expect([...classifyChange('dockerfile')].sort()).toEqual(['aliases', 'infra'])
     expect([...classifyChange('Dockerfile')].sort()).toEqual(['aliases', 'infra'])
+  })
+
+  it('re-enumerates files so a source edit rebuilds its FileNode', () => {
+    // A source edit retires the file's CONTAINS edge (evidence.file matches).
+    // The re-extract has to walk files again to put it back, or the FileNode
+    // is left orphaned from its service.
+    expect(classifyChange(`src${sep}index.ts`).has('files')).toBe(true)
+    expect(classifyChange(`app${sep}main.py`).has('files')).toBe(true)
+  })
+})
+
+describe('watch re-extract on an edited imported file', () => {
+  beforeEach(() => resetGraph())
+
+  const importsEdge =
+    'IMPORTS:file:fixture-imports-ts-service:index.ts->file:fixture-imports-ts-service:mongo.ts'
+
+  it('rebuilds the graph cleanly when the imported file changes', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, TS_SERVICE)
+    expect(graph.hasEdge(importsEdge)).toBe(true)
+    expect(fileNodesWithoutContainer(graph)).toEqual([])
+
+    // mongo.ts is imported by index.ts. Editing it retires mongo.ts's CONTAINS
+    // edge; the re-extract must recreate it.
+    retireEdgesByFile(graph, 'mongo.ts')
+    await runExtractPhases(graph, TS_SERVICE, classifyChange('mongo.ts'))
+
+    expect(graph.hasEdge(importsEdge)).toBe(true)
+    expect(fileNodesWithoutContainer(graph)).toEqual([])
+  })
+
+  it('does not crash or orphan nodes when the importer file changes', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, TS_SERVICE)
+
+    // Editing the importer retires its CONTAINS *and* its outbound IMPORTS,
+    // which orphans the importer FileNode. Without a file re-enumeration the
+    // next addImports emits an edge from a node that no longer exists and
+    // throws.
+    retireEdgesByFile(graph, 'index.ts')
+    await expect(
+      runExtractPhases(graph, TS_SERVICE, classifyChange('index.ts')),
+    ).resolves.toBeDefined()
+
+    expect(graph.hasNode('file:fixture-imports-ts-service:index.ts')).toBe(true)
+    expect(graph.hasEdge(importsEdge)).toBe(true)
+    expect(fileNodesWithoutContainer(graph)).toEqual([])
   })
 })


### PR DESCRIPTION
`neat watch`'s phase runner (`runExtractPhases`) skipped the file-enumeration step (`addFiles`) that the full `init` pass runs. Two failures fell out of that gap:

- **Skeletal graph on a fresh project.** The initial watch extract produced a ServiceNode-only graph, unlike `neat init`. Imports and calls originate their edges from FileNodes, and nothing created them.
- **Crash and corruption on an imported-file edit.** Editing a file that other files import (or the importer itself) crashed the re-extract loop. Retiring the edited file's edges also drops its `CONTAINS` edge — whose `evidence.file` is the file itself — and can leave the FileNode orphaned. The next `addImports` then emitted an edge off a node that no longer existed and threw (`NotFoundGraphError`), leaving the snapshot inconsistent.

The fix gives `runExtractPhases` a `files` phase that walks the source tree and rebuilds FileNodes before imports and calls run, and `classifyChange` routes source edits through it. `addFiles` is idempotent, so an unchanged tree stays a no-op.

## Test

`watch.test.ts` gets a re-extract group that runs a full extract, then replays the flush sequence (`retireEdgesByFile` + `runExtractPhases`) for both an edited imported file and an edited importer. Before the fix the importer case threw `NotFoundGraphError` and the imported-file case left an orphaned FileNode; both now complete cleanly with every FileNode owned by a `CONTAINS` edge. `classifyChange` assertions updated to expect the `files` phase on source edits.

Full `@neat.is/core` suite: the 12 pre-existing failures (REST API, observed-dependencies, python, http-declared-dead, extract-against-demo) are present on `origin/main` without this change and are untouched by it.

Refs #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)