### PR TITLE
Mint an OBSERVED CONNECTS_TO edge for in-process database reads

### DIFF
--- a/docs/contracts/otel-ingest.md
+++ b/docs/contracts/otel-ingest.md
@@ -5,7 +5,7 @@ governs:
   - "packages/core/src/ingest.ts"
   - "packages/core/src/otel.ts"
   - "packages/core/src/otel-grpc.ts"
-adr: [ADR-033, ADR-113, ADR-117, ADR-029, ADR-030, ADR-068]
+adr: [ADR-033, ADR-113, ADR-117, ADR-118, ADR-029, ADR-030, ADR-068]
 enforcement: [lint, review]
 ---
 
@@ -45,6 +45,14 @@ When `handleSpan` resolves a `service.name` not present in the graph, it creates
 Auto-created nodes carry `discoveredVia: 'otel'` (schema growth governed by ADR-031 — adds an optional field, snapshot regenerates).
 
 When static extraction later finds the same id, attributes **merge** per ADR-028 §3. Static fields override OTel-derived fields where both exist (because static is more authoritative on declared intent: language, version, dependencies). `discoveredVia` becomes `'merged'` if both layers recorded the node independently. Issue #134.
+
+## In-process databases mint a file-grained `CONNECTS_TO` edge (ADR-118, refs #576 / #546)
+
+A `db.system` span carries the datastore relationship whether or not the datastore is across the network. A networked database — Postgres, a remote Redis — carries a peer address, and its `CONNECTS_TO` OBSERVED edge points at `databaseId(host)`. An in-process / embedded database — SQLite, better-sqlite3, an in-memory store — crosses no network boundary and carries no peer address, so it mints the same edge keyed on a **service-scoped local identity**: `localDatabaseId(span.service, name)` → `database:<service>/<name>`, where `name` is the span's `db.name` when present and the engine string (`db.system`) otherwise. Service-scoping keeps two services that each read their own `app.db` on distinct nodes rather than collapsing onto one. The local `DatabaseNode` records **no `host`** — an embedded database has no network host, and evidence is never fabricated (file-awareness.md §6); a host-less `DatabaseNode` is cleanly skipped by host-mismatch divergence.
+
+Both edges are **file-grained** through the same call-site path as any other OBSERVED edge (file-awareness.md §4): when the span processor stamped `code.*` on the synchronous DB CLIENT span, the edge originates from the caller's `FileNode` at the exact `file:line`, reconciled onto the EXTRACTED service-relative path (`reconcileObservedRelPath`) so the OBSERVED and EXTRACTED layers fuse into one node. A DB span with no call site stays service-level, honestly. The caller-side gate (`spanMintsObservedEdge`) applies unchanged; the in-process edge is minted only from the caller/producer side, never fabricated from an INTERNAL connection span.
+
+The inbound-server liveness edge and the queue / GraphQL / gRPC / WebSocket and non-DB in-process boundaries remain deferred to #576's later cuts.
 
 ## OBSERVED provenance for span-derived edges (ADR-068)
 

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -21,6 +21,7 @@ import {
   Provenance,
   confidenceForObservedSignal,
   databaseId,
+  localDatabaseId,
   extractedEdgeId,
   fileId,
   frontierId,
@@ -37,7 +38,8 @@ import { emitNeatEvent } from './events.js'
 // Maps OTel spans to graph signal:
 //   * Cross-service span → upsert CALLS edge.
 //   * Database span (db.system attr present) → upsert CONNECTS_TO edge to a
-//     DatabaseNode resolved by host.
+//     DatabaseNode resolved by host, or a service-scoped local DatabaseNode when
+//     the span carries no peer host (an in-process / embedded DB, ADR-118).
 //   * Span with status.code === 2 → ErrorEvent appended to errors.ndjson.
 //
 // Contract anchors (see /docs/contracts.md):
@@ -900,6 +902,37 @@ function ensureDatabaseNode(graph: NeatGraph, host: string, engine: string): str
   return id
 }
 
