### PR TITLE
Release 0.4.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10683,7 +10683,7 @@
     },
     "packages/claude-skill": {
       "name": "@neat.is/claude-skill",
-      "version": "0.4.22",
+      "version": "0.4.23",
       "license": "BUSL-1.1",
       "engines": {
         "node": ">=20"
@@ -10691,14 +10691,14 @@
     },
     "packages/core": {
       "name": "@neat.is/core",
-      "version": "0.4.22",
+      "version": "0.4.23",
       "license": "BUSL-1.1",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
         "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
         "@neat.is/instrumentation-registry": "^1.0.0",
-        "@neat.is/types": "^0.4.22",
+        "@neat.is/types": "^0.4.23",
         "chokidar": "^4.0.3",
         "fastify": "^5.0.0",
         "graphology": "^0.25.4",
@@ -10760,11 +10760,11 @@
     },
     "packages/mcp": {
       "name": "@neat.is/mcp",
-      "version": "0.4.22",
+      "version": "0.4.23",
       "license": "BUSL-1.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@neat.is/types": "^0.4.22",
+        "@neat.is/types": "^0.4.23",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -10782,13 +10782,13 @@
       }
     },
     "packages/neat.is": {
-      "version": "0.4.22",
+      "version": "0.4.23",
       "license": "BUSL-1.1",
       "dependencies": {
-        "@neat.is/claude-skill": "^0.4.22",
-        "@neat.is/core": "^0.4.22",
-        "@neat.is/mcp": "^0.4.22",
-        "@neat.is/web": "^0.4.22"
+        "@neat.is/claude-skill": "^0.4.23",
+        "@neat.is/core": "^0.4.23",
+        "@neat.is/mcp": "^0.4.23",
+        "@neat.is/web": "^0.4.23"
       },
       "bin": {
         "neat": "bin/neat",
@@ -10802,7 +10802,7 @@
     },
     "packages/types": {
       "name": "@neat.is/types",
-      "version": "0.4.22",
+      "version": "0.4.23",
       "license": "BUSL-1.1",
       "dependencies": {
         "zod": "^3.23.8"
@@ -10818,11 +10818,11 @@
     },
     "packages/web": {
       "name": "@neat.is/web",
-      "version": "0.4.22",
+      "version": "0.4.23",
       "license": "BUSL-1.1",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
-        "@neat.is/types": "^0.4.22",
+        "@neat.is/types": "^0.4.23",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cytoscape": "^3.33.3",

--- a/packages/claude-skill/package.json
+++ b/packages/claude-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/claude-skill",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "description": "Claude Code skill drop-in for NEAT — wires the @neat.is/mcp server into Claude's MCP config",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/core",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "description": "NEAT graph engine: tree-sitter extraction, OTel ingest, REST API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -51,7 +51,7 @@
     "@fastify/cors": "^10.0.0",
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
-    "@neat.is/types": "^0.4.22",
+    "@neat.is/types": "^0.4.23",
     "chokidar": "^4.0.3",
     "fastify": "^5.0.0",
     "graphology": "^0.25.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/mcp",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "description": "NEAT MCP server: exposes graph queries to AI agents over stdio",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@neat.is/types": "^0.4.22",
+    "@neat.is/types": "^0.4.23",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/neat.is/package.json
+++ b/packages/neat.is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neat.is",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "description": "NEAT — live semantic graph of a software system, queryable from AI agents over MCP. Install once, get the neat / neatd / neat-mcp CLIs.",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -26,9 +26,9 @@
     "README.md"
   ],
   "dependencies": {
-    "@neat.is/core": "^0.4.22",
-    "@neat.is/mcp": "^0.4.22",
-    "@neat.is/claude-skill": "^0.4.22",
-    "@neat.is/web": "^0.4.22"
+    "@neat.is/core": "^0.4.23",
+    "@neat.is/mcp": "^0.4.23",
+    "@neat.is/claude-skill": "^0.4.23",
+    "@neat.is/web": "^0.4.23"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/types",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "description": "Shared Zod schemas, types, and runtime constants for NEAT",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/web",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "description": "NEAT web shell — minimal Next.js app fronting the core API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
-    "@neat.is/types": "^0.4.22",
+    "@neat.is/types": "^0.4.23",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cytoscape": "^3.33.3",


### PR DESCRIPTION
Version bump to 0.4.23 (lockstep + lockfile). Adds async/worker incident visibility (#614 / ADR-117) on top of the 0.4.22 stability release.