### PR TITLE
Return the prompt after the one-command flow, log the daemon to a file

### DIFF
--- a/docs/contracts/one-command-cli.md
+++ b/docs/contracts/one-command-cli.md
@@ -31,6 +31,10 @@ When the first positional argument resolves to a directory and does **not** matc
 5. Browser open against the web UI (per [`web-bootstrap.md`](./web-bootstrap.md)).
 6. Summary block — what landed on disk, plus the OTel env-vars block the operator pastes into their deploy platform (matches §5 below).
 
+The orchestrator is a **run-once command that returns the prompt**. It spawns the daemon fully detached — its own session, `unref`'d — with stdout and stderr redirected to `<project>/neat-out/daemon.log`, never inherited from the caller. The daemon keeps running in the background exactly as [`project-daemon.md`](./project-daemon.md) describes (binds, serves REST/OTLP/dashboard, steps ports, writes `daemon.json`, reconciles on exit); the caller prints its summary and hands the terminal back cleanly, so the daemon's ongoing logs never stream into the operator's shell. Daemon startup faults — a `BindAuthorityError`, a bind collision — land in the log file; the orchestrator's own `/health` readiness poll is what surfaces a failed start to the operator, pointing at `neat-out/daemon.log` for the detail.
+
+The summary block closes with the onboarding signpost: the daemon is running, where its log lives, and the honest next step — run the operator's **own app or test suite** so OBSERVED edges fill in as it executes and divergences surface where code and runtime disagree. It never suggests generating synthetic traffic.
+
 Defaults: instrument yes, open dashboard yes. Overrides:
 
 - `--no-instrument` — skip step 3. Useful for read-only first-look runs.

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -749,12 +749,23 @@ export function waitForDaemonReadyForTest(
   return waitForDaemonReady(restPort, project, timeoutMs)
 }
 
-// Spawn the daemon as a child process the orchestrator drives. Returns the
-// child handle so the caller can read its stderr verbatim when the bind
-// gate (or any other startup failure) reports back through that pipe
-// (issue #341). The `detached: true` + `unref()` pair survives the
-// orchestrator exiting cleanly; the inherited stderr keeps the operator
-// informed when something does fail.
+// Where a project's daemon writes its stdout/stderr. Lives beside the
+// snapshot under the project's own `neat-out/` so the operator finds it next
+// to everything else NEAT wrote for that project.
+export function daemonLogPath(projectPath: string): string {
+  return path.join(projectPath, 'neat-out', 'daemon.log')
+}
+
+// Spawn the daemon as a fully detached background process and hand the terminal
+// back. `detached: true` puts it in its own session and `unref()` lets the
+// orchestrator exit cleanly the moment its own work is done — the one-command
+// flow prints its summary and returns the prompt (#639/#529). The daemon's
+// stdout and stderr go to `<project>/neat-out/daemon.log`, never the caller's
+// fds: an inherited stderr keeps the shell attached and streams the daemon's
+// ongoing logs into the operator's terminal indefinitely. Startup faults (a
+// `BindAuthorityError`, a bind collision) land in that log; the caller's
+// `/health` readiness poll is what tells the operator a start failed, and
+// points them at the log for the detail.
 //
 // ADR-096 — when `spec` is given the daemon is spawned scoped to that one
 // project on the allocated ports (passed through the env neatd + startDaemon
@@ -819,15 +830,27 @@ function spawnDaemonDetached(
     env.NEAT_WEB_PORT = String(spec.ports.web)
   }
 
+  // Redirect the daemon's output to a log file rather than inheriting the
+  // caller's fds (#639/#529). Inherited stderr keeps the shell attached — the
+  // prompt never returns and the daemon's ongoing warnings spill into the
+  // operator's terminal. A per-project `neat-out/daemon.log` keeps the output
+  // reachable without holding the terminal. We open once and hand the same fd
+  // to stdout and stderr; the OS dups it into the child at spawn, so the parent
+  // closes its copy right after. With no spec (legacy multi-project form) there
+  // is no project dir to write into, so output is discarded.
+  let logFd: number | null = null
+  if (spec) {
+    const logPath = daemonLogPath(spec.projectPath)
+    fsSync.mkdirSync(path.dirname(logPath), { recursive: true })
+    logFd = fsSync.openSync(logPath, 'a')
+  }
   const child = spawn(process.execPath, [entry, 'start'], {
     detached: true,
-    // stderr inherits the orchestrator's fd so the daemon's
-    // `BindAuthorityError` message lands in front of the operator instead
-    // of being swallowed (issue #341).
-    stdio: ['ignore', 'ignore', 'inherit'],
+    stdio: ['ignore', logFd ?? 'ignore', logFd ?? 'ignore'],
     env,
   })
   child.unref()
+  if (logFd !== null) fsSync.closeSync(logFd)
   return child
 }
 
@@ -1091,8 +1114,18 @@ export async function runOrchestrator(opts: OrchestratorOptions): Promise<Orches
     result.steps.browser = openBrowser(dashboardUrl)
   }
 
-  // ── Step 6: summary (stub — PR 4 replaces with the value-forward shape)
-  printSummary(result, graph, dashboardUrl)
+  // ── Step 6: summary + onboarding signpost ────────────────────────────
+  // The daemon runs in the background writing to its own log; point the
+  // operator at it and at the honest next step (run their own app/tests).
+  const daemonRunning =
+    result.steps.daemon === 'spawned' || result.steps.daemon === 'already-running'
+  // Show the log path relative to the project root — the summary already
+  // printed the project path up top, so `neat-out/daemon.log` reads cleanly
+  // and matches what the operator sees on disk.
+  const daemonLog = daemonRunning
+    ? path.relative(opts.scanPath, daemonLogPath(opts.scanPath))
+    : null
+  printSummary(result, graph, dashboardUrl, daemonLog)
 
   return result
 }
