### PR TITLE
Give gRPC a method-grain, two-sided topology

### DIFF
--- a/docs/contracts/identity.md
+++ b/docs/contracts/identity.md
@@ -6,7 +6,7 @@ governs:
   - "packages/core/src/ingest.ts"
   - "packages/types/src/nodes.ts"
   - "packages/types/src/identity.ts"
-adr: [ADR-028, ADR-122]
+adr: [ADR-028, ADR-122, ADR-123]
 enforcement: [lint, review]
 ---
 
@@ -17,7 +17,7 @@ Every node id in NEAT is constructed via the helpers in `packages/types/src/iden
 ## Helpers
 
 ```ts
-import { serviceId, databaseId, configId, infraId, frontierId, graphqlOperationId } from '@neat.is/types'
+import { serviceId, databaseId, configId, infraId, frontierId, graphqlOperationId, grpcMethodId } from '@neat.is/types'
 
 serviceId('checkout')                     // 'service:checkout'
 databaseId('db.example.com')              // 'database:db.example.com'
@@ -25,6 +25,7 @@ configId('apps/web/.env')                 // 'config:apps/web/.env'
 infraId('redis', 'cache.internal')        // 'infra:redis:cache.internal'
 frontierId('payments-api:8080')           // 'frontier:payments-api:8080'
 graphqlOperationId('api', 'query', 'GetUser')  // 'graphql:api:query GetUser'
