### PR TITLE
Use a \u0000 escape for the incident-key delimiter

### DIFF
--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -1833,7 +1833,7 @@ function dedupeIncidents(events: ErrorEvent[]): ErrorEvent[] {
     once.push(ev)
   }
 
-  const groupKey = (ev: ErrorEvent): string => `${ev.traceId} ${ev.affectedNode}`
+  const groupKey = (ev: ErrorEvent): string => `${ev.traceId}\u0000${ev.affectedNode}`
   const hasRealFailure = new Set<string>()
   for (const ev of once) {
     if (ev.traceId && !isSynthesizedHttpIncident(ev)) hasRealFailure.add(groupKey(ev))


### PR DESCRIPTION
Follow-up to #628. The incident dedup key used a literal NUL byte, which made ingest.ts read as binary to grep/editors. Swapped for the `\u0000` escape — identical byte at runtime, plain-text source.