+// An in-process / embedded database (SQLite, better-sqlite3, an in-memory
+// store) crosses no network boundary, so its span carries no peer host to key a
+// DatabaseNode on. Key it on a service-scoped local identity instead so two
+// services each reading their own `app.db` stay distinct nodes rather than
+// collapsing onto one (ADR-118). `name` is the logical database from the span
+// (db.name) when present, the engine string otherwise. `host` is intentionally
+// omitted — an embedded database has no network host, and evidence is never
+// fabricated (file-awareness.md §6); host-mismatch divergence skips a hostless
+// DatabaseNode. Returns the node id so the caller can point the CONNECTS_TO edge
+// at it. Idempotent — high-volume DB spans upsert, never grow the node set.
+function ensureLocalDatabaseNode(
+  graph: NeatGraph,
+  serviceName: string,
+  name: string,
+  engine: string,
+): string {
+  const id = localDatabaseId(serviceName, name)
+  if (graph.hasNode(id)) return id
+  const node: DatabaseNode = {
+    id,
+    type: NodeType.DatabaseNode,
+    name,
+    engine,
+    engineVersion: 'unknown',
+    compatibleDrivers: [],
+    discoveredVia: 'otel',
+  }
+  graph.addNode(id, node)
+  return id
+}
+
 function ensureFrontierNode(graph: NeatGraph, host: string, ts: string): string {
   const id = frontierIdFor(host)
   if (graph.hasNode(id)) {
@@ -1365,13 +1398,31 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
   const mintsFromCallerSide = spanMintsObservedEdge(span.kind)
 
   if (span.dbSystem) {
-    // Database span — try to resolve the DatabaseNode by host.
-    const host = pickAddress(span)
-    if (mintsFromCallerSide && host) {
-      // Auto-create a minimal DatabaseNode when this host hasn't been seen.
-      // Engine comes off the OTel attribute as a string per Rule 8.
-      ensureDatabaseNode(ctx.graph, host, span.dbSystem)
-      const targetId = databaseId(host)
+    // Database span. A networked database resolves its DatabaseNode by peer
+    // host; an in-process / embedded one (SQLite, better-sqlite3, an in-memory
+    // store) crosses no network boundary and carries no peer address, so it
+    // keys on a service-scoped local identity instead (ADR-118). Both mint the
+    // same file-grained service→database CONNECTS_TO OBSERVED edge — the edge
+    // that makes a leaf service's datastore reads legible (#576, #546).
+    if (mintsFromCallerSide) {
+      const host = pickAddress(span)
+      // Engine comes off the OTel attribute as a string per Rule 8 — no
+      // hardcoded engine list on either branch.
+      let targetId: string
+      if (host) {
+        ensureDatabaseNode(ctx.graph, host, span.dbSystem)
+        targetId = databaseId(host)
+      } else {
+        // No peer host — an in-process DB. Name the node by its logical
+        // database (db.name) when the span carries one, the engine otherwise.
+        const localName = span.dbName ?? span.dbSystem
+        targetId = ensureLocalDatabaseNode(
+          ctx.graph,
+          span.service,
+          localName,
+          span.dbSystem,
+        )
+      }
       const result = upsertObservedEdge(
         ctx.graph,
         EdgeType.CONNECTS_TO,

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -7,7 +7,9 @@ import {
   EdgeType,
   type EdgeTypeValue,
   type ErrorEvent,
+  type DatabaseNode,
   fileId,
+  localDatabaseId,
   type GraphEdge,
   type GraphNode,
   NodeType,
@@ -1815,5 +1817,169 @@ describe('EXTRACTED and OBSERVED FileNodes fuse for the same source file', () =>
     // name the same fused path, not the raw /var/task deployed path.
     expect(edge.evidence?.file).toBe('src/client.ts')
     expect(edge.source).toBe(staticFileId)
+  })
+})
+
+// Issue #576 / #546 — an in-process / embedded database (SQLite, better-sqlite3,
+// an in-memory store) serves a leaf service's reads without crossing a network
+// boundary, so its span carries no peer address. It mints the same file-grained
+// service→database CONNECTS_TO OBSERVED edge a networked DB does, keyed on a
+// service-scoped local identity (ADR-118). Fixtures use REAL SDK span shape: a
+// wire CLIENT span (kind 3), an ABSOLUTE `code.filepath` (the deployed root the
+// SpanProcessor stamps), and `db.system` / `db.name` as an embedded-DB driver
+// emits them — never `server.address`, which an in-process DB has no value for.
+describe('handleSpan in-process database spans (#576 / #546)', () => {
+  let tmpDir: string
+  let ctx: IngestContext
+
+  beforeEach(async () => {
+    resetParentSpanCache()
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-inproc-db-'))
+    ctx = { graph: newGraph(), errorsPath: path.join(tmpDir, 'errors.ndjson') }
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+    resetParentSpanCache()
+  })
+
+  // A better-sqlite3 query span: synchronous, so the SpanProcessor's stack walk
+  // stamps the user call site; embedded, so there is no peer address at all.
+  function inProcessDbSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
+    return {
+      service: 'service-a',
+      traceId: 'trace-inproc',
+      spanId: 'span-db',
+      name: 'SELECT users',
+      kind: 3,
+      startTimeUnixNano: '0',
+      endTimeUnixNano: '0',
+      durationNanos: 0n,
+      env: 'unknown',
+      attributes: {
+        'db.system': 'sqlite',
+        'db.name': '/var/task/data/app.db',
+        'code.filepath': '/var/task/src/db/user-repo.ts',
+        'code.lineno': 24,
+        'code.function': 'findUser',
+      },
+      dbSystem: 'sqlite',
+      dbName: '/var/task/data/app.db',
+      statusCode: 0,
+      ...overrides,
+    }
+  }
+
+  it('mints a file-grained CONNECTS_TO edge to a service-scoped local DatabaseNode', async () => {
+    // The extractor already parsed the repo file the query runs in.
+    ensureFileNode(ctx.graph, 'service-a', 'service:service-a', 'src/db/user-repo.ts')
+
+    await handleSpan(ctx, inProcessDbSpan())
+
+    // The DatabaseNode is keyed on the service-scoped local identity, not on a
+    // fabricated host. It carries the engine and NO host.
+    const dbNodeId = localDatabaseId('service-a', '/var/task/data/app.db')
+    expect(dbNodeId).toBe('database:service-a//var/task/data/app.db')
+    expect(ctx.graph.hasNode(dbNodeId)).toBe(true)
+    const dbNode = ctx.graph.getNodeAttributes(dbNodeId) as DatabaseNode
+    expect(dbNode.type).toBe(NodeType.DatabaseNode)
+    expect(dbNode.engine).toBe('sqlite')
+    expect(dbNode.host).toBeUndefined()
+    expect(dbNode.discoveredVia).toBe('otel')
+
+    // The edge originates from the FileNode at the exact call site — file-grained,
+    // fused onto the EXTRACTED path (not the raw /var/task deployed path).
+    const fileNodeId = fileId('service-a', 'src/db/user-repo.ts')
+    const edgeId = `${EdgeType.CONNECTS_TO}:OBSERVED:${fileNodeId}->${dbNodeId}`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.source).toBe(fileNodeId)
+    expect(edge.evidence?.file).toBe('src/db/user-repo.ts')
+    expect(edge.evidence?.line).toBe(24)
+  })
+
+  it('fuses the OBSERVED FileNode onto the EXTRACTED one — one node, both provenances, no twin', async () => {
+    const staticFileId = fileId('service-a', 'src/db/user-repo.ts')
+    ensureFileNode(ctx.graph, 'service-a', 'service:service-a', 'src/db/user-repo.ts')
+    expect(ctx.graph.getNodeAttributes(staticFileId)).toMatchObject({
+      discoveredVia: 'static',
+      path: 'src/db/user-repo.ts',
+    })
+
+    await handleSpan(ctx, inProcessDbSpan())
+
+    // Exactly ONE FileNode exists and it is the EXTRACTED one — the absolute
+    // `code.filepath` reconciled onto it rather than forking a /var/task twin.
+    const fileNodeIds: string[] = []
+    ctx.graph.forEachNode((id, attrs) => {
+      if ((attrs as { type: string }).type === NodeType.FileNode) fileNodeIds.push(id)
+    })
+    expect(fileNodeIds).toEqual([staticFileId])
+    expect(ctx.graph.hasNode('file:service-a:var/task/src/db/user-repo.ts')).toBe(false)
+
+    // Both layers hang off the one node id: the EXTRACTED CONTAINS from static
+    // analysis and the OBSERVED CONNECTS_TO from runtime.
+    const provenancesTouchingFile = new Set<string>()
+    ctx.graph.forEachEdge((_id, attrs) => {
+      const e = attrs as GraphEdge
+      if (e.source === staticFileId || e.target === staticFileId) {
+        provenancesTouchingFile.add(e.provenance)
+      }
+    })
+    expect(provenancesTouchingFile.has(Provenance.EXTRACTED)).toBe(true)
+    expect(provenancesTouchingFile.has(Provenance.OBSERVED)).toBe(true)
+  })
+
+  it('names the local DatabaseNode by the engine when the span carries no db.name', async () => {
+    await handleSpan(
+      ctx,
+      inProcessDbSpan({
+        attributes: {
+          'db.system': 'sqlite',
+          'code.filepath': '/var/task/src/db/user-repo.ts',
+          'code.lineno': 24,
+        },
+        dbName: undefined,
+      }),
+    )
+
+    const dbNodeId = localDatabaseId('service-a', 'sqlite')
+    expect(ctx.graph.hasNode(dbNodeId)).toBe(true)
+    const dbNode = ctx.graph.getNodeAttributes(dbNodeId) as DatabaseNode
+    expect(dbNode.name).toBe('sqlite')
+    expect(dbNode.engine).toBe('sqlite')
+    expect(dbNode.host).toBeUndefined()
+  })
+
+  it('keeps two services with their own app.db on distinct local DatabaseNodes', async () => {
+    // service-a and service-b each read an embedded app.db of their own. The
+    // service-scoped id keeps them separate rather than collapsing onto one node.
+    await handleSpan(ctx, inProcessDbSpan({ service: 'service-a', dbName: 'app.db', attributes: {
+      'db.system': 'sqlite',
+      'db.name': 'app.db',
+      'code.filepath': '/srv/a/src/repo.ts',
+      'code.lineno': 5,
+    } }))
+    await handleSpan(ctx, inProcessDbSpan({ service: 'service-b', spanId: 'span-db-b', traceId: 'trace-b', dbName: 'app.db', attributes: {
+      'db.system': 'sqlite',
+      'db.name': 'app.db',
+      'code.filepath': '/srv/b/src/repo.ts',
+      'code.lineno': 9,
+    } }))
+
+    expect(ctx.graph.hasNode(localDatabaseId('service-a', 'app.db'))).toBe(true)
+    expect(ctx.graph.hasNode(localDatabaseId('service-b', 'app.db'))).toBe(true)
+    expect(localDatabaseId('service-a', 'app.db')).not.toBe(localDatabaseId('service-b', 'app.db'))
+  })
+
+  it('leaves a networked database span keyed on its host, unchanged', async () => {
+    // Regression guard — a DB span that DOES carry a peer address still keys on
+    // databaseId(host), never the local identity.
+    await handleSpan(ctx, dbSpan())
+    const id = `${EdgeType.CONNECTS_TO}:OBSERVED:service:service-b->database:payments-db`
+    expect(ctx.graph.hasEdge(id)).toBe(true)
+    // No local-identity node was minted for the networked DB.
+    expect(ctx.graph.hasNode(localDatabaseId('service-b', 'neatdemo'))).toBe(false)
   })
 })

--- a/packages/types/src/identity.ts
+++ b/packages/types/src/identity.ts
@@ -56,6 +56,17 @@ export function parseDatabaseId(id: string): string | null {
   return id.startsWith(DATABASE_PREFIX) ? id.slice(DATABASE_PREFIX.length) : null
 }
 
+// In-process / embedded DatabaseNode id: `database:<service>/<name>`. An
+// embedded database (SQLite, better-sqlite3, an in-memory store) crosses no
+// network boundary, so a span for it carries no peer host to key `databaseId`
+// on. Two services each reading their own `app.db` would then collapse onto one
+// node; scoping the id by the observing service keeps them distinct. `name` is
+// the logical database (`db.name`) when the span carries one, the engine string
+// otherwise. Env-unscoped like `databaseId` (env-dimension.md). See ADR-118.
+export function localDatabaseId(service: string, name: string): string {
+  return `${DATABASE_PREFIX}${service}/${name}`
+}
+
 // ConfigNode id: `config:<relPath>` where <relPath> is the path relative to
 // the scan root, with forward slashes regardless of platform. ConfigNodes
 // record file existence only (ADR-016).


### PR DESCRIPTION
A `db.system` span carries a service's datastore relationship whether or not the datastore is across the network. A networked database — Postgres, a remote Redis — carries a peer address, so its `CONNECTS_TO` OBSERVED edge resolves a host and lands. An in-process / embedded database — SQLite, better-sqlite3, an in-memory store — crosses no network boundary and carries no peer address, so host resolution finds nothing and the edge has no target. A normal Express-on-SQLite leaf service that serves requests and reads its own database is exactly the shape the OBSERVED thesis rides on, and its datastore reads are what make it legible.

This teaches ingest to mint the same file-grained service→database `CONNECTS_TO` OBSERVED edge for an in-process database that it already mints for a networked one. When a DB span carries no resolvable peer host, the `DatabaseNode` is keyed on a service-scoped local identity — `localDatabaseId(service, name)` → `database:<service>/<name>`, where `name` is the span's `db.name` when present and the engine string otherwise. Service-scoping keeps two services that each read their own `app.db` on distinct nodes rather than collapsing onto one. The local node records no `host` (an embedded database has no network host; evidence is never fabricated), so host-mismatch divergence cleanly skips it.

The edge is file-grained through the existing call-site path: the span processor stamps `code.*` on the synchronous DB client span, so the edge originates from the caller's `FileNode` at the exact `file:line` and reconciles onto the EXTRACTED service-relative path, fusing the OBSERVED and EXTRACTED layers into one node instead of a twin. That reuses the #526 / #536 parent-span call-site attribution work rather than inventing a new path.

Scope is deliberately the in-process DB `CONNECTS_TO` edge only. Inbound-server liveness edges and the queue / GraphQL / gRPC / WebSocket and non-DB in-process boundaries stay deferred to #576's later cuts.

Governed by `otel-ingest.md` (amended here) under ADR-118.

Tests use real SDK span shape — a wire CLIENT span, an absolute `code.filepath`, and `db.system` / `db.name` as an embedded-DB driver emits them, never a `server.address`. New coverage: the file-grained edge to the service-scoped local node, fusion onto the EXTRACTED FileNode (one node, both provenances, no twin), the engine-name fallback when `db.name` is absent, two services keeping distinct `app.db` nodes, and a regression guard that a networked DB span still keys on its host.

Build + `vitest run --root packages/core`: 58 files, 1204 passed, 2 skipped, 5 todo, 0 failures.

Refs #576. Also serves #546 (a silent sqlite3 CRUD server now mints its DB edge) and advances the #526 / #536 call-site attribution by reusing it on this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)