### PR TITLE
Mint an observed edge for queue consumers and producers

### DIFF
--- a/docs/contracts/otel-ingest.md
+++ b/docs/contracts/otel-ingest.md
@@ -1,11 +1,11 @@
 ---
 name: otel-ingest
-description: OTel receiver replies before mutation, lastObserved derives from span time, parent-span cache correlates cross-service CALLS, exception data is parsed from span events, unseen services and DBs are auto-created, span-derived edges always carry OBSERVED provenance.
+description: OTel receiver replies before mutation, lastObserved derives from span time, parent-span cache correlates cross-service CALLS, exception data is parsed from span events, unseen services and DBs are auto-created, queue producers and consumers mint file-grained messaging edges to the destination topic, span-derived edges always carry OBSERVED provenance.
 governs:
   - "packages/core/src/ingest.ts"
   - "packages/core/src/otel.ts"
   - "packages/core/src/otel-grpc.ts"
-adr: [ADR-033, ADR-113, ADR-117, ADR-118, ADR-029, ADR-030, ADR-068]
+adr: [ADR-033, ADR-113, ADR-117, ADR-118, ADR-121, ADR-029, ADR-030, ADR-068]
 enforcement: [lint, review]
 ---
 
@@ -52,7 +52,15 @@ A `db.system` span carries the datastore relationship whether or not the datasto
 
 Both edges are **file-grained** through the same call-site path as any other OBSERVED edge (file-awareness.md §4): when the span processor stamped `code.*` on the synchronous DB CLIENT span, the edge originates from the caller's `FileNode` at the exact `file:line`, reconciled onto the EXTRACTED service-relative path (`reconcileObservedRelPath`) so the OBSERVED and EXTRACTED layers fuse into one node. A DB span with no call site stays service-level, honestly. The caller-side gate (`spanMintsObservedEdge`) applies unchanged; the in-process edge is minted only from the caller/producer side, never fabricated from an INTERNAL connection span.
 
