### PR TITLE
Share the repo into tart VMs with a named --dir mount

### DIFF
--- a/e2e/tart/run.sh
+++ b/e2e/tart/run.sh
@@ -84,8 +84,8 @@ run_one() {
   # --dir mounts under /Volumes/My Shared Files/<tag> inside the VM. The
   # scenario reads the fixture + screenshot script from there and writes
   # artifacts back into the same tree (the mount is read-write unless :ro).
-  say "booting $vm with the repo mounted (--dir neat=$REPO_ROOT)"
-  tart run "$vm" --no-graphics --dir "neat=$REPO_ROOT" &
+  say "booting $vm with the repo mounted (--dir neat:$REPO_ROOT)"
+  tart run "$vm" --no-graphics --dir "neat:$REPO_ROOT" &
   local run_pid=$!
 
   # Wait for an IP.


### PR DESCRIPTION
The tart e2e harness shares the repo into each matrix VM through tart's `--dir` flag. That flag wants the mount name and path separated by a colon (`--dir <[name:]path>`), so this switches the share to `neat:$REPO_ROOT`. The guest then exposes it at `/Volumes/My Shared Files/neat`, exactly where the scenario side already reads the fixture and screenshot script, so the matrix VMs boot with a valid directory-sharing device and the run reaches the scenario step.

Harness-only shell change: no product code, no build. The adjacent log line is updated to match. Confirmed there's no other `neat=$REPO_ROOT` occurrence in the file, and shellcheck reports only the two pre-existing unrelated notes.

Refs #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)