### PR TITLE
Resolve the per-profile token before the auth gate redirects

### DIFF
--- a/docs/contracts/web-multi-project.md
+++ b/docs/contracts/web-multi-project.md
@@ -66,6 +66,10 @@ The selector is a pure function (`resolveProfile` in `lib/resolve-project.ts`, r
 
 `?project=<name>` and `neat:lastProject` remain **names** (the profile's label). They resolve to the discovered profile whose `project` matches **and is reachable**; a stored name with no matching reachable daemon resolves to **null**, not an error. The URL/localStorage key shape does not change shape under ADR-101 — only what they resolve *to* (a profile, not a `/projects` entry).
 
+### 2.5 The auth gate reads the bearer through the same chain (ADR-073 + ADR-101)
+
+The token that gates the dashboard is per-profile (`neat:authToken:<name>`, ADR-101), so the gate needs a profile label to pick the right key — the same label the shell resolves. `useAuthGate` (`lib/use-auth-gate.ts`) reads the bearer through the resolution chain of rule 2: the URL/localStorage name synchronously, then daemon discovery when those are empty. On a bare `/` entry (no `?project=`, empty `neat:lastProject`) the synchronous read has no hint, so the gate consults `/api/profiles`; when discovery yields a single profile — the daemon the shell is about to resolve toward — it reads that profile's stored bearer. The redirect to `/login` fires only when a resolvable profile has no stored token (and the daemon is not public-read / auth-proxied). Discovery that is empty, or ambiguous (more than one profile with no name hint), carries no bearer to read and falls through to the redirect decision. The gate resolves a token; it never invents a profile name (rule 8).
+
 ### 2a. Client-only render boundaries (ADR-062 + 2026-05-11 amendment, supersedes the SSR-safety amendment to ADR-057)
 
 Two page entrypoints mount client-only via `next/dynamic` with `{ ssr: false }`:

--- a/packages/web/lib/use-auth-gate.ts
+++ b/packages/web/lib/use-auth-gate.ts
@@ -2,7 +2,35 @@
 
 import { useEffect } from 'react'
 import { loadDaemonAuthConfig } from './public-read-mode'
-import { getActiveAuthToken } from './active-profile'
+import { getActiveAuthToken, readProfileToken } from './active-profile'
+import { asProfileList } from './resolve-project'
+
+/**
+ * Resolve the per-profile bearer through daemon discovery when the synchronous
+ * hints come up empty (#637). On a bare `/` entry — no `?project=` in the URL,
+ * empty `neat:lastProject` — the gate has no profile label to key
+ * `neat:authToken:<project>` off (ADR-101), so `getActiveAuthToken()` reads
+ * nothing even though the first login left a token in storage.
+ *
+ * The shell resolves its profile through URL → localStorage → daemon discovery
+ * (web-multi-project §2); the gate reads the token through the same chain. When
+ * discovery yields a single profile, that is the daemon the shell will resolve
+ * toward, so its stored bearer is the one that matters — return it and the gate
+ * stays put. With no discovered profile, or more than one and no hint to
+ * disambiguate between them, there is nothing to read here and the gate falls
+ * through to its public-read / redirect decision.
+ */
+async function tokenForDiscoveredProfile(): Promise<string | null> {
+  try {
+    const res = await fetch('/api/profiles', { cache: 'no-store' })
+    if (!res.ok) return null
+    const profiles = asProfileList(await res.json())
+    if (profiles.length !== 1) return null
+    return readProfileToken(profiles[0].project)
+  } catch {
+    return null
+  }
+}
 
 /**
  * Client-side auth gate. When the operator has not yet pasted a NEAT token at
@@ -27,20 +55,29 @@ export function useAuthGate(): void {
     // ADR-101 — read the active profile's bearer (per-profile, not a single
     // `neat:authToken`); falls back to the profile the shell is resolving
     // toward so a stored token short-circuits the redirect on mount.
-    const token = getActiveAuthToken()
-    if (token) return
+    if (getActiveAuthToken()) return
 
     const path = window.location.pathname
     if (path === '/login') return
 
     let cancelled = false
-    void loadDaemonAuthConfig().then((cfg) => {
+    void (async () => {
+      // No synchronous hint on a bare `/` entry: fall to daemon discovery (the
+      // same step-3 source the shell resolves through) to learn which
+      // per-profile token key to read. A stored token for the resolvable
+      // profile means the operator has already authenticated — don't bounce
+      // them to /login (#637).
+      const discovered = await tokenForDiscoveredProfile()
+      if (cancelled) return
+      if (discovered) return
+
+      const cfg = await loadDaemonAuthConfig()
       if (cancelled) return
       if (cfg.publicRead) return
 
       const next = encodeURIComponent(path + window.location.search)
       window.location.href = `/login?next=${next}`
-    })
+    })()
     return () => {
       cancelled = true
     }

--- a/packages/web/test/auth-gate-bare-root.test.tsx
+++ b/packages/web/test/auth-gate-bare-root.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+
+// #637 (ADR-073 §3 / ADR-101) — a token-secured daemon, first login done, then a
+// bare `/` entry: no `?project=` in the URL, empty `neat:lastProject`. The gate
+// has no synchronous profile hint to key `neat:authToken:<name>` off, so it must
+// fall to daemon discovery (the same step-3 source the shell resolves through)
+// to learn which per-profile token key to read. A single discovered profile with
+// a stored bearer means the operator is already authenticated — the gate stays
+// put instead of bouncing to /login. It only redirects when a resolvable profile
+// genuinely has no stored token (and the daemon is not public-read).
+
+import { useAuthGate } from '../lib/use-auth-gate'
+import { setActiveProfile, writeProfileToken } from '../lib/active-profile'
+import { resetDaemonAuthConfigForTests } from '../lib/public-read-mode'
+
+function Gated() {
+  useAuthGate()
+  return <div data-testid="gated" />
+}
+
+function makeStorage(): Storage {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v))
+    },
+    removeItem: (k: string) => {
+      store.delete(k)
+    },
+    clear: () => store.clear(),
+  }
+}
+
+// A writable location stub so the gate can set `href` without jsdom's
+// unimplemented-navigation noise; the test reads it back to assert redirects.
+let location: { pathname: string; search: string; href: string }
+
+beforeEach(() => {
+  resetDaemonAuthConfigForTests()
+  setActiveProfile(null)
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: makeStorage(),
+  })
+  location = { pathname: '/', search: '', href: '' }
+  Object.defineProperty(window, 'location', { configurable: true, value: location })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  setActiveProfile(null)
+})
+
+function stubFetch(opts: { profiles: unknown; publicRead?: boolean }): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/api/profiles')) {
+        return new Response(JSON.stringify(opts.profiles), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      if (url.includes('/api/config')) {
+        return new Response(JSON.stringify({ publicRead: opts.publicRead === true, authProxy: false }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      return new Response('{}', { status: 200 })
+    }),
+  )
+}
+
+describe('#637 — auth gate on a bare `/` entry', () => {
+  it('stays put when the single discovered profile has a stored token', async () => {
+    // The first login wrote the bearer under the profile's per-profile key.
+    writeProfileToken('alpha', 'tok-from-first-login')
+    stubFetch({ profiles: [{ project: 'alpha', endpoint: 'http://127.0.0.1:8080', status: 'running' }] })
+
+    render(<Gated />)
+
+    // Give the discovery + config chain time to settle, then assert no bounce.
+    await waitFor(() => {
+      expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0)
+    })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(location.href).toBe('')
+  })
+
+  it('redirects to /login when the single discovered profile has no stored token', async () => {
+    stubFetch({ profiles: [{ project: 'alpha', endpoint: 'http://127.0.0.1:8080', status: 'running' }] })
+
+    render(<Gated />)
+
+    await waitFor(() => {
+      expect(location.href).toContain('/login')
+    })
+  })
+
+  it('does not redirect when the daemon is public-read, even with no token', async () => {
+    stubFetch({
+      profiles: [{ project: 'alpha', endpoint: 'http://127.0.0.1:8080', status: 'running' }],
+      publicRead: true,
+    })
+
+    render(<Gated />)
+
+    await new Promise((r) => setTimeout(r, 20))
+    expect(location.href).toBe('')
+  })
+})


### PR DESCRIPTION
On a token-secured daemon, a session returning to a bare `/` — no `?project=` in the URL, empty localStorage — was bouncing back to /login. The dashboard's auth gate reads a per-profile bearer (`neat:authToken:<name>`, ADR-101), but a bare `/` hands it no profile label, so it found no token and redirected before the shell could resolve which daemon it was talking to. Coming back the way the switcher does (`/?project=default`) worked, because the label was in the URL.

The gate now reads the token through the same chain the shell resolves its profile through: the URL/localStorage name synchronously, then daemon discovery when those are empty. On a bare `/` it consults `/api/profiles`, and when discovery names a single daemon it reads that profile's stored bearer and stays put. The redirect to /login fires only when a resolvable profile genuinely has no token (and the daemon isn't public-read or auth-proxied). No profile name is invented — discovery that is empty or ambiguous falls through to the redirect decision.

`web-multi-project` §2.5 documents the shared resolution chain the gate now honors, in step with rule 2.

Verify: `packages/web/test/auth-gate-bare-root.test.tsx` reproduces the bare-`/` entry (single discovered profile, stored token) and confirms the gate no longer redirects, while the genuinely-unauthenticated case still lands on /login. `npx turbo test --filter=@neat.is/web` green (52 tests), build and lint clean.

Refs #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)