-The inbound-server liveness edge and the queue / GraphQL / gRPC / WebSocket and non-DB in-process boundaries remain deferred to #576's later cuts.
+The inbound-server liveness edge and the GraphQL / gRPC / WebSocket and non-DB in-process boundaries remain deferred to #576's later cuts.
+
+## Queue producers and consumers mint file-grained messaging edges (ADR-121, refs #614)
+
+A messaging span carries its **topic / queue / stream** as the thing the code talks to — the broker host is transport, not the destination. `handleSpan` reads the messaging semconv (`messaging.system` and `messaging.destination.name`, with the legacy `messaging.destination` as fallback) and mints an OBSERVED edge to the destination node: a **PRODUCER** span (wire kind 4) mints `PUBLISHES_TO`, a **CONSUMER** span (wire kind 5) mints `CONSUMES_FROM`. Both are the observed mirror of the static extractor's messaging edges — the queue-side pair of directions, so declared and observed queue topology fuse rather than twin.
+
+The destination node is keyed **identically to the static extractor** so the OBSERVED and EXTRACTED edges land on one node: the static Kafka side names its topic `infra:kafka-topic:<topic>` (`extract/calls/kafka.ts`), so the node kind is `<messaging.system>-topic` — `kafka` → `kafka-topic` — and the same shape generalises to every messaging system the semconv names (Redis Streams, and beyond). The node carries `provider: 'self'`, matching the static extractor's non-AWS provider, so an observed-first destination merges cleanly when static analysis later reaches the same topic.
+
+The edge is **file-grained** through the same call-site path as any other OBSERVED edge (file-awareness.md §4): when the span carries `code.*`, the edge originates from the producer's / consumer's `FileNode` at the exact `file:line`, reconciled onto the EXTRACTED service-relative path (`reconcileObservedRelPath`, ADR-118) so the OBSERVED and EXTRACTED layers fuse into one edge grain — the same `(source, target, type)` the static `PUBLISHES_TO` / `CONSUMES_FROM` uses. A messaging span with no call site stays service-level, honestly. The messaging gate (`spanMintsMessagingEdge`) admits only PRODUCER and CONSUMER kinds, and only when the span actually names a destination — a destination-less consumer span (the ADR-117 worker-incident shape) mints no edge, and a CONSUMER span never mints a spurious service-level `CALLS`.
 
 ## OBSERVED provenance for span-derived edges (ADR-068)
 

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -8,6 +8,7 @@ import type {
   FrontierNode,
   GraphEdge,
   GraphNode,
+  InfraNode,
   Policy,
   ServiceNode,
   StaleEvent,
@@ -26,6 +27,7 @@ import {
   fileId,
   frontierId,
   inferredEdgeId,
+  infraId,
   observedEdgeId,
   serviceId,
   type EdgeTypeValue,
@@ -712,15 +714,22 @@ const STITCH_EDGE_TYPES = new Set<EdgeTypeValue>([
 // CLIENT call-site spans in ingest.test.ts (kind 3).
 const WIRE_SPAN_KIND_CLIENT = 3
 const WIRE_SPAN_KIND_PRODUCER = 4
+const WIRE_SPAN_KIND_CONSUMER = 5
 
-// An OBSERVED edge originates from the caller/producer side of a call. CLIENT
-// and PRODUCER spans are that side; INTERNAL / SERVER / CONSUMER are not — a
-// SERVER span is the callee, and its edge is minted from its parent CLIENT via
-// the parent-span fallback (the mirror image of CLIENT+SERVER, and of
-// PRODUCER+CONSUMER for queues). Without this gate every INTERNAL span that
-// happens to carry a peer address — e.g. a `tcp.connect` / `tls.connect` to an
-// AWS endpoint — mints a spurious service-level edge (issue #429), because no
-// §4 capture layer stamps `code.*` on INTERNAL spans.
+// The caller-side gate for the CALLS / CONNECTS_TO paths. A CLIENT or PRODUCER
+// span is the caller/producer side of a service-to-service call or a datastore
+// read; INTERNAL / SERVER spans are not — a SERVER span is the callee, and its
+// edge is minted from its parent CLIENT via the parent-span fallback. Without
+// this gate every INTERNAL span that happens to carry a peer address — e.g. a
+// `tcp.connect` / `tls.connect` to an AWS endpoint — mints a spurious
+// service-level edge (issue #429), because no §4 capture layer stamps `code.*`
+// on INTERNAL spans.
+//
+// CONSUMER spans are handled by the messaging branch in handleSpan, not here:
+// a queue consumer isn't calling a service, it's reading a topic, so it mints a
+// CONSUMES_FROM edge to the destination node (spanMintsMessagingEdge below) —
+// the observed mirror of the static consumer→topic edge, the queue-side pair of
+// the PRODUCER→topic PUBLISHES_TO edge.
 //
 // A span that reports no kind (undefined) or UNSPECIFIED (0) carries no
 // caller/callee signal, so it falls back to the historical unconditional
@@ -729,6 +738,46 @@ const WIRE_SPAN_KIND_PRODUCER = 4
 function spanMintsObservedEdge(kind: number | undefined): boolean {
   if (kind === undefined || kind === 0) return true
   return kind === WIRE_SPAN_KIND_CLIENT || kind === WIRE_SPAN_KIND_PRODUCER
+}
+
+// The messaging counterpart to the caller-side gate. A PRODUCER span publishes
+// to a destination; a CONSUMER span reads from one. Both sides mint an OBSERVED
+// edge to the topic/queue node — the PRODUCER a PUBLISHES_TO, the CONSUMER a
+// CONSUMES_FROM — so declared and observed queue topology fuse. Only spans that
+// actually carry a messaging destination reach this (handleSpan checks the
+// semconv attrs first), so a stray CONSUMER span with no destination stays inert.
+function spanMintsMessagingEdge(kind: number | undefined): boolean {
+  return kind === WIRE_SPAN_KIND_PRODUCER || kind === WIRE_SPAN_KIND_CONSUMER
+}
+
+// A messaging destination node (Kafka topic, queue, stream) keyed exactly the
+// way the static extractor keys it, so the OBSERVED and EXTRACTED edges fuse
+// onto one node instead of twinning. The Kafka static side names its topic
+// `infra:kafka-topic:<topic>` (extract/calls/kafka.ts), so the kind is
+// `<messaging.system>-topic` — `kafka` → `kafka-topic` — and the same shape
+// generalises to every messaging system the semconv names. `provider: 'self'`
+// mirrors the static extractor's non-AWS provider so an observed-first node
+// merges cleanly when static analysis later reaches the same destination.
+function messagingDestinationKind(system: string): string {
+  return `${system}-topic`
+}
+
+function ensureMessagingDestinationNode(
+  graph: NeatGraph,
+  system: string,
+  destination: string,
+): string {
+  const id = infraId(messagingDestinationKind(system), destination)
+  if (graph.hasNode(id)) return id
+  const node: InfraNode = {
+    id,
+    type: NodeType.InfraNode,
+    name: destination,
+    provider: 'self',
+    kind: messagingDestinationKind(system),
+  }
+  graph.addNode(id, node)
+  return id
 }
 
 // Parent-span TTL cache (ADR-033). Address-based peer resolution (server.address /
@@ -1434,6 +1483,42 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
       )
       if (result) affectedNode = targetId
     }
+  } else if (
+    span.messagingSystem &&
+    span.messagingDestination &&
+    spanMintsMessagingEdge(span.kind)
+  ) {
+    // Messaging span. The semantic destination is the topic / queue / stream the
+    // code talks to — not the broker host, which is transport. A PRODUCER span
+    // publishes; a CONSUMER span consumes. Both mint an OBSERVED edge to the same
+    // destination node the static extractor names (extract/calls/kafka.ts), so
+    // the declared and observed queue edges fuse into one (→ divergence) instead
+    // of twinning. File-grained through the same call-site path as any other
+    // OBSERVED edge (file-awareness.md §4): when the span carries `code.*`, the
+    // edge originates from the caller's FileNode at the exact call site,
+    // reconciled onto the EXTRACTED service-relative path (`reconcileObservedRelPath`,
+    // ADR-118); without a call site it stays service-level, honestly. This is the
+    // consumer-side pair of the producer edge — the queue topology the OBSERVED
+    // layer used to leave dark on the consumer side (issue #614).
+    const targetId = ensureMessagingDestinationNode(
+      ctx.graph,
+      span.messagingSystem,
+      span.messagingDestination,
+    )
+    const edgeType =
+      span.kind === WIRE_SPAN_KIND_CONSUMER
+        ? EdgeType.CONSUMES_FROM
+        : EdgeType.PUBLISHES_TO
+    const result = upsertObservedEdge(
+      ctx.graph,
+      edgeType,
+      observedSource(),
+      targetId,
+      ts,
+      isError,
+      callSiteEvidence,
+    )
+    if (result) affectedNode = targetId
   } else {
     // Possibly a cross-service call. Resolve the peer; if it matches a known
     // ServiceNode, record an OBSERVED CALLS edge to the typed target. If it

--- a/packages/core/src/otel.ts
+++ b/packages/core/src/otel.ts
@@ -49,6 +49,15 @@ export interface ParsedSpan {
   // Convenience accessors for the attributes #8 cares about.
   dbSystem?: string
   dbName?: string
+  // Messaging semconv (OTel). `messaging.system` names the broker family
+  // (kafka, rabbitmq, redis, …); the destination is the topic/queue the span
+  // produced to or consumed from — the canonical `messaging.destination.name`
+  // (SC v1.24+) with the legacy `messaging.destination` as fallback. handleSpan
+  // reads these to mint a PUBLISHES_TO (PRODUCER) or CONSUMES_FROM (CONSUMER)
+  // OBSERVED edge to the destination node, fusing with the static extractor's
+  // topic node. See docs/contracts/otel-ingest.md §Queue producers and consumers.
+  messagingSystem?: string
+  messagingDestination?: string
   // 0 = UNSET, 1 = OK, 2 = ERROR per OTLP. We only care that 2 means error.
   statusCode?: number
   errorMessage?: string
@@ -244,6 +253,21 @@ function pickEnv(
   return ENV_FALLBACK
 }
 
+// The messaging destination (topic / queue / stream) a producer or consumer
+// span names. `messaging.destination.name` is the canonical semconv key
+// (SC v1.24+); `messaging.destination` is the older form some instrumentations
+// still emit. Prefer the canonical one, fall back to the legacy, and treat an
+// empty string as absent so an anonymous destination never keys a node.
+function messagingDestinationOf(
+  attrs: Record<string, AttributeValue>,
+): string | undefined {
+  for (const key of ['messaging.destination.name', 'messaging.destination']) {
+    const v = attrs[key]
+    if (typeof v === 'string' && v.length > 0) return v
+  }
+  return undefined
+}
+
 export function parseOtlpRequest(body: OtlpTracesRequest): ParsedSpan[] {
   const out: ParsedSpan[] = []
   for (const rs of body.resourceSpans ?? []) {
@@ -278,6 +302,11 @@ export function parseOtlpRequest(body: OtlpTracesRequest): ParsedSpan[] {
           attributes: attrs,
           dbSystem: typeof attrs['db.system'] === 'string' ? (attrs['db.system'] as string) : undefined,
           dbName: typeof attrs['db.name'] === 'string' ? (attrs['db.name'] as string) : undefined,
+          messagingSystem:
+            typeof attrs['messaging.system'] === 'string'
+              ? (attrs['messaging.system'] as string)
+              : undefined,
+          messagingDestination: messagingDestinationOf(attrs),
           statusCode: span.status?.code,
           errorMessage: span.status?.message,
           exception: extractExceptionFromEvents(span.events),

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -9,6 +9,8 @@ import {
   type ErrorEvent,
   type DatabaseNode,
   fileId,
+  infraId,
+  type InfraNode,
   localDatabaseId,
   type GraphEdge,
   type GraphNode,
@@ -1981,5 +1983,227 @@ describe('handleSpan in-process database spans (#576 / #546)', () => {
     expect(ctx.graph.hasEdge(id)).toBe(true)
     // No local-identity node was minted for the networked DB.
     expect(ctx.graph.hasNode(localDatabaseId('service-b', 'neatdemo'))).toBe(false)
+  })
+})
+
+// Issue #614 — the queue side of the OBSERVED layer. A PRODUCER span publishes
+// to a topic; a CONSUMER span reads from one. Both mint an OBSERVED edge to the
+// SAME destination node the static extractor names (extract/calls/kafka.ts:
+// `infra:kafka-topic:<topic>`), so declared and observed queue topology fuse
+// into one edge (→ divergence) instead of twinning. The consumer side is what
+// the OBSERVED layer used to leave dark (only CLIENT/PRODUCER minted). Fixtures
+// use REAL SDK messaging span shape: PRODUCER/CONSUMER wire kind, `messaging.
+// system`, `messaging.destination.name`, and an ABSOLUTE `code.filepath` the
+// SpanProcessor stamps — reconciled onto the EXTRACTED path (ADR-118).
+describe('handleSpan queue producer/consumer spans (#614)', () => {
+  let tmpDir: string
+  let ctx: IngestContext
+
+  beforeEach(async () => {
+    resetParentSpanCache()
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-queue-'))
+    ctx = { graph: newGraph(), errorsPath: path.join(tmpDir, 'errors.ndjson') }
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+    resetParentSpanCache()
+  })
+
+  // A kafkajs consumer "process" span: CONSUMER kind (5), the messaging semconv,
+  // and a code.* call site for the handler the job runs in.
+  function consumerSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
+    return {
+      service: 'service-a',
+      traceId: 'trace-consume',
+      spanId: 'span-consume',
+      name: 'orders process',
+      kind: 5, // CONSUMER
+      startTimeUnixNano: '0',
+      endTimeUnixNano: '0',
+      durationNanos: 0n,
+      env: 'unknown',
+      attributes: {
+        'messaging.system': 'kafka',
+        'messaging.operation': 'process',
+        'messaging.destination.name': 'orders',
+        'code.filepath': '/var/task/src/consumers/orders.ts',
+        'code.lineno': 31,
+        'code.function': 'handleOrder',
+      },
+      messagingSystem: 'kafka',
+      messagingDestination: 'orders',
+      statusCode: 0,
+      ...overrides,
+    }
+  }
+
+  it('mints a file-grained CONSUMES_FROM edge from a CONSUMER span to the topic node', async () => {
+    // The extractor already parsed the consumer file the handler lives in.
+    ensureFileNode(ctx.graph, 'service-a', 'service:service-a', 'src/consumers/orders.ts')
+
+    await handleSpan(ctx, consumerSpan())
+
+    // The destination node is keyed exactly the way the static extractor keys a
+    // kafka topic, so the two sides fuse rather than twin.
+    const topicId = infraId('kafka-topic', 'orders')
+    expect(topicId).toBe('infra:kafka-topic:orders')
+    expect(ctx.graph.hasNode(topicId)).toBe(true)
+    const topic = ctx.graph.getNodeAttributes(topicId) as InfraNode
+    expect(topic.type).toBe(NodeType.InfraNode)
+    expect(topic.name).toBe('orders')
+    expect(topic.kind).toBe('kafka-topic')
+    expect(topic.provider).toBe('self')
+
+    // The edge originates from the consumer's FileNode at the exact call site —
+    // file-grained, fused onto the EXTRACTED path (not the /var/task deployed one).
+    const fileNodeId = fileId('service-a', 'src/consumers/orders.ts')
+    const edgeId = `${EdgeType.CONSUMES_FROM}:OBSERVED:${fileNodeId}->${topicId}`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.type).toBe(EdgeType.CONSUMES_FROM)
+    expect(edge.source).toBe(fileNodeId)
+    expect(edge.target).toBe(topicId)
+    expect(edge.evidence?.file).toBe('src/consumers/orders.ts')
+    expect(edge.evidence?.line).toBe(31)
+  })
+
+  it('mints a file-grained PUBLISHES_TO edge from a PRODUCER span to the same topic node', async () => {
+    ensureFileNode(ctx.graph, 'service-a', 'service:service-a', 'src/producers/orders.ts')
+
+    await handleSpan(
+      ctx,
+      consumerSpan({
+        kind: 4, // PRODUCER
+        spanId: 'span-produce',
+        name: 'orders send',
+        attributes: {
+          'messaging.system': 'kafka',
+          'messaging.operation': 'publish',
+          'messaging.destination.name': 'orders',
+          'code.filepath': '/var/task/src/producers/orders.ts',
+          'code.lineno': 12,
+        },
+      }),
+    )
+
+    const topicId = infraId('kafka-topic', 'orders')
+    const fileNodeId = fileId('service-a', 'src/producers/orders.ts')
+    const edgeId = `${EdgeType.PUBLISHES_TO}:OBSERVED:${fileNodeId}->${topicId}`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.type).toBe(EdgeType.PUBLISHES_TO)
+    expect(edge.target).toBe(topicId)
+
+    // The topic is the destination — not the broker host. A messaging span mints
+    // no CALLS edge to a broker transport.
+    let callsEdges = 0
+    ctx.graph.forEachEdge((_id, a) => {
+      if ((a as GraphEdge).type === EdgeType.CALLS) callsEdges++
+    })
+    expect(callsEdges).toBe(0)
+  })
+
+  it('fuses the OBSERVED CONSUMES_FROM onto the static one — one grain, both provenances, no twin', async () => {
+    const fileNodeId = fileId('service-a', 'src/consumers/orders.ts')
+    const topicId = infraId('kafka-topic', 'orders')
+
+    // Static extraction already found the consumer call site and its topic: a
+    // file → topic EXTRACTED CONSUMES_FROM edge to infra:kafka-topic:orders.
+    ensureFileNode(ctx.graph, 'service-a', 'service:service-a', 'src/consumers/orders.ts')
+    ctx.graph.addNode(topicId, {
+      id: topicId,
+      type: NodeType.InfraNode,
+      name: 'orders',
+      provider: 'self',
+      kind: 'kafka-topic',
+    })
+    const staticEdgeId = `${EdgeType.CONSUMES_FROM}:${fileNodeId}->${topicId}`
+    ctx.graph.addEdgeWithKey(staticEdgeId, fileNodeId, topicId, {
+      id: staticEdgeId,
+      source: fileNodeId,
+      target: topicId,
+      type: EdgeType.CONSUMES_FROM,
+      provenance: Provenance.EXTRACTED,
+    })
+
+    await handleSpan(ctx, consumerSpan())
+
+    // Exactly one topic InfraNode and one consumer FileNode — the absolute
+    // `code.filepath` reconciled onto the EXTRACTED node rather than forking a
+    // /var/task twin, and the observed edge reused the static topic node.
+    const infraNodes: string[] = []
+    ctx.graph.forEachNode((id, a) => {
+      if ((a as { type: string }).type === NodeType.InfraNode) infraNodes.push(id)
+    })
+    expect(infraNodes).toEqual([topicId])
+    expect(ctx.graph.hasNode('file:service-a:var/task/src/consumers/orders.ts')).toBe(false)
+
+    // Both provenances ride the same (file → topic) CONSUMES_FROM grain: the
+    // EXTRACTED declaration and the OBSERVED runtime edge, no twin node.
+    expect(ctx.graph.hasEdge(staticEdgeId)).toBe(true)
+    expect((ctx.graph.getEdgeAttributes(staticEdgeId) as GraphEdge).provenance).toBe(
+      Provenance.EXTRACTED,
+    )
+    const observedId = `${EdgeType.CONSUMES_FROM}:OBSERVED:${fileNodeId}->${topicId}`
+    expect(ctx.graph.hasEdge(observedId)).toBe(true)
+
+    const consumesEdges: GraphEdge[] = []
+    ctx.graph.forEachEdge((_id, a) => {
+      const e = a as GraphEdge
+      if (e.type === EdgeType.CONSUMES_FROM) consumesEdges.push(e)
+    })
+    expect(consumesEdges).toHaveLength(2)
+    expect(new Set(consumesEdges.map((e) => e.source))).toEqual(new Set([fileNodeId]))
+    expect(new Set(consumesEdges.map((e) => e.target))).toEqual(new Set([topicId]))
+    expect(new Set(consumesEdges.map((e) => e.provenance))).toEqual(
+      new Set([Provenance.EXTRACTED, Provenance.OBSERVED]),
+    )
+  })
+
+  it('keys the destination node off messaging.system for a non-Kafka broker (Redis Streams)', async () => {
+    // A Redis-Streams consumer with no code.* call site — the edge stays
+    // service-level, honestly, and the node id generalises to `<system>-topic`.
+    await handleSpan(
+      ctx,
+      consumerSpan({
+        messagingSystem: 'redis',
+        messagingDestination: 'events',
+        attributes: {
+          'messaging.system': 'redis',
+          'messaging.destination.name': 'events',
+        },
+      }),
+    )
+
+    const topicId = infraId('redis-topic', 'events')
+    expect(ctx.graph.hasNode(topicId)).toBe(true)
+    const edgeId = `${EdgeType.CONSUMES_FROM}:OBSERVED:service:service-a->${topicId}`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    expect((ctx.graph.getEdgeAttributes(edgeId) as GraphEdge).target).toBe(topicId)
+  })
+
+  it('mints no messaging edge for a CONSUMER span that carries no destination', async () => {
+    // The ADR-117 worker-incident path fires on a destination-less consumer
+    // span; the queue edge must not. No destination, no topic node, no edge.
+    await handleSpan(
+      ctx,
+      consumerSpan({
+        messagingDestination: undefined,
+        attributes: { 'messaging.system': 'kafka', 'messaging.operation': 'process' },
+      }),
+    )
+    let infraNodes = 0
+    ctx.graph.forEachNode((_id, a) => {
+      if ((a as { type: string }).type === NodeType.InfraNode) infraNodes++
+    })
+    expect(infraNodes).toBe(0)
+    let messagingEdges = 0
+    ctx.graph.forEachEdge((_id, a) => {
+      const e = a as GraphEdge
+      if (e.type === EdgeType.CONSUMES_FROM || e.type === EdgeType.PUBLISHES_TO) messagingEdges++
+    })
+    expect(messagingEdges).toBe(0)
   })
 })

--- a/packages/core/test/otel.test.ts
+++ b/packages/core/test/otel.test.ts
@@ -92,6 +92,75 @@ describe('parseOtlpRequest', () => {
     expect(spans[1].dbName).toBe('neatdemo')
   })
 
+  it('hoists messaging.system and the canonical destination onto the parsed span', () => {
+    const spans = parseOtlpRequest({
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [{ key: 'service.name', value: { stringValue: 'orders-worker' } }],
+          },
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  traceId: 't',
+                  spanId: 's',
+                  name: 'orders process',
+                  kind: 5,
+                  startTimeUnixNano: '0',
+                  endTimeUnixNano: '0',
+                  attributes: [
+                    { key: 'messaging.system', value: { stringValue: 'kafka' } },
+                    { key: 'messaging.destination.name', value: { stringValue: 'orders' } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    expect(spans[0].messagingSystem).toBe('kafka')
+    expect(spans[0].messagingDestination).toBe('orders')
+  })
+
+  it('falls back to the legacy messaging.destination when the canonical name is absent', () => {
+    const spans = parseOtlpRequest({
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [{ key: 'service.name', value: { stringValue: 'orders-worker' } }],
+          },
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  traceId: 't',
+                  spanId: 's',
+                  name: 'orders send',
+                  kind: 4,
+                  startTimeUnixNano: '0',
+                  endTimeUnixNano: '0',
+                  attributes: [
+                    { key: 'messaging.system', value: { stringValue: 'kafka' } },
+                    { key: 'messaging.destination', value: { stringValue: 'orders' } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    expect(spans[0].messagingDestination).toBe('orders')
+  })
+
+  it('leaves messaging fields undefined on a non-messaging span', () => {
+    const spans = parseOtlpRequest(SAMPLE_BODY)
+    expect(spans[0].messagingSystem).toBeUndefined()
+    expect(spans[0].messagingDestination).toBeUndefined()
+  })
+
   it('preserves the full attribute bag', () => {
     const spans = parseOtlpRequest(SAMPLE_BODY)
     expect(spans[0].attributes['http.method']).toBe('GET')


### PR DESCRIPTION
Async queue topology now reads the same on the OBSERVED side as it does on the declared side. A messaging span carries its topic/queue as the thing the code talks to, so `handleSpan` reads the messaging semconv (`messaging.system`, `messaging.destination.name`, with the legacy `messaging.destination` as fallback) and mints the matching edge to the destination node: a PRODUCER span publishes (`PUBLISHES_TO`), a CONSUMER span consumes (`CONSUMES_FROM`).

The destination node is keyed exactly the way the static extractor keys a Kafka topic (`infra:kafka-topic:<topic>`), so the observed and declared edges fuse onto one node instead of twinning — one edge, both provenances, ready for divergence. The same `<system>-topic` shape generalises to the other messaging systems the semconv names (Redis Streams and beyond), and `provider: 'self'` matches the static side so an observed-first topic merges cleanly when extraction later reaches it.

The edge is file-grained through the usual call-site path (file-awareness §4): when the span carries `code.*`, it originates from the producer's or consumer's `FileNode`, reconciled onto the extracted service-relative path (ADR-118), so both provenances ride one edge grain. A messaging span with no call site stays service-level, honestly; a destination-less consumer span (the ADR-117 worker shape) mints no edge, and a CONSUMER span never mints a spurious service-level `CALLS`.

Decision recorded as ADR-121; the `otel-ingest` contract now describes consumer- and producer-side messaging minting.

Tests use real OTel messaging span shapes (PRODUCER/CONSUMER wire kind, `messaging.system`, `messaging.destination.name`, absolute `code.filepath`) and assert a file-grained edge to the topic node that fuses with a static Kafka `CONSUMES_FROM`. `packages/core` ingest and otel suites pass (110 tests including 8 new). The remaining `packages/core` failures on this branch are pre-existing on `main` from the #649 route merge (RouteNode schema drift) and are identical with and without this change.

Completes the queue-edge half of the async gap; the worker-failure incident half shipped in ADR-117.

Refs #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)