+grpcMethodId('orders.OrderService', 'GetOrder')  // 'grpc:orders.OrderService/GetOrder'
 ```
 
 Inverses (`parseServiceId`, `parseDatabaseId`, etc.) return the inner segment or `null` if the id doesn't match. Use them anywhere a consumer strips a prefix.
@@ -39,6 +40,7 @@ Inverses (`parseServiceId`, `parseDatabaseId`, etc.) return the inner segment or
 | InfraNode     | `infra:<kind>:<name>`         | free-string kind sub-typing per ADR-022             |
 | FrontierNode  | `frontier:<host>`             | host:port from OTel peer attribute                  |
 | GraphQLOperationNode | `graphql:<service>:<type> <name>` | serving service + lower-cased operation type + client operation name (ADR-122) |
+| GrpcMethodNode | `grpc:<rpcService>/<rpcMethod>` | fully-qualified gRPC `rpc.service` (`<package>.<Service>`) + method — the wire contract, NOT the NEAT manifest name, so OBSERVED span and static `.proto` fuse (ADR-123) |
 
 ## Reconciliation rules
 

--- a/docs/contracts/otel-ingest.md
+++ b/docs/contracts/otel-ingest.md
@@ -1,11 +1,11 @@
 ---
 name: otel-ingest
-description: OTel receiver replies before mutation, lastObserved derives from span time, parent-span cache correlates cross-service CALLS, exception data is parsed from span events, unseen services and DBs are auto-created, queue producers and consumers mint file-grained messaging edges to the destination topic, GraphQL execution spans mint an operation-grain CONTAINS edge, span-derived edges always carry OBSERVED provenance.
+description: OTel receiver replies before mutation, lastObserved derives from span time, parent-span cache correlates cross-service CALLS, exception data is parsed from span events, unseen services and DBs are auto-created, queue producers and consumers mint file-grained messaging edges to the destination topic, GraphQL execution spans mint an operation-grain CONTAINS edge, gRPC execution spans mint a method-grain CONTAINS edge, span-derived edges always carry OBSERVED provenance.
 governs:
   - "packages/core/src/ingest.ts"
   - "packages/core/src/otel.ts"
   - "packages/core/src/otel-grpc.ts"
-adr: [ADR-033, ADR-113, ADR-117, ADR-118, ADR-121, ADR-122, ADR-029, ADR-030, ADR-068]
+adr: [ADR-033, ADR-113, ADR-117, ADR-118, ADR-121, ADR-122, ADR-123, ADR-029, ADR-030, ADR-068]
 enforcement: [lint, review]
 ---
 
@@ -71,6 +71,18 @@ The operation node is keyed on `graphqlOperationId(service, operationType, opera
 The edge is **file-grained** through the same call-site path as any other OBSERVED edge (file-awareness.md §4): when the execution span carries `code.*` (the resolver call site), the edge originates from that `FileNode` at the exact `file:line`, reconciled onto the EXTRACTED service-relative path (`reconcileObservedRelPath`, ADR-118); without a call site it stays service-level, honestly. The GraphQL gate (`spanServesGraphqlOperation`) admits only the serving side — SERVER / INTERNAL / unkinded spans — and only when the span names **both** an operation name and type: a CLIENT/PRODUCER/CONSUMER span mints nothing (client-side operation attribution is deferred), and a nameless or typeless execution span falls through rather than keying a fabricated operation.
 
 Deferred: resolver / field-grain edges, static GraphQL schema extraction, and client-side operation attribution.
+
+## gRPC execution spans mint a method-grain `CONTAINS` edge (ADR-123, refs #616)
+
+gRPC used to engage only at service grain: every RPC method collapsed onto one service→service edge, so the per-method topology was invisible, and it was one-sided — nothing read the `.proto` service contract. The serving span carries the method the caller actually invoked: `handleSpan` reads `rpc.service` (the fully-qualified `orders.OrderService`) and `rpc.method` (`GetOrder`) under `rpc.system=grpc` and mints an OBSERVED `CONTAINS` edge from the serving service to a per-method `GrpcMethodNode`, recovering the method-level shape the service-grain edge flattens.
+
+The method node is keyed on `grpcMethodId(rpcService, rpcMethod)` → `grpc:<rpcService>/<rpcMethod>` (identity.md). Unlike the route / GraphQL-operation ids, it keys on the **fully-qualified `rpc.service`, not the NEAT manifest service name** — that FQN is the wire contract both the OBSERVED span and the static `.proto` carry verbatim, and it is globally unique across a gRPC mesh, so keying on it is exactly what fuses the observed method and its declared `.proto` definition onto one node. The ownership edge is `CONTAINS` — the same structural verb a service has over a route (ADR-119), a GraphQL operation (ADR-122), and a file (file-awareness.md §2) — carrying OBSERVED provenance; the implementing service's ownership is that edge, not part of the node identity.
+
+The edge is **file-grained** through the same call-site path as any other OBSERVED edge (file-awareness.md §4): when the serving span carries `code.*` (the handler call site), the edge originates from that `FileNode` at the exact `file:line`, reconciled onto the EXTRACTED service-relative path (`reconcileObservedRelPath`, ADR-118); without a call site it stays service-level, honestly. The gRPC gate (`spanServesGrpcMethod`) admits only the serving side — SERVER / INTERNAL / unkinded spans — and only when `rpc.system` is `grpc` and the span names **both** a service and a method: a CLIENT span mints no ownership (client-side attribution is deferred) and instead falls through to the cross-service resolver, so the caller→callee edge is unaffected; a non-gRPC `rpc.system` (Thrift, Connect) falls through.
+
+The static half — `.proto` service/method extraction minting the same nodes — lives in [static-extraction.md](./static-extraction.md); the two provenances fuse into a method-grain divergence.
+
+Deferred: client-side method attribution, `grpc.status_code` / error-detail enrichment on incidents, and `.proto` `import` resolution across files.
 
 ## OBSERVED provenance for span-derived edges (ADR-068)
 

--- a/docs/contracts/static-extraction.md
+++ b/docs/contracts/static-extraction.md
@@ -4,7 +4,7 @@ description: Producers under packages/core/src/extract/* read source code and co
 governs:
   - "packages/core/src/extract/**"
   - "packages/core/src/watch.ts"
-adr: [ADR-032, ADR-065, ADR-115, ADR-119, ADR-030, ADR-031, ADR-024, ADR-055]
+adr: [ADR-032, ADR-065, ADR-115, ADR-119, ADR-123, ADR-030, ADR-031, ADR-024, ADR-055]
 enforcement: [lint, review]
 ---
 
@@ -98,6 +98,7 @@ Other extensions are skipped silently by `walkSourceFiles` per `IGNORED_DIRS` an
 | `calls/{aws,grpc,http,kafka,redis,supabase}.ts` | CALLS / PUBLISHES_TO / CONSUMES_FROM | ✅          |
 | `routes.ts`          | RouteNode + `service ──CONTAINS──▶ route` (ADR-119) | ✅         |
 | `calls/route-match.ts` | client `file ──CALLS──▶ route` cross-service match (ADR-119) | ✅ |
+| `proto.ts`           | GrpcMethodNode + `service ──CONTAINS──▶ method` from `.proto` (ADR-123) | ✅ |
 | `infra/{docker-compose,dockerfile,k8s,terraform}.ts` | InfraNode + DEPENDS_ON / RUNS_ON / CONNECTS_TO | ✅ (evidence populated) |
 
 New producers under `calls/` for source-level DB connections (`new pg.Pool(...)`) and inter-service imports land under issue #141. They follow the same interface, same evidence shape, same idempotency.
@@ -137,6 +138,12 @@ The declared template is kept verbatim on the node (`/users/:id`), so a future O
 **Client↔route matching (`calls/route-match.ts`).** A recognised HTTP client call site — `fetch`, `axios` (default instance + method calls), node `http`/`https` — carries its method and path-template alongside the host. The host resolves to a service through the shared `buildServiceHostIndex` / `urlMatchesHost` path (ADR-065 #5); the path-template matches a server route by reducing both sides to a param-agnostic key (`normalizePathTemplate`: every dynamic segment — `:id`, `{id}`, `[id]`, a `${…}` interpolation, or a concrete id — collapses to `:param`, literals lowercase). A match mints a route-grained `file ──CALLS──▶ route` EXTRACTED edge from the client's FileNode to the server's RouteNode, carrying the method + path-template on its evidence. It grades `verified-call-site` (0.85) — both endpoints are recognised — so it clears the precision floor. The host + path must sit in the same URL literal for a match; split base-URL + path is out of scope for this slice. Route extraction runs before the calls phase so the matcher sees the full route table.
 
 This realises the cross-service contract-matching idea: the route-grained edge is the shared target an OBSERVED server-span edge (issue #576) also lands on, so `get_divergences` compares declared against observed at route grain, not only at service grain — see [`divergence-query.md`](./divergence-query.md). Per [ADR-119](../decisions.md#adr-119--http-client-call-site--cross-service-route-matching).
+
+## gRPC `.proto` method extraction (ADR-123)
+
+Static extraction reaches gRPC method grain. `proto.ts` reads each service's `.proto` files **as data** — a bounded, brace-balanced line-scan for `service X { rpc Method(Req) returns (Res); }`, the way `calls/kafka.ts` scans for topics and the infra extractors read terraform / Dockerfiles. No tree-sitter grammar and no new language enter the toolchain (CLAUDE.md: Node 20 + TS only; polyglot files are read as data). Each `rpc` becomes a `GrpcMethodNode`, owned by the service the proto lives in through a `service ──CONTAINS──▶ method` edge (structural, evidence pinned to the `rpc` line). Streaming qualifiers (`stream Req` / `stream Res`) don't change method identity.
+
+The node id is `grpcMethodId(rpcService, rpcMethod)` → `grpc:<rpcService>/<rpcMethod>`, built from the identity helper, where `rpcService` is the **fully-qualified** `<package>.<Service>` name the `.proto` declares (`orders.OrderService`). That FQN is precisely the `rpc.service` an OBSERVED gRPC execution span carries (see [`otel-ingest.md`](./otel-ingest.md) §gRPC methods), so the declared method and its observed counterpart fuse onto **one node** rather than twinning — the static half of two-sided gRPC observation. This is the same shape as route extraction: a static producer and an OBSERVED span landing on a shared node, so `get_divergences` compares declared gRPC methods against observed traffic at method grain. Message / field grain, `import` resolution across proto files, and error-detail enrichment are out of scope for this slice. Per ADR-123.
 
 ## Precision filters (ADR-065)
 

--- a/packages/core/src/extract/index.ts
+++ b/packages/core/src/extract/index.ts
@@ -1,7 +1,8 @@
 // Static-extraction pipeline. Phase order is load-bearing:
-//   services → aliases → databases (+ compat) → configs → routes → calls → infra → frontier promotion.
+//   services → aliases → databases (+ compat) → configs → routes → grpc → calls → infra → frontier promotion.
 //   Routes precede calls so the cross-service matcher (ADR-119) sees the full
-//   RouteNode table when it resolves client call sites to server routes.
+//   RouteNode table when it resolves client call sites to server routes. gRPC
+//   `.proto` extraction (ADR-123) mints the method nodes an OBSERVED span fuses onto.
 //
 // Contract anchors (see /docs/contracts.md):
 //   * Rule 1 — Every emitted edge carries Provenance.EXTRACTED from @neat.is/types.
@@ -24,6 +25,7 @@ import { addImports } from './imports.js'
 import { addDatabasesAndCompat } from './databases/index.js'
 import { addConfigNodes } from './configs.js'
 import { addRoutes } from './routes.js'
+import { addGrpcMethods } from './proto.js'
 import { addCallEdges } from './calls/index.js'
 import { addInfra } from './infra/index.js'
 import {
@@ -99,6 +101,11 @@ export async function extractFromDirectory(
   // Route extraction (ADR-119) runs before calls so the RouteNodes exist when
   // addCallEdges' cross-service matcher (route-match.ts) looks them up.
   const routePhase = await addRoutes(graph, services)
+  // gRPC `.proto` service/method extraction (ADR-123). Independent of the call
+  // phase — it reads the proto contract surface, not JS/TS call sites — and mints
+  // the same method nodes an OBSERVED gRPC span lands on, so declared and observed
+  // methods fuse.
+  const grpcPhase = await addGrpcMethods(graph, services)
   const phase4 = await addCallEdges(graph, services)
   const phase5 = await addInfra(graph, scanPath, services)
   // #140 — drop EXTRACTED edges whose evidence.file no longer exists on disk.
@@ -162,6 +169,7 @@ export async function extractFromDirectory(
       phase2.nodesAdded +
       phase3.nodesAdded +
       routePhase.nodesAdded +
+      grpcPhase.nodesAdded +
       phase4.nodesAdded +
       phase5.nodesAdded,
     edgesAdded:
@@ -170,6 +178,7 @@ export async function extractFromDirectory(
       phase2.edgesAdded +
       phase3.edgesAdded +
       routePhase.edgesAdded +
+      grpcPhase.edgesAdded +
       phase4.edgesAdded +
       phase5.edgesAdded,
     frontiersPromoted,

--- a/packages/core/src/extract/proto.ts
+++ b/packages/core/src/extract/proto.ts
@@ -1,0 +1,198 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import type { GraphEdge, GrpcMethodNode } from '@neat.is/types'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  confidenceForExtracted,
+  extractedEdgeId,
+  grpcMethodId,
+} from '@neat.is/types'
+import type { NeatGraph } from '../graph.js'
+import { IGNORED_DIRS, isPythonVenvDir, isTestPath, type DiscoveredService } from './shared.js'
+import { recordExtractionError } from './errors.js'
+import { snippet, toPosix } from './calls/shared.js'
+
+// gRPC `.proto` service/method extraction (ADR-123). gRPC used to engage only at
+// service grain — the client-stub detector in calls/grpc.ts maps a
+// `new OrderServiceClient()` to one `infra:grpc-service:*` node, and nothing read
+// the method surface at all. This producer reads the `.proto` service contract
+// as DATA (a bounded line-scan, no tree-sitter grammar — polyglot files are read
+// as data, CLAUDE.md) and materialises each `rpc` as a `GrpcMethodNode`, owned by
+// the service the proto lives in through a `service ──CONTAINS──▶ method` edge.
+//
+// This is the static half of two-sided gRPC observation: the node is keyed on the
+// fully-qualified `<package>.<Service>` name — the exact `rpc.service` an OBSERVED
+// execution span carries — so a declared method and its observed counterpart fuse
+// onto one node into a method-grain divergence (docs/contracts/otel-ingest.md
+// §gRPC methods). Scope is the service/method definitions only; message/field
+// grain, `import` resolution across proto files, and error-detail enrichment are
+// out of scope for this slice.
+
+const PROTO_EXTENSION = '.proto'
+
+// A `.proto` service/method definition parsed out of one file.
+export interface ExtractedGrpcMethod {
+  rpcService: string // fully-qualified `<package>.<Service>` (or bare `<Service>` when the file declares no package)
+  rpcMethod: string // bare method name, e.g. `GetOrder`
+  line: number // 1-indexed line the `rpc` is declared on
+}
+
+// ── `.proto` parsing (data, not a grammar) ──────────────────────────────────
+
+// The file-level `package foo.bar;` declaration, if present. gRPC fully-qualifies
+// `rpc.service` as `<package>.<Service>`, so the package prefixes every service
+// name in the file. proto2/proto3 both use this single-line form.
+function packageOf(content: string): string | null {
+  const m = content.match(/^\s*package\s+([A-Za-z_][A-Za-z0-9_.]*)\s*;/m)
+  return m ? m[1]! : null
+}
+
+// The 1-indexed line an absolute character offset falls on.
+function lineAt(content: string, offset: number): number {
+  return content.slice(0, offset).split('\n').length
+}
+
+// Scan a `.proto` file's `service X { rpc M(Req) returns (Res); }` blocks and
+// emit one method per `rpc`. Brace-balanced so a service body is read to its
+// close; the `rpc` scan is confined to that body. Streaming qualifiers
+// (`rpc M(stream Req) returns (stream Res)`) don't change the method identity, so
+// they're accepted and ignored. Comment-only or option lines that merely mention
+// `rpc`/`service` don't match — both anchors require the keyword followed by an
+// identifier and the structural token (`{` for a service, `(` for an rpc).
+export function grpcMethodsFromProto(content: string, fqPackage: string | null): ExtractedGrpcMethod[] {
+  const out: ExtractedGrpcMethod[] = []
+  const serviceRe = /\bservice\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{/g
+  let sm: RegExpExecArray | null
+  while ((sm = serviceRe.exec(content)) !== null) {
+    const serviceName = sm[1]!
+    const rpcService = fqPackage ? `${fqPackage}.${serviceName}` : serviceName
+    // Walk from the opening brace to its matching close, tracking depth so a
+    // nested block (an inline `option`/message) doesn't end the service early.
+    const bodyStart = serviceRe.lastIndex // index just past the `{`
+    let depth = 1
+    let i = bodyStart
+    for (; i < content.length && depth > 0; i++) {
+      const ch = content[i]
+      if (ch === '{') depth++
+      else if (ch === '}') depth--
+    }
+    const body = content.slice(bodyStart, i - 1)
+    const rpcRe = /\brpc\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g
+    let rm: RegExpExecArray | null
+    while ((rm = rpcRe.exec(body)) !== null) {
+      const rpcMethod = rm[1]!
+      const line = lineAt(content, bodyStart + rm.index)
+      out.push({ rpcService, rpcMethod, line })
+    }
+    // Continue the outer scan past this service body.
+    serviceRe.lastIndex = i
+  }
+  return out
+}
+
+// ── file discovery ──────────────────────────────────────────────────────────
+
+// Walk a service directory for `.proto` files, honouring the shared ignore set
+// (node_modules, .git, …) and Python venvs the same way walkSourceFiles does.
+// `.proto` isn't a SERVICE_FILE_EXTENSION, so the source-file walker skips it —
+// this is a dedicated pass over the proto contract surface.
+async function walkProtoFiles(dir: string): Promise<string[]> {
+  const out: string[] = []
+  async function walk(current: string): Promise<void> {
+    const entries = await fs.readdir(current, { withFileTypes: true }).catch(() => [])
+    for (const entry of entries) {
+      const full = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        if (IGNORED_DIRS.has(entry.name)) continue
+        if (await isPythonVenvDir(full)) continue
+        await walk(full)
+      } else if (entry.isFile() && path.extname(entry.name) === PROTO_EXTENSION) {
+        out.push(full)
+      }
+    }
+  }
+  await walk(dir)
+  return out
+}
+
+// ── producer ─────────────────────────────────────────────────────────────────
+
+export async function addGrpcMethods(
+  graph: NeatGraph,
+  services: DiscoveredService[],
+): Promise<{ nodesAdded: number; edgesAdded: number }> {
+  let nodesAdded = 0
+  let edgesAdded = 0
+
+  for (const service of services) {
+    const protoPaths = await walkProtoFiles(service.dir)
+    for (const protoPath of protoPaths) {
+      // ADR-065 #1 — test-scope exclusion. A `.proto` under a test tree isn't the
+      // service's declared contract surface.
+      if (isTestPath(protoPath)) continue
+      const relFile = toPosix(path.relative(service.dir, protoPath))
+
+      let content: string
+      try {
+        content = await fs.readFile(protoPath, 'utf8')
+      } catch (err) {
+        recordExtractionError('proto extraction', protoPath, err)
+        continue
+      }
+
+      let methods: ExtractedGrpcMethod[]
+      try {
+        methods = grpcMethodsFromProto(content, packageOf(content))
+      } catch (err) {
+        recordExtractionError('proto extraction', protoPath, err)
+        continue
+      }
+      if (methods.length === 0) continue
+
+      for (const method of methods) {
+        const mid = grpcMethodId(method.rpcService, method.rpcMethod)
+        if (!graph.hasNode(mid)) {
+          const node: GrpcMethodNode = {
+            id: mid,
+            type: NodeType.GrpcMethodNode,
+            name: `${method.rpcService}/${method.rpcMethod}`,
+            rpcService: method.rpcService,
+            rpcMethod: method.rpcMethod,
+            path: relFile,
+            line: method.line,
+            discoveredVia: 'static',
+          }
+          graph.addNode(mid, node)
+          nodesAdded++
+        }
+        // `service ──CONTAINS──▶ method` — the service owns the methods its
+        // `.proto` declares, the same structural verb it has over its routes
+        // (ADR-119) and files (file-awareness.md §2). Evidence pinned to the
+        // `rpc` line. The node id is the wire-canonical FQN, so an OBSERVED
+        // execution span lands on this same node — declared and observed fuse.
+        const containsId = extractedEdgeId(service.node.id, mid, EdgeType.CONTAINS)
+        if (!graph.hasEdge(containsId)) {
+          const edge: GraphEdge = {
+            id: containsId,
+            source: service.node.id,
+            target: mid,
+            type: EdgeType.CONTAINS,
+            provenance: Provenance.EXTRACTED,
+            confidence: confidenceForExtracted('structural'),
+            evidence: {
+              file: relFile,
+              line: method.line,
+              snippet: snippet(content, method.line),
+            },
+          }
+          graph.addEdgeWithKey(containsId, service.node.id, mid, edge)
+          edgesAdded++
+        }
+      }
+    }
+  }
+
+  return { nodesAdded, edgesAdded }
+}

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -9,6 +9,7 @@ import type {
   GraphEdge,
   GraphNode,
   GraphQLOperationNode,
+  GrpcMethodNode,
   InfraNode,
   Policy,
   ServiceNode,
@@ -28,6 +29,7 @@ import {
   fileId,
   frontierId,
   graphqlOperationId,
+  grpcMethodId,
   inferredEdgeId,
   infraId,
   observedEdgeId,
@@ -789,6 +791,46 @@ function ensureGraphqlOperationNode(
     service: serviceName,
     operationType: operationType.toLowerCase(),
     operationName,
+    discoveredVia: 'otel',
+  }
+  graph.addNode(id, node)
+  return id
+}
+
+// The gRPC execution span carrying `rpc.service` / `rpc.method` is emitted on
+// both sides of a call — the SERVER that resolves the method and the CLIENT that
+// invokes it. Only the serving side owns the method (ADR-123): gating out the
+// caller/producer/consumer kinds keeps a CLIENT gRPC span from attributing
+// ownership to the caller (that client span still falls through to the
+// cross-service resolver below, so the caller→callee edge is unaffected).
+// Client→method attribution is deferred. An unkinded / UNSET span still mints,
+// mirroring the graphql and caller-side gates' legacy fallbacks.
+function spanServesGrpcMethod(kind: number | undefined): boolean {
+  return (
+    kind !== WIRE_SPAN_KIND_CLIENT &&
+    kind !== WIRE_SPAN_KIND_PRODUCER &&
+    kind !== WIRE_SPAN_KIND_CONSUMER
+  )
+}
+
+// A gRPC method node keyed on (rpcService, rpcMethod) via grpcMethodId (ADR-123).
+// `rpcService` is the fully-qualified `rpc.service` the wire carries verbatim
+// (`orders.OrderService`), so an OBSERVED span and a static `.proto` definition
+// fuse onto one node rather than twinning. Idempotent — a high-volume method
+// upserts, never grows the node set.
+function ensureGrpcMethodNode(
+  graph: NeatGraph,
+  rpcService: string,
+  rpcMethod: string,
+): string {
+  const id = grpcMethodId(rpcService, rpcMethod)
+  if (graph.hasNode(id)) return id
+  const node: GrpcMethodNode = {
+    id,
+    type: NodeType.GrpcMethodNode,
+    name: `${rpcService}/${rpcMethod}`,
+    rpcService,
+    rpcMethod,
     discoveredVia: 'otel',
   }
   graph.addNode(id, node)
@@ -1591,6 +1633,43 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
       span.graphqlOperationType,
       span.graphqlOperationName,
     )
+    const result = upsertObservedEdge(
+      ctx.graph,
+      EdgeType.CONTAINS,
+      observedSource(),
+      targetId,
+      ts,
+      isError,
+      callSiteEvidence,
+    )
+    if (result) affectedNode = targetId
+  } else if (
+    span.rpcSystem === 'grpc' &&
+    span.rpcService &&
+    span.rpcMethod &&
+    spanServesGrpcMethod(span.kind)
+  ) {
+    // gRPC execution span (issue #616). gRPC used to engage only at service
+    // grain: every method collapsed onto one service→service edge, so the
+    // per-method topology was invisible and one-sided. The serving span carries
+    // the method the caller actually invoked — `rpc.service` (the fully-qualified
+    // `orders.OrderService`) with `rpc.method` (`GetOrder`) — so mint an OBSERVED
+    // `CONTAINS` edge from the serving service to a per-method node, the same
+    // ownership shape a service has over a route (ADR-119), a GraphQL operation
+    // (ADR-122), and a file (file-awareness.md §2). The node is keyed on the
+    // fully-qualified `rpc.service` — the wire contract both the span and the
+    // `.proto` carry verbatim — so the static `.proto` extractor's declared
+    // method fuses onto this same id into a two-sided divergence (ADR-123).
+    // File-grained through the same call-site path as any other OBSERVED edge
+    // (file-awareness.md §4): when the span carries `code.*` (the handler call
+    // site) the edge originates from that `FileNode` at the exact `file:line`,
+    // reconciled onto the EXTRACTED service-relative path; without a call site it
+    // stays service-level, honestly. The gate admits only the serving side —
+    // SERVER / INTERNAL / unkinded — so a CLIENT span mints no ownership
+    // (client→method attribution is deferred) and instead falls through to the
+    // cross-service resolver, leaving the caller→callee edge intact. Both service
+    // and method must be present to key a stable id.
+    const targetId = ensureGrpcMethodNode(ctx.graph, span.rpcService, span.rpcMethod)
     const result = upsertObservedEdge(
       ctx.graph,
       EdgeType.CONTAINS,

--- a/packages/core/src/otel.ts
+++ b/packages/core/src/otel.ts
@@ -67,6 +67,17 @@ export interface ParsedSpan {
   // operations.
   graphqlOperationName?: string
   graphqlOperationType?: string
+  // gRPC RPC semconv (OTel). `rpc.system` names the RPC framework (`grpc`);
+  // `rpc.service` is the fully-qualified proto service (`orders.OrderService`)
+  // and `rpc.method` the bare method (`GetOrder`). The serving (SERVER) and
+  // calling (CLIENT) sides both carry these. handleSpan reads them off the
+  // serving span to mint an OBSERVED `CONTAINS` edge from the serving service to
+  // a per-method node, recovering the method-level topology gRPC's service-grain
+  // edge collapses — and keyed so the static `.proto` definition fuses onto the
+  // same node. See docs/contracts/otel-ingest.md §gRPC methods.
+  rpcSystem?: string
+  rpcService?: string
+  rpcMethod?: string
   // 0 = UNSET, 1 = OK, 2 = ERROR per OTLP. We only care that 2 means error.
   statusCode?: number
   errorMessage?: string
@@ -325,6 +336,21 @@ export function parseOtlpRequest(body: OtlpTracesRequest): ParsedSpan[] {
             typeof attrs['graphql.operation.type'] === 'string' &&
             (attrs['graphql.operation.type'] as string).length > 0
               ? (attrs['graphql.operation.type'] as string)
+              : undefined,
+          rpcSystem:
+            typeof attrs['rpc.system'] === 'string' &&
+            (attrs['rpc.system'] as string).length > 0
+              ? (attrs['rpc.system'] as string)
+              : undefined,
+          rpcService:
+            typeof attrs['rpc.service'] === 'string' &&
+            (attrs['rpc.service'] as string).length > 0
+              ? (attrs['rpc.service'] as string)
+              : undefined,
+          rpcMethod:
+            typeof attrs['rpc.method'] === 'string' &&
+            (attrs['rpc.method'] as string).length > 0
+              ? (attrs['rpc.method'] as string)
               : undefined,
           statusCode: span.status?.code,
           errorMessage: span.status?.message,

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -91,6 +91,13 @@ export function embedText(node: GraphNode): string {
       if (opType) parts.push(`operationType=${opType}`)
       break
     }
+    case 'GrpcMethodNode': {
+      const rpcService = (node as { rpcService?: string }).rpcService
+      const rpcMethod = (node as { rpcMethod?: string }).rpcMethod
+      if (rpcService) parts.push(`rpcService=${rpcService}`)
+      if (rpcMethod) parts.push(`rpcMethod=${rpcMethod}`)
+      break
+    }
     default:
       break
   }

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -1433,6 +1433,37 @@
               "_literal": "GraphQLOperationNode"
             }
           }
+        },
+        "GrpcMethodNode": {
+          "_object": {
+            "discoveredVia": {
+              "_optional": {
+                "_enum": [
+                  "merged",
+                  "otel",
+                  "static"
+                ]
+              }
+            },
+            "id": "_string",
+            "line": {
+              "_optional": {
+                "_number": [
+                  "int",
+                  "min"
+                ]
+              }
+            },
+            "name": "_string",
+            "path": {
+              "_optional": "_string"
+            },
+            "rpcMethod": "_string",
+            "rpcService": "_string",
+            "type": {
+              "_literal": "GrpcMethodNode"
+            }
+          }
         }
       }
     }
@@ -1444,6 +1475,7 @@
       "FileNode",
       "FrontierNode",
       "GraphQLOperationNode",
+      "GrpcMethodNode",
       "InfraNode",
       "RouteNode",
       "ServiceNode"
@@ -1503,6 +1535,7 @@
                             "FileNode",
                             "FrontierNode",
                             "GraphQLOperationNode",
+                            "GrpcMethodNode",
                             "InfraNode",
                             "RouteNode",
                             "ServiceNode"
@@ -1515,6 +1548,7 @@
                             "FileNode",
                             "FrontierNode",
                             "GraphQLOperationNode",
+                            "GrpcMethodNode",
                             "InfraNode",
                             "RouteNode",
                             "ServiceNode"
@@ -1599,6 +1633,7 @@
                             "FileNode",
                             "FrontierNode",
                             "GraphQLOperationNode",
+                            "GrpcMethodNode",
                             "InfraNode",
                             "RouteNode",
                             "ServiceNode"
@@ -1632,6 +1667,7 @@
                             "FileNode",
                             "FrontierNode",
                             "GraphQLOperationNode",
+                            "GrpcMethodNode",
                             "InfraNode",
                             "RouteNode",
                             "ServiceNode"

--- a/packages/core/test/extract-proto.test.ts
+++ b/packages/core/test/extract-proto.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import { handleSpan, type IngestContext } from '../src/ingest.js'
+import type { ParsedSpan } from '../src/otel.js'
+import type { GraphEdge, GrpcMethodNode } from '@neat.is/types'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  extractedEdgeId,
+  grpcMethodId,
+  serviceId,
+} from '@neat.is/types'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES = path.resolve(__dirname, 'fixtures', 'grpc')
+
+// ADR-123 — gRPC `.proto` service/method extraction, the static half of two-sided
+// gRPC observation. The fixture is a real `orders` service carrying an
+// `orders.proto` that declares `service OrderService { rpc GetOrder…; rpc
+// ListOrders…; }` under `package orders;`. The producer reads it as data and
+// mints a GrpcMethodNode per rpc, keyed on the fully-qualified `orders.OrderService`
+// — the exact `rpc.service` an OBSERVED span carries — so declared and observed
+// methods fuse.
+describe('gRPC .proto method extraction (ADR-123)', () => {
+  beforeEach(() => resetGraph())
+
+  it('materialises a GrpcMethodNode per rpc with FQ service + method + file:line', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    const getOrder = grpcMethodId('orders.OrderService', 'GetOrder')
+    expect(getOrder).toBe('grpc:orders.OrderService/GetOrder')
+    expect(graph.hasNode(getOrder)).toBe(true)
+    const node = graph.getNodeAttributes(getOrder) as GrpcMethodNode
+    expect(node.type).toBe(NodeType.GrpcMethodNode)
+    expect(node.rpcService).toBe('orders.OrderService')
+    expect(node.rpcMethod).toBe('GetOrder')
+    expect(node.name).toBe('orders.OrderService/GetOrder')
+    expect(node.path).toBe('proto/orders.proto')
+    expect(node.line).toBeGreaterThan(0)
+    expect(node.discoveredVia).toBe('static')
+
+    // The streaming rpc is a method like any other — the `stream` qualifier
+    // doesn't change identity.
+    expect(graph.hasNode(grpcMethodId('orders.OrderService', 'ListOrders'))).toBe(true)
+  })
+
+  it('owns each method through a service ──CONTAINS──▶ method edge carrying file:line', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    const getOrder = grpcMethodId('orders.OrderService', 'GetOrder')
+    const containsId = extractedEdgeId(serviceId('orders'), getOrder, EdgeType.CONTAINS)
+    expect(graph.hasEdge(containsId)).toBe(true)
+    const contains = graph.getEdgeAttributes(containsId) as GraphEdge
+    expect(contains.type).toBe(EdgeType.CONTAINS)
+    expect(contains.provenance).toBe(Provenance.EXTRACTED)
+    expect(contains.source).toBe(serviceId('orders'))
+    expect(contains.target).toBe(getOrder)
+    expect(contains.evidence?.file).toBe('proto/orders.proto')
+    expect(contains.evidence?.line).toBeGreaterThan(0)
+  })
+
+  // The point of the whole feature: a `.proto`-declared method and an OBSERVED
+  // gRPC span for the same rpc.service/method land on ONE node — both provenances,
+  // no twin — because both key on the wire-canonical FQN.
+  it('fuses the declared method and the observed span onto one node (two-sided)', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    // Sanity: after static extraction the method node exists with a static origin.
+    const methodId = grpcMethodId('orders.OrderService', 'GetOrder')
+    expect(graph.hasNode(methodId)).toBe(true)
+
+    // Now an OBSERVED serving span for the same method arrives.
+    const ctx: IngestContext = { graph }
+    const span: ParsedSpan = {
+      service: 'orders',
+      traceId: 'trace-fuse',
+      spanId: 'span-fuse',
+      name: 'orders.OrderService/GetOrder',
+      kind: 2, // SERVER
+      startTimeUnixNano: '0',
+      endTimeUnixNano: '0',
+      durationNanos: 0n,
+      env: 'unknown',
+      attributes: {
+        'rpc.system': 'grpc',
+        'rpc.service': 'orders.OrderService',
+        'rpc.method': 'GetOrder',
+      },
+      rpcSystem: 'grpc',
+      rpcService: 'orders.OrderService',
+      rpcMethod: 'GetOrder',
+      statusCode: 0,
+    }
+    await handleSpan(ctx, span)
+
+    // Exactly one node for this method — the observed span reused the declared id.
+    const methodNodes: string[] = []
+    graph.forEachNode((id, a) => {
+      if ((a as { type: string }).type === NodeType.GrpcMethodNode && id === methodId) {
+        methodNodes.push(id)
+      }
+    })
+    expect(methodNodes).toEqual([methodId])
+
+    // Both provenances of CONTAINS point at it: the EXTRACTED `.proto` ownership
+    // and the OBSERVED serving edge — this is the two-sided divergence surface.
+    const extractedContains = extractedEdgeId(serviceId('orders'), methodId, EdgeType.CONTAINS)
+    const observedContains = `${EdgeType.CONTAINS}:OBSERVED:service:orders->${methodId}`
+    expect(graph.hasEdge(extractedContains)).toBe(true)
+    expect(graph.hasEdge(observedContains)).toBe(true)
+    expect((graph.getEdgeAttributes(extractedContains) as GraphEdge).provenance).toBe(
+      Provenance.EXTRACTED,
+    )
+    expect((graph.getEdgeAttributes(observedContains) as GraphEdge).provenance).toBe(
+      Provenance.OBSERVED,
+    )
+  })
+})

--- a/packages/core/test/fixtures/grpc/orders/package.json
+++ b/packages/core/test/fixtures/grpc/orders/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "orders",
+  "version": "1.0.0",
+  "dependencies": {
+    "@grpc/grpc-js": "^1.9.0"
+  }
+}

--- a/packages/core/test/fixtures/grpc/orders/proto/orders.proto
+++ b/packages/core/test/fixtures/grpc/orders/proto/orders.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package orders;
+
+// The order service contract. rpc.service on the wire is the fully-qualified
+// `orders.OrderService`, which is what a NEAT GrpcMethodNode keys on.
+service OrderService {
+  // Unary.
+  rpc GetOrder(GetOrderRequest) returns (GetOrderResponse);
+  // Server-streaming — the `stream` qualifier doesn't change method identity.
+  rpc ListOrders(ListOrdersRequest) returns (stream OrderSummary);
+}
+
+message GetOrderRequest {
+  string id = 1;
+}
+
+message GetOrderResponse {
+  string id = 1;
+  string status = 2;
+}
+
+message ListOrdersRequest {
+  string customer_id = 1;
+}
+
+message OrderSummary {
+  string id = 1;
+}

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -10,12 +10,14 @@ import {
   type DatabaseNode,
   fileId,
   graphqlOperationId,
+  grpcMethodId,
   infraId,
   type InfraNode,
   localDatabaseId,
   type GraphEdge,
   type GraphNode,
   type GraphQLOperationNode,
+  type GrpcMethodNode,
   NodeType,
   Provenance,
 } from '@neat.is/types'
@@ -2364,5 +2366,169 @@ describe('handleSpan GraphQL execution spans (#615)', () => {
       if ((a as { type: string }).type === NodeType.GraphQLOperationNode) opNodes++
     })
     expect(opNodes).toBe(0)
+  })
+})
+
+// ── gRPC method spans (#616, ADR-123) ──────────────────────────────────────
+// gRPC used to engage only at service grain: every method collapsed onto one
+// service→service edge, so the per-method topology was invisible and one-sided.
+// The serving span carries the method the caller invoked (`rpc.service` +
+// `rpc.method` under `rpc.system=grpc`), so handleSpan mints an OBSERVED
+// `service ──CONTAINS──▶ method` edge to a per-method node — keyed on the
+// fully-qualified `rpc.service` so the static `.proto` extractor fuses onto the
+// same id. Fixtures use REAL gRPC execution shape: SERVER wire kind (2), the
+// `rpc.*` semconv, and an ABSOLUTE `code.filepath` the SpanProcessor stamps —
+// reconciled onto the EXTRACTED path.
+describe('handleSpan gRPC method spans (#616)', () => {
+  let tmpDir: string
+  let ctx: IngestContext
+
+  beforeEach(async () => {
+    resetParentSpanCache()
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-grpc-'))
+    ctx = { graph: newGraph(), errorsPath: path.join(tmpDir, 'errors.ndjson') }
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+    resetParentSpanCache()
+  })
+
+  // An @opentelemetry SERVER span for a resolved gRPC unary call: SERVER kind (2),
+  // the rpc semconv with a fully-qualified `rpc.service`, and a code.* call site
+  // for the handler file.
+  function grpcSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
+    return {
+      // The NEAT service (`service-a`) is deliberately not the gRPC service FQN
+      // (`orders.OrderService`) — the method node keys on the wire FQN, not the
+      // NEAT manifest name, so ownership and identity stay decoupled.
+      service: 'service-a',
+      traceId: 'trace-grpc',
+      spanId: 'span-grpc',
+      name: 'orders.OrderService/GetOrder',
+      kind: 2, // SERVER
+      startTimeUnixNano: '0',
+      endTimeUnixNano: '0',
+      durationNanos: 0n,
+      env: 'unknown',
+      attributes: {
+        'rpc.system': 'grpc',
+        'rpc.service': 'orders.OrderService',
+        'rpc.method': 'GetOrder',
+        'code.filepath': '/var/task/src/handlers/order.ts',
+        'code.lineno': 17,
+        'code.function': 'getOrder',
+      },
+      rpcSystem: 'grpc',
+      rpcService: 'orders.OrderService',
+      rpcMethod: 'GetOrder',
+      statusCode: 0,
+      ...overrides,
+    }
+  }
+
+  it('mints a file-grained OBSERVED CONTAINS edge from the serving service to the method node', async () => {
+    // The extractor already parsed the handler file the method runs in.
+    ensureFileNode(ctx.graph, 'service-a', 'service:service-a', 'src/handlers/order.ts')
+
+    await handleSpan(ctx, grpcSpan())
+
+    // Keyed on the fully-qualified rpc.service so the static `.proto` definition
+    // fuses onto the same id.
+    const methodId = grpcMethodId('orders.OrderService', 'GetOrder')
+    expect(methodId).toBe('grpc:orders.OrderService/GetOrder')
+    expect(ctx.graph.hasNode(methodId)).toBe(true)
+    const m = ctx.graph.getNodeAttributes(methodId) as GrpcMethodNode
+    expect(m.type).toBe(NodeType.GrpcMethodNode)
+    expect(m.name).toBe('orders.OrderService/GetOrder')
+    expect(m.rpcService).toBe('orders.OrderService')
+    expect(m.rpcMethod).toBe('GetOrder')
+    expect(m.discoveredVia).toBe('otel')
+
+    // The edge originates from the handler's FileNode at the exact call site —
+    // file-grained, fused onto the EXTRACTED path (not the /var/task deployed one).
+    const fileNodeId = fileId('service-a', 'src/handlers/order.ts')
+    const edgeId = `${EdgeType.CONTAINS}:OBSERVED:${fileNodeId}->${methodId}`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.type).toBe(EdgeType.CONTAINS)
+    expect(edge.source).toBe(fileNodeId)
+    expect(edge.target).toBe(methodId)
+    expect(edge.evidence?.file).toBe('src/handlers/order.ts')
+    expect(edge.evidence?.line).toBe(17)
+  })
+
+  it('keys a distinct node per (rpcService, rpcMethod) — no collapse onto a service edge', async () => {
+    await handleSpan(ctx, grpcSpan())
+    await handleSpan(
+      ctx,
+      grpcSpan({
+        spanId: 'span-grpc-2',
+        name: 'orders.OrderService/ListOrders',
+        attributes: {
+          'rpc.system': 'grpc',
+          'rpc.service': 'orders.OrderService',
+          'rpc.method': 'ListOrders',
+        },
+        rpcMethod: 'ListOrders',
+      }),
+    )
+
+    const getId = grpcMethodId('orders.OrderService', 'GetOrder')
+    const listId = grpcMethodId('orders.OrderService', 'ListOrders')
+    const methodNodes: string[] = []
+    ctx.graph.forEachNode((id, a) => {
+      if ((a as { type: string }).type === NodeType.GrpcMethodNode) methodNodes.push(id)
+    })
+    expect(new Set(methodNodes)).toEqual(new Set([getId, listId]))
+  })
+
+  it('stays service-level when the serving span carries no call site', async () => {
+    await handleSpan(
+      ctx,
+      grpcSpan({
+        attributes: {
+          'rpc.system': 'grpc',
+          'rpc.service': 'orders.OrderService',
+          'rpc.method': 'GetOrder',
+        },
+      }),
+    )
+    const methodId = grpcMethodId('orders.OrderService', 'GetOrder')
+    const edgeId = `${EdgeType.CONTAINS}:OBSERVED:service:service-a->${methodId}`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.source).toBe('service:service-a')
+    expect(edge.evidence).toBeUndefined()
+  })
+
+  it('mints no method node from the CLIENT side — client-side attribution is deferred', async () => {
+    await handleSpan(ctx, grpcSpan({ kind: 3 })) // CLIENT
+    let methodNodes = 0
+    ctx.graph.forEachNode((_id, a) => {
+      if ((a as { type: string }).type === NodeType.GrpcMethodNode) methodNodes++
+    })
+    expect(methodNodes).toBe(0)
+  })
+
+  it('mints no method node when the span is not a gRPC RPC', async () => {
+    // A non-grpc rpc.system (e.g. Connect / Thrift) is out of scope for this cut.
+    await handleSpan(
+      ctx,
+      grpcSpan({
+        rpcSystem: 'apache_thrift',
+        attributes: {
+          'rpc.system': 'apache_thrift',
+          'rpc.service': 'orders.OrderService',
+          'rpc.method': 'GetOrder',
+        },
+      }),
+    )
+    let methodNodes = 0
+    ctx.graph.forEachNode((_id, a) => {
+      if ((a as { type: string }).type === NodeType.GrpcMethodNode) methodNodes++
+    })
+    expect(methodNodes).toBe(0)
   })
 })

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -53,6 +53,17 @@ export const NodeType = {
   // semconv. Minted observed-first from OTel; a future static GraphQL extractor
   // fuses onto the same id. See docs/contracts/otel-ingest.md.
   GraphQLOperationNode: 'GraphQLOperationNode',
+  // A single gRPC method — one `rpc` in a `.proto` service — at
+  // (rpcService, rpcMethod) granularity (ADR-123). gRPC used to engage only at
+  // service grain: every method collapsed onto one service→service edge, so the
+  // per-method topology was invisible and one-sided. This node recovers the
+  // method-level shape from both sides: the OBSERVED execution span's
+  // `rpc.service` / `rpc.method` semconv and the static `.proto` service/method
+  // definitions. It keys on the fully-qualified `rpc.service` — the wire
+  // contract both sides carry verbatim — so a declared method and an observed
+  // one fuse onto the same node into a two-sided divergence. See
+  // docs/contracts/otel-ingest.md and docs/contracts/static-extraction.md.
+  GrpcMethodNode: 'GrpcMethodNode',
 } as const
 
 export type NodeTypeValue = (typeof NodeType)[keyof typeof NodeType]
@@ -71,4 +82,5 @@ export const NodeTypeSchema = z.enum([
   NodeType.FileNode,
   NodeType.RouteNode,
   NodeType.GraphQLOperationNode,
+  NodeType.GrpcMethodNode,
 ])

--- a/packages/types/src/identity.ts
+++ b/packages/types/src/identity.ts
@@ -15,6 +15,7 @@ const FRONTIER_PREFIX = 'frontier:'
 const FILE_PREFIX = 'file:'
 const ROUTE_PREFIX = 'route:'
 const GRAPHQL_OP_PREFIX = 'graphql:'
+const GRPC_METHOD_PREFIX = 'grpc:'
 
 // ServiceNode id: `service:<name>` for env-unknown nodes (the default,
 // produced by static extraction or by ingest when the span carries no env
@@ -209,6 +210,38 @@ export function parseGraphqlOperationId(
     return null
   }
   return { service, operationType, operationName }
+}
+
+// GrpcMethodNode id: `grpc:<rpcService>/<rpcMethod>` (ADR-123). Unlike the
+// RouteNode / GraphQLOperationNode ids, this one is NOT scoped to the NEAT
+// manifest service name — it keys on the fully-qualified gRPC `rpc.service`
+// (`orders.OrderService`, the proto's `<package>.<Service>`) instead. That FQN is
+// the wire contract: an OTel span and a `.proto` definition both carry it
+// verbatim, and it is globally unique across a gRPC mesh (the package qualifier
+// disambiguates), so keying on it — rather than on whoever happens to serve or
+// call the method — is exactly what fuses the OBSERVED span and the EXTRACTED
+// `.proto` onto one node. The implementing service's ownership is a separate
+// `CONTAINS` edge, not part of identity. `/` separates service from method
+// unambiguously: an `rpc.service` FQN carries dots but never a slash, and a
+// method name is a bare identifier.
+export function grpcMethodId(rpcService: string, rpcMethod: string): string {
+  return `${GRPC_METHOD_PREFIX}${rpcService}/${rpcMethod}`
+}
+
+// Parse a gRPC method id into its (rpcService, rpcMethod) tuple. Returns null
+// when the input isn't a gRPC method id. Splits on the first slash after the
+// prefix — the service FQN carries no slash, the method is a bare identifier.
+export function parseGrpcMethodId(
+  id: string,
+): { rpcService: string; rpcMethod: string } | null {
+  if (!id.startsWith(GRPC_METHOD_PREFIX)) return null
+  const rest = id.slice(GRPC_METHOD_PREFIX.length)
+  const slash = rest.indexOf('/')
+  if (slash === -1) return null
+  const rpcService = rest.slice(0, slash)
+  const rpcMethod = rest.slice(slash + 1)
+  if (rpcService.length === 0 || rpcMethod.length === 0) return null
+  return { rpcService, rpcMethod }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/types/src/nodes.ts
+++ b/packages/types/src/nodes.ts
@@ -210,6 +210,35 @@ export const GraphQLOperationNodeSchema = z.object({
 })
 export type GraphQLOperationNode = z.infer<typeof GraphQLOperationNodeSchema>
 
+// GrpcMethodNode — a single gRPC method at (rpcService, rpcMethod) granularity
+// (ADR-123 / docs/contracts/otel-ingest.md + static-extraction.md). gRPC used to
+// engage only at service grain, collapsing every method onto one service→service
+// edge; this node recovers the per-method topology. Identified by
+// `grpcMethodId(rpcService, rpcMethod)` → `grpc:<rpcService>/<rpcMethod>`.
+// `rpcService` is the fully-qualified proto service name — the OTel `rpc.service`
+// (`orders.OrderService`), which is the `<package>.<Service>` a `.proto`
+// declares — and `rpcMethod` is the bare method (`GetOrder`). That FQN is the
+// wire contract both the OBSERVED span and the static `.proto` carry verbatim, so
+// keying on it (globally, not scoped to the NEAT manifest name) lets an observed
+// method and its declared definition fuse onto one node; the implementing service
+// owns it through a separate `CONTAINS` edge. `path` / `line` locate the `rpc`
+// line in the `.proto` when the static producer fills them in, or the resolver
+// call site an OBSERVED span carried — absent when neither is known, never
+// fabricated (file-awareness.md §6). Minted from either side; fusing the two
+// provenances onto one node is what makes a method-grain two-sided divergence
+// possible.
+export const GrpcMethodNodeSchema = z.object({
+  id: z.string(),
+  type: z.literal(NodeType.GrpcMethodNode),
+  name: z.string(),
+  rpcService: z.string(),
+  rpcMethod: z.string(),
+  path: z.string().optional(),
+  line: z.number().int().nonnegative().optional(),
+  discoveredVia: DiscoveredViaSchema.optional(),
+})
+export type GrpcMethodNode = z.infer<typeof GrpcMethodNodeSchema>
+
 export const GraphNodeSchema = z.discriminatedUnion('type', [
   ServiceNodeSchema,
   DatabaseNodeSchema,
@@ -219,5 +248,6 @@ export const GraphNodeSchema = z.discriminatedUnion('type', [
   FileNodeSchema,
   RouteNodeSchema,
   GraphQLOperationNodeSchema,
+  GrpcMethodNodeSchema,
 ])
 export type GraphNode = z.infer<typeof GraphNodeSchema>

--- a/packages/types/test/schemas.test.ts
+++ b/packages/types/test/schemas.test.ts
@@ -25,11 +25,12 @@ describe('runtime constants', () => {
     // IMPORTS joined with the import graph (ADR-092).
     expect(Object.values(EdgeType)).toHaveLength(9)
   })
-  it('NodeType has 8 values', () => {
+  it('NodeType has 9 values', () => {
     // FileNode joined the set with the file-first graph (ADR-089); RouteNode
     // joined with server-route extraction (ADR-119); GraphQLOperationNode joined
-    // with operation-grain GraphQL observation (ADR-122).
-    expect(Object.values(NodeType)).toHaveLength(8)
+    // with operation-grain GraphQL observation (ADR-122); GrpcMethodNode joined
+    // with method-grain gRPC observation + `.proto` extraction (ADR-123).
+    expect(Object.values(NodeType)).toHaveLength(9)
   })
 })
 


### PR DESCRIPTION
gRPC currently engages only at service grain: every RPC method collapses onto a single service edge, and nothing reads the `.proto` contract, so the topology is coarse and one-sided. Declared methods are invisible; observed ones are nameless.

This gives gRPC the same treatment routes (#649) and GraphQL operations (#651) got — a static extractor and OBSERVED edges fusing on a shared node — at method grain, from both sides.

**OBSERVED.** When a serving span carries `rpc.system=grpc` with `rpc.service` and `rpc.method`, `handleSpan` mints an OBSERVED `CONTAINS` edge from the serving service to a per-method `GrpcMethodNode` — the same ownership verb a service has over a route, a GraphQL operation, and a file. File-grained through the usual `code.*` call-site path; service-level when the span carries no call site, honestly. The gate admits only the serving side (SERVER / INTERNAL / unkinded), so a CLIENT gRPC span still falls through to the cross-service resolver and the caller→callee edge is untouched.

**Static.** A new `extract/proto.ts` producer reads each service's `.proto` files as data — a bounded, brace-balanced line-scan for `service X { rpc Method(Req) returns (Res); }`, the way the Kafka and infra extractors read their inputs. No tree-sitter grammar, no new language in the toolchain. Each `rpc` becomes the same method node, owned through a `service ──CONTAINS──▶ method` edge.

**Fusion.** The node keys on the fully-qualified `rpc.service` (`grpc:orders.OrderService/GetOrder`), not the NEAT manifest name — that FQN is the wire contract both the span and the `.proto` carry verbatim, so a declared method and its observed counterpart land on one node into a two-sided divergence rather than twinning.

`GrpcMethodNode` is the 9th `NodeType`; the schema snapshot regenerates additively.

Method-grain and two-sided for this cut. Client-side method attribution, `grpc.status_code` / error-detail enrichment on incidents, and `.proto` import resolution across files are deferred.

Refs #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)