@@ -1101,6 +1134,7 @@ function printSummary(
   result: OrchestratorResult,
   graph: ReturnType<typeof getGraph>,
   dashboardUrl: string,
+  daemonLog: string | null,
 ): void {
   const nodes: GraphNode[] = []
   graph.forEachNode((_id, attrs) => nodes.push(attrs))
@@ -1130,5 +1164,20 @@ function printSummary(
     console.log(`auth token: ${token}`)
   } else {
     console.log('running locally — open the dashboard, no token needed')
+  }
+
+  // Onboarding signpost — the one-command flow returns here, so the last thing
+  // the operator reads has to tell them the daemon is up (and where its log is)
+  // and what to do next. The honest next step is to run their own app or test
+  // suite: the graph fills its OBSERVED layer as their code executes, and
+  // divergences surface where code and runtime disagree. Never suggest
+  // synthetic traffic — the point is what their real system does.
+  if (daemonLog !== null) {
+    console.log('')
+    console.log(`daemon running in the background (logs: ${daemonLog})`)
+    console.log(
+      'next: run your app or your test suite — OBSERVED edges fill in as it executes,',
+    )
+    console.log('      and divergences surface where code and runtime disagree.')
   }
 }

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -10329,10 +10329,24 @@ describe('ADR-073 — one-command CLI + deployment-target + delegated auth', () 
     const orchestrator = readFileSync(join(CORE_SRC, 'orchestrator.ts'), 'utf8')
     expect(orchestrator).toMatch(/NEAT_AUTH_TOKEN/)
     expect(orchestrator).toMatch(/env\.HOST\s*=\s*'127\.0\.0\.1'/)
-    // The daemon's stderr inherits the orchestrator's so the
-    // BindAuthorityError message reaches the operator instead of being
-    // swallowed.
-    expect(orchestrator).toMatch(/stdio:\s*\[[^\]]*'inherit'[^\]]*\]/)
+  })
+
+  it('#639/#529 — the one-command flow returns the prompt: daemon detached, output to a log file, never inherited', () => {
+    // The daemon runs in the background and the caller returns. Inheriting the
+    // caller's stderr keeps the shell attached — the prompt never comes back
+    // and the daemon's ongoing logs stream into the terminal. So the spawn
+    // stays `detached` + `unref`'d and redirects stdout/stderr to the project's
+    // `neat-out/daemon.log` rather than inheriting them.
+    const orchestrator = readFileSync(join(CORE_SRC, 'orchestrator.ts'), 'utf8')
+    expect(orchestrator).toMatch(/detached:\s*true/)
+    expect(orchestrator).toMatch(/daemonLogPath\(/)
+    expect(orchestrator).toMatch(/['"]neat-out['"]\s*,\s*['"]daemon\.log['"]/)
+    // The daemon's stdio must not inherit the caller's fds anymore.
+    expect(orchestrator).not.toMatch(/stdio:\s*\[[^\]]*'inherit'[^\]]*\]/)
+    // The summary points the operator at their own app/tests, never synthetic
+    // traffic, and names where the log lives.
+    expect(orchestrator).toMatch(/OBSERVED edges fill in/)
+    expect(orchestrator).toMatch(/run your app or your test suite/)
   })
 
   it('ADR-073 §3 — NEAT_AUTH_TOKEN unset + loopback bind: daemon starts unauthenticated (laptop dev path)', async () => {


### PR DESCRIPTION
A cold human run of `npx neat.is@0.4.24 <path>` reaches the `=== summary ===` block and then hangs — the prompt never comes back, and the daemon's ongoing warnings keep streaming into the terminal. The cause: the background daemon inherited the caller's stderr, so the one-command process stayed attached to it.

## What changed

- The daemon spawns **fully detached** (own session, `unref`'d) with its stdout and stderr redirected to `<project>/neat-out/daemon.log` instead of the caller's fds. The one-command flow prints its summary and hands the terminal back cleanly; the daemon keeps running in the background exactly as before (binds, serves REST/OTLP/dashboard, steps ports, writes `daemon.json`, reconciles on exit — none of that regresses). Startup faults land in the log, and the orchestrator's `/health` readiness poll still surfaces a failed start.
- The summary closes with an **onboarding signpost**: the daemon is running, where its log lives (`neat-out/daemon.log`), and the honest next step — run your own app or test suite so OBSERVED edges fill in as it executes and divergences surface where code and runtime disagree. It never suggests synthetic traffic.
- The `one-command-cli` contract picks up the detach + log-to-file + return behavior and the signpost (prose first). The `#341` source-assertion test is updated: the daemon no longer inherits the caller's stdio, and a new assertion pins the detached + log-to-file + signpost shape.

## Verification

On a throwaway app in an isolated `NEAT_HOME` (Node 20), reserved ports left free by stepping past them:

- The command **returns to the shell** (exit 0, ~2s) — no hang.
- The daemon is **up and healthy** on stepped ports (REST 8082 / OTLP 4320 / web 6330): `/health` → 200, project `active`.
- The daemon's output is in **`neat-out/daemon.log`** (REST/OTLP listening, `daemon.json written`, etc.); **zero** `neatd:` lines leaked into the CLI stdout.
- The signpost prints: `daemon running in the background (logs: neat-out/daemon.log)` plus the run-your-app next step.
- `npx turbo test --filter=@neat.is/core` green: 58 files, 1199 passed.

Refs #639
Refs #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)