### PR TITLE
Signal when the OTLP receiver drops spans for a bad token

### DIFF
--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -68,6 +68,13 @@ export interface AuthOptions {
   // Extra paths (or path suffixes) to leave unauthenticated. Used by tests
   // and by ad-hoc callers that mount their own probes.
   extraUnauthenticatedSuffixes?: ReadonlyArray<string>
+  // Diagnostic hook fired whenever a request is rejected with 401 for a
+  // missing or invalid bearer. The REST host leaves this unset — a human
+  // running `curl` doesn't need a server-side line for their own 401. The
+  // OTLP receiver passes it so an app whose telemetry is being dropped for a
+  // bad token leaves a signal on the daemon side instead of failing silently.
+  // The hook does not change the response body or status; it only observes.
+  onReject?: () => void
 }
 
 // Verbs the public-read split treats as reads. Everything else is a write
@@ -117,11 +124,13 @@ export function mountBearerAuth(app: FastifyInstance, opts: AuthOptions): void {
 
     const header = req.headers.authorization
     if (typeof header !== 'string' || !header.startsWith('Bearer ')) {
+      opts.onReject?.()
       void reply.code(401).send({ error: 'unauthorized' })
       return
     }
     const provided = Buffer.from(header.slice('Bearer '.length).trim(), 'utf8')
     if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+      opts.onReject?.()
       void reply.code(401).send({ error: 'unauthorized' })
       return
     }

--- a/packages/core/src/otel.ts
+++ b/packages/core/src/otel.ts
@@ -379,7 +379,28 @@ export async function buildOtelReceiver(
   // ADR-073 §4 — bearer on `/v1/traces`. `/health` stays unauthenticated via
   // the default suffix list (the CI smoke and supervisors lean on it for
   // liveness probes).
-  mountBearerAuth(app, { token: opts.authToken, trustProxy: opts.trustProxy })
+  //
+  // A rejected OTLP POST is a silent failure on the sender's side — the app
+  // gets a bare 401 and its telemetry vanishes, so the operator sees an empty
+  // OBSERVED layer with no clue why. Emit a server-side warning when that
+  // happens, rate-limited to one line per interval so a chatty misconfigured
+  // exporter (they retry hard) can't flood the log. The plain REST 401 path
+  // stays quiet — that surface leaves this hook unset.
+  const REJECT_WARN_INTERVAL_MS = 60_000
+  let lastRejectWarnAt = 0
+  const warnRejectedOtlp = (): void => {
+    const now = Date.now()
+    if (now - lastRejectWarnAt < REJECT_WARN_INTERVAL_MS) return
+    lastRejectWarnAt = now
+    console.warn(
+      '[neatd] rejecting OTLP spans on /v1/traces — missing or invalid bearer token (set NEAT_OTEL_TOKEN on the instrumented app)',
+    )
+  }
+  mountBearerAuth(app, {
+    token: opts.authToken,
+    trustProxy: opts.trustProxy,
+    onReject: warnRejectedOtlp,
+  })
 
   // Non-blocking ingest (ADR-033). The receiver replies 200 OK as soon as the
   // body is parsed; mutation runs through this queue, drained on the next tick.

--- a/packages/core/test/otel.test.ts
+++ b/packages/core/test/otel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type { FastifyInstance } from 'fastify'
 import {
   buildOtelReceiver,
@@ -417,5 +417,86 @@ describe('buildOtelReceiver', () => {
     expect(good.statusCode).toBe(200)
     await (app as unknown as { flushPending: () => Promise<void> }).flushPending()
     expect(seen.length).toBeGreaterThan(0)
+  })
+})
+
+// A token-secured receiver that drops a span for a missing or wrong bearer must
+// not do so silently. The sender gets its 401, but the operator also gets one
+// server-side line explaining that telemetry is being rejected — rate-limited so
+// a retrying exporter can't flood the log.
+describe('buildOtelReceiver — rejected-span visibility', () => {
+  let app: FastifyInstance
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(async () => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    app = await buildOtelReceiver({
+      onSpan: () => {},
+      authToken: 'right-token',
+    })
+  })
+
+  afterEach(async () => {
+    await app.close()
+    warnSpy.mockRestore()
+  })
+
+  const rejectionWarnings = (): string[] =>
+    warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((line) => line.includes('rejecting OTLP spans on /v1/traces'))
+
+  it('warns once when spans arrive with no bearer, still replying 401', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/traces',
+      headers: { 'content-type': 'application/json' },
+      payload: SAMPLE_BODY,
+    })
+    expect(res.statusCode).toBe(401)
+    const warnings = rejectionWarnings()
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('NEAT_OTEL_TOKEN')
+  })
+
+  it('warns once when spans arrive with the wrong bearer', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/traces',
+      headers: {
+        'content-type': 'application/json',
+        authorization: 'Bearer wrong-token',
+      },
+      payload: SAMPLE_BODY,
+    })
+    expect(res.statusCode).toBe(401)
+    expect(rejectionWarnings()).toHaveLength(1)
+  })
+
+  it('rate-limits the warning — a retrying exporter gets one line, not one per batch', async () => {
+    for (let i = 0; i < 5; i++) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/traces',
+        headers: { 'content-type': 'application/json' },
+        payload: SAMPLE_BODY,
+      })
+      expect(res.statusCode).toBe(401)
+    }
+    expect(rejectionWarnings()).toHaveLength(1)
+  })
+
+  it('stays quiet and accepts the span when the bearer is correct', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/traces',
+      headers: {
+        'content-type': 'application/json',
+        authorization: 'Bearer right-token',
+      },
+      payload: SAMPLE_BODY,
+    })
+    expect(res.statusCode).toBe(200)
+    expect(rejectionWarnings()).toHaveLength(0)
   })
 })


### PR DESCRIPTION
A token-secured daemon that turns away an unauthenticated OTLP POST hands the sender a bare 401 and, until now, kept quiet on its own side. An operator staring at an empty OBSERVED layer had no way to tell that spans were arriving and being refused — the failure looked identical to no telemetry at all.

This gives the OTLP ingest path a voice. `mountBearerAuth` gains an optional `onReject` hook that fires on the 401 path, and the OTLP receiver passes one that logs a single line pointing at `NEAT_OTEL_TOKEN`:

```
[neatd] rejecting OTLP spans on /v1/traces — missing or invalid bearer token (set NEAT_OTEL_TOKEN on the instrumented app)
```

The line is rate-limited to one per 60s per receiver, mirroring the dropped-span warning in `daemon.ts`, so a retrying exporter hammering the endpoint can't flood the log. The plain REST 401 path leaves the hook unset and stays silent — someone running `curl` against the API gets their 401 and needs nothing more. The response body and status are untouched on both surfaces.

Tests cover a missing bearer, a wrong bearer, the rate limit across a burst, and the quiet happy path where a correct token accepts the span with no warning.

Refs #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)