### PR TITLE
Extract server routes and match HTTP client calls to them

### DIFF
--- a/docs/contracts/divergence-query.md
+++ b/docs/contracts/divergence-query.md
@@ -8,7 +8,7 @@ governs:
   - "packages/core/src/cli.ts"
   - "packages/core/src/cli-client.ts"
   - "packages/mcp/src/index.ts"
-adr: [ADR-060, ADR-066, ADR-115, ADR-029, ADR-039, ADR-050, ADR-027, ADR-061, ADR-095]
+adr: [ADR-060, ADR-066, ADR-115, ADR-119, ADR-029, ADR-039, ADR-050, ADR-027, ADR-061, ADR-095]
 enforcement: [lint, breaker, review]
 ---
 
@@ -115,6 +115,10 @@ The five divergence types are not symmetric peers. `missing-extracted` is the he
 ### 5b. Envelope (ADR-061)
 
 `/graph/divergences` is a structured-result endpoint per ADR-061 §2 b — it returns the documented `DivergenceResultSchema` shape (`{ divergences, totalAffected, computedAt }`) on snapshot-load, zero-result, and live-state paths at both mount points (default + project-scoped). No `null`, no bare values. The contract scan asserts the shape end-to-end.
+
+### 5c. Route-grained comparison (ADR-119)
+
+Static extraction now reaches route grain: the HTTP client↔route matcher mints a `file ──CALLS──▶ route` EXTRACTED edge whose target is a `RouteNode` at `(method, path-template)` grain (see [`static-extraction.md`](./static-extraction.md), ADR-119). Because that RouteNode is the same node an OBSERVED server-span edge lands on (issue #576), the `missing-observed` / `missing-extracted` pair compares a declared client↔route call against its observed twin at route grain — sharper than the service-grained comparison a host-only edge allows. This is the file-awareness §7 "shared grain" principle applied one level finer: same triple `(source, target, type)`, now with a route as the target. The five divergence types and their weighting (§5a) are unchanged — a route-grained edge is an ordinary EXTRACTED CALLS edge to the query; what changes is how precisely the target names the thing both sides are talking about.
 
 ### 6. Allowlist amendments are explicit
 

--- a/docs/contracts/static-extraction.md
+++ b/docs/contracts/static-extraction.md
@@ -4,7 +4,7 @@ description: Producers under packages/core/src/extract/* read source code and co
 governs:
   - "packages/core/src/extract/**"
   - "packages/core/src/watch.ts"
-adr: [ADR-032, ADR-065, ADR-115, ADR-030, ADR-031, ADR-024, ADR-055]
+adr: [ADR-032, ADR-065, ADR-115, ADR-119, ADR-030, ADR-031, ADR-024, ADR-055]
 enforcement: [lint, review]
 ---
 
@@ -96,6 +96,8 @@ Other extensions are skipped silently by `walkSourceFiles` per `IGNORED_DIRS` an
 | `databases/*`        | DatabaseNode + CONNECTS_TO                     | ❌ — #140      |
 | `configs.ts`         | ConfigNode + CONFIGURED_BY                     | ❌ — #140      |
 | `calls/{aws,grpc,http,kafka,redis,supabase}.ts` | CALLS / PUBLISHES_TO / CONSUMES_FROM | ✅          |
+| `routes.ts`          | RouteNode + `service ──CONTAINS──▶ route` (ADR-119) | ✅         |
+| `calls/route-match.ts` | client `file ──CALLS──▶ route` cross-service match (ADR-119) | ✅ |
 | `infra/{docker-compose,dockerfile,k8s,terraform}.ts` | InfraNode + DEPENDS_ON / RUNS_ON / CONNECTS_TO | ✅ (evidence populated) |
 
 New producers under `calls/` for source-level DB connections (`new pg.Pool(...)`) and inter-service imports land under issue #141. They follow the same interface, same evidence shape, same idempotency.
@@ -117,6 +119,24 @@ Issue #142 adds `framework?: string` to `ServiceNodeSchema`. This is **schema gr
 | `django` (Python)      | `django`         |
 
 The table lives in `compat.json` or a sibling data file. Population happens at extract time. The snapshot guard catches schema drift.
+
+## Route extraction + HTTP client↔route matching (ADR-119)
+
+Static extraction reaches route grain. Two producers turn the two static islands — a client that names a URL and a server that declares a route — into one matched, file-precise relationship.
+
+**Server routes (`routes.ts`).** A mainstream router's route table becomes `RouteNode`s at `(method, path-template)` grain, one per declared route, owned by the service through a `service ──CONTAINS──▶ route` edge (structural, evidence pinned to the defining `file:line`). The node id is `routeId(service, method, pathTemplate)` → `route:<service>:<METHOD> <template>`, built from the identity helper. Coverage is a dependency-gated registry — a service is read for routes only when its manifest declares one of the supported routers:
+
+| Router | Recognised shape |
+|---|---|
+| Express | `app.<method>('/path', …)` / `router.<method>('/path', …)` |
+| Fastify | `fastify.<method>('/path', …)` and `fastify.route({ method, url })` |
+| Next.js | app-router `app/**/route.*` handler exports (`GET`/`POST`/…), pages `pages/api/**` handlers |
+
+The declared template is kept verbatim on the node (`/users/:id`), so a future OBSERVED server span carrying the same `http.route` lands on the same node. Mount-prefix resolution (`app.use('/api', router)`) and intra-file call-graph resolution are out of scope for this slice — the declared path is captured as-is. Coverage grows one router at a time through the registry, the same way instrumentation coverage grows; exhaustive router heuristics are a non-goal.
+
+**Client↔route matching (`calls/route-match.ts`).** A recognised HTTP client call site — `fetch`, `axios` (default instance + method calls), node `http`/`https` — carries its method and path-template alongside the host. The host resolves to a service through the shared `buildServiceHostIndex` / `urlMatchesHost` path (ADR-065 #5); the path-template matches a server route by reducing both sides to a param-agnostic key (`normalizePathTemplate`: every dynamic segment — `:id`, `{id}`, `[id]`, a `${…}` interpolation, or a concrete id — collapses to `:param`, literals lowercase). A match mints a route-grained `file ──CALLS──▶ route` EXTRACTED edge from the client's FileNode to the server's RouteNode, carrying the method + path-template on its evidence. It grades `verified-call-site` (0.85) — both endpoints are recognised — so it clears the precision floor. The host + path must sit in the same URL literal for a match; split base-URL + path is out of scope for this slice. Route extraction runs before the calls phase so the matcher sees the full route table.
+
+This realises the cross-service contract-matching idea: the route-grained edge is the shared target an OBSERVED server-span edge (issue #576) also lands on, so `get_divergences` compares declared against observed at route grain, not only at service grain — see [`divergence-query.md`](./divergence-query.md). Per [ADR-119](../decisions.md#adr-119--http-client-call-site--cross-service-route-matching).
 
 ## Precision filters (ADR-065)
 

--- a/packages/core/src/extract/calls/http.ts
+++ b/packages/core/src/extract/calls/http.ts
@@ -17,7 +17,13 @@ import {
   type DiscoveredService,
 } from '../shared.js'
 import { recordExtractionError, noteExtractedDropped } from '../errors.js'
-import { ensureFileNode, loadSourceFiles, snippet, toPosix } from './shared.js'
+import {
+  buildServiceHostIndex,
+  ensureFileNode,
+  loadSourceFiles,
+  snippet,
+  toPosix,
+} from './shared.js'
 
 // JS uses `string_fragment` for the textual interior of a template/string;
 // Python uses `string_content` inside a `string` node. Either way we want the
@@ -160,14 +166,9 @@ export async function addHttpCallEdges(
   const jsParser = makeJsParser()
   const pyParser = makePyParser()
 
-  const knownHosts = new Set<string>()
-  const hostToNodeId = new Map<string, string>()
-  for (const service of services) {
-    knownHosts.add(path.basename(service.dir))
-    knownHosts.add(service.pkg.name)
-    hostToNodeId.set(path.basename(service.dir), service.node.id)
-    hostToNodeId.set(service.pkg.name, service.node.id)
-  }
+  // Host → owning ServiceNode id (ADR-065 #5), shared with the route-matching
+  // producer so both resolve a URL's host to a service the same way.
+  const { knownHosts, hostToNodeId } = buildServiceHostIndex(services)
 
   let nodesAdded = 0
   let edgesAdded = 0

--- a/packages/core/src/extract/calls/index.ts
+++ b/packages/core/src/extract/calls/index.ts
@@ -15,6 +15,7 @@ import {
   type DiscoveredService,
 } from '../shared.js'
 import { addHttpCallEdges } from './http.js'
+import { addRouteCallEdges } from './route-match.js'
 import { ensureFileNode, loadSourceFiles, toPosix, type ExternalEndpoint } from './shared.js'
 import { kafkaEndpointsFromFile } from './kafka.js'
 import { redisEndpointsFromFile } from './redis.js'
@@ -151,8 +152,12 @@ export async function addCallEdges(
 ): Promise<CallExtractResult> {
   const http = await addHttpCallEdges(graph, services)
   const ext = await addExternalEndpointEdges(graph, services)
+  // Cross-service contract matching (ADR-119). Runs after the RouteNodes are in
+  // the graph (addRoutes, a prior phase) so client call sites can be matched
+  // against the full route table, minting route-grained CALLS edges.
+  const routes = await addRouteCallEdges(graph, services)
   return {
-    nodesAdded: http.nodesAdded + ext.nodesAdded,
-    edgesAdded: http.edgesAdded + ext.edgesAdded,
+    nodesAdded: http.nodesAdded + ext.nodesAdded + routes.nodesAdded,
+    edgesAdded: http.edgesAdded + ext.edgesAdded + routes.edgesAdded,
   }
 }

--- a/packages/core/src/extract/calls/route-match.ts
+++ b/packages/core/src/extract/calls/route-match.ts
@@ -1,0 +1,416 @@
+import path from 'node:path'
+import Parser from 'tree-sitter'
+import JavaScript from 'tree-sitter-javascript'
+import type { GraphEdge, RouteNode } from '@neat.is/types'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  confidenceForExtracted,
+  passesExtractedFloor,
+  serviceId,
+} from '@neat.is/types'
+import type { NeatGraph } from '../../graph.js'
+import { isTestPath, makeEdgeId, urlMatchesHost, type DiscoveredService } from '../shared.js'
+import { recordExtractionError, noteExtractedDropped } from '../errors.js'
+import { normalizePathTemplate } from '../routes.js'
+import {
+  buildServiceHostIndex,
+  ensureFileNode,
+  loadSourceFiles,
+  snippet,
+  toPosix,
+} from './shared.js'
+
+// Cross-service contract matching (ADR-119). This is the bridge between the two
+// static islands: a client call site names a URL (host + method + path); a
+// server RouteNode (extracted by routes.ts) declares (method, path-template).
+// When a client call's (host→service, method, normalised path) resolves to a
+// server route, this producer mints a route-grained EXTRACTED CALLS edge from
+// the client's FileNode to the server's RouteNode. It reuses the host→service
+// resolution the HTTP producers share (buildServiceHostIndex / urlMatchesHost),
+// adding path-template matching for the route half.
+//
+// The edge pairs with the OBSERVED server-span edge landing on the same
+// RouteNode (#576), giving get_divergences a file-precise, two-sided comparison
+// at route grain instead of only at service grain.
+//
+// Mainstream clients only: `fetch`, `axios` (default instance + method calls),
+// and node `http`/`https` `.request`/`.get`. The host and path must sit in the
+// same URL literal (or template literal) for a match — split base-URL + path
+// across variables is out of scope for this slice.
+
+const PARSE_CHUNK = 16384
+
+function parseSource(parser: Parser, source: string): Parser.Tree {
+  return parser.parse((index: number) =>
+    index >= source.length ? '' : source.slice(index, index + PARSE_CHUNK),
+  )
+}
+
+function makeJsParser(): Parser {
+  const p = new Parser()
+  p.setLanguage(JavaScript)
+  return p
+}
+
+const JS_CLIENT_EXTENSIONS = new Set(['.js', '.jsx', '.mjs', '.cjs', '.ts', '.tsx'])
+const AXIOS_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'request'])
+
+export interface ClientCallSite {
+  host: string // the known host the URL literal named (basename or pkg name)
+  method?: string // upper-cased; undefined when not statically determinable
+  pathTemplate: string // the URL path, with `:param` for interpolations
+  line: number
+  snippet: string
+}
+
+// ── AST helpers ─────────────────────────────────────────────────────────────
+
+function walk(node: Parser.SyntaxNode, visit: (n: Parser.SyntaxNode) => void): void {
+  visit(node)
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i)
+    if (child) walk(child, visit)
+  }
+}
+
+// Reconstruct the URL text a string / template-string argument names. A template
+// substitution (`${id}`) becomes the literal `:param` so the reconstructed URL
+// is a valid string with a param-shaped path segment: `/users/${id}` →
+// `/users/:param`. Returns null for anything that isn't a string-ish literal.
+function reconstructUrl(node: Parser.SyntaxNode): string | null {
+  if (node.type === 'string') {
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i)
+      if (child?.type === 'string_fragment') return child.text
+    }
+    return ''
+  }
+  if (node.type === 'template_string') {
+    let out = ''
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i)
+      if (!child) continue
+      if (child.type === 'string_fragment') out += child.text
+      else if (child.type === 'template_substitution') out += ':param'
+    }
+    // A template with no fragments/subs (empty) — fall back to stripped text.
+    if (out.length === 0) {
+      const raw = node.text
+      return raw.length >= 2 ? raw.slice(1, -1) : ''
+    }
+    return out
+  }
+  return null
+}
+
+// Read the `method` string off an options / config object (`{ method: 'POST' }`).
+function methodFromOptions(objNode: Parser.SyntaxNode): string | undefined {
+  for (let i = 0; i < objNode.namedChildCount; i++) {
+    const pair = objNode.namedChild(i)
+    if (!pair || pair.type !== 'pair') continue
+    const k = pair.childForFieldName('key')
+    const kText = k ? (k.type === 'string' ? stringText(k) : k.text) : null
+    if (kText !== 'method') continue
+    const v = pair.childForFieldName('value')
+    if (v && (v.type === 'string' || v.type === 'template_string')) {
+      const s = stringText(v)
+      return s ? s.toUpperCase() : undefined
+    }
+  }
+  return undefined
+}
+
+function stringText(node: Parser.SyntaxNode): string | null {
+  if (node.type === 'string') {
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i)
+      if (child?.type === 'string_fragment') return child.text
+    }
+    return ''
+  }
+  return null
+}
+
+// The URL string a config object names (`axios({ url: '…', method })`).
+function urlNodeFromConfig(objNode: Parser.SyntaxNode): Parser.SyntaxNode | null {
+  for (let i = 0; i < objNode.namedChildCount; i++) {
+    const pair = objNode.namedChild(i)
+    if (!pair || pair.type !== 'pair') continue
+    const k = pair.childForFieldName('key')
+    const kText = k ? (k.type === 'string' ? stringText(k) : k.text) : null
+    if (kText === 'url') return pair.childForFieldName('value')
+  }
+  return null
+}
+
+// Parse the path out of a reconstructed URL string. Returns null when the string
+// isn't URL-shaped (no scheme + host). `:param` in the path survives parsing.
+function pathOf(urlStr: string): string | null {
+  try {
+    const candidate = urlStr.startsWith('//') ? `http:${urlStr}` : urlStr
+    const parsed = new URL(candidate)
+    return parsed.pathname || '/'
+  } catch {
+    return null
+  }
+}
+
+// Resolve which known host a reconstructed URL names (ADR-065 #5 — scheme +
+// exact hostname). Returns the host token or null.
+function matchHost(urlStr: string, knownHosts: Set<string>): string | null {
+  for (const host of knownHosts) {
+    if (urlMatchesHost(urlStr, host)) return host
+  }
+  return null
+}
+
+// ── client call-site recognition ────────────────────────────────────────────
+
+// Extract every recognised HTTP client call site whose URL literal names a
+// known host. Each site carries the method (when statically determinable) and
+// the path-template, ready to be matched against the server route table.
+export function clientCallSitesFromSource(
+  source: string,
+  parser: Parser,
+  knownHosts: Set<string>,
+): ClientCallSite[] {
+  const tree = parseSource(parser, source)
+  const out: ClientCallSite[] = []
+
+  const push = (
+    urlNode: Parser.SyntaxNode,
+    method: string | undefined,
+    callNode: Parser.SyntaxNode,
+  ): void => {
+    const urlStr = reconstructUrl(urlNode)
+    if (!urlStr) return
+    const host = matchHost(urlStr, knownHosts)
+    if (!host) return
+    const p = pathOf(urlStr)
+    if (p === null) return
+    const line = callNode.startPosition.row + 1
+    out.push({
+      host,
+      method,
+      pathTemplate: p,
+      line,
+      snippet: snippet(source, line),
+    })
+  }
+
+  walk(tree.rootNode, (node) => {
+    if (node.type !== 'call_expression') return
+    const fn = node.childForFieldName('function')
+    if (!fn) return
+    const args = node.childForFieldName('arguments')
+    const first = args?.namedChild(0)
+    if (!first) return
+
+    // fetch(url, opts?) — global or member (globalThis.fetch).
+    const fnName =
+      fn.type === 'identifier'
+        ? fn.text
+        : fn.type === 'member_expression'
+          ? (fn.childForFieldName('property')?.text ?? '')
+          : ''
+
+    if (fn.type === 'identifier' && fnName === 'fetch') {
+      const opts = args?.namedChild(1)
+      const method = opts && opts.type === 'object' ? (methodFromOptions(opts) ?? 'GET') : 'GET'
+      push(first, method, node)
+      return
+    }
+
+    // axios(url | config) — default instance called directly.
+    if (fn.type === 'identifier' && fnName === 'axios') {
+      if (first.type === 'object') {
+        const urlNode = urlNodeFromConfig(first)
+        if (urlNode) push(urlNode, methodFromOptions(first) ?? 'GET', node)
+      } else {
+        const opts = args?.namedChild(1)
+        const method = opts && opts.type === 'object' ? (methodFromOptions(opts) ?? 'GET') : 'GET'
+        push(first, method, node)
+      }
+      return
+    }
+
+    if (fn.type === 'member_expression') {
+      const obj = fn.childForFieldName('object')
+      const objName = obj?.text ?? ''
+
+      // axios.get('/x') / axios.post('/x', body) / axios.request({ url, method }).
+      if (objName === 'axios' && AXIOS_METHODS.has(fnName)) {
+        if (fnName === 'request' && first.type === 'object') {
+          const urlNode = urlNodeFromConfig(first)
+          if (urlNode) push(urlNode, methodFromOptions(first) ?? 'GET', node)
+        } else {
+          push(first, fnName.toUpperCase(), node)
+        }
+        return
+      }
+
+      // node http/https .request(url, …) / .get(url, …).
+      if ((objName === 'http' || objName === 'https') && (fnName === 'request' || fnName === 'get')) {
+        const opts = args?.namedChild(1)
+        const method =
+          opts && opts.type === 'object'
+            ? (methodFromOptions(opts) ?? (fnName === 'get' ? 'GET' : 'GET'))
+            : 'GET'
+        push(first, method, node)
+        return
+      }
+    }
+  })
+
+  return out
+}
+
+// ── route index + matching ──────────────────────────────────────────────────
+
+interface RouteEntry {
+  method: string // upper, or 'ALL'
+  normalizedPath: string
+  routeNodeId: string
+}
+
+// Group every RouteNode in the graph by its owning ServiceNode id, keyed for
+// (method, normalised-path) lookup. Built once per pass so client matching is a
+// map read, not a graph scan per call site.
+function buildRouteIndex(graph: NeatGraph): Map<string, RouteEntry[]> {
+  const index = new Map<string, RouteEntry[]>()
+  graph.forEachNode((_id, attrs) => {
+    const node = attrs as unknown as { type?: string }
+    if (node.type !== NodeType.RouteNode) return
+    const route = attrs as unknown as RouteNode
+    const owner = serviceId(route.service)
+    const entry: RouteEntry = {
+      method: route.method.toUpperCase(),
+      normalizedPath: normalizePathTemplate(route.pathTemplate),
+      routeNodeId: route.id,
+    }
+    const list = index.get(owner)
+    if (list) list.push(entry)
+    else index.set(owner, [entry])
+  })
+  return index
+}
+
+// A client call matches a route when the normalised paths agree and the methods
+// are compatible: exact, or the route is method-agnostic (`ALL`), or the client
+// method couldn't be read statically.
+function findRoute(
+  entries: RouteEntry[],
+  method: string | undefined,
+  normalizedPath: string,
+): RouteEntry | undefined {
+  return entries.find(
+    (e) =>
+      e.normalizedPath === normalizedPath &&
+      (e.method === 'ALL' || method === undefined || e.method === method),
+  )
+}
+
+export async function addRouteCallEdges(
+  graph: NeatGraph,
+  services: DiscoveredService[],
+): Promise<{ nodesAdded: number; edgesAdded: number }> {
+  const jsParser = makeJsParser()
+  const { knownHosts, hostToNodeId } = buildServiceHostIndex(services)
+  const routeIndex = buildRouteIndex(graph)
+  if (routeIndex.size === 0) return { nodesAdded: 0, edgesAdded: 0 }
+
+  let nodesAdded = 0
+  let edgesAdded = 0
+
+  for (const service of services) {
+    const files = await loadSourceFiles(service.dir)
+    // One edge per (client file, route) pair even if a file calls the route on
+    // several lines (function grain is deferred, matching http.ts).
+    const seen = new Set<string>()
+    for (const file of files) {
+      // ADR-065 #1 — test-scope exclusion.
+      if (isTestPath(file.path)) continue
+      if (!JS_CLIENT_EXTENSIONS.has(path.extname(file.path))) continue
+
+      let sites: ClientCallSite[]
+      try {
+        sites = clientCallSitesFromSource(file.content, jsParser, knownHosts)
+      } catch (err) {
+        recordExtractionError('route-match call extraction', file.path, err)
+        continue
+      }
+      if (sites.length === 0) continue
+
+      const relFile = toPosix(path.relative(service.dir, file.path))
+      for (const site of sites) {
+        const serverServiceId = hostToNodeId.get(site.host)
+        // Skip an unresolved host or a self-call (intra-service — no
+        // cross-service contract to match, mirroring http.ts).
+        if (!serverServiceId || serverServiceId === service.node.id) continue
+        const entries = routeIndex.get(serverServiceId)
+        if (!entries) continue
+        const normalizedPath = normalizePathTemplate(site.pathTemplate)
+        const match = findRoute(entries, site.method, normalizedPath)
+        if (!match) continue
+
+        const dedupKey = `${relFile}|${match.routeNodeId}`
+        if (seen.has(dedupKey)) continue
+        seen.add(dedupKey)
+
+        // The matched call site is a parsed fact — the client FileNode and its
+        // service ──CONTAINS──▶ file edge materialise regardless (file-awareness
+        // §1). Only the file→route edge is gated by the precision floor.
+        const { fileNodeId, nodesAdded: n, edgesAdded: e } = ensureFileNode(
+          graph,
+          service.pkg.name,
+          service.node.id,
+          relFile,
+        )
+        nodesAdded += n
+        edgesAdded += e
+
+        // A matched client↔route contract grades at verified-call-site (0.85):
+        // both endpoints are recognised — a framework-aware client shape and a
+        // parsed route definition — so it clears the floor and enters the graph
+        // (ADR-119).
+        const confidence = confidenceForExtracted('verified-call-site')
+        const ev = {
+          file: relFile,
+          line: site.line,
+          snippet: site.snippet,
+          method: site.method ?? match.method,
+          pathTemplate: site.pathTemplate,
+        }
+        if (!passesExtractedFloor(confidence)) {
+          noteExtractedDropped({
+            source: fileNodeId,
+            target: match.routeNodeId,
+            type: EdgeType.CALLS,
+            confidence,
+            confidenceKind: 'verified-call-site',
+            evidence: ev,
+          })
+          continue
+        }
+        const edgeId = makeEdgeId(fileNodeId, match.routeNodeId, EdgeType.CALLS)
+        if (!graph.hasEdge(edgeId)) {
+          const edge: GraphEdge = {
+            id: edgeId,
+            source: fileNodeId,
+            target: match.routeNodeId,
+            type: EdgeType.CALLS,
+            provenance: Provenance.EXTRACTED,
+            confidence,
+            evidence: ev,
+          }
+          graph.addEdgeWithKey(edgeId, fileNodeId, match.routeNodeId, edge)
+          edgesAdded++
+        }
+      }
+    }
+  }
+
+  return { nodesAdded, edgesAdded }
+}

--- a/packages/core/src/extract/calls/shared.ts
+++ b/packages/core/src/extract/calls/shared.ts
@@ -15,7 +15,31 @@ import {
   SERVICE_FILE_EXTENSIONS,
   isNeatAuthoredSourceFile,
   isPythonVenvDir,
+  type DiscoveredService,
 } from '../shared.js'
+
+// Host → owning ServiceNode id, the cross-service resolution the HTTP call-site
+// producers share (ADR-065 #5, ADR-119). A service is reachable by either its
+// directory basename or its manifest name; both map to the same node id. Reused
+// by http.ts (host-level CALLS edges) and route-match.ts (client↔route
+// matching) so the two producers resolve a URL's host to a service identically.
+export interface ServiceHostIndex {
+  knownHosts: Set<string>
+  hostToNodeId: Map<string, string>
+}
+
+export function buildServiceHostIndex(services: DiscoveredService[]): ServiceHostIndex {
+  const knownHosts = new Set<string>()
+  const hostToNodeId = new Map<string, string>()
+  for (const service of services) {
+    const base = path.basename(service.dir)
+    knownHosts.add(base)
+    knownHosts.add(service.pkg.name)
+    hostToNodeId.set(base, service.node.id)
+    hostToNodeId.set(service.pkg.name, service.node.id)
+  }
+  return { knownHosts, hostToNodeId }
+}
 
 export interface SourceFile {
   path: string

--- a/packages/core/src/extract/index.ts
+++ b/packages/core/src/extract/index.ts
@@ -1,5 +1,7 @@
 // Static-extraction pipeline. Phase order is load-bearing:
-//   services → aliases → databases (+ compat) → configs → calls → infra → frontier promotion.
+//   services → aliases → databases (+ compat) → configs → routes → calls → infra → frontier promotion.
+//   Routes precede calls so the cross-service matcher (ADR-119) sees the full
+//   RouteNode table when it resolves client call sites to server routes.
 //
 // Contract anchors (see /docs/contracts.md):
 //   * Rule 1 — Every emitted edge carries Provenance.EXTRACTED from @neat.is/types.
@@ -21,6 +23,7 @@ import { addFiles } from './files.js'
 import { addImports } from './imports.js'
 import { addDatabasesAndCompat } from './databases/index.js'
 import { addConfigNodes } from './configs.js'
+import { addRoutes } from './routes.js'
 import { addCallEdges } from './calls/index.js'
 import { addInfra } from './infra/index.js'
 import {
@@ -93,6 +96,9 @@ export async function extractFromDirectory(
   const importGraph = await addImports(graph, services)
   const phase2 = await addDatabasesAndCompat(graph, services, scanPath)
   const phase3 = await addConfigNodes(graph, services, scanPath)
+  // Route extraction (ADR-119) runs before calls so the RouteNodes exist when
+  // addCallEdges' cross-service matcher (route-match.ts) looks them up.
+  const routePhase = await addRoutes(graph, services)
   const phase4 = await addCallEdges(graph, services)
   const phase5 = await addInfra(graph, scanPath, services)
   // #140 — drop EXTRACTED edges whose evidence.file no longer exists on disk.
@@ -155,12 +161,17 @@ export async function extractFromDirectory(
       importGraph.nodesAdded +
       phase2.nodesAdded +
       phase3.nodesAdded +
+      routePhase.nodesAdded +
       phase4.nodesAdded +
       phase5.nodesAdded,
     edgesAdded:
       fileEnum.edgesAdded +
       importGraph.edgesAdded +
-      phase2.edgesAdded + phase3.edgesAdded + phase4.edgesAdded + phase5.edgesAdded,
+      phase2.edgesAdded +
+      phase3.edgesAdded +
+      routePhase.edgesAdded +
+      phase4.edgesAdded +
+      phase5.edgesAdded,
     frontiersPromoted,
     extractionErrors: errorEntries.length,
     errorEntries,

--- a/packages/core/src/extract/routes.ts
+++ b/packages/core/src/extract/routes.ts
@@ -1,0 +1,464 @@
+import path from 'node:path'
+import Parser from 'tree-sitter'
+import JavaScript from 'tree-sitter-javascript'
+import type { GraphEdge, RouteNode } from '@neat.is/types'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  confidenceForExtracted,
+  extractedEdgeId,
+  routeId,
+} from '@neat.is/types'
+import type { NeatGraph } from '../graph.js'
+import { isTestPath, type DiscoveredService } from './shared.js'
+import { recordExtractionError } from './errors.js'
+import { loadSourceFiles, snippet, toPosix } from './calls/shared.js'
+
+// Server-route extraction (ADR-119). Reads a mainstream router's route table —
+// Express (`app.get`/`router.post`/…), Fastify (`fastify.get`, `fastify.route`),
+// Next.js (app-router `route.*` handlers, pages `api/` handlers) — and
+// materialises each route as a RouteNode at (method, path-template) grain, owned
+// by its service through a `service ──CONTAINS──▶ route` edge. This is the
+// server half of the static contract-matching in calls/route-match.ts: a
+// client call site is matched to the route it names, bridging the two static
+// islands into a route-grained cross-service CALLS edge.
+//
+// Scope is mainstream routers only, gated by manifest dependency (the extensible
+// registry pattern — coverage grows one router at a time, not by exhaustive
+// heuristics). A service with none of these deps is skipped.
+
+const PARSE_CHUNK = 16384
+
+function parseSource(parser: Parser, source: string): Parser.Tree {
+  return parser.parse((index: number) =>
+    index >= source.length ? '' : source.slice(index, index + PARSE_CHUNK),
+  )
+}
+
+function makeJsParser(): Parser {
+  const p = new Parser()
+  p.setLanguage(JavaScript)
+  return p
+}
+
+// The HTTP verbs an Express / Fastify router registers a route under. `all`
+// registers a method-agnostic route; it normalises to the `ALL` method token.
+const ROUTER_METHODS = new Set([
+  'get',
+  'post',
+  'put',
+  'patch',
+  'delete',
+  'options',
+  'head',
+  'all',
+])
+
+// The exported handler names a Next.js app-router `route.*` file uses, one per
+// HTTP method it serves.
+const NEXT_APP_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'])
+
+const JS_ROUTE_EXTENSIONS = new Set(['.js', '.jsx', '.mjs', '.cjs', '.ts', '.tsx'])
+
+export interface ExtractedRoute {
+  method: string // upper-cased HTTP method, or 'ALL' for a method-agnostic route
+  pathTemplate: string // canonicalised declared template, e.g. '/users/:id'
+  line: number // 1-indexed line the route is declared on
+  framework: string // 'express' | 'fastify' | 'next'
+}
+
+// ── path-template canonicalisation ──────────────────────────────────────────
+
+// Canonicalise a declared route path for use as a RouteNode's stable template:
+// drop any query/hash, ensure a leading slash, drop a trailing slash (except
+// root). The template keeps its declared params verbatim (`:id`, `{id}`) so an
+// OBSERVED server span carrying the same `http.route` lands on the same node.
+export function canonicalizeTemplate(raw: string): string {
+  let p = raw.split('?')[0]!.split('#')[0]!
+  if (!p.startsWith('/')) p = '/' + p
+  if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1)
+  return p
+}
+
+// A path segment is dynamic when it names a parameter rather than a literal.
+// Covers the router param syntaxes (`:id`, `{id}`, `[id]`, `[...slug]`), a
+// reconstructed client interpolation (`:param`), and a concrete value a client
+// URL carries in a param position (all-digits, uuid, long hex / Mongo id).
+function isDynamicSegment(seg: string): boolean {
+  if (seg.length === 0) return false
+  if (seg.includes(':')) return true // :id (express/fastify) or reconstructed :param
+  if (seg.startsWith('{') || seg.startsWith('[')) return true // {id} openapi, [id] next
+  if (/^\d+$/.test(seg)) return true // concrete numeric id
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(seg)) return true // uuid
+  if (/^[0-9a-f]{24,}$/i.test(seg)) return true // mongo objectid / long hex token
+  return false
+}
+
+// Normalise a path-template to a param-agnostic matching key: every dynamic
+// segment collapses to `:param`, every literal segment lowercases. This is the
+// comparison form both a server route's declared template and a client call's
+// URL path reduce to, so `/users/:id` (server) matches `/users/123` and
+// `/users/${userId}` (client). The declared template is kept intact on the
+// node; only matching uses this reduction.
+export function normalizePathTemplate(raw: string): string {
+  const canonical = canonicalizeTemplate(raw)
+  const segments = canonical.split('/').filter((s) => s.length > 0)
+  const normalised = segments.map((seg) => (isDynamicSegment(seg) ? ':param' : seg.toLowerCase()))
+  return '/' + normalised.join('/')
+}
+
+// ── AST helpers ─────────────────────────────────────────────────────────────
+
+function walk(node: Parser.SyntaxNode, visit: (n: Parser.SyntaxNode) => void): void {
+  visit(node)
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i)
+    if (child) walk(child, visit)
+  }
+}
+
+// The interior text of a string literal, stripped of quotes. Returns null for a
+// template string carrying interpolation (a route path is a static literal).
+function staticStringText(node: Parser.SyntaxNode): string | null {
+  if (node.type === 'string') {
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i)
+      if (child?.type === 'string_fragment') return child.text
+    }
+    // Empty string literal ('' — no fragment child).
+    return ''
+  }
+  if (node.type === 'template_string') {
+    // Only a template with no substitution is a usable static path.
+    for (let i = 0; i < node.namedChildCount; i++) {
+      if (node.namedChild(i)?.type === 'template_substitution') return null
+    }
+    const raw = node.text
+    return raw.length >= 2 ? raw.slice(1, -1) : ''
+  }
+  return null
+}
+
+// Read a string-valued property off an object-expression node (`{ url: '/x' }`).
+function objectStringProp(objNode: Parser.SyntaxNode, key: string): string | null {
+  for (let i = 0; i < objNode.namedChildCount; i++) {
+    const pair = objNode.namedChild(i)
+    if (!pair || pair.type !== 'pair') continue
+    const k = pair.childForFieldName('key')
+    if (!k) continue
+    const kText = k.type === 'string' ? staticStringText(k) : k.text
+    if (kText !== key) continue
+    const v = pair.childForFieldName('value')
+    if (v) return staticStringText(v)
+  }
+  return null
+}
+
+// Read the `method` property off a Fastify route-options object. Accepts a
+// single string (`method: 'GET'`) or an array (`method: ['GET','POST']`).
+function fastifyRouteMethods(objNode: Parser.SyntaxNode): string[] {
+  for (let i = 0; i < objNode.namedChildCount; i++) {
+    const pair = objNode.namedChild(i)
+    if (!pair || pair.type !== 'pair') continue
+    const k = pair.childForFieldName('key')
+    const kText = k ? (k.type === 'string' ? staticStringText(k) : k.text) : null
+    if (kText !== 'method') continue
+    const v = pair.childForFieldName('value')
+    if (!v) return []
+    if (v.type === 'string' || v.type === 'template_string') {
+      const s = staticStringText(v)
+      return s ? [s.toUpperCase()] : []
+    }
+    if (v.type === 'array') {
+      const out: string[] = []
+      for (let j = 0; j < v.namedChildCount; j++) {
+        const el = v.namedChild(j)
+        if (el && (el.type === 'string' || el.type === 'template_string')) {
+          const s = staticStringText(el)
+          if (s) out.push(s.toUpperCase())
+        }
+      }
+      return out
+    }
+  }
+  return []
+}
+
+// ── Express / Fastify call-expression routes ────────────────────────────────
+
+// Recognise route registrations of the shape `<router>.<method>('/path', …)`
+// and Fastify's `<fastify>.route({ method, url })`. The guard that keeps this
+// off `db.get('key')` / `_.get(obj, path)` is a string first argument that
+// starts with '/', combined with the caller-side dep gate in addRoutes (only
+// services that depend on express / fastify reach here). Mount-prefix
+// resolution (`app.use('/api', router)`) and `.route().get()` chaining are out
+// of scope for this slice — the literal declared path is captured as-is.
+export function serverRoutesFromSource(
+  source: string,
+  parser: Parser,
+  hasExpress: boolean,
+  hasFastify: boolean,
+): ExtractedRoute[] {
+  const tree = parseSource(parser, source)
+  const out: ExtractedRoute[] = []
+  const framework = hasExpress ? 'express' : 'fastify'
+  walk(tree.rootNode, (node) => {
+    if (node.type !== 'call_expression') return
+    const fn = node.childForFieldName('function')
+    if (!fn || fn.type !== 'member_expression') return
+    const prop = fn.childForFieldName('property')
+    if (!prop) return
+    const method = prop.text.toLowerCase()
+    const args = node.childForFieldName('arguments')
+    const first = args?.namedChild(0)
+    if (!first) return
+    const line = node.startPosition.row + 1
+
+    if (ROUTER_METHODS.has(method)) {
+      const p = staticStringText(first)
+      if (p && p.startsWith('/')) {
+        out.push({
+          method: method === 'all' ? 'ALL' : method.toUpperCase(),
+          pathTemplate: canonicalizeTemplate(p),
+          line,
+          framework,
+        })
+      }
+      return
+    }
+
+    // Fastify's generic form: fastify.route({ method, url }).
+    if (method === 'route' && hasFastify && first.type === 'object') {
+      const url = objectStringProp(first, 'url')
+      if (!url || !url.startsWith('/')) return
+      const methods = fastifyRouteMethods(first)
+      const list = methods.length > 0 ? methods : ['ALL']
+      for (const m of list) {
+        out.push({
+          method: m === 'ALL' ? 'ALL' : m.toUpperCase(),
+          pathTemplate: canonicalizeTemplate(url),
+          line,
+          framework: 'fastify',
+        })
+      }
+    }
+  })
+  return out
+}
+
+// ── Next.js file-convention routes ──────────────────────────────────────────
+
+function segmentsOf(relFile: string): string[] {
+  return toPosix(relFile).split('/').filter((s) => s.length > 0)
+}
+
+// An app-router route handler file: `<…>/app/**/route.{js,ts,jsx,tsx,…}` (also
+// `src/app`). Route handlers live only in a file literally named `route`.
+export function isNextAppRouteFile(relFile: string): boolean {
+  const segs = segmentsOf(relFile)
+  if (!segs.includes('app')) return false
+  const base = segs[segs.length - 1] ?? ''
+  return /^route\.(?:js|jsx|mjs|cjs|ts|tsx)$/.test(base)
+}
+
+// A pages-router API file: `<…>/pages/api/**/*.{js,ts,…}`. Skips Next's special
+// `_app` / `_document` / `_middleware` files, which aren't routes.
+export function isNextPagesApiFile(relFile: string): boolean {
+  const segs = segmentsOf(relFile)
+  const pagesIdx = segs.indexOf('pages')
+  if (pagesIdx === -1 || segs[pagesIdx + 1] !== 'api') return false
+  const base = segs[segs.length - 1] ?? ''
+  if (/^_(app|document|middleware)\./.test(base)) return false
+  return JS_ROUTE_EXTENSIONS.has(path.extname(base))
+}
+
+// Convert one Next path segment to its template form: route groups `(group)`
+// drop out, `[...slug]` / `[[...slug]]` catch-alls and `[id]` dynamics become
+// `:name`, everything else stays literal.
+function nextSegment(seg: string): string | null {
+  if (seg.startsWith('(') && seg.endsWith(')')) return null // route group — not in the URL
+  const catchAll = seg.match(/^\[\[?\.\.\.(.+?)\]?\]$/)
+  if (catchAll) return ':' + catchAll[1]
+  const dynamic = seg.match(/^\[(.+?)\]$/)
+  if (dynamic) return ':' + dynamic[1]
+  return seg
+}
+
+// Derive the URL path-template from an app-router `route.*` file's directory:
+// `app/users/[id]/route.ts` → `/users/:id`.
+function nextAppPathTemplate(relFile: string): string {
+  const segs = segmentsOf(relFile)
+  const appIdx = segs.lastIndexOf('app')
+  const between = segs.slice(appIdx + 1, segs.length - 1) // dirs between app/ and route.*
+  const parts: string[] = []
+  for (const seg of between) {
+    const mapped = nextSegment(seg)
+    if (mapped !== null) parts.push(mapped)
+  }
+  return '/' + parts.join('/')
+}
+
+// Derive the URL path-template from a pages `api/` file:
+// `pages/api/users/[id].ts` → `/api/users/:id`, `pages/api/index.ts` → `/api`.
+function nextPagesApiPathTemplate(relFile: string): string {
+  const segs = segmentsOf(relFile)
+  const pagesIdx = segs.indexOf('pages')
+  const rest = segs.slice(pagesIdx + 1) // api/...
+  const parts: string[] = []
+  for (let i = 0; i < rest.length; i++) {
+    let seg = rest[i]!
+    if (i === rest.length - 1) {
+      seg = seg.replace(/\.(?:js|jsx|mjs|cjs|ts|tsx)$/, '')
+      if (seg === 'index') continue
+    }
+    const mapped = nextSegment(seg)
+    if (mapped !== null) parts.push(mapped)
+  }
+  return '/' + parts.join('/')
+}
+
+// The exported HTTP-method handler names in an app-router `route.*` file:
+// `export async function GET() {}` / `export const POST = …`. Each is one route.
+function nextAppMethods(root: Parser.SyntaxNode): { method: string; line: number }[] {
+  const out: { method: string; line: number }[] = []
+  walk(root, (node) => {
+    if (node.type !== 'export_statement') return
+    const decl = node.childForFieldName('declaration')
+    if (!decl) return
+    const line = node.startPosition.row + 1
+    if (decl.type === 'function_declaration') {
+      const name = decl.childForFieldName('name')?.text
+      if (name && NEXT_APP_METHODS.has(name)) out.push({ method: name, line })
+      return
+    }
+    if (decl.type === 'lexical_declaration' || decl.type === 'variable_declaration') {
+      for (let i = 0; i < decl.namedChildCount; i++) {
+        const d = decl.namedChild(i)
+        if (d?.type !== 'variable_declarator') continue
+        const name = d.childForFieldName('name')?.text
+        if (name && NEXT_APP_METHODS.has(name)) out.push({ method: name, line })
+      }
+    }
+  })
+  return out
+}
+
+function nextRoutesFromFile(
+  source: string,
+  relFile: string,
+  parser: Parser,
+): ExtractedRoute[] {
+  if (isNextAppRouteFile(relFile)) {
+    const tree = parseSource(parser, source)
+    const template = nextAppPathTemplate(relFile)
+    return nextAppMethods(tree.rootNode).map(({ method, line }) => ({
+      method,
+      pathTemplate: canonicalizeTemplate(template),
+      line,
+      framework: 'next',
+    }))
+  }
+  if (isNextPagesApiFile(relFile)) {
+    // A pages API handler is the module's default export and serves every
+    // method — recorded as a single method-agnostic route.
+    return [
+      {
+        method: 'ALL',
+        pathTemplate: canonicalizeTemplate(nextPagesApiPathTemplate(relFile)),
+        line: 1,
+        framework: 'next',
+      },
+    ]
+  }
+  return []
+}
+
+// ── producer ────────────────────────────────────────────────────────────────
+
+export async function addRoutes(
+  graph: NeatGraph,
+  services: DiscoveredService[],
+): Promise<{ nodesAdded: number; edgesAdded: number }> {
+  const jsParser = makeJsParser()
+  let nodesAdded = 0
+  let edgesAdded = 0
+
+  for (const service of services) {
+    const deps = {
+      ...(service.pkg.dependencies ?? {}),
+      ...(service.pkg.devDependencies ?? {}),
+    }
+    const hasExpress = deps['express'] !== undefined
+    const hasFastify = deps['fastify'] !== undefined
+    const hasNext = deps['next'] !== undefined
+    if (!hasExpress && !hasFastify && !hasNext) continue
+
+    const files = await loadSourceFiles(service.dir)
+    for (const file of files) {
+      // ADR-065 #1 — test-scope exclusion. A test that spins up a router isn't
+      // the service's declared route surface.
+      if (isTestPath(file.path)) continue
+      if (!JS_ROUTE_EXTENSIONS.has(path.extname(file.path))) continue
+      const relFile = toPosix(path.relative(service.dir, file.path))
+
+      let routes: ExtractedRoute[]
+      try {
+        if (hasNext && (isNextAppRouteFile(relFile) || isNextPagesApiFile(relFile))) {
+          routes = nextRoutesFromFile(file.content, relFile, jsParser)
+        } else if (hasExpress || hasFastify) {
+          routes = serverRoutesFromSource(file.content, jsParser, hasExpress, hasFastify)
+        } else {
+          routes = []
+        }
+      } catch (err) {
+        recordExtractionError('route extraction', file.path, err)
+        continue
+      }
+      if (routes.length === 0) continue
+
+      for (const route of routes) {
+        const rid = routeId(service.pkg.name, route.method, route.pathTemplate)
+        if (!graph.hasNode(rid)) {
+          const node: RouteNode = {
+            id: rid,
+            type: NodeType.RouteNode,
+            name: `${route.method} ${route.pathTemplate}`,
+            service: service.pkg.name,
+            method: route.method,
+            pathTemplate: route.pathTemplate,
+            path: relFile,
+            line: route.line,
+            framework: route.framework,
+            discoveredVia: 'static',
+          }
+          graph.addNode(rid, node)
+          nodesAdded++
+        }
+        // `service ──CONTAINS──▶ route` — the service owns its routes the same
+        // way it owns its files (file-awareness.md §2). Structural ownership,
+        // evidence pinned to the defining file:line.
+        const containsId = extractedEdgeId(service.node.id, rid, EdgeType.CONTAINS)
+        if (!graph.hasEdge(containsId)) {
+          const edge: GraphEdge = {
+            id: containsId,
+            source: service.node.id,
+            target: rid,
+            type: EdgeType.CONTAINS,
+            provenance: Provenance.EXTRACTED,
+            confidence: confidenceForExtracted('structural'),
+            evidence: {
+              file: relFile,
+              line: route.line,
+              snippet: snippet(file.content, route.line),
+            },
+          }
+          graph.addEdgeWithKey(containsId, service.node.id, rid, edge)
+          edgesAdded++
+        }
+      }
+    }
+  }
+
+  return { nodesAdded, edgesAdded }
+}

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -79,6 +79,13 @@ export function embedText(node: GraphNode): string {
       if (filePath) parts.push(`path=${filePath}`)
       break
     }
+    case 'RouteNode': {
+      const method = (node as { method?: string }).method
+      const tmpl = (node as { pathTemplate?: string }).pathTemplate
+      if (method) parts.push(`method=${method}`)
+      if (tmpl) parts.push(`path=${tmpl}`)
+      break
+    }
     default:
       break
   }

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -103,6 +103,12 @@
                                 ]
                               }
                             },
+                            "method": {
+                              "_optional": "_string"
+                            },
+                            "pathTemplate": {
+                              "_optional": "_string"
+                            },
                             "snippet": {
                               "_optional": "_string"
                             }
@@ -226,6 +232,12 @@
                                   "min"
                                 ]
                               }
+                            },
+                            "method": {
+                              "_optional": "_string"
+                            },
+                            "pathTemplate": {
+                              "_optional": "_string"
                             },
                             "snippet": {
                               "_optional": "_string"
@@ -383,6 +395,12 @@
                                 ]
                               }
                             },
+                            "method": {
+                              "_optional": "_string"
+                            },
+                            "pathTemplate": {
+                              "_optional": "_string"
+                            },
                             "snippet": {
                               "_optional": "_string"
                             }
@@ -538,6 +556,12 @@
                           ]
                         }
                       },
+                      "method": {
+                        "_optional": "_string"
+                      },
+                      "pathTemplate": {
+                        "_optional": "_string"
+                      },
                       "snippet": {
                         "_optional": "_string"
                       }
@@ -661,6 +685,12 @@
                             "min"
                           ]
                         }
+                      },
+                      "method": {
+                        "_optional": "_string"
+                      },
+                      "pathTemplate": {
+                        "_optional": "_string"
                       },
                       "snippet": {
                         "_optional": "_string"
@@ -817,6 +847,12 @@
                             "min"
                           ]
                         }
+                      },
+                      "method": {
+                        "_optional": "_string"
+                      },
+                      "pathTemplate": {
+                        "_optional": "_string"
                       },
                       "snippet": {
                         "_optional": "_string"
@@ -1027,6 +1063,12 @@
                   "min"
                 ]
               }
+            },
+            "method": {
+              "_optional": "_string"
+            },
+            "pathTemplate": {
+              "_optional": "_string"
             },
             "snippet": {
               "_optional": "_string"
@@ -1326,6 +1368,39 @@
               "_literal": "FileNode"
             }
           }
+        },
+        "RouteNode": {
+          "_object": {
+            "discoveredVia": {
+              "_optional": {
+                "_enum": [
+                  "merged",
+                  "otel",
+                  "static"
+                ]
+              }
+            },
+            "framework": {
+              "_optional": "_string"
+            },
+            "id": "_string",
+            "line": {
+              "_optional": {
+                "_number": [
+                  "int",
+                  "min"
+                ]
+              }
+            },
+            "method": "_string",
+            "name": "_string",
+            "path": "_string",
+            "pathTemplate": "_string",
+            "service": "_string",
+            "type": {
+              "_literal": "RouteNode"
+            }
+          }
         }
       }
     }
@@ -1337,6 +1412,7 @@
       "FileNode",
       "FrontierNode",
       "InfraNode",
+      "RouteNode",
       "ServiceNode"
     ]
   },
@@ -1394,6 +1470,7 @@
                             "FileNode",
                             "FrontierNode",
                             "InfraNode",
+                            "RouteNode",
                             "ServiceNode"
                           ]
                         },
@@ -1404,6 +1481,7 @@
                             "FileNode",
                             "FrontierNode",
                             "InfraNode",
+                            "RouteNode",
                             "ServiceNode"
                           ]
                         },
@@ -1486,6 +1564,7 @@
                             "FileNode",
                             "FrontierNode",
                             "InfraNode",
+                            "RouteNode",
                             "ServiceNode"
                           ]
                         },
@@ -1517,6 +1596,7 @@
                             "FileNode",
                             "FrontierNode",
                             "InfraNode",
+                            "RouteNode",
                             "ServiceNode"
                           ]
                         },

--- a/packages/core/test/extract-routes.test.ts
+++ b/packages/core/test/extract-routes.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import type { GraphEdge, RouteNode } from '@neat.is/types'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  extractedEdgeId,
+  fileId,
+  routeId,
+  serviceId,
+} from '@neat.is/types'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES = path.resolve(__dirname, 'fixtures', 'routes')
+
+// ADR-119 — server-route extraction + HTTP client↔route cross-service matching.
+// The fixture is a real two-service shape: an Express `api-server` defining
+// routes and a `web-client` calling them through fetch / axios, plus Fastify
+// and Next.js servers for router-coverage. Everything parses like real source.
+describe('route extraction + client↔route matching (ADR-119)', () => {
+  beforeEach(() => resetGraph())
+
+  it('materialises Express route nodes with method + path-template + file:line', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    const getUser = routeId('api-server', 'GET', '/users/:id')
+    expect(graph.hasNode(getUser)).toBe(true)
+    const node = graph.getNodeAttributes(getUser) as RouteNode
+    expect(node.type).toBe(NodeType.RouteNode)
+    expect(node.method).toBe('GET')
+    expect(node.pathTemplate).toBe('/users/:id')
+    expect(node.service).toBe('api-server')
+    expect(node.path).toBe('index.js')
+    expect(node.line).toBeGreaterThan(0)
+    expect(node.framework).toBe('express')
+
+    expect(graph.hasNode(routeId('api-server', 'POST', '/users'))).toBe(true)
+    expect(graph.hasNode(routeId('api-server', 'GET', '/health'))).toBe(true)
+
+    // The service owns its routes through a CONTAINS edge, carrying file:line.
+    const containsId = extractedEdgeId(serviceId('api-server'), getUser, EdgeType.CONTAINS)
+    expect(graph.hasEdge(containsId)).toBe(true)
+    const contains = graph.getEdgeAttributes(containsId) as GraphEdge
+    expect(contains.provenance).toBe(Provenance.EXTRACTED)
+    expect(contains.evidence?.file).toBe('index.js')
+    expect(contains.evidence?.line).toBeGreaterThan(0)
+  })
+
+  it('extracts Fastify routes (method call + fastify.route object form)', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    expect(graph.hasNode(routeId('fastify-server', 'GET', '/ping'))).toBe(true)
+    const del = routeId('fastify-server', 'DELETE', '/items/:itemId')
+    expect(graph.hasNode(del)).toBe(true)
+    expect((graph.getNodeAttributes(del) as RouteNode).framework).toBe('fastify')
+  })
+
+  it('extracts Next.js app-router and pages-api routes from file convention', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    // app/orders/[orderId]/route.ts exports GET + POST → two routes at /orders/:orderId.
+    expect(graph.hasNode(routeId('next-app', 'GET', '/orders/:orderId'))).toBe(true)
+    expect(graph.hasNode(routeId('next-app', 'POST', '/orders/:orderId'))).toBe(true)
+    // pages/api/legacy/[id].ts → a method-agnostic route.
+    const legacy = routeId('next-app', 'ALL', '/api/legacy/:id')
+    expect(graph.hasNode(legacy)).toBe(true)
+    expect((graph.getNodeAttributes(legacy) as RouteNode).framework).toBe('next')
+  })
+
+  it('mints a matched cross-service CALLS edge at route granularity', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    const clientFile = fileId('web-client', 'index.js')
+    const route = routeId('api-server', 'GET', '/users/:id')
+    const edgeId = extractedEdgeId(clientFile, route, EdgeType.CALLS)
+
+    expect(graph.hasEdge(edgeId)).toBe(true)
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.type).toBe(EdgeType.CALLS)
+    expect(edge.provenance).toBe(Provenance.EXTRACTED)
+    // verified-call-site grade — a recognised client shape matched to a parsed
+    // route on both ends.
+    expect(edge.confidence).toBeCloseTo(0.85, 2)
+
+    // The client call-site edge carries the method + path-template it named.
+    expect(edge.evidence?.file).toBe('index.js')
+    expect(edge.evidence?.line).toBeGreaterThan(0)
+    expect(edge.evidence?.method).toBe('GET')
+    expect(edge.evidence?.pathTemplate).toBe('/users/:param')
+  })
+
+  it('matches the POST body-method call and the axios method-call form', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    const clientFile = fileId('web-client', 'index.js')
+
+    const post = extractedEdgeId(
+      clientFile,
+      routeId('api-server', 'POST', '/users'),
+      EdgeType.CALLS,
+    )
+    expect(graph.hasEdge(post)).toBe(true)
+    expect((graph.getEdgeAttributes(post) as GraphEdge).evidence?.method).toBe('POST')
+
+    const health = extractedEdgeId(
+      clientFile,
+      routeId('api-server', 'GET', '/health'),
+      EdgeType.CALLS,
+    )
+    expect(graph.hasEdge(health)).toBe(true)
+    expect((graph.getEdgeAttributes(health) as GraphEdge).evidence?.method).toBe('GET')
+  })
+
+  it('is idempotent — a second pass adds no nodes or edges', async () => {
+    const graph = getGraph()
+    const first = await extractFromDirectory(graph, FIXTURES)
+    const second = await extractFromDirectory(graph, FIXTURES)
+    expect(second.nodesAdded).toBe(0)
+    expect(second.edgesAdded).toBe(0)
+    expect(first.nodesAdded).toBeGreaterThan(0)
+  })
+})

--- a/packages/core/test/fixtures/routes/api-server/index.js
+++ b/packages/core/test/fixtures/routes/api-server/index.js
@@ -1,0 +1,17 @@
+const express = require('express')
+
+const app = express()
+
+app.get('/health', (req, res) => {
+  res.send('ok')
+})
+
+app.get('/users/:id', (req, res) => {
+  res.json({ id: req.params.id })
+})
+
+app.post('/users', (req, res) => {
+  res.status(201).json({ created: true })
+})
+
+module.exports = app

--- a/packages/core/test/fixtures/routes/api-server/package.json
+++ b/packages/core/test/fixtures/routes/api-server/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "api-server",
+  "version": "1.0.0",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/packages/core/test/fixtures/routes/fastify-server/index.js
+++ b/packages/core/test/fixtures/routes/fastify-server/index.js
@@ -1,0 +1,13 @@
+const Fastify = require('fastify')
+
+const fastify = Fastify()
+
+fastify.get('/ping', async () => ({ pong: true }))
+
+fastify.route({
+  method: 'DELETE',
+  url: '/items/:itemId',
+  handler: async () => ({ deleted: true }),
+})
+
+module.exports = fastify

--- a/packages/core/test/fixtures/routes/fastify-server/package.json
+++ b/packages/core/test/fixtures/routes/fastify-server/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fastify-server",
+  "version": "1.0.0",
+  "dependencies": {
+    "fastify": "^4.24.0"
+  }
+}

--- a/packages/core/test/fixtures/routes/next-app/app/orders/[orderId]/route.ts
+++ b/packages/core/test/fixtures/routes/next-app/app/orders/[orderId]/route.ts
@@ -1,0 +1,7 @@
+export async function GET() {
+  return new Response('ok')
+}
+
+export async function POST() {
+  return new Response('created', { status: 201 })
+}

--- a/packages/core/test/fixtures/routes/next-app/package.json
+++ b/packages/core/test/fixtures/routes/next-app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "next-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "next": "^14.1.0"
+  }
+}

--- a/packages/core/test/fixtures/routes/next-app/pages/api/legacy/[id].ts
+++ b/packages/core/test/fixtures/routes/next-app/pages/api/legacy/[id].ts
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.status(200).json({ ok: true })
+}

--- a/packages/core/test/fixtures/routes/web-client/index.js
+++ b/packages/core/test/fixtures/routes/web-client/index.js
@@ -1,0 +1,22 @@
+const axios = require('axios')
+
+// GET with an interpolated path param — matches the server's `/users/:id`.
+async function getUser(id) {
+  const res = await fetch(`http://api-server:4000/users/${id}`)
+  return res.json()
+}
+
+// POST with an explicit method option — matches the server's `POST /users`.
+async function createUser(body) {
+  return fetch('http://api-server:4000/users', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+// axios method-call form — matches the server's `GET /health`.
+async function health() {
+  return axios.get('http://api-server:4000/health')
+}
+
+module.exports = { getUser, createUser, health }

--- a/packages/core/test/fixtures/routes/web-client/package.json
+++ b/packages/core/test/fixtures/routes/web-client/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "web-client",
+  "version": "1.0.0",
+  "dependencies": {
+    "axios": "^1.6.0"
+  }
+}

--- a/packages/types/src/confidence.ts
+++ b/packages/types/src/confidence.ts
@@ -24,6 +24,12 @@ export type ExtractedConfidenceKind =
   // near a *Client, grpc-js Client construction with the import context,
   // import-aware *Client classification (#238), and @supabase/supabase-js /
   // @supabase/ssr createClient construction with the import in scope (#482).
+  // Also covers a matched HTTP client↔route contract (ADR-119): a recognised
+  // fetch / axios / node-http client call site whose (host, method, path-
+  // template) resolves to a server route NEAT extracted from a mainstream
+  // router. Both endpoints are recognised — a framework-aware client shape on
+  // one side, a parsed route definition on the other — so the cross-service
+  // CALLS edge lands at this tier rather than the looser url-literal grade.
   | 'verified-call-site'
   // 0.5 — URL-shaped literal with structural support. Today's `redis://host` /
   // `rediss://host` URL captures fit here: the scheme proves it's a redis URL,

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -38,6 +38,13 @@ export const NodeType = {
   // by a service; relationships originate from it. See
   // docs/contracts/file-awareness.md §1.
   FileNode: 'FileNode',
+  // A server route at (method, path-template) granularity (ADR-119). Extracted
+  // from a mainstream router (Express / Fastify / Next.js) so a client call
+  // site can be matched to the exact route it names, rather than only to the
+  // owning service. The node an OBSERVED server span lands on too, which is
+  // what makes a two-sided divergence possible at route grain. See
+  // docs/contracts/static-extraction.md.
+  RouteNode: 'RouteNode',
 } as const
 
 export type NodeTypeValue = (typeof NodeType)[keyof typeof NodeType]
@@ -54,4 +61,5 @@ export const NodeTypeSchema = z.enum([
   NodeType.InfraNode,
   NodeType.FrontierNode,
   NodeType.FileNode,
+  NodeType.RouteNode,
 ])

--- a/packages/types/src/edges.ts
+++ b/packages/types/src/edges.ts
@@ -30,6 +30,12 @@ export const EdgeEvidenceSchema = z.object({
   file: z.string(),
   line: z.number().int().nonnegative().optional(),
   snippet: z.string().optional(),
+  // HTTP shape of a recognised client call site (ADR-119). Present on a
+  // client↔route CALLS edge so the edge records the method + path-template the
+  // client named, alongside the file:line it named them at. Absent on every
+  // other edge — a config or infra edge has no HTTP method.
+  method: z.string().optional(),
+  pathTemplate: z.string().optional(),
 })
 export type EdgeEvidence = z.infer<typeof EdgeEvidenceSchema>
 

--- a/packages/types/src/identity.ts
+++ b/packages/types/src/identity.ts
@@ -13,6 +13,7 @@ const CONFIG_PREFIX = 'config:'
 const INFRA_PREFIX = 'infra:'
 const FRONTIER_PREFIX = 'frontier:'
 const FILE_PREFIX = 'file:'
+const ROUTE_PREFIX = 'route:'
 
 // ServiceNode id: `service:<name>` for env-unknown nodes (the default,
 // produced by static extraction or by ingest when the span carries no env
@@ -118,6 +119,42 @@ export function parseFileId(id: string): { service: string; relPath: string } | 
   const relPath = rest.slice(colon + 1)
   if (service.length === 0 || relPath.length === 0) return null
   return { service, relPath }
+}
+
+// RouteNode id: `route:<service>:<METHOD> <pathTemplate>` (ADR-119). The
+// `service` segment is the owning (server) service's manifest name, matching
+// the FileNode / ServiceNode convention so a shared path across monorepo
+// packages stays distinct. `method` is upper-cased (`GET`, `POST`, or `ALL`
+// for a method-agnostic route); `pathTemplate` is the route's declared template
+// verbatim (`/users/:id`), lightly canonicalised (leading slash, no trailing
+// slash). The space between method and template is unambiguous — a method token
+// never contains a space and a service name never contains a colon. Routes are
+// a server-side artifact of a package, not an environment, so the id is
+// env-unscoped like FileNode: an EXTRACTED route and a future OBSERVED server
+// span land on the same node, which is what makes a two-sided divergence
+// possible at route grain.
+export function routeId(service: string, method: string, pathTemplate: string): string {
+  return `${ROUTE_PREFIX}${service}:${method.toUpperCase()} ${pathTemplate}`
+}
+
+// Parse a route id into its (service, method, pathTemplate) tuple. Returns null
+// when the input isn't a route id. Splits service on the first colon after the
+// prefix (service names carry no colon), then method on the first space.
+export function parseRouteId(
+  id: string,
+): { service: string; method: string; pathTemplate: string } | null {
+  if (!id.startsWith(ROUTE_PREFIX)) return null
+  const rest = id.slice(ROUTE_PREFIX.length)
+  const colon = rest.indexOf(':')
+  if (colon === -1) return null
+  const service = rest.slice(0, colon)
+  const tail = rest.slice(colon + 1)
+  const space = tail.indexOf(' ')
+  if (space === -1) return null
+  const method = tail.slice(0, space)
+  const pathTemplate = tail.slice(space + 1)
+  if (service.length === 0 || method.length === 0 || pathTemplate.length === 0) return null
+  return { service, method, pathTemplate }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/types/src/nodes.ts
+++ b/packages/types/src/nodes.ts
@@ -158,6 +158,31 @@ export const FileNodeSchema = z.object({
 })
 export type FileNode = z.infer<typeof FileNodeSchema>
 
+// RouteNode — a server route at (method, path-template) granularity (ADR-119 /
+// docs/contracts/static-extraction.md). Extracted from a mainstream router
+// (Express / Fastify / Next.js), identified by
+// `routeId(service, method, pathTemplate)` → `route:<service>:<METHOD> <tmpl>`.
+// `service` is the owning server service; `method` is upper-cased (`ALL` for a
+// method-agnostic route); `pathTemplate` is the declared template (`/users/:id`).
+// `path` / `line` locate the route's definition in source (file-first
+// provenance, file-awareness.md §6). `framework` names the router the route was
+// recognised from. The node an EXTRACTED client↔route CALLS edge targets, and
+// the node a future OBSERVED server span lands on — the shared target that makes
+// a route-grained two-sided divergence possible.
+export const RouteNodeSchema = z.object({
+  id: z.string(),
+  type: z.literal(NodeType.RouteNode),
+  name: z.string(),
+  service: z.string(),
+  method: z.string(),
+  pathTemplate: z.string(),
+  path: z.string(),
+  line: z.number().int().nonnegative().optional(),
+  framework: z.string().optional(),
+  discoveredVia: DiscoveredViaSchema.optional(),
+})
+export type RouteNode = z.infer<typeof RouteNodeSchema>
+
 export const GraphNodeSchema = z.discriminatedUnion('type', [
   ServiceNodeSchema,
   DatabaseNodeSchema,
@@ -165,5 +190,6 @@ export const GraphNodeSchema = z.discriminatedUnion('type', [
   InfraNodeSchema,
   FrontierNodeSchema,
   FileNodeSchema,
+  RouteNodeSchema,
 ])
 export type GraphNode = z.infer<typeof GraphNodeSchema>

--- a/packages/types/test/schemas.test.ts
+++ b/packages/types/test/schemas.test.ts
@@ -25,9 +25,10 @@ describe('runtime constants', () => {
     // IMPORTS joined with the import graph (ADR-092).
     expect(Object.values(EdgeType)).toHaveLength(9)
   })
-  it('NodeType has 6 values', () => {
-    // FileNode joined the set with the file-first graph (ADR-089).
-    expect(Object.values(NodeType)).toHaveLength(6)
+  it('NodeType has 7 values', () => {
+    // FileNode joined the set with the file-first graph (ADR-089); RouteNode
+    // joined with server-route extraction (ADR-119).
+    expect(Object.values(NodeType)).toHaveLength(7)
   })
 })
 


### PR DESCRIPTION
Static extraction was file-level for HTTP: a client call resolved only to the service it named, and the server side had no route surface at all. Divergence stayed one-sided on the static half — there was nothing to compare an observed server route against.

This takes extraction to route grain, the first slice of #595.

## What lands

- **Server routes (`extract/routes.ts`).** A new producer reads a mainstream router's route table and materializes each route as a `RouteNode` at `(method, path-template)` grain, owned by its service through `CONTAINS`. Coverage is a dependency-gated registry — a service is read for routes only when its manifest names a supported router:
  - **Express** — `app.get`/`router.post`/… 
  - **Fastify** — `fastify.get` and `fastify.route({ method, url })`
  - **Next.js** — app-router `route.*` handler exports and `pages/api` handlers
- **Client capture + matching (`extract/calls/route-match.ts`).** The `fetch` / `axios` / node-`http` call sites now carry method + path-template. A matcher resolves them to the server route they name — host through the existing `urlMatchesHost` path (ADR-065 #5), path through a param-agnostic normalization so `/users/:id`, `/users/123`, and `/users/${id}` line up. A match mints a route-grained `file ──CALLS──▶ route` edge, graded `verified-call-site`.
- **Types.** New `RouteNode` + `routeId`/`parseRouteId`; optional `method` / `pathTemplate` on `EdgeEvidence`. Schema-snapshot regenerated (additive growth).

The `RouteNode` is the shared target an OBSERVED server-span edge lands on (the #576 work in parallel flight), so `get_divergences` gains a file-precise, two-sided comparison at route grain instead of only at service grain — the cross-service contract matching the divergence surface has been missing.

## Governance

- Realizes **ADR-119** (HTTP client call-site + cross-service route matching).
- Amends the public **static-extraction** and **divergence-query** contracts, both citing ADR-119.

## Scope

Mainstream routers + clients only, via the registry. Mount-prefix resolution (`app.use('/api', router)`), split base-URL + path, and the general intra-file call graph are left for later slices of #595.

## Tests

New `extract-routes.test.ts` drives a real two-service fixture (Express `api-server` + `web-client` calling it via fetch/axios, plus Fastify and Next servers): asserts route nodes with method + path-template + file:line, matched cross-service CALLS edges at route granularity carrying method + path-template on evidence, and idempotency. Full `packages/core` suite green (1205 passed) with a realistic timeout; the `otlp-port-step` and `GET /projects` blips are the known environment flakes (5s daemon-startup timeout / live `~/.neat` read) and pass in isolation.

Refs #595. Advances #592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)