### PR TITLE
Count each failed request once and name non-HTTP failures

### DIFF
--- a/docs/contracts/otel-ingest.md
+++ b/docs/contracts/otel-ingest.md
@@ -59,12 +59,16 @@ Both paths go through `upsertObservedEdge`, which writes the `signal` block (`sp
 
 `OtlpSpan` is extended with `events: Array<{ name, timeUnixNano, attributes }>`. When a span has an `events[]` entry with `name === 'exception'`, the parser extracts `exception.type`, `exception.message`, and `exception.stacktrace` from its attributes.
 
-`handleSpan`'s ErrorEvent path reads exception data directly. `span.name` is intentionally absent from the fallback chain — OTel HTTP server instrumentation populates it with the request method (`"GET"`, `"POST"`), which is misleading at the incident surface. `span.status.message` is similarly absent for the same reason. When neither layer carries an exception, the literal `'unknown error'` keeps the schema's required-string contract intact while surfacing the gap:
+`handleSpan`'s ErrorEvent path reads exception data directly. `span.name` is intentionally absent from the fallback chain — OTel HTTP server instrumentation populates it with the request method (`"GET"`, `"POST"`), which is misleading at the incident surface. `span.status.message` is similarly absent for the same reason. Before the `'unknown error'` floor, the chain reads the failure the span still carries in its attributes even without an `exception` event — the HTTP response context (`"500 on GET /users/:id"`), then a non-HTTP failure: a non-OK gRPC status (`rpc.grpc.status_code` / `rpc.grpc.status_message`, rendered against the canonical gRPC status names) or a transport-level connection error (`error.type`, e.g. `ECONNREFUSED`, named with the peer). The literal `'unknown error'` is the floor for a genuinely opaque failure — no exception, no HTTP context, no gRPC or connection signal — and keeps the schema's required-string contract intact while surfacing the gap:
 
 ```
-exceptionMessage = events.find(e => e.name === 'exception')?.attributes['exception.message']
-                ?? 'unknown error'
+incidentMessage = exception.message
+               ?? httpFailureMessage(attrs)       // "500 on GET /users/:id"
+               ?? nonHttpFailureMessage(attrs)     // "gRPC UNAVAILABLE", "ECONNREFUSED connecting to pay"
+               ?? 'unknown error'
 ```
+
+The gRPC status-code → name table is a fixed protocol enum (grpc/status.proto), not driver/engine data, so it lives as a constant in `ingest.ts` rather than in `compat.json` — Rule 8 governs engine identification, not a wire enum.
 
 `exception.type` is added to ErrorEvent as an optional field (schema growth via ADR-031). Issue #135.
 
@@ -108,6 +112,8 @@ An incident records when a span carries an unambiguous failure or when a run of 
 3. **An isolated 4xx → no incident.** A lone 4xx is frequently correct application behavior — an auth probe, a conditional fetch, a not-yet-created resource. It records nothing until the burst threshold is crossed.
 
 `NEAT_INCIDENT_THRESHOLDS` is a JSON override (`{ "threshold": <n>, "windowMs": <ms> }`), mirroring `NEAT_STALE_THRESHOLDS`. Either key may be set on its own; the other keeps its default. Both default to the constants near the other ingest tunables in `ingest.ts`.
+
+**One incident per failed request per node (read-time collapse).** A single failed request often produces two error spans in one trace: the span that actually threw (a DB driver, a downstream gRPC call) records its exception, and the HTTP server span that answered 5xx records a *synthesized* HTTP echo of it (`httpFailureMessage`, no exception of its own). Both attribute to the same `(traceId, affectedNode)`, so the request counts twice at the surface. The exact-`(traceId, spanId)` collapse below can't see it — the spanIds differ. `readErrorEvents` runs a second collapse: when a real failure incident shares a `(traceId, affectedNode)` with a synthesized HTTP echo, the echo is dropped so the request counts once. The synthesized echo survives only when it is the sole record for that node in the trace (a clean 5xx with nothing deeper explaining it). This preserves the cross-service split — a caller's failing-response incident (`affectedNode` = the caller) and the callee's exception (`affectedNode` = the callee) land on different nodes, so they stay two separate ledgers as before. The sidecar stays append-only; the collapse is read-time only.
 
 A failing-response incident is attributed to the **source service** — the caller whose outbound calls are failing is the node a debugging session asks about, so `affectedNode` is `serviceId(span.service)` and the peer is carried in the message and the passed-through attributes. This sits alongside the OBSERVED edge's resolved target (frontier or known service); incidents and edges are separate ledgers, and the incident answers "this service's calls to X are failing," not "X failed." `GET /incidents/:nodeId` (which `get_incident_history` wraps) surfaces these on the source service node.
 

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -173,13 +173,19 @@ function loadIncidentThresholdsFromEnv(): { threshold: number; windowMs: number 
   }
 }
 
-// Read the HTTP response status off a span. OTel semconv renamed this attribute
-// — modern SDKs write `http.response.status_code`, older ones `http.status_code`.
-// Returns undefined when neither is present or parseable, so a span with no
-// response status is never misclassified as a failure.
-function httpResponseStatus(span: ParsedSpan): number | undefined {
+// An attribute bag — either a live span's `attributes` or the passthrough set a
+// recorded ErrorEvent carries. The message helpers read from both, so the same
+// "what failed here" logic that names an incident at record time can re-derive
+// it at read time (dedupeIncidents).
+type AttrBag = Record<string, unknown>
+
+// Read the HTTP response status off an attribute bag. OTel semconv renamed this
+// attribute — modern SDKs write `http.response.status_code`, older ones
+// `http.status_code`. Returns undefined when neither is present or parseable, so
+// a span with no response status is never misclassified as a failure.
+function httpResponseStatusFromAttrs(attrs: AttrBag): number | undefined {
   for (const key of ['http.response.status_code', 'http.status_code']) {
-    const v = span.attributes[key]
+    const v = attrs[key]
     if (typeof v === 'number' && Number.isFinite(v)) return v
     if (typeof v === 'string') {
       const n = Number(v)
@@ -189,32 +195,99 @@ function httpResponseStatus(span: ParsedSpan): number | undefined {
   return undefined
 }
 
-// HTTP method/route off a span, across the OTel semconv rename (modern
-// `http.request.method` / legacy `http.method`; `http.route` is the matched
-// template, with `http.target` / `url.path` as the concrete-path fallback).
-function httpMethod(span: ParsedSpan): string | undefined {
-  return pickAttr(span, 'http.request.method', 'http.method')
-}
-
-function httpRoute(span: ParsedSpan): string | undefined {
-  return pickAttr(span, 'http.route', 'http.target', 'url.path')
+function httpResponseStatus(span: ParsedSpan): number | undefined {
+  return httpResponseStatusFromAttrs(span.attributes)
 }
 
 // A human incident line built from the HTTP context a server span carries even
 // when no exception event was recorded — an Express error handler that answers
 // 500 cleanly leaves `span.exception` empty but still carries the route and
 // status. "500 on GET /users/:id" reads better than the literal 'unknown
-// error'. Returns undefined when the span has no usable HTTP context, so a
-// non-HTTP failure still falls back to 'unknown error'.
-function httpFailureMessage(span: ParsedSpan): string | undefined {
-  const status = httpResponseStatus(span)
-  const route = httpRoute(span)
-  const method = httpMethod(span)
+// error'. Returns undefined when the bag has no usable HTTP context, so a
+// non-HTTP failure falls through to nonHttpFailureMessage / 'unknown error'.
+// Method/route follow the OTel semconv rename (modern `http.request.method` /
+// legacy `http.method`; `http.route` matched template, `http.target` / `url.path`
+// concrete-path fallback).
+function httpFailureMessageFromAttrs(attrs: AttrBag): string | undefined {
+  const status = httpResponseStatusFromAttrs(attrs)
+  const route = pickAttrFrom(attrs, 'http.route', 'http.target', 'url.path')
+  const method = pickAttrFrom(attrs, 'http.request.method', 'http.method')
   const where = route ? `${method ? `${method} ` : ''}${route}` : undefined
   if (status !== undefined && where) return `${status} on ${where}`
   if (status !== undefined) return `HTTP ${status}`
   if (where) return `error on ${where}`
   return undefined
+}
+
+// Canonical gRPC status code → name (grpc/status.proto). Fixed protocol
+// constants shared by every gRPC implementation — not driver/engine data, so
+// they don't belong in compat.json (Rule 8 governs the latter, not a wire enum).
+const GRPC_STATUS_NAMES: Record<number, string> = {
+  1: 'CANCELLED',
+  2: 'UNKNOWN',
+  3: 'INVALID_ARGUMENT',
+  4: 'DEADLINE_EXCEEDED',
+  5: 'NOT_FOUND',
+  6: 'ALREADY_EXISTS',
+  7: 'PERMISSION_DENIED',
+  8: 'RESOURCE_EXHAUSTED',
+  9: 'FAILED_PRECONDITION',
+  10: 'ABORTED',
+  11: 'OUT_OF_RANGE',
+  12: 'UNIMPLEMENTED',
+  13: 'INTERNAL',
+  14: 'UNAVAILABLE',
+  15: 'DATA_LOSS',
+  16: 'UNAUTHENTICATED',
+}
+
+function grpcStatusCodeFromAttrs(attrs: AttrBag): number | undefined {
+  const v = attrs['rpc.grpc.status_code']
+  if (typeof v === 'number' && Number.isFinite(v)) return v
+  if (typeof v === 'string') {
+    const n = Number(v)
+    if (Number.isFinite(n)) return n
+  }
+  return undefined
+}
+
+// A non-HTTP failure still carries its cause in span attributes — a non-OK gRPC
+// status, or a transport-level connection error (ECONNREFUSED reaching a peer).
+// Reading them keeps the incident from degrading to the literal 'unknown error'
+// when the span has no exception event and no HTTP response code. Returns
+// undefined for a span carrying neither, so the 'unknown error' floor still
+// applies to a genuinely opaque failure (issue #624).
+function nonHttpFailureMessageFromAttrs(attrs: AttrBag): string | undefined {
+  const grpc = grpcStatusCodeFromAttrs(attrs)
+  if (grpc !== undefined && grpc !== 0) {
+    const name = GRPC_STATUS_NAMES[grpc] ?? `status ${grpc}`
+    const detail = pickAttrFrom(attrs, 'rpc.grpc.status_message')
+    return detail ? `gRPC ${name}: ${detail}` : `gRPC ${name}`
+  }
+  // Transport/connection failure — OTel's `error.type` carries the errno
+  // (ECONNREFUSED, ETIMEDOUT, …) or the exception class for a call that never
+  // got a response. Skip the HTTP status-class forms ("500", "_OTHER") that
+  // http semconv also writes there; the HTTP path above owns those.
+  const errType = pickAttrFrom(attrs, 'error.type')
+  if (errType && errType !== '_OTHER' && !/^\d+$/.test(errType)) {
+    const peer = pickAttrFrom(attrs, 'server.address', 'net.peer.name', 'net.host.name')
+    return peer ? `${errType} connecting to ${peer}` : errType
+  }
+  return undefined
+}
+
+// The incident's human message: the recorded exception first, then the HTTP
+// context a server span still carries, then a non-HTTP (gRPC / connection)
+// failure read from attributes, and only then the 'unknown error' floor. Shared
+// by every incident write path so the fallback chain can't drift between the
+// receiver's synchronous write and handleSpan's inline write.
+function incidentMessage(span: ParsedSpan): string {
+  return (
+    span.exception?.message ??
+    httpFailureMessageFromAttrs(span.attributes) ??
+    nonHttpFailureMessageFromAttrs(span.attributes) ??
+    'unknown error'
+  )
 }
 
 // In-flight 4xx burst against one (source, peer) pair. Lives on IngestContext so
@@ -279,12 +352,16 @@ export function resetNoSourceMapWarnings(): void {
   noSourceMapWarnedServices.clear()
 }
 
-function pickAttr(span: ParsedSpan, ...keys: string[]): string | undefined {
+function pickAttrFrom(attrs: AttrBag, ...keys: string[]): string | undefined {
   for (const k of keys) {
-    const v = span.attributes[k]
+    const v = attrs[k]
     if (typeof v === 'string' && v.length > 0) return v
   }
   return undefined
+}
+
+function pickAttr(span: ParsedSpan, ...keys: string[]): string | undefined {
+  return pickAttrFrom(span.attributes, ...keys)
 }
 
 function hostFromUrl(u: string | undefined): string | undefined {
@@ -1017,7 +1094,7 @@ export function buildErrorEventForReceiver(span: ParsedSpan): ErrorEvent | null 
     service: span.service,
     traceId: span.traceId,
     spanId: span.spanId,
-    errorMessage: span.exception?.message ?? httpFailureMessage(span) ?? 'unknown error',
+    errorMessage: incidentMessage(span),
     ...(span.exception?.type ? { exceptionType: span.exception.type } : {}),
     ...(span.exception?.stacktrace
       ? { exceptionStacktrace: span.exception.stacktrace }
@@ -1323,7 +1400,7 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
         service: span.service,
         traceId: span.traceId,
         spanId: span.spanId,
-        errorMessage: span.exception?.message ?? httpFailureMessage(span) ?? 'unknown error',
+        errorMessage: incidentMessage(span),
         ...(span.exception?.type ? { exceptionType: span.exception.type } : {}),
         ...(span.exception?.stacktrace
           ? { exceptionStacktrace: span.exception.stacktrace }
@@ -1643,32 +1720,70 @@ export async function readErrorEvents(errorsPath: string): Promise<ErrorEvent[]>
   }
 }
 
-// Make the incident surface idempotent on `(traceId, spanId)`. The ndjson
-// sidecar is append-only (persistence contract), so a re-delivered span — OTel
+// A synthesized HTTP-status incident carries no failure of its own — it's the
+// "500 on GET /users/:id" line handleSpan mints for a server span that answered
+// 5xx with no exception event of its own (httpFailureMessage). When the real
+// failure surfaced deeper in the same trace (a DB driver threw, a downstream
+// gRPC returned UNAVAILABLE), that exception is recorded as its own incident on
+// the same node, and the server's HTTP echo is a duplicate of it. A record is
+// "synthesized HTTP" when it carries no exception data, no explicit errorType
+// (the coalesced http-failure incidents set one and carry their own count), and
+// its message is exactly the HTTP line re-derived from its own attributes.
+function isSynthesizedHttpIncident(ev: ErrorEvent): boolean {
+  if (ev.exceptionType || ev.exceptionStacktrace) return false
+  if (ev.errorType) return false
+  if (!ev.attributes) return false
+  const synth = httpFailureMessageFromAttrs(ev.attributes)
+  return synth !== undefined && synth === ev.errorMessage
+}
+
+// Make the incident surface idempotent per failure. Two passes:
+//
+// Pass 1 — collapse exact `(traceId, spanId)` re-deliveries. The ndjson sidecar
+// is append-only (persistence contract), so a re-delivered span — OTel
 // BatchSpanProcessor retries, or a receiver + handler both writing one POST —
-// leaves duplicate lines on disk. An incident is one event per `(traceId,
-// spanId)`; collapsing on read keeps the count honest without rewriting the
-// append-only file. The deterministic incident `id` already encodes the pair
-// (`${traceId}:${spanId}`); we dedupe on it directly, falling back to the raw
-// pair for any record that predates the id. Records that carry neither (extract
-// parse-failure rows, `source: 'extract'`) pass through untouched — they aren't
-// span incidents. First write wins so the original timestamp is preserved.
+// leaves duplicate lines on disk. The deterministic incident `id` already
+// encodes the pair (`${traceId}:${spanId}`); we dedupe on it directly, falling
+// back to the raw pair for any record that predates the id. Records that carry
+// neither (extract parse-failure rows, `source: 'extract'`) pass through
+// untouched — they aren't span incidents. First write wins so the original
+// timestamp is preserved.
+//
+// Pass 2 — collapse one failure recorded from two spans of the same trace. A
+// failing request lands one incident from the span that actually threw (the DB
+// child's exception, a downstream gRPC error) and a second, synthesized one from
+// the HTTP server span that echoed it as a 5xx. Both key to the same
+// `(traceId, affectedNode)`; the exact-id pass can't see it because the spanIds
+// differ. When a real failure shares a trace and node with a synthesized HTTP
+// echo, drop the echo so the request counts once (issue #624). A cross-service
+// failure keeps both sides: the caller's failing-response incident and the
+// callee's exception land on different `affectedNode`s (separate ledgers per the
+// otel-ingest contract), so they never share a group.
 function dedupeIncidents(events: ErrorEvent[]): ErrorEvent[] {
   const seen = new Set<string>()
-  const out: ErrorEvent[] = []
+  const once: ErrorEvent[] = []
   for (const ev of events) {
     const key =
       ev.id ??
       (ev.traceId && ev.spanId ? `${ev.traceId}:${ev.spanId}` : undefined)
     if (key === undefined) {
-      out.push(ev)
+      once.push(ev)
       continue
     }
     if (seen.has(key)) continue
     seen.add(key)
-    out.push(ev)
+    once.push(ev)
   }
-  return out
+
+  const groupKey = (ev: ErrorEvent): string => `${ev.traceId} ${ev.affectedNode}`
+  const hasRealFailure = new Set<string>()
+  for (const ev of once) {
+    if (ev.traceId && !isSynthesizedHttpIncident(ev)) hasRealFailure.add(groupKey(ev))
+  }
+  return once.filter((ev) => {
+    if (!ev.traceId || !isSynthesizedHttpIncident(ev)) return true
+    return !hasRealFailure.has(groupKey(ev))
+  })
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/traverse.ts
+++ b/packages/core/src/traverse.ts
@@ -480,7 +480,14 @@ function localizeFromIncidents(
   const route = typeof attrs['http.route'] === 'string' ? attrs['http.route'] : undefined
   const location = filepath ? `${filepath}${lineno !== undefined ? `:${lineno}` : ''}` : undefined
 
-  const count = relevant.length
+  // Count the incidents of *this* failure mode, not every incident on the node.
+  // The reason names one message (`latest.errorMessage`); pairing it with the
+  // node's total incident count reads as though that one error happened N times
+  // when the node may be failing several different ways. Scope the count to the
+  // records sharing this message so "3 recorded incidents" means three of the
+  // failure the reason actually describes (issue #624).
+  const sameMode = relevant.filter((ev) => ev.errorMessage === latest.errorMessage)
+  const count = sameMode.length
   const tail = count > 1 ? ` (${count} recorded incidents)` : ' (1 recorded incident)'
   const reasonParts = [`${latest.service}: ${latest.errorMessage}`]
   if (location) reasonParts.push(`surfaced at ${location}`)

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -369,6 +369,85 @@ describe('handleSpan', () => {
     } as ErrorEvent)
   })
 
+  it('collapses one failure recorded from two spans of a trace to one incident (#624)', async () => {
+    // A failed request: the DB driver throws (recorded from the db child span)
+    // and the HTTP server span echoes it as a synthesized "500 on ...". Both
+    // land on the same service in the same trace — two lines on disk, but one
+    // failed request, so the surface must count one and keep the real cause.
+    const httpAttrs = {
+      'http.response.status_code': 500,
+      'http.route': '/users/:id',
+      'http.request.method': 'GET',
+    }
+    const serverSpan: ParsedSpan = {
+      ...clientHttpSpan({ service: 'checkout', spanId: 'srv', kind: 2, statusCode: 2 }),
+      attributes: httpAttrs,
+    }
+    const dbChildSpan: ParsedSpan = dbSpan({
+      service: 'checkout',
+      spanId: 'db',
+      parentSpanId: 'srv',
+      statusCode: 2,
+      exception: { type: 'Error', message: 'SASL: SCRAM-SERVER-FIRST-MESSAGE failed' },
+      attributes: { 'db.system': 'postgresql', 'server.address': 'payments-db' },
+    })
+
+    const ev1 = buildErrorEventForReceiver(serverSpan)!
+    const ev2 = buildErrorEventForReceiver(dbChildSpan)!
+    expect(ev1.errorMessage).toBe('500 on GET /users/:id')
+    expect(ev1.affectedNode).toBe(ev2.affectedNode) // both attribute to service:checkout
+    await fs.writeFile(ctx.errorsPath, JSON.stringify(ev1) + '\n' + JSON.stringify(ev2) + '\n')
+
+    const events = await readErrorEvents(ctx.errorsPath)
+    expect(events).toHaveLength(1)
+    // The synthesized HTTP echo is dropped; the real exception survives.
+    expect(events[0]!.errorMessage).toContain('SCRAM')
+  })
+
+  it('keeps a lone synthesized 5xx incident when nothing deeper explains it (#624)', async () => {
+    // A clean 500 with no exception anywhere in the trace is still a real
+    // incident — the collapse only drops the echo when a real failure shares
+    // its trace and node.
+    const serverSpan: ParsedSpan = {
+      ...clientHttpSpan({ service: 'checkout', spanId: 'srv', kind: 2, statusCode: 2 }),
+      attributes: {
+        'http.response.status_code': 500,
+        'http.route': '/health',
+        'http.request.method': 'GET',
+      },
+    }
+    const ev = buildErrorEventForReceiver(serverSpan)!
+    await fs.writeFile(ctx.errorsPath, JSON.stringify(ev) + '\n')
+    const events = await readErrorEvents(ctx.errorsPath)
+    expect(events).toHaveLength(1)
+    expect(events[0]!.errorMessage).toBe('500 on GET /health')
+  })
+
+  it('reads the gRPC status for a non-HTTP failure instead of unknown error (#624)', () => {
+    const grpcSpan: ParsedSpan = {
+      ...clientHttpSpan({ service: 'checkout', spanId: 'rpc', kind: 3, statusCode: 2 }),
+      name: 'pay.Payments/Charge',
+      attributes: {
+        'rpc.system': 'grpc',
+        'rpc.grpc.status_code': 14,
+        'rpc.grpc.status_message': 'upstream connect error',
+        'server.address': 'payments',
+      },
+    }
+    const ev = buildErrorEventForReceiver(grpcSpan)!
+    expect(ev.errorMessage).toBe('gRPC UNAVAILABLE: upstream connect error')
+  })
+
+  it('reads a connection error for a non-HTTP failure instead of unknown error (#624)', () => {
+    const connSpan: ParsedSpan = {
+      ...clientHttpSpan({ service: 'checkout', spanId: 'conn', kind: 3, statusCode: 2 }),
+      name: 'GET',
+      attributes: { 'error.type': 'ECONNREFUSED', 'server.address': 'payments' },
+    }
+    const ev = buildErrorEventForReceiver(connSpan)!
+    expect(ev.errorMessage).toBe('ECONNREFUSED connecting to payments')
+  })
+
   it('preserves span attributes on the ErrorEvent (ADR-068 follow-up)', async () => {
     await handleSpan(
       ctx,

--- a/packages/core/test/traverse.test.ts
+++ b/packages/core/test/traverse.test.ts
@@ -332,6 +332,26 @@ describe('getRootCause — incident-localized fallback (#584)', () => {
     expect(result!.fixRecommendation).toContain('/users/:id')
   })
 
+  it('counts only the failure mode the reason names, not the node total (#624)', () => {
+    const g = harvestGraph()
+    // The node is failing two different ways. The reason names the most recent
+    // one, so its count must be the number of *that* failure, not every incident
+    // on the node — "1 recorded incident", not "2".
+    const incidents = [
+      incident({
+        id: 'trace-y:span-y',
+        timestamp: '2026-06-30T11:00:00.000Z',
+        errorMessage: 'connect ECONNREFUSED 10.0.0.5:5432',
+      }),
+      incident(), // newer, '500 on GET /users/:id'
+    ]
+    const result = getRootCause(g, 'service:harvest-api', undefined, incidents)
+    expect(result).not.toBeNull()
+    expect(result!.rootCauseReason).toContain('500 on GET /users/:id')
+    expect(result!.rootCauseReason).toContain('1 recorded incident')
+    expect(result!.rootCauseReason).not.toContain('2 recorded incidents')
+  })
+
   it('matches incidents to the service by service name when affectedNode is file-grained', () => {
     const g = harvestGraph()
     // Querying the service must still surface a file-grained incident — the


### PR DESCRIPTION
Three incident-quality fixes from breaker round 2 (against main 3478e50). One test per sub-fix.

**One incident per failed request.** A single failed request could surface two incidents under one traceId — the span that actually threw (a DB driver, a downstream gRPC call) recording its exception, plus the HTTP server span echoing it as a synthesized "500 on ...". The #604 read-dedup only collapses exact `(traceId, spanId)` matches, so these distinct-span lines both survived and inflated the count. `readErrorEvents` now runs a second pass that drops the synthesized HTTP echo when a real failure shares its `(traceId, affectedNode)`. Cross-service failures still keep both sides — the caller's failing-response incident and the callee's exception land on different nodes, so they stay separate ledgers. Append-only sidecar untouched; the collapse is read-time.

**Non-HTTP failures get a real message.** A gRPC failure or a cross-service connection-refused was degrading to the literal 'unknown error' even though the span carried the cause in its attributes. The incident message now reads a non-OK gRPC status (`rpc.grpc.status_code` / `rpc.grpc.status_message`, rendered against the canonical gRPC status names) or a transport-level connection error (`error.type` with the peer) before the 'unknown error' floor.

**Root-cause count matches the failure it names.** `get_root_cause` was pairing one error message with the node's total incident count, reading as though that one failure happened N times. It now counts the incidents of the failure mode the reason actually describes.

The otel-ingest contract picks up the per-request collapse and the extended message chain. The gRPC status-code table is a fixed wire enum (grpc/status.proto), not driver data, so it stays a constant in `ingest.ts` rather than `compat.json`.

Refs #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)