### PR TITLE
Give GraphQL services an observed operation-grain topology

### DIFF
--- a/docs/contracts/identity.md
+++ b/docs/contracts/identity.md
@@ -6,7 +6,7 @@ governs:
   - "packages/core/src/ingest.ts"
   - "packages/types/src/nodes.ts"
   - "packages/types/src/identity.ts"
-adr: [ADR-028]
+adr: [ADR-028, ADR-122]
 enforcement: [lint, review]
 ---
 
@@ -17,13 +17,14 @@ Every node id in NEAT is constructed via the helpers in `packages/types/src/iden
 ## Helpers
 
 ```ts
-import { serviceId, databaseId, configId, infraId, frontierId } from '@neat.is/types'
+import { serviceId, databaseId, configId, infraId, frontierId, graphqlOperationId } from '@neat.is/types'
 
-serviceId('checkout')                  // 'service:checkout'
-databaseId('db.example.com')           // 'database:db.example.com'
-configId('apps/web/.env')              // 'config:apps/web/.env'
-infraId('redis', 'cache.internal')     // 'infra:redis:cache.internal'
-frontierId('payments-api:8080')        // 'frontier:payments-api:8080'
+serviceId('checkout')                     // 'service:checkout'
+databaseId('db.example.com')              // 'database:db.example.com'
+configId('apps/web/.env')                 // 'config:apps/web/.env'
+infraId('redis', 'cache.internal')        // 'infra:redis:cache.internal'
+frontierId('payments-api:8080')           // 'frontier:payments-api:8080'
+graphqlOperationId('api', 'query', 'GetUser')  // 'graphql:api:query GetUser'
 ```
 
 Inverses (`parseServiceId`, `parseDatabaseId`, etc.) return the inner segment or `null` if the id doesn't match. Use them anywhere a consumer strips a prefix.
@@ -37,6 +38,7 @@ Inverses (`parseServiceId`, `parseDatabaseId`, etc.) return the inner segment or
 | ConfigNode    | `config:<relPath>`            | path relative to scan root, forward slashes         |
 | InfraNode     | `infra:<kind>:<name>`         | free-string kind sub-typing per ADR-022             |
 | FrontierNode  | `frontier:<host>`             | host:port from OTel peer attribute                  |
+| GraphQLOperationNode | `graphql:<service>:<type> <name>` | serving service + lower-cased operation type + client operation name (ADR-122) |
 
 ## Reconciliation rules
 

--- a/docs/contracts/otel-ingest.md
+++ b/docs/contracts/otel-ingest.md
@@ -1,11 +1,11 @@
 ---
 name: otel-ingest
-description: OTel receiver replies before mutation, lastObserved derives from span time, parent-span cache correlates cross-service CALLS, exception data is parsed from span events, unseen services and DBs are auto-created, queue producers and consumers mint file-grained messaging edges to the destination topic, span-derived edges always carry OBSERVED provenance.
+description: OTel receiver replies before mutation, lastObserved derives from span time, parent-span cache correlates cross-service CALLS, exception data is parsed from span events, unseen services and DBs are auto-created, queue producers and consumers mint file-grained messaging edges to the destination topic, GraphQL execution spans mint an operation-grain CONTAINS edge, span-derived edges always carry OBSERVED provenance.
 governs:
   - "packages/core/src/ingest.ts"
   - "packages/core/src/otel.ts"
   - "packages/core/src/otel-grpc.ts"
-adr: [ADR-033, ADR-113, ADR-117, ADR-118, ADR-121, ADR-029, ADR-030, ADR-068]
+adr: [ADR-033, ADR-113, ADR-117, ADR-118, ADR-121, ADR-122, ADR-029, ADR-030, ADR-068]
 enforcement: [lint, review]
 ---
 
@@ -61,6 +61,16 @@ A messaging span carries its **topic / queue / stream** as the thing the code ta
 The destination node is keyed **identically to the static extractor** so the OBSERVED and EXTRACTED edges land on one node: the static Kafka side names its topic `infra:kafka-topic:<topic>` (`extract/calls/kafka.ts`), so the node kind is `<messaging.system>-topic` — `kafka` → `kafka-topic` — and the same shape generalises to every messaging system the semconv names (Redis Streams, and beyond). The node carries `provider: 'self'`, matching the static extractor's non-AWS provider, so an observed-first destination merges cleanly when static analysis later reaches the same topic.
 
 The edge is **file-grained** through the same call-site path as any other OBSERVED edge (file-awareness.md §4): when the span carries `code.*`, the edge originates from the producer's / consumer's `FileNode` at the exact `file:line`, reconciled onto the EXTRACTED service-relative path (`reconcileObservedRelPath`, ADR-118) so the OBSERVED and EXTRACTED layers fuse into one edge grain — the same `(source, target, type)` the static `PUBLISHES_TO` / `CONSUMES_FROM` uses. A messaging span with no call site stays service-level, honestly. The messaging gate (`spanMintsMessagingEdge`) admits only PRODUCER and CONSUMER kinds, and only when the span actually names a destination — a destination-less consumer span (the ADR-117 worker-incident shape) mints no edge, and a CONSUMER span never mints a spurious service-level `CALLS`.
+
+## GraphQL execution spans mint an operation-grain `CONTAINS` edge (ADR-122, refs #615)
+
+Every GraphQL request rides one HTTP endpoint — `POST /graphql` — so at HTTP grain the whole API collapses to a single edge and the operation-level topology is invisible. The GraphQL execution span carries the operation the client actually named: `handleSpan` reads `graphql.operation.name` and `graphql.operation.type` (`query` / `mutation` / `subscription`) and mints an OBSERVED `CONTAINS` edge from the serving service to a per-operation `GraphQLOperationNode`, recovering the topology HTTP grain flattens.
+
+The operation node is keyed on `graphqlOperationId(service, operationType, operationName)` → `graphql:<service>:<type> <name>` (identity.md), with `operationType` normalised lower-case so `query` and `Query` land on one node. The ownership edge is `CONTAINS` — the same structural verb a service has over a route (ADR-119) and a file (file-awareness.md §2) — carrying OBSERVED provenance. The node is minted **observed-first**: this cut does **not** parse the GraphQL SDL or resolver map statically, so the node's identity is chosen so a future static GraphQL extractor fuses onto the same id rather than twinning.
+
+The edge is **file-grained** through the same call-site path as any other OBSERVED edge (file-awareness.md §4): when the execution span carries `code.*` (the resolver call site), the edge originates from that `FileNode` at the exact `file:line`, reconciled onto the EXTRACTED service-relative path (`reconcileObservedRelPath`, ADR-118); without a call site it stays service-level, honestly. The GraphQL gate (`spanServesGraphqlOperation`) admits only the serving side — SERVER / INTERNAL / unkinded spans — and only when the span names **both** an operation name and type: a CLIENT/PRODUCER/CONSUMER span mints nothing (client-side operation attribution is deferred), and a nameless or typeless execution span falls through rather than keying a fabricated operation.
+
+Deferred: resolver / field-grain edges, static GraphQL schema extraction, and client-side operation attribution.
 
 ## OBSERVED provenance for span-derived edges (ADR-068)
 

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -8,6 +8,7 @@ import type {
   FrontierNode,
   GraphEdge,
   GraphNode,
+  GraphQLOperationNode,
   InfraNode,
   Policy,
   ServiceNode,
@@ -26,6 +27,7 @@ import {
   extractedEdgeId,
   fileId,
   frontierId,
+  graphqlOperationId,
   inferredEdgeId,
   infraId,
   observedEdgeId,
@@ -748,6 +750,49 @@ function spanMintsObservedEdge(kind: number | undefined): boolean {
 // semconv attrs first), so a stray CONSUMER span with no destination stays inert.
 function spanMintsMessagingEdge(kind: number | undefined): boolean {
   return kind === WIRE_SPAN_KIND_PRODUCER || kind === WIRE_SPAN_KIND_CONSUMER
+}
+
+// The GraphQL execution span is emitted by the service that RESOLVES the
+// operation — a SERVER or INTERNAL span (the instrumentation's `graphql.execute`),
+// never the CLIENT side that only ever sees an opaque `POST /graphql`. Gating out
+// the caller/producer/consumer kinds keeps a client-side operation span from
+// attributing the operation to the caller (client-side operation attribution is
+// deferred, ADR-122); an unkinded / UNSET span still mints, mirroring the
+// caller-side gate's legacy-producer fallback.
+function spanServesGraphqlOperation(kind: number | undefined): boolean {
+  return (
+    kind !== WIRE_SPAN_KIND_CLIENT &&
+    kind !== WIRE_SPAN_KIND_PRODUCER &&
+    kind !== WIRE_SPAN_KIND_CONSUMER
+  )
+}
+
+// A GraphQL operation node keyed on (service, operationType, operationName) via
+// graphqlOperationId (ADR-122). Minted observed-first from the execution span so
+// operation-level topology is legible even before any static GraphQL extractor
+// exists; a later static extractor fuses onto the same id. `operationType` is
+// stored lower-cased to match the id's normalisation, so a `query` observed and a
+// `Query` static resolver land on one node. Idempotent — a high-volume operation
+// upserts, never grows the node set.
+function ensureGraphqlOperationNode(
+  graph: NeatGraph,
+  serviceName: string,
+  operationType: string,
+  operationName: string,
+): string {
+  const id = graphqlOperationId(serviceName, operationType, operationName)
+  if (graph.hasNode(id)) return id
+  const node: GraphQLOperationNode = {
+    id,
+    type: NodeType.GraphQLOperationNode,
+    name: operationName,
+    service: serviceName,
+    operationType: operationType.toLowerCase(),
+    operationName,
+    discoveredVia: 'otel',
+  }
+  graph.addNode(id, node)
+  return id
 }
 
 // A messaging destination node (Kafka topic, queue, stream) keyed exactly the
@@ -1512,6 +1557,43 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
     const result = upsertObservedEdge(
       ctx.graph,
       edgeType,
+      observedSource(),
+      targetId,
+      ts,
+      isError,
+      callSiteEvidence,
+    )
+    if (result) affectedNode = targetId
+  } else if (
+    span.graphqlOperationName &&
+    span.graphqlOperationType &&
+    spanServesGraphqlOperation(span.kind)
+  ) {
+    // GraphQL execution span (issue #615). Every GraphQL request rides one HTTP
+    // endpoint (`POST /graphql`), so at HTTP grain the whole API collapses to a
+    // single edge and the operation-level topology is invisible. The execution
+    // span carries the operation the client actually named — `graphql.operation.name`
+    // with `graphql.operation.type` — so mint an OBSERVED `CONTAINS` edge from the
+    // serving service to a per-operation node, the same ownership shape a service
+    // has over a route (ADR-119) and a file (file-awareness.md §2). OBSERVED-only:
+    // the SDL / resolver map is not parsed statically in this cut; the node is
+    // minted observed-first and a future static GraphQL extractor fuses onto the
+    // same id (ADR-122). File-grained through the same call-site path as any other
+    // OBSERVED edge (file-awareness.md §4): when the span carries `code.*` (the
+    // resolver call site) the edge originates from that `FileNode` at the exact
+    // `file:line`, reconciled onto the EXTRACTED service-relative path; without a
+    // call site it stays service-level, honestly. Both operation name and type
+    // must be present to key a stable id — a nameless/typeless execution span
+    // falls through rather than minting a fabricated operation.
+    const targetId = ensureGraphqlOperationNode(
+      ctx.graph,
+      span.service,
+      span.graphqlOperationType,
+      span.graphqlOperationName,
+    )
+    const result = upsertObservedEdge(
+      ctx.graph,
+      EdgeType.CONTAINS,
       observedSource(),
       targetId,
       ts,

--- a/packages/core/src/otel.ts
+++ b/packages/core/src/otel.ts
@@ -58,6 +58,15 @@ export interface ParsedSpan {
   // topic node. See docs/contracts/otel-ingest.md §Queue producers and consumers.
   messagingSystem?: string
   messagingDestination?: string
+  // GraphQL semconv (OTel). `graphql.operation.name` is the client-supplied
+  // operation name the execution span resolved (`GetUser`); `graphql.operation.type`
+  // is the operation kind (`query` / `mutation` / `subscription`). handleSpan reads
+  // both to mint an OBSERVED `CONTAINS` edge from the serving service to a
+  // per-operation node, recovering the operation-level topology that HTTP grain
+  // collapses onto `POST /graphql`. See docs/contracts/otel-ingest.md §GraphQL
+  // operations.
+  graphqlOperationName?: string
+  graphqlOperationType?: string
   // 0 = UNSET, 1 = OK, 2 = ERROR per OTLP. We only care that 2 means error.
   statusCode?: number
   errorMessage?: string
@@ -307,6 +316,16 @@ export function parseOtlpRequest(body: OtlpTracesRequest): ParsedSpan[] {
               ? (attrs['messaging.system'] as string)
               : undefined,
           messagingDestination: messagingDestinationOf(attrs),
+          graphqlOperationName:
+            typeof attrs['graphql.operation.name'] === 'string' &&
+            (attrs['graphql.operation.name'] as string).length > 0
+              ? (attrs['graphql.operation.name'] as string)
+              : undefined,
+          graphqlOperationType:
+            typeof attrs['graphql.operation.type'] === 'string' &&
+            (attrs['graphql.operation.type'] as string).length > 0
+              ? (attrs['graphql.operation.type'] as string)
+              : undefined,
           statusCode: span.status?.code,
           errorMessage: span.status?.message,
           exception: extractExceptionFromEvents(span.events),

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -86,6 +86,11 @@ export function embedText(node: GraphNode): string {
       if (tmpl) parts.push(`path=${tmpl}`)
       break
     }
+    case 'GraphQLOperationNode': {
+      const opType = (node as { operationType?: string }).operationType
+      if (opType) parts.push(`operationType=${opType}`)
+      break
+    }
     default:
       break
   }

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -1401,6 +1401,38 @@
               "_literal": "RouteNode"
             }
           }
+        },
+        "GraphQLOperationNode": {
+          "_object": {
+            "discoveredVia": {
+              "_optional": {
+                "_enum": [
+                  "merged",
+                  "otel",
+                  "static"
+                ]
+              }
+            },
+            "id": "_string",
+            "line": {
+              "_optional": {
+                "_number": [
+                  "int",
+                  "min"
+                ]
+              }
+            },
+            "name": "_string",
+            "operationName": "_string",
+            "operationType": "_string",
+            "path": {
+              "_optional": "_string"
+            },
+            "service": "_string",
+            "type": {
+              "_literal": "GraphQLOperationNode"
+            }
+          }
         }
       }
     }
@@ -1411,6 +1443,7 @@
       "DatabaseNode",
       "FileNode",
       "FrontierNode",
+      "GraphQLOperationNode",
       "InfraNode",
       "RouteNode",
       "ServiceNode"
@@ -1469,6 +1502,7 @@
                             "DatabaseNode",
                             "FileNode",
                             "FrontierNode",
+                            "GraphQLOperationNode",
                             "InfraNode",
                             "RouteNode",
                             "ServiceNode"
@@ -1480,6 +1514,7 @@
                             "DatabaseNode",
                             "FileNode",
                             "FrontierNode",
+                            "GraphQLOperationNode",
                             "InfraNode",
                             "RouteNode",
                             "ServiceNode"
@@ -1563,6 +1598,7 @@
                             "DatabaseNode",
                             "FileNode",
                             "FrontierNode",
+                            "GraphQLOperationNode",
                             "InfraNode",
                             "RouteNode",
                             "ServiceNode"
@@ -1595,6 +1631,7 @@
                             "DatabaseNode",
                             "FileNode",
                             "FrontierNode",
+                            "GraphQLOperationNode",
                             "InfraNode",
                             "RouteNode",
                             "ServiceNode"

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -9,11 +9,13 @@ import {
   type ErrorEvent,
   type DatabaseNode,
   fileId,
+  graphqlOperationId,
   infraId,
   type InfraNode,
   localDatabaseId,
   type GraphEdge,
   type GraphNode,
+  type GraphQLOperationNode,
   NodeType,
   Provenance,
 } from '@neat.is/types'
@@ -2205,5 +2207,162 @@ describe('handleSpan queue producer/consumer spans (#614)', () => {
       if (e.type === EdgeType.CONSUMES_FROM || e.type === EdgeType.PUBLISHES_TO) messagingEdges++
     })
     expect(messagingEdges).toBe(0)
+  })
+})
+
+// ── GraphQL operation spans (#615, ADR-122) ────────────────────────────────
+// Every GraphQL request rides one HTTP endpoint (POST /graphql), so at HTTP
+// grain the whole API collapses to a single edge and operation-level topology is
+// invisible. The execution span carries the operation the client actually named
+// (`graphql.operation.name` + `graphql.operation.type`), so handleSpan mints an
+// OBSERVED `service ──CONTAINS──▶ operation` edge to a per-operation node —
+// OBSERVED-only, keyed so a future static GraphQL extractor fuses onto the same
+// id. Fixtures use REAL SDK GraphQL execution shape: INTERNAL wire kind, the
+// `graphql.operation.*` semconv, and an ABSOLUTE `code.filepath` the
+// SpanProcessor stamps — reconciled onto the EXTRACTED path.
+describe('handleSpan GraphQL execution spans (#615)', () => {
+  let tmpDir: string
+  let ctx: IngestContext
+
+  beforeEach(async () => {
+    resetParentSpanCache()
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-graphql-'))
+    ctx = { graph: newGraph(), errorsPath: path.join(tmpDir, 'errors.ndjson') }
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+    resetParentSpanCache()
+  })
+
+  // An @opentelemetry/instrumentation-graphql execute span: INTERNAL kind (1),
+  // the graphql semconv, and a code.* call site for the resolver file.
+  function graphqlSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
+    return {
+      service: 'service-a',
+      traceId: 'trace-gql',
+      spanId: 'span-gql',
+      name: 'query GetUser',
+      kind: 1, // INTERNAL
+      startTimeUnixNano: '0',
+      endTimeUnixNano: '0',
+      durationNanos: 0n,
+      env: 'unknown',
+      attributes: {
+        'graphql.operation.name': 'GetUser',
+        'graphql.operation.type': 'query',
+        'code.filepath': '/var/task/src/resolvers/user.ts',
+        'code.lineno': 42,
+        'code.function': 'getUser',
+      },
+      graphqlOperationName: 'GetUser',
+      graphqlOperationType: 'query',
+      statusCode: 0,
+      ...overrides,
+    }
+  }
+
+  it('mints a file-grained OBSERVED CONTAINS edge from the serving service to the operation node', async () => {
+    // The extractor already parsed the resolver file the operation runs in.
+    ensureFileNode(ctx.graph, 'service-a', 'service:service-a', 'src/resolvers/user.ts')
+
+    await handleSpan(ctx, graphqlSpan())
+
+    // The operation node is keyed on (service, type, name) so a future static
+    // GraphQL extractor fuses onto the same id.
+    const opId = graphqlOperationId('service-a', 'query', 'GetUser')
+    expect(opId).toBe('graphql:service-a:query GetUser')
+    expect(ctx.graph.hasNode(opId)).toBe(true)
+    const op = ctx.graph.getNodeAttributes(opId) as GraphQLOperationNode
+    expect(op.type).toBe(NodeType.GraphQLOperationNode)
+    expect(op.name).toBe('GetUser')
+    expect(op.service).toBe('service-a')
+    expect(op.operationType).toBe('query')
+    expect(op.operationName).toBe('GetUser')
+    expect(op.discoveredVia).toBe('otel')
+
+    // The edge originates from the resolver's FileNode at the exact call site —
+    // file-grained, fused onto the EXTRACTED path (not the /var/task deployed one).
+    const fileNodeId = fileId('service-a', 'src/resolvers/user.ts')
+    const edgeId = `${EdgeType.CONTAINS}:OBSERVED:${fileNodeId}->${opId}`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.type).toBe(EdgeType.CONTAINS)
+    expect(edge.source).toBe(fileNodeId)
+    expect(edge.target).toBe(opId)
+    expect(edge.evidence?.file).toBe('src/resolvers/user.ts')
+    expect(edge.evidence?.line).toBe(42)
+  })
+
+  it('keys a distinct node per (operationType, operationName) — a mutation is not a query', async () => {
+    await handleSpan(ctx, graphqlSpan())
+    await handleSpan(
+      ctx,
+      graphqlSpan({
+        spanId: 'span-gql-2',
+        name: 'mutation CreateUser',
+        attributes: {
+          'graphql.operation.name': 'CreateUser',
+          'graphql.operation.type': 'mutation',
+        },
+        graphqlOperationName: 'CreateUser',
+        graphqlOperationType: 'mutation',
+      }),
+    )
+
+    const queryId = graphqlOperationId('service-a', 'query', 'GetUser')
+    const mutationId = graphqlOperationId('service-a', 'mutation', 'CreateUser')
+    expect(ctx.graph.hasNode(queryId)).toBe(true)
+    expect(ctx.graph.hasNode(mutationId)).toBe(true)
+
+    // No node collapse onto POST /graphql: two named operations, two nodes.
+    const opNodes: string[] = []
+    ctx.graph.forEachNode((id, a) => {
+      if ((a as { type: string }).type === NodeType.GraphQLOperationNode) opNodes.push(id)
+    })
+    expect(new Set(opNodes)).toEqual(new Set([queryId, mutationId]))
+  })
+
+  it('stays service-level when the execution span carries no call site', async () => {
+    await handleSpan(
+      ctx,
+      graphqlSpan({
+        attributes: {
+          'graphql.operation.name': 'GetUser',
+          'graphql.operation.type': 'query',
+        },
+      }),
+    )
+    const opId = graphqlOperationId('service-a', 'query', 'GetUser')
+    const edgeId = `${EdgeType.CONTAINS}:OBSERVED:service:service-a->${opId}`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.source).toBe('service:service-a')
+    expect(edge.evidence).toBeUndefined()
+  })
+
+  it('mints no operation node from the CLIENT side — client-side attribution is deferred', async () => {
+    await handleSpan(ctx, graphqlSpan({ kind: 3 })) // CLIENT
+    let opNodes = 0
+    ctx.graph.forEachNode((_id, a) => {
+      if ((a as { type: string }).type === NodeType.GraphQLOperationNode) opNodes++
+    })
+    expect(opNodes).toBe(0)
+  })
+
+  it('mints no operation node when the span names no operation type', async () => {
+    await handleSpan(
+      ctx,
+      graphqlSpan({
+        graphqlOperationType: undefined,
+        attributes: { 'graphql.operation.name': 'GetUser' },
+      }),
+    )
+    let opNodes = 0
+    ctx.graph.forEachNode((_id, a) => {
+      if ((a as { type: string }).type === NodeType.GraphQLOperationNode) opNodes++
+    })
+    expect(opNodes).toBe(0)
   })
 })

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -45,6 +45,14 @@ export const NodeType = {
   // what makes a two-sided divergence possible at route grain. See
   // docs/contracts/static-extraction.md.
   RouteNode: 'RouteNode',
+  // A named GraphQL operation — one query, mutation, or subscription — at
+  // (service, operationType, operationName) granularity (ADR-122). Every
+  // GraphQL request rides one HTTP endpoint (POST /graphql), so at HTTP grain
+  // the whole API collapses to a single edge; this node recovers the
+  // operation-level topology from the execution span's `graphql.operation.*`
+  // semconv. Minted observed-first from OTel; a future static GraphQL extractor
+  // fuses onto the same id. See docs/contracts/otel-ingest.md.
+  GraphQLOperationNode: 'GraphQLOperationNode',
 } as const
 
 export type NodeTypeValue = (typeof NodeType)[keyof typeof NodeType]
@@ -62,4 +70,5 @@ export const NodeTypeSchema = z.enum([
   NodeType.FrontierNode,
   NodeType.FileNode,
   NodeType.RouteNode,
+  NodeType.GraphQLOperationNode,
 ])

--- a/packages/types/src/identity.ts
+++ b/packages/types/src/identity.ts
@@ -14,6 +14,7 @@ const INFRA_PREFIX = 'infra:'
 const FRONTIER_PREFIX = 'frontier:'
 const FILE_PREFIX = 'file:'
 const ROUTE_PREFIX = 'route:'
+const GRAPHQL_OP_PREFIX = 'graphql:'
 
 // ServiceNode id: `service:<name>` for env-unknown nodes (the default,
 // produced by static extraction or by ingest when the span carries no env
@@ -166,6 +167,48 @@ export function parseRouteId(
   const pathTemplate = tail.slice(space + 1)
   if (service.length === 0 || method.length === 0 || pathTemplate.length === 0) return null
   return { service, method, pathTemplate }
+}
+
+// GraphQLOperationNode id: `graphql:<service>:<type> <operationName>` (ADR-122).
+// The `service` segment is the serving service's manifest name, matching the
+// FileNode / RouteNode convention so a shared operation name across monorepo
+// packages stays distinct. `type` is lower-cased (`query` / `mutation` /
+// `subscription`); `operationName` is the client-supplied operation name
+// verbatim. The space between type and name is unambiguous — a GraphQL operation
+// type never contains a space and a service name never contains a colon. A
+// GraphQL operation is a server-side artifact of a package, not an environment,
+// so the id is env-unscoped like FileNode / RouteNode: an OBSERVED execution
+// span and a future EXTRACTED schema/resolver land on the same node, which is
+// what makes an operation-grained two-sided divergence possible.
+export function graphqlOperationId(
+  service: string,
+  operationType: string,
+  operationName: string,
+): string {
+  return `${GRAPHQL_OP_PREFIX}${service}:${operationType.toLowerCase()} ${operationName}`
+}
+
+// Parse a GraphQL operation id into its (service, operationType, operationName)
+// tuple. Returns null when the input isn't a GraphQL operation id. Splits
+// service on the first colon after the prefix (service names carry no colon),
+// then type on the first space.
+export function parseGraphqlOperationId(
+  id: string,
+): { service: string; operationType: string; operationName: string } | null {
+  if (!id.startsWith(GRAPHQL_OP_PREFIX)) return null
+  const rest = id.slice(GRAPHQL_OP_PREFIX.length)
+  const colon = rest.indexOf(':')
+  if (colon === -1) return null
+  const service = rest.slice(0, colon)
+  const tail = rest.slice(colon + 1)
+  const space = tail.indexOf(' ')
+  if (space === -1) return null
+  const operationType = tail.slice(0, space)
+  const operationName = tail.slice(space + 1)
+  if (service.length === 0 || operationType.length === 0 || operationName.length === 0) {
+    return null
+  }
+  return { service, operationType, operationName }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/types/src/nodes.ts
+++ b/packages/types/src/nodes.ts
@@ -183,6 +183,33 @@ export const RouteNodeSchema = z.object({
 })
 export type RouteNode = z.infer<typeof RouteNodeSchema>
 
+// GraphQLOperationNode — a named GraphQL operation at
+// (service, operationType, operationName) granularity (ADR-122 /
+// docs/contracts/otel-ingest.md). Every GraphQL request rides one HTTP endpoint
+// (`POST /graphql`), so at HTTP grain the whole API collapses to a single edge;
+// this node recovers the operation-level topology the client actually named.
+// Identified by `graphqlOperationId(service, operationType, operationName)` →
+// `graphql:<service>:<type> <name>`. `service` is the serving service; `type` is
+// the operation kind (`query` / `mutation` / `subscription`); `name` mirrors
+// `operationName` for the shared node-name convention. `path` / `line` locate
+// the resolver in source when a future static GraphQL extractor fills them in —
+// absent in the observed-first cut, never fabricated (file-awareness.md §6). The
+// node is minted OBSERVED-first from the execution span's `graphql.operation.*`
+// semconv; a later static extractor fuses onto the same id, which is what makes
+// a two-sided divergence possible at operation grain.
+export const GraphQLOperationNodeSchema = z.object({
+  id: z.string(),
+  type: z.literal(NodeType.GraphQLOperationNode),
+  name: z.string(),
+  service: z.string(),
+  operationType: z.string(),
+  operationName: z.string(),
+  path: z.string().optional(),
+  line: z.number().int().nonnegative().optional(),
+  discoveredVia: DiscoveredViaSchema.optional(),
+})
+export type GraphQLOperationNode = z.infer<typeof GraphQLOperationNodeSchema>
+
 export const GraphNodeSchema = z.discriminatedUnion('type', [
   ServiceNodeSchema,
   DatabaseNodeSchema,
@@ -191,5 +218,6 @@ export const GraphNodeSchema = z.discriminatedUnion('type', [
   FrontierNodeSchema,
   FileNodeSchema,
   RouteNodeSchema,
+  GraphQLOperationNodeSchema,
 ])
 export type GraphNode = z.infer<typeof GraphNodeSchema>

--- a/packages/types/test/schemas.test.ts
+++ b/packages/types/test/schemas.test.ts
@@ -25,10 +25,11 @@ describe('runtime constants', () => {
     // IMPORTS joined with the import graph (ADR-092).
     expect(Object.values(EdgeType)).toHaveLength(9)
   })
-  it('NodeType has 7 values', () => {
+  it('NodeType has 8 values', () => {
     // FileNode joined the set with the file-first graph (ADR-089); RouteNode
-    // joined with server-route extraction (ADR-119).
-    expect(Object.values(NodeType)).toHaveLength(7)
+    // joined with server-route extraction (ADR-119); GraphQLOperationNode joined
+    // with operation-grain GraphQL observation (ADR-122).
+    expect(Object.values(NodeType)).toHaveLength(8)
   })
 })
 


### PR DESCRIPTION
A GraphQL service yields zero OBSERVED edges worth reading today: every operation rides one HTTP endpoint (`POST /graphql`), so at HTTP grain the whole API collapses to a single edge and the operation-level topology stays invisible.

This reads the GraphQL execution span. When a span carries `graphql.operation.name` and `graphql.operation.type`, `handleSpan` mints an OBSERVED `CONTAINS` edge from the serving service to a per-operation `GraphQLOperationNode` — the same structural ownership verb a service has over a route (ADR-119) and a file (file-awareness.md §2). The graph now shows the operations a client actually names, not one flattened endpoint.

Design (ADR-122):

- **Operation-grain.** One node per named operation, keyed on `graphqlOperationId(service, operationType, operationName)` → `graphql:<service>:<type> <name>`, with the type normalised lower-case so `query` and `Query` land on one node.
- **OBSERVED-only.** The SDL / resolver map is not parsed statically in this cut. The node is minted observed-first, its id chosen so a future static GraphQL extractor fuses onto the same node rather than twinning.
- **File-grained** through the usual `code.*` call-site path (the resolver span) when present, service-level otherwise — never fabricated.
- **Serving side only.** The gate admits SERVER / INTERNAL / unkinded spans and requires both operation name and type; a CLIENT/PRODUCER/CONSUMER span mints nothing.

Deferred: resolver / field-grain edges, static GraphQL schema extraction, and client-side operation attribution.

Contracts `otel-ingest.md` and `identity.md` carry the new section and wire-format row; the schema snapshot regenerates additively (`NodeType` 7 → 8).

Refs #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)