### PR TITLE
Prefer a running daemon for /api/config's no-project default

### DIFF
--- a/packages/web/app/api/config/route.ts
+++ b/packages/web/app/api/config/route.ts
@@ -1,4 +1,4 @@
-import { discoverProfiles, proxyGet } from '../../../lib/proxy'
+import { discoverProfiles, firstReachableEndpoint, proxyGet } from '../../../lib/proxy'
 
 // This route resolves a live daemon by reading the discovery directory, so it
 // must never be served from a build-time cache. It already reads `request.url`,
@@ -11,14 +11,16 @@ export const dynamic = 'force-dynamic'
 // endpoint. Always unauthenticated, returns `{ publicRead, authProxy }`. Under
 // ADR-101 there is no single core URL, so we resolve the daemon the same way
 // the rest of the proxy does: the `?project=<label>` profile if named, else the
-// first discovered daemon. With no daemon discovered, fall back to the
+// first *running* discovered daemon (web-multi-project §2.3 — never blindly the
+// first profile, or the browser negotiates auth against a stopped daemon while a
+// live one waits later in the list). With no daemon discovered, fall back to the
 // conservative default so the browser still gets one stable answer.
 export async function GET(request: Request): Promise<Response> {
   const project = new URL(request.url).searchParams.get('project')
   const profiles = await discoverProfiles()
   const endpoint =
     (project ? profiles.find((p) => p.project === project)?.endpoint : undefined) ??
-    profiles[0]?.endpoint
+    firstReachableEndpoint(profiles)
   if (!endpoint) {
     return Response.json({ publicRead: false, authProxy: false })
   }

--- a/packages/web/lib/proxy.ts
+++ b/packages/web/lib/proxy.ts
@@ -73,6 +73,20 @@ export async function discoverProfiles(): Promise<DaemonProfile[]> {
   return profiles
 }
 
+// Pick the default daemon endpoint when no `?project=` label is named. Prefer
+// the first profile whose discovery record reports `running` over a blind
+// `profiles[0]` — a stopped daemon sits first in the sorted list just as often
+// as a live one, and cold-opening the auth negotiation against it blanks the
+// dashboard even when a running daemon exists later in the list (#419/#559). The
+// `status` field is the signal (no network probe here — the client's
+// resolveProfile does the reachability check before auto-selecting). Fall back
+// to `profiles[0]` when nothing is marked running so a single stopped-daemon dev
+// box still gets one stable answer.
+export function firstReachableEndpoint(profiles: DaemonProfile[]): string | undefined {
+  const running = profiles.find((p) => p.status === 'running')
+  return (running ?? profiles[0])?.endpoint
+}
+
 // Resolve the daemon endpoint for a profile label (the project name carried in
 // `?project=`). Returns null when no discovered daemon matches that label — the
 // caller then serves the fixture (DEMO) or a 502.

--- a/packages/web/test/proxy-core-url.test.ts
+++ b/packages/web/test/proxy-core-url.test.ts
@@ -76,3 +76,29 @@ describe('ADR-101 — per-daemon discovery replaces the single core URL', () => 
     expect(profiles.map((p) => p.project)).toEqual(['good'])
   })
 })
+
+describe('firstReachableEndpoint — the no-project default prefers a running daemon (#559)', () => {
+  it('skips a stopped first profile for a running one later in the list', async () => {
+    // 'alpha' sorts first but is stopped; 'beta' is running. The auth
+    // negotiation must land on beta, not the dead alpha (web-multi-project §2.3).
+    writeDaemon('alpha', 8080, 'stopped')
+    writeDaemon('beta', 9090, 'running')
+    const { discoverProfiles, firstReachableEndpoint } = await import('../lib/proxy')
+    const profiles = await discoverProfiles()
+    expect(firstReachableEndpoint(profiles)).toBe('http://127.0.0.1:9090')
+  })
+
+  it('falls back to profiles[0] when none are running (single stopped dev box)', async () => {
+    writeDaemon('alpha', 8080, 'stopped')
+    writeDaemon('beta', 9090, 'stopped')
+    const { discoverProfiles, firstReachableEndpoint } = await import('../lib/proxy')
+    const profiles = await discoverProfiles()
+    // Preserve today's last-resort behavior: alpha sorts first, so it wins.
+    expect(firstReachableEndpoint(profiles)).toBe('http://127.0.0.1:8080')
+  })
+
+  it('returns undefined for an empty discovery set', async () => {
+    const { firstReachableEndpoint } = await import('../lib/proxy')
+    expect(firstReachableEndpoint([])).toBeUndefined()
+  })
+})


### PR DESCRIPTION
`/api/config` is the auth-mode negotiation endpoint the browser hits before it knows which project it's looking at. With no `?project=` to go on, it picks a default daemon from discovery. That default now prefers the first profile whose discovery record reports `running`, so the negotiation lands on a live daemon rather than whichever one happens to sort first — which matters when the first profile is stopped and a running daemon sits later in the list (the browser would otherwise negotiate against a dead endpoint and the dashboard comes up blank).

The pick is a small shared helper, `firstReachableEndpoint(profiles)` in `lib/proxy.ts`. It reads the discovery record's `status` hint only — no network probe, that stays the client's `resolveProfile` job (web-multi-project §2.3). When nothing is marked `running` it falls back to `profiles[0]`, so a single stopped-daemon dev box still gets one stable answer.

`endpointForProject` was checked and does not share the flaw — it only resolves a named label and returns `null` otherwise. This matches web-multi-project rule 2.3, which already states step 3 must not blindly take the first profile.

Tests: extended `test/proxy-core-url.test.ts` — a stopped-first / running-later set resolves to the running endpoint, an all-stopped set still returns `profiles[0]`, and an empty set returns `undefined`. `npx vitest run test/proxy-core-url.test.ts` → 8 passed.

Refs #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)