### PR TITLE
Record incidents from any failure span, not only HTTP status

### DIFF
--- a/docs/contracts/otel-ingest.md
+++ b/docs/contracts/otel-ingest.md
@@ -5,7 +5,7 @@ governs:
   - "packages/core/src/ingest.ts"
   - "packages/core/src/otel.ts"
   - "packages/core/src/otel-grpc.ts"
-adr: [ADR-033, ADR-113, ADR-029, ADR-030, ADR-068]
+adr: [ADR-033, ADR-113, ADR-117, ADR-029, ADR-030, ADR-068]
 enforcement: [lint, review]
 ---
 
@@ -101,11 +101,11 @@ The gRPC receiver still awaits `onSpan` synchronously per request (non-blocking 
 
 ErrorEvent shape stays as defined in `@neat.is/types`. The fields added by issue #135 (`exceptionType`, `exceptionStacktrace`) landed via the schema-growth contract.
 
-## What records an incident (amended — refs #481)
+## What records an incident (amended — refs #481, #614)
 
-An incident records when a span carries an unambiguous failure or when a run of failing responses against one peer accumulates into a signal. The model spans three cases:
+An incident records from **any failure span** — a span carrying an ERROR status or an `exception` event — independent of HTTP context, plus a run of failing responses against one peer that accumulates into a signal. The model spans three cases:
 
-1. **Unambiguous failure → one incident.** A span with `status: ERROR` (`statusCode === 2`), an `events[]` entry named `exception`, or `http.response.status_code >= 500` records an incident on its own. ERROR/exception flow through the §Error-events path above; a 5xx records here in `handleSpan` even when its status stays UNSET. OTel HTTP-client semconv leaves a CLIENT span's status UNSET on a 5xx, so a status-only gate is blind to a server-error response — the response-code read closes that. A 5xx that *also* carries ERROR status records once: the response-code path skips `statusCode === 2` so the §Error-events write owns it.
+1. **Any failure span → one incident.** A span with `status: ERROR` (`statusCode === 2`), an `events[]` entry named `exception`, or `http.response.status_code >= 500` records an incident on its own — the failure signal is what counts, not the presence of HTTP context. A span carrying an ERROR status flows through the §Error-events path above. An `exception` event records an incident even when the span left its status UNSET and carries no HTTP response — the async / queue / background-worker case, a bullmq or Redis-Streams job that throws: `handleSpan` records it, attributed to the span's service and to the handler `file:line` when the span carries `code.filepath`. Its message follows the exception → HTTP context → non-HTTP → `'unknown error'` chain (§Exception data), the same chain every incident write shares. A 5xx records here in `handleSpan` even when its status stays UNSET — OTel HTTP-client semconv leaves a CLIENT span's status UNSET on a 5xx, so a status-only gate is blind to a server-error response; the response-code read closes that. A 5xx that *also* carries ERROR status records once: the response-code path skips `statusCode === 2` so the §Error-events write owns it. The HTTP-status path is a subset of failure-span recording; the exact-`(traceId, spanId)` and one-incident-per-request collapses apply unchanged ([ADR-117](../decisions.md#adr-117--incident-recording-covers-any-failure-span-not-only-http-status-amends-adr-033--adr-113) amends ADR-033 / ADR-113).
 
 2. **A run of 4xx against one peer → one coalesced incident.** A `4xx` `http.response.status_code` on a CLIENT/PRODUCER span feeds a per-`(source, peer)` burst. When `NEAT_INCIDENT_THRESHOLDS.threshold` (default 5) consecutive 4xx land within `NEAT_INCIDENT_THRESHOLDS.windowMs` (default 60s) of each other, one incident records carrying the count (`incidentCount`), the dominant status code (`httpStatusCode`), and the burst's `firstTimestamp` / `lastTimestamp` — span time per §lastObserved-from-span-time, not wall clock. The burst clears on flush; the next run records its own incident. A 4xx more than the window after the previous one starts a fresh burst rather than extending the old one, so a slow trickle of probes never coalesces. Coalescing is what makes 4xx signal: per-span 4xx would let a 404-probing healthcheck drown the history.
 

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -1206,6 +1206,39 @@ async function recordFailingResponseIncident(
   await appendErrorEvent(ctx, ev)
 }
 
+// Record one incident for a span that carries an exception event but no ERROR
+// status and no HTTP failure code — an async / queue / background worker
+// (bullmq, Redis Streams, a scheduled task) whose job threw (ADR-117). Incident
+// recording keys on the failure signal, not on HTTP context: the message
+// follows the shared incidentMessage chain and the record attributes to the
+// handler file:line when the span carries `code.filepath`, else to the
+// originating service (incidentAffectedNode). handleSpan owns this write — the
+// receiver's synchronous error-writer fires only for statusCode === 2, so an
+// exception-only worker span reaches durability here, the same way the
+// response-code incidents below do.
+async function recordExceptionIncident(
+  ctx: IngestContext,
+  span: ParsedSpan,
+  ts: string,
+): Promise<void> {
+  const attrs = sanitizeAttributes(span.attributes)
+  const ev: ErrorEvent = {
+    id: `${span.traceId}:${span.spanId}`,
+    timestamp: ts,
+    service: span.service,
+    traceId: span.traceId,
+    spanId: span.spanId,
+    errorMessage: incidentMessage(span),
+    ...(span.exception?.type ? { exceptionType: span.exception.type } : {}),
+    ...(span.exception?.stacktrace
+      ? { exceptionStacktrace: span.exception.stacktrace }
+      : {}),
+    ...(Object.keys(attrs).length > 0 ? { attributes: attrs } : {}),
+    affectedNode: incidentAffectedNode(span, ctx.graph, ctx.scanPath),
+  }
+  await appendErrorEvent(ctx, ev)
+}
+
 // Advance the 4xx burst for this (source, peer) pair (issue #481). A burst
 // accumulates silently; only when it crosses the threshold inside the window
 // does it flush ONE coalesced incident. A 4xx that arrives more than windowMs
@@ -1487,13 +1520,23 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
   // these spans never reach that durability handoff — handleSpan owns them.
   if (span.statusCode !== 2) {
     const status = httpResponseStatus(span)
-    // A failing-response incident is attributed to the SOURCE service — the
-    // caller whose outbound calls are failing is the node a debugger asks
-    // about ("why is my service erroring"). The peer it failed against is
-    // carried in the message and in attributes. This is deliberately not the
-    // edge target (frontier/peer) the OBSERVED edge above resolved to: the
-    // signal is "this service's calls to X are failing", not "X failed".
-    if (status !== undefined && status >= 500) {
+    // ADR-117 — an exception event on a span that left its status UNSET is
+    // still an unambiguous failure: a bullmq / Redis-Streams / background
+    // worker whose job threw carries the exception and no HTTP response
+    // context, so the status-only and response-code paths both miss it. Record
+    // it independent of HTTP, attributed to the handler file:line (or the
+    // service) the same way the statusCode === 2 path is. Ordered first because
+    // the exception is the unambiguous signal; the response-code branches below
+    // carry the exception-less HTTP failures.
+    if (span.exception) {
+      await recordExceptionIncident(ctx, span, ts)
+    } else if (status !== undefined && status >= 500) {
+      // A failing-response incident is attributed to the SOURCE service — the
+      // caller whose outbound calls are failing is the node a debugger asks
+      // about ("why is my service erroring"). The peer it failed against is
+      // carried in the message and in attributes. This is deliberately not the
+      // edge target (frontier/peer) the OBSERVED edge above resolved to: the
+      // signal is "this service's calls to X are failing", not "X failed".
       await recordFailingResponseIncident(ctx, span, sourceId, ts, status, 1)
     } else if (
       status !== undefined &&

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -702,6 +702,111 @@ describe('handleSpan — failing-response incidents (#481)', () => {
   })
 })
 
+// Async / queue / background-worker failures (ADR-117, #614). An OTel worker
+// span (bullmq, Redis Streams) that throws carries an exception event and a
+// code.* call site but no HTTP response context, so the response-code path
+// never sees it. Incident recording keys on the failure signal instead: an
+// exception event records an incident independent of HTTP, attributed to the
+// handler file:line or the service.
+describe('handleSpan — async/worker failure incidents (ADR-117, #614)', () => {
+  let tmpDir: string
+  let ctx: IngestContext
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-worker-incident-'))
+    ctx = {
+      graph: newGraph(),
+      errorsPath: path.join(tmpDir, 'errors.ndjson'),
+    }
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  // A bullmq / Redis-Streams job span: CONSUMER kind (5), an exception event, a
+  // code.* call site, and NO HTTP response context.
+  function workerSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
+    return {
+      service: 'email-worker',
+      traceId: 'trace-w',
+      spanId: 'span-w',
+      name: 'sendWelcome',
+      kind: 5, // CONSUMER
+      startTimeUnixNano: '0',
+      endTimeUnixNano: '0',
+      durationNanos: 0n,
+      env: 'unknown',
+      startTimeIso: '2026-06-30T12:00:00.000Z',
+      attributes: {
+        'messaging.system': 'redis',
+        'messaging.operation': 'process',
+        'code.filepath': 'src/jobs/email.ts',
+        'code.lineno': 42,
+        'code.function': 'sendWelcome',
+      },
+      exception: { message: 'Error: SMTP connection refused', type: 'Error' },
+      statusCode: 0,
+      ...overrides,
+    }
+  }
+
+  it('records an incident for an exception-event worker span with UNSET status and no HTTP context', async () => {
+    await handleSpan(ctx, workerSpan())
+    const events = await readErrorEvents(ctx.errorsPath)
+    expect(events).toHaveLength(1)
+    expect(events[0]!.errorMessage).toBe('Error: SMTP connection refused')
+    // Attributed to the handler file:line the job threw in (code.filepath),
+    // the same file grain OBSERVED CALLS edges land on.
+    expect(events[0]!.affectedNode).toBe('file:email-worker:src/jobs/email.ts')
+    expect(events[0]!.attributes!['code.lineno']).toBe(42)
+    expect(events[0]!.exceptionType).toBe('Error')
+  })
+
+  it('records an incident for a worker span that also carries ERROR status, no HTTP context', async () => {
+    await handleSpan(ctx, workerSpan({ spanId: 'span-w2', statusCode: 2 }))
+    const events = await readErrorEvents(ctx.errorsPath)
+    expect(events).toHaveLength(1)
+    expect(events[0]!.errorMessage).toBe('Error: SMTP connection refused')
+    // The ERROR-status path attributes to the worker's service; the handler
+    // file:line rides along in the passed-through code.* attributes.
+    expect(events[0]!.affectedNode).toBe('service:email-worker')
+    expect(events[0]!.attributes!['code.filepath']).toBe('src/jobs/email.ts')
+  })
+
+  it('records once — the (traceId, spanId) collapse holds on job redelivery', async () => {
+    // Same trace + span redelivered (a retried job). Both writes share the id
+    // `${traceId}:${spanId}`; readErrorEvents collapses them to one (ADR-113).
+    await handleSpan(ctx, workerSpan())
+    await handleSpan(ctx, workerSpan())
+    const events = await readErrorEvents(ctx.errorsPath)
+    expect(events).toHaveLength(1)
+  })
+
+  it('a clean worker span (no exception, no error status) records nothing', async () => {
+    await handleSpan(ctx, workerSpan({ exception: undefined }))
+    expect(await readErrorEvents(ctx.errorsPath)).toEqual([])
+  })
+
+  it('leaves the HTTP failing-response path intact alongside worker incidents', async () => {
+    // A worker exception and an HTTP 5xx in the same store both record, on
+    // their own nodes — the HTTP path is unchanged by the exception trigger.
+    await handleSpan(ctx, workerSpan())
+    await handleSpan(
+      ctx,
+      clientHttpSpan({
+        service: 'service-a',
+        spanId: 'http-5xx',
+        attributes: { 'http.method': 'GET', 'http.response.status_code': 502 },
+      }),
+    )
+    const events = await readErrorEvents(ctx.errorsPath)
+    expect(events).toHaveLength(2)
+    expect(events.some((e) => e.affectedNode === 'file:email-worker:src/jobs/email.ts')).toBe(true)
+    expect(events.some((e) => e.httpStatusCode === 502)).toBe(true)
+  })
+})
+
 describe('markStaleEdges', () => {
   it('demotes OBSERVED edges whose lastObserved is older than the threshold to STALE', async () => {
     const graph = newGraph()


### PR DESCRIPTION
Incident recording keyed on HTTP failure signal, so an async worker's failure — a bullmq / Redis-Streams / background-task span that throws — carried an ERROR status and an `exception` event but no HTTP response context, and produced no incident. That whole class of failures (async / queue / worker) stayed out of `/incidents` and out of `get_root_cause`.

`handleSpan` now records an incident on **any failure span** — an ERROR status (`statusCode === 2`) or an `exception` event — independent of HTTP context. An exception-event span that left its status UNSET records through the same store the HTTP incidents already use, attributed to the handler `file:line` when the span carries `code.filepath` and to the service otherwise, with the message following the shared exception → HTTP context → non-HTTP → `'unknown error'` chain. The existing HTTP-status path is a subset of this; the `(traceId, spanId)` and one-incident-per-request collapses apply unchanged.

Scope is incident visibility only. The consumer-side OBSERVED edge / queue-topology work stays with #576.

## What changed
- `packages/core/src/ingest.ts` — a new `recordExceptionIncident` writer, fired from the `statusCode !== 2` incident path when a span carries an exception event, ahead of the response-code branches. Reuses the existing `incidentMessage` chain and `incidentAffectedNode` (file-grained handler attribution).
- `docs/contracts/otel-ingest.md` — the incident-recording section now states incidents record from any failure span, not only HTTP status; `ADR-117` added to the `adr:` frontmatter and cited inline.
- `packages/core/test/ingest.test.ts` — a worker-incident suite: an exception-event worker span with UNSET status and no HTTP context records an incident attributed to its handler file:line; an ERROR-status worker span records attributed to its service; the redelivery collapse holds; a clean worker span records nothing; and the HTTP failing-response path stays intact alongside.

`npx turbo test --filter=@neat.is/core` is green (1198 passed).

Refs #614, ADR-117