### PR TITLE
Reconcile incident affectedNode and OBSERVED evidence.file onto the fused file

### DIFF
--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -1028,7 +1028,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
         onErrorSpanSync: async (span) => {
           const slot = await resolveTargetSlot(span.service, span.traceId)
           if (!slot) return
-          await makeErrorSpanWriter(slot.paths.errorsPath)(span)
+          await makeErrorSpanWriter(slot.paths.errorsPath, slot.graph, slot.entry.path)(span)
         },
         // Project-scoped route (issue #367) — the URL already named the
         // project. Resolution is a direct slot lookup; service.name resolves
@@ -1051,7 +1051,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
         onProjectErrorSpanSync: async (project, span) => {
           const slot = await resolveSlotByName(project, span.service, span.traceId)
           if (!slot) return
-          await makeErrorSpanWriter(slot.paths.errorsPath)(span)
+          await makeErrorSpanWriter(slot.paths.errorsPath, slot.graph, slot.entry.path)(span)
         },
       })
       otlpAddress = await otlpApp.listen({ port: otlpPort, host })

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -964,15 +964,36 @@ async function appendErrorEvent(ctx: IngestContext, ev: ErrorEvent): Promise<voi
 // the same file grain OBSERVED CALLS edges land on (file-awareness.md §4) —
 // resolving a compiled `dist/...js` frame through its disk-adjacent source map
 // when one is present. Without a call site it stays at the originating service,
-// the honest fallback (§2). No graph access is needed: the file id is built
-// from the span's own `code.*` and `service` attributes, so the receiver can
-// attribute at file grain before the graph has caught up. The file node may not
-// yet be materialised, but querying the service still surfaces the incident, and
-// the recorded file:line is real evidence either way (§6 — never fabricated).
-function incidentAffectedNode(span: ParsedSpan): string {
-  const callSite = callSiteFromSpan(span)
-  if (callSite) return fileId(span.service, callSite.relPath)
-  return serviceId(span.service, span.env)
+// the honest fallback (§2).
+//
+// The runtime `code.filepath` is a deploy-absolute path (`/var/task/...` on
+// Lambda, `/app/...` in a container image) that need not match the daemon's
+// checkout. When the graph is available it's reconciled onto the service-
+// relative path the extractor already minted (reconcileObservedRelPath, the
+// same trailing-suffix match the OBSERVED edge origin uses), so the incident
+// lands on the ONE fused FileNode instead of a phantom keyed off the absolute
+// path — the node root-cause actually walks. Without a graph the honest runtime
+// path stands: the file node may not be materialised yet, but querying the
+// service still surfaces the incident, and the file:line is real (§6 — never
+// fabricated).
+function incidentAffectedNode(
+  span: ParsedSpan,
+  graph?: NeatGraph,
+  scanPath?: string,
+): string {
+  const sid = serviceId(span.service, span.env)
+  const serviceNode =
+    graph && graph.hasNode(sid)
+      ? (graph.getNodeAttributes(sid) as ServiceNode)
+      : undefined
+  const callSite = callSiteFromSpan(span, serviceNode, scanPath)
+  if (callSite) {
+    const relPath = graph
+      ? reconcileObservedRelPath(graph, span.service, callSite.relPath)
+      : callSite.relPath
+    return fileId(span.service, relPath)
+  }
+  return sid
 }
 
 // Build the minimal ErrorEvent the receiver writes synchronously before
@@ -1007,7 +1028,11 @@ function sanitizeAttributes(
   return out
 }
 
-export function buildErrorEventForReceiver(span: ParsedSpan): ErrorEvent | null {
+export function buildErrorEventForReceiver(
+  span: ParsedSpan,
+  graph?: NeatGraph,
+  scanPath?: string,
+): ErrorEvent | null {
   if (span.statusCode !== 2) return null
   const ts = span.startTimeIso ?? new Date().toISOString()
   const attrs = sanitizeAttributes(span.attributes)
@@ -1023,7 +1048,7 @@ export function buildErrorEventForReceiver(span: ParsedSpan): ErrorEvent | null 
       ? { exceptionStacktrace: span.exception.stacktrace }
       : {}),
     ...(Object.keys(attrs).length > 0 ? { attributes: attrs } : {}),
-    affectedNode: incidentAffectedNode(span),
+    affectedNode: incidentAffectedNode(span, graph, scanPath),
   }
 }
 
