### PR TITLE
Keep the daemon-discovery routes off Next's static cache

### DIFF
--- a/packages/web/app/api/config/route.ts
+++ b/packages/web/app/api/config/route.ts
@@ -1,5 +1,12 @@
 import { discoverProfiles, proxyGet } from '../../../lib/proxy'
 
+// This route resolves a live daemon by reading the discovery directory, so it
+// must never be served from a build-time cache. It already reads `request.url`,
+// which marks it dynamic today, but the dependency is on runtime state rather
+// than the URL — pin it explicitly so a future refactor that stops touching the
+// URL can't silently make it cacheable.
+export const dynamic = 'force-dynamic'
+
 // ADR-073 §3 amendment — `/api/config` is the daemon's auth-mode negotiation
 // endpoint. Always unauthenticated, returns `{ publicRead, authProxy }`. Under
 // ADR-101 there is no single core URL, so we resolve the daemon the same way

--- a/packages/web/app/api/profiles/route.ts
+++ b/packages/web/app/api/profiles/route.ts
@@ -1,6 +1,14 @@
 import { discoverProfiles, DEMO } from '../../../lib/proxy'
 import { FIXTURE_PROFILES } from '../../../lib/fixtures'
 
+// This handler reads runtime state (the `~/.neat/daemons/*.json` discovery
+// directory) but takes no `request`, so nothing tells Next.js it depends on
+// live state. Left unpinned it gets statically prerendered at build time and
+// then serves whatever the build machine discovered — an empty list — forever,
+// with `x-nextjs-cache: HIT` even against a running daemon. Force it dynamic so
+// every request re-enumerates the discovery directory.
+export const dynamic = 'force-dynamic'
+
 // ADR-101 — the daemon-discovery enumerator (was `/api/projects`). Enumerates
 // `~/.neat/daemons/*.json` → one profile per per-project daemon
 // (`{ project, endpoint, status }`). This is the only local↔hosted swap point:


### PR DESCRIPTION
The local web dashboard shipped in 0.4.23 can't resolve a profile against a live daemon. `packages/web/app/api/profiles/route.ts` is the daemon-discovery enumerator (ADR-101), but its `GET` takes no `request` argument and declares no `dynamic`/`revalidate` export, so Next statically prerenders it at build time. From then on it serves whatever the build machine discovered — an empty list — no matter what daemons are actually running. `curl /api/profiles` returns `[]` with `x-nextjs-cache: HIT` even with a daemon writing `$NEAT_HOME/daemons/*.json`, the switcher has nothing to select, and login dead-ends with "Can't reach the daemon" because the login form reads this same route to find its target.

Pinning `export const dynamic = 'force-dynamic'` on the enumerator makes every request re-read the discovery directory.

## Audit

I checked every `app/api/**/route.ts`. The distinguishing shape of the bug is a `GET` that reads runtime state without taking `request` (so nothing signals Next that the response depends on live state):

- `/api/profiles` — the actual bug. No `request` arg, reads the daemon discovery dir. **Pinned.**
- `/api/config` — takes `request` and reads `request.url` today, so it's dynamic in practice, but its real dependency is runtime daemon discovery, not the URL. The build-time diagnostic flagged it as the same family. **Pinned defensively** so a refactor that stops touching the URL can't silently make it cacheable.
- Everything else (`/api/graph`, `/api/graph/*`, `/api/health`, `/api/events`, `/api/incidents`, `/api/instrumentation`, `/api/policies/violations`, `/api/search`, `/api/stale-events`) already takes and reads `request`, which keeps it dynamic. Left as-is.

## Verification

- `npx turbo build --filter=@neat.is/web` — `/api/profiles` now builds as `ƒ (Dynamic)` (was `○ Static`).
- Started a daemon on a throwaway fixture with an isolated `NEAT_HOME` and kernel-allocated ports (nowhere near the live demo), then served the built dashboard against it. `curl /api/profiles` returns the live record — `[{"project":"default","endpoint":"http://127.0.0.1:62321","status":"running"}]` — with no `x-nextjs-cache` header.
- Drove the dashboard in a browser: the shell resolves the profile and renders the live daemon's graph (2 nodes / 1 edge, "Core connected", SSE connected), no longer the empty/demo state.
- `npx turbo test --filter=@neat.is/web` green (49 passed).

Refs #635