@@ -1031,9 +1056,11 @@ export function buildErrorEventForReceiver(span: ParsedSpan): ErrorEvent | null 
 // before replying, so a write failure surfaces as 500 → OTel SDK retries.
 export function makeErrorSpanWriter(
   errorsPath: string,
+  graph?: NeatGraph,
+  scanPath?: string,
 ): (span: ParsedSpan) => Promise<void> {
   return async (span) => {
-    const ev = buildErrorEventForReceiver(span)
+    const ev = buildErrorEventForReceiver(span, graph, scanPath)
     if (!ev) return
     await fs.mkdir(path.dirname(errorsPath), { recursive: true })
     await fs.appendFile(errorsPath, JSON.stringify(ev) + '\n', 'utf8')
@@ -1185,9 +1212,15 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
     callSite ? ensureObservedFileNode(ctx.graph, span.service, sourceId, callSite) : sourceId
   // Evidence for the OBSERVED edge — populated from the span's code.* semconv
   // when the call site resolved (file-awareness.md §4 + §6). Never fabricated:
-  // absent call site → undefined evidence.
+  // absent call site → undefined evidence. The path is reconciled the same way
+  // the edge's origin node is (reconcileObservedRelPath), so evidence.file names
+  // the fused EXTRACTED path the edge lands on rather than the raw deployed
+  // absolute path — otherwise the edge node and its own evidence disagree.
   const callSiteEvidence: { file: string; line?: number } | undefined = callSite
-    ? { file: callSite.relPath, ...(callSite.line !== undefined ? { line: callSite.line } : {}) }
+    ? {
+        file: reconcileObservedRelPath(ctx.graph, span.service, callSite.relPath),
+        ...(callSite.line !== undefined ? { line: callSite.line } : {}),
+      }
     : undefined
 
   let affectedNode = sourceId
@@ -1287,7 +1320,11 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
         const fallbackEvidence: { file: string; line?: number } | undefined =
           parent.callSite
             ? {
-                file: parent.callSite.relPath,
+                file: reconcileObservedRelPath(
+                  ctx.graph,
+                  parent.service,
+                  parent.callSite.relPath,
+                ),
                 ...(parent.callSite.line !== undefined
                   ? { line: parent.callSite.line }
                   : {}),

--- a/packages/core/src/watch.ts
+++ b/packages/core/src/watch.ts
@@ -455,7 +455,7 @@ export async function startWatch(
     writeErrorEventInline: false,
     onPolicyTrigger,
   })
-  const onErrorSpanSync = makeErrorSpanWriter(opts.errorsPath)
+  const onErrorSpanSync = makeErrorSpanWriter(opts.errorsPath, graph, opts.scanPath)
   const otelHttp = await buildOtelReceiver({ onSpan, onErrorSpanSync })
   await otelHttp.listen({ port: otelPort, host })
   console.log(`neat-core OTLP receiver on http://${host}:${otelPort}/v1/traces`)

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -25,6 +25,7 @@ import {
   thresholdForEdgeType,
   type IngestContext,
 } from '../src/ingest.js'
+import { getRootCause } from '../src/traverse.js'
 import type { ParsedSpan } from '../src/otel.js'
 import type { NeatGraph } from '../src/graph.js'
 
@@ -1499,5 +1500,65 @@ describe('EXTRACTED and OBSERVED FileNodes fuse for the same source file', () =>
     // The honest runtime path stands; evidence is never fabricated onto the
     // wrong static node.
     expect(fileNodeIds.some((id) => id.endsWith('src/uninstrumented.ts'))).toBe(true)
+  })
+
+  // #619 — the fusion fix reconciled OBSERVED edge NODE ids onto the EXTRACTED
+  // path, but the incident `affectedNode` and the OBSERVED edge's own
+  // `evidence.file` still carried the raw deployed absolute path. On a
+  // serverless deploy (runtime rooted at /var/task, daemon rooted elsewhere)
+  // that split the incident off from the fused node and left the edge naming a
+  // path its node id didn't match. Both must reconcile onto the fused FileNode.
+  it('reconciles the incident affectedNode onto the fused FileNode so root-cause lands on it', async () => {
+    const staticFileId = fileId('service-a', 'src/client.ts')
+    ensureFileNode(ctx.graph, 'service-a', 'service:service-a', 'src/client.ts')
+
+    // A failing span for that file, carrying the deployed absolute path the
+    // SpanProcessor stamped. No scanPath is wired (the ad-hoc surface), and
+    // `/var/task` is the Lambda task root, not the daemon's checkout.
+    const span = clientHttpSpan({
+      statusCode: 2,
+      exception: { message: 'boom' },
+      attributes: {
+        'server.address': 'service-b',
+        'code.filepath': '/var/task/src/client.ts',
+        'code.lineno': 42,
+      },
+    })
+
+    // The receiver-path incident (production daemon path) attributes to the ONE
+    // fused node, not the phantom `file:service-a:var/task/src/client.ts`.
+    const ev = buildErrorEventForReceiver(span, ctx.graph)
+    expect(ev).not.toBeNull()
+    expect(ev!.affectedNode).toBe(staticFileId)
+    expect(ctx.graph.hasNode(ev!.affectedNode)).toBe(true)
+
+    // And root-cause on that fused node returns it — the query that came back
+    // empty before, because the incident pointed at a node absent from the graph.
+    const rc = getRootCause(ctx.graph, staticFileId, ev!, [ev!])
+    expect(rc).not.toBeNull()
+    expect(rc!.rootCauseNode).toBe(staticFileId)
+  })
+
+  it("reconciles the OBSERVED edge's evidence.file onto the fused path (node id and evidence agree)", async () => {
+    const staticFileId = fileId('service-a', 'src/client.ts')
+    ensureFileNode(ctx.graph, 'service-a', 'service:service-a', 'src/client.ts')
+
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        attributes: {
+          'server.address': 'service-b',
+          'code.filepath': '/var/task/src/client.ts',
+          'code.lineno': 42,
+        },
+      }),
+    )
+
+    const observedCallsId = `${EdgeType.CALLS}:OBSERVED:${staticFileId}->service:service-b`
+    const edge = ctx.graph.getEdgeAttributes(observedCallsId) as GraphEdge
+    // The edge's node id already reconciled onto src/client.ts; its evidence must
+    // name the same fused path, not the raw /var/task deployed path.
+    expect(edge.evidence?.file).toBe('src/client.ts')
+    expect(edge.source).toBe(staticFileId)
   })
 })


### PR DESCRIPTION
The #602 fusion fix taught OBSERVED edges to reconcile their node id onto the service-relative path the extractor already minted, so a runtime span and the static parse fuse into one FileNode. Two sibling attributions were left carrying the raw runtime path, and a serverless deploy (breaker round 2) is where that split shows.

On a deploy whose runtime path is rooted somewhere the daemon's checkout can't anchor (`/var/task` on Lambda, `/app` in a container image):

- **Incident affectedNode pointed at a phantom.** `buildErrorEventForReceiver` → `incidentAffectedNode` built `fileId(service, relPath)` straight off the deployed path with no graph in hand, so the incident named a FileNode absent from the graph. Root-cause on the real fused node came back empty.
- **The OBSERVED edge's evidence.file disagreed with its own node id.** The edge origin reconciled onto `src/...` through `ensureObservedFileNode`, but `evidence.file` was still set from the raw `callSite.relPath` — the edge landing on the fused node while its evidence named the deployed absolute path.

Both now run through the same trailing-suffix `reconcileObservedRelPath` the edge origin uses. `incidentAffectedNode` takes the graph (threaded through `buildErrorEventForReceiver` and `makeErrorSpanWriter`, wired at both the single-project and per-project daemon receivers plus `watch`) and lands the incident on the fused node. `evidence.file` reconciles alongside the node id it belongs to, on both the caller-side and the parent-fallback edge.

A focused test in `ingest.test.ts` drives an error span carrying `/var/task/src/client.ts` against an extracted `src/client.ts`: the receiver-path incident attributes to the fused node (not the `var/task` phantom), root-cause on that node returns it, and the OBSERVED edge's `evidence.file` reads `src/client.ts`.

Not touched here: the spurious OBSERVED `CONNECTS_TO` from a route file that issues no SQL is a separate call-site attribution question (a db-client span inheriting the handler-file frame via the §4 handler-entry floor), not a path-reconciliation one — different root, left for its own issue.

Note: `api.test.ts` carries 4 pre-existing blast-radius failures on the base commit (3478e50), unrelated to this change; `tsc` on the base also reports pre-existing `ObservedDependenciesResult` export gaps. Neither touches the files in this PR.

Refs #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)