### PR TITLE
Give WebSocket apps a channel-grain observed topology

### DIFF
--- a/docs/contracts/divergence-query.md
+++ b/docs/contracts/divergence-query.md
@@ -8,7 +8,7 @@ governs:
   - "packages/core/src/cli.ts"
   - "packages/core/src/cli-client.ts"
   - "packages/mcp/src/index.ts"
-adr: [ADR-060, ADR-066, ADR-115, ADR-119, ADR-029, ADR-039, ADR-050, ADR-027, ADR-061, ADR-095]
+adr: [ADR-060, ADR-066, ADR-115, ADR-119, ADR-125, ADR-029, ADR-039, ADR-050, ADR-027, ADR-061, ADR-095]
 enforcement: [lint, breaker, review]
 ---
 
@@ -119,6 +119,17 @@ The five divergence types are not symmetric peers. `missing-extracted` is the he
 ### 5c. Route-grained comparison (ADR-119)
 
 Static extraction now reaches route grain: the HTTP client↔route matcher mints a `file ──CALLS──▶ route` EXTRACTED edge whose target is a `RouteNode` at `(method, path-template)` grain (see [`static-extraction.md`](./static-extraction.md), ADR-119). Because that RouteNode is the same node an OBSERVED server-span edge lands on (issue #576), the `missing-observed` / `missing-extracted` pair compares a declared client↔route call against its observed twin at route grain — sharper than the service-grained comparison a host-only edge allows. This is the file-awareness §7 "shared grain" principle applied one level finer: same triple `(source, target, type)`, now with a route as the target. The five divergence types and their weighting (§5a) are unchanged — a route-grained edge is an ordinary EXTRACTED CALLS edge to the query; what changes is how precisely the target names the thing both sides are talking about.
+
+### 5d. OBSERVED-only nodes are excluded from `missing-extracted` (ADR-125)
+
+`missing-extracted` fires when an OBSERVED edge has no EXTRACTED twin on the same `(source, target, type)`. That is the right signal for a CALLS-family edge whose target is a durably-declared artifact — a service, a route, a database — where a static twin *could* exist and its absence is the finding. It is the wrong signal when the **target node is OBSERVED-only by design**: a node that is minted from a span and has no static producer at all can never have an EXTRACTED twin, so flagging its edge as `missing-extracted` reports a gap that no code change could ever close — noise, not signal.
+
+`computeDivergences` therefore suppresses `missing-extracted` when the target is such a node. Two exclusions exist, both keyed on the target so the intent is legible at the point of decision:
+
+- **`CONTAINS` edge type** — structural ownership (service → file / operation / method), never a declared-vs-observed relationship (file-awareness.md §2).
+- **`WebSocketChannelNode` target** — a WebSocket channel is minted OBSERVED-only from the HTTP upgrade span (ADR-125, [otel-ingest.md](./otel-ingest.md)); its edge reuses `CONNECTS_TO`, which is in the observable allowlist, so without this exclusion an OBSERVED-only `service ──CONNECTS_TO──▶ ws-channel` would flag a spurious `missing-extracted`.
+
+Both are **signal-preserving, not signal-hiding**: there is no static edge that *should* exist, so suppressing the finding removes a false positive without hiding a real gap. Adding a future OBSERVED-only node type is the moment to consider a matching exclusion — the allowlist stays deliberate.
 
 ### 6. Allowlist amendments are explicit
 

--- a/docs/contracts/identity.md
+++ b/docs/contracts/identity.md
@@ -6,7 +6,7 @@ governs:
   - "packages/core/src/ingest.ts"
   - "packages/types/src/nodes.ts"
   - "packages/types/src/identity.ts"
-adr: [ADR-028, ADR-122, ADR-123]
+adr: [ADR-028, ADR-122, ADR-123, ADR-125]
 enforcement: [lint, review]
 ---
 
@@ -17,7 +17,7 @@ Every node id in NEAT is constructed via the helpers in `packages/types/src/iden
 ## Helpers
 
 ```ts
-import { serviceId, databaseId, configId, infraId, frontierId, graphqlOperationId, grpcMethodId } from '@neat.is/types'
+import { serviceId, databaseId, configId, infraId, frontierId, graphqlOperationId, grpcMethodId, websocketChannelId } from '@neat.is/types'
 
 serviceId('checkout')                     // 'service:checkout'
 databaseId('db.example.com')              // 'database:db.example.com'
@@ -26,6 +26,7 @@ infraId('redis', 'cache.internal')        // 'infra:redis:cache.internal'
 frontierId('payments-api:8080')           // 'frontier:payments-api:8080'
 graphqlOperationId('api', 'query', 'GetUser')  // 'graphql:api:query GetUser'
 grpcMethodId('orders.OrderService', 'GetOrder')  // 'grpc:orders.OrderService/GetOrder'
+websocketChannelId('chat-api', '/chat')   // 'ws:chat-api:/chat'
 ```
 
 Inverses (`parseServiceId`, `parseDatabaseId`, etc.) return the inner segment or `null` if the id doesn't match. Use them anywhere a consumer strips a prefix.
@@ -41,6 +42,7 @@ Inverses (`parseServiceId`, `parseDatabaseId`, etc.) return the inner segment or
 | FrontierNode  | `frontier:<host>`             | host:port from OTel peer attribute                  |
 | GraphQLOperationNode | `graphql:<service>:<type> <name>` | serving service + lower-cased operation type + client operation name (ADR-122) |
 | GrpcMethodNode | `grpc:<rpcService>/<rpcMethod>` | fully-qualified gRPC `rpc.service` (`<package>.<Service>`) + method — the wire contract, NOT the NEAT manifest name, so OBSERVED span and static `.proto` fuse (ADR-123) |
+| WebSocketChannelNode | `ws:<service>:<channel>` | serving service manifest name + connection path/channel — scoped to the service like a route (a WS path is not globally unique), OBSERVED-only (ADR-125) |
 
 ## Reconciliation rules
 

--- a/docs/contracts/otel-ingest.md
+++ b/docs/contracts/otel-ingest.md
@@ -1,11 +1,11 @@
 ---
 name: otel-ingest
-description: OTel receiver replies before mutation, lastObserved derives from span time, parent-span cache correlates cross-service CALLS, exception data is parsed from span events, unseen services and DBs are auto-created, queue producers and consumers mint file-grained messaging edges to the destination topic, GraphQL execution spans mint an operation-grain CONTAINS edge, gRPC execution spans mint a method-grain CONTAINS edge, span-derived edges always carry OBSERVED provenance, the same edge-minting primitives serve pull-based connector signals.
+description: OTel receiver replies before mutation, lastObserved derives from span time, parent-span cache correlates cross-service CALLS, exception data is parsed from span events, unseen services and DBs are auto-created, queue producers and consumers mint file-grained messaging edges to the destination topic, GraphQL execution spans mint an operation-grain CONTAINS edge, gRPC execution spans mint a method-grain CONTAINS edge, WebSocket upgrade spans mint a channel-grain CONNECTS_TO edge, span-derived edges always carry OBSERVED provenance, the same edge-minting primitives serve pull-based connector signals.
 governs:
   - "packages/core/src/ingest.ts"
   - "packages/core/src/otel.ts"
   - "packages/core/src/otel-grpc.ts"
-adr: [ADR-033, ADR-113, ADR-117, ADR-118, ADR-121, ADR-122, ADR-123, ADR-124, ADR-029, ADR-030, ADR-068]
+adr: [ADR-033, ADR-113, ADR-117, ADR-118, ADR-121, ADR-122, ADR-123, ADR-124, ADR-125, ADR-029, ADR-030, ADR-068]
 enforcement: [lint, review]
 ---
 
@@ -83,6 +83,18 @@ The edge is **file-grained** through the same call-site path as any other OBSERV
 The static half — `.proto` service/method extraction minting the same nodes — lives in [static-extraction.md](./static-extraction.md); the two provenances fuse into a method-grain divergence.
 
 Deferred: client-side method attribution, `grpc.status_code` / error-detail enrichment on incidents, and `.proto` `import` resolution across files.
+
+## WebSocket upgrade spans mint a channel-grain `CONNECTS_TO` edge (ADR-125, refs #617)
+
+A WebSocket app used to produce no OBSERVED topology at all: only message-handler errors surfaced, as incidents, and the channels themselves stayed invisible — the frames after the handshake ride the socket, not more spans. The one span that reliably marks a channel is the HTTP upgrade that opens it: a SERVER `GET` carrying `Upgrade: websocket` and the connection path. `otel.ts` derives `websocketChannel` off that span — the upgrade request header (`http.request.header.upgrade` naming `websocket`, array- or string-valued) gates it, and the path is the templated `http.route` when present, else `url.path` / `http.target` with any query string trimmed. `handleSpan` reads it and mints an OBSERVED edge from the serving service to a per-channel `WebSocketChannelNode`.
+
+The channel node is keyed on `websocketChannelId(service, channel)` → `ws:<service>:<channel>` (identity.md). Like the route / GraphQL-operation ids and unlike the gRPC id, it is **scoped to the serving service's manifest name**: a WS path (`/chat`, `/socket.io`) carries no package qualifier and is not unique across a mesh, so the serving service disambiguates it exactly as it does a route path. The node is minted **OBSERVED-only**: a WebSocket channel is known from observation, never from static extraction, so — unlike RouteNode / GraphQLOperationNode / GrpcMethodNode — it has no declared twin to fuse with, and `path` / `line` stay absent, never fabricated (file-awareness.md §6).
+
+The edge **reuses the existing `CONNECTS_TO`** — the same connection verb a service has to a datastore (ADR-118, #576) — **not a new edge type**. Unlike the structural `CONTAINS` a service has over a route / operation / method — durably declared artifacts whose edge never goes stale — a channel's whole meaning is liveness, so `CONNECTS_TO` is the honest shape: the edge carries `lastObserved` and **decays OBSERVED → STALE on `CONNECTS_TO`'s own staleness threshold** (no new threshold) when the channel goes quiet, via the daemon staleness loop (#532). It is **file-grained** through the same call-site path as any other OBSERVED edge (file-awareness.md §4): when the upgrade span carries `code.*` the edge originates from that `FileNode` at the exact `file:line`, reconciled onto the EXTRACTED service-relative path; without a call site it stays service-level, honestly. The WebSocket gate (`spanServesWebsocketChannel`) admits only the serving side — SERVER / INTERNAL / unkinded spans — so a CLIENT upgrade span mints no channel (client-side attribution is deferred).
+
+Because the channel node is OBSERVED-only by design, its OBSERVED-only `CONNECTS_TO` is **excluded from `missing-extracted`** — there is no static twin it should diverge against (see [divergence-query.md](./divergence-query.md)).
+
+Deferred: client-side channel attribution, per-message / event-grain topology, and static WebSocket route extraction.
 
 ## Connector-sourced OBSERVED edges share the same minting path (ADR-124, refs #653)
 

--- a/packages/core/src/divergences.ts
+++ b/packages/core/src/divergences.ts
@@ -101,6 +101,20 @@ function nodeIsFrontier(graph: NeatGraph, nodeId: string): boolean {
   return attrs.type === NodeType.FrontierNode
 }
 
+// A WebSocketChannelNode is minted OBSERVED-only from the HTTP upgrade span
+// (ADR-125): a channel is known from observation, never from static extraction,
+// so it has no declared twin to diverge against. Its edge is a `CONNECTS_TO`,
+// which is in the OBSERVABLE_EDGE_TYPES allowlist, so an OBSERVED-only
+// `service ──CONNECTS_TO──▶ ws-channel` would otherwise flag a spurious
+// `missing-extracted`. Suppressing it where the target is a channel node is
+// signal-preserving — there is no static edge that "should" exist — not
+// signal-hiding. See docs/contracts/divergence-query.md.
+function nodeIsWebsocketChannel(graph: NeatGraph, nodeId: string): boolean {
+  if (!graph.hasNode(nodeId)) return false
+  const attrs = graph.getNodeAttributes(nodeId) as GraphNode
+  return attrs.type === NodeType.WebSocketChannelNode
+}
+
 function clampConfidence(n: number): number {
   if (!Number.isFinite(n)) return 0
   return Math.max(0, Math.min(1, n))
@@ -191,9 +205,12 @@ function detectMissingDivergences(
     }
   }
 
-  if (bucket.observed && !bucket.extracted) {
+  if (bucket.observed && !bucket.extracted && !nodeIsWebsocketChannel(graph, bucket.target)) {
     // ADR-066 §4 — cascade from the OBSERVED edge's graded confidence.
-    // OBSERVED-led finding; the headline divergence type.
+    // OBSERVED-led finding; the headline divergence type. A WebSocketChannelNode
+    // target is skipped: it is OBSERVED-only by design (ADR-125), so an
+    // OBSERVED-only CONNECTS_TO onto it is expected, not a missing-extracted
+    // divergence — mirrors the CONTAINS exclusion above, keyed on target type.
     out.push({
       type: 'missing-extracted',
       source: bucket.source,

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -14,6 +14,7 @@ import type {
   Policy,
   ServiceNode,
   StaleEvent,
+  WebSocketChannelNode,
 } from '@neat.is/types'
 import type { PersistedGraph } from './persist.js'
 import type { EvaluationContext as PolicyEvaluationContext } from './policy.js'
@@ -34,6 +35,7 @@ import {
   infraId,
   observedEdgeId,
   serviceId,
+  websocketChannelId,
   type EdgeTypeValue,
 } from '@neat.is/types'
 import type { NeatGraph } from './graph.js'
@@ -831,6 +833,46 @@ function ensureGrpcMethodNode(
     name: `${rpcService}/${rpcMethod}`,
     rpcService,
     rpcMethod,
+    discoveredVia: 'otel',
+  }
+  graph.addNode(id, node)
+  return id
+}
+
+// The HTTP upgrade span that opens a WebSocket is emitted by the service that
+// SERVES the channel — a SERVER span (the framework's inbound `GET`), or an
+// unkinded / INTERNAL span from a hand-built handshake. The CLIENT that dials the
+// socket carries the same upgrade header, but the channel belongs to the server
+// (ADR-125), so gating out the caller/producer/consumer kinds keeps a client-side
+// upgrade span from attributing the channel to the caller. An unkinded / UNSET
+// span still mints, mirroring the graphql and gRPC serving-side gates.
+function spanServesWebsocketChannel(kind: number | undefined): boolean {
+  return (
+    kind !== WIRE_SPAN_KIND_CLIENT &&
+    kind !== WIRE_SPAN_KIND_PRODUCER &&
+    kind !== WIRE_SPAN_KIND_CONSUMER
+  )
+}
+
+// A WebSocket channel node keyed on (service, channel) via websocketChannelId
+// (ADR-125). Minted OBSERVED-only from the upgrade span — a WebSocket channel is
+// known from observation, never from static extraction, so there is no declared
+// twin to fuse with and no static producer to fill in `path` / `line` (those stay
+// absent, never fabricated — file-awareness.md §6). Idempotent — every reconnect
+// on the same channel upserts, never grows the node set.
+function ensureWebsocketChannelNode(
+  graph: NeatGraph,
+  serviceName: string,
+  channel: string,
+): string {
+  const id = websocketChannelId(serviceName, channel)
+  if (graph.hasNode(id)) return id
+  const node: WebSocketChannelNode = {
+    id,
+    type: NodeType.WebSocketChannelNode,
+    name: channel,
+    service: serviceName,
+    channel,
     discoveredVia: 'otel',
   }
   graph.addNode(id, node)
@@ -1673,6 +1715,45 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
     const result = upsertObservedEdge(
       ctx.graph,
       EdgeType.CONTAINS,
+      observedSource(),
+      targetId,
+      ts,
+      isError,
+      callSiteEvidence,
+    )
+    if (result) affectedNode = targetId
+  } else if (span.websocketChannel && spanServesWebsocketChannel(span.kind)) {
+    // WebSocket upgrade span (issue #617). A WebSocket app used to produce no
+    // OBSERVED topology at all: only message-handler errors surfaced, as
+    // incidents, and the channels themselves stayed invisible — the frames after
+    // the handshake ride the socket, not more spans. The one span that reliably
+    // marks a channel is the HTTP upgrade that opens it: a SERVER `GET` carrying
+    // `Upgrade: websocket` and the connection path. So mint an OBSERVED
+    // `CONNECTS_TO` edge from the serving service to a per-channel node —
+    // reusing the same connection edge a service has to a datastore (#576), not a
+    // new edge type. Unlike the structural `CONTAINS` a service has over a route /
+    // operation / method — durably declared artifacts whose edge never goes
+    // stale — a channel's whole meaning is liveness, so `CONNECTS_TO` is the right
+    // shape: it carries `lastObserved` and decays OBSERVED → STALE on
+    // CONNECTS_TO's own threshold when the channel goes quiet (the daemon
+    // staleness loop, #532). OBSERVED-only: a WebSocket channel is known from
+    // observation, never from static extraction, so the node has no declared twin
+    // and is excluded from `missing-extracted` (divergences.ts). File-grained
+    // through the same call-site path as any other OBSERVED edge
+    // (file-awareness.md §4): when the span carries `code.*` the edge originates
+    // from that `FileNode` at the exact `file:line`, reconciled onto the EXTRACTED
+    // service-relative path; without a call site it stays service-level, honestly.
+    // The gate admits only the serving side — SERVER / INTERNAL / unkinded — so a
+    // CLIENT upgrade span mints no channel (client→channel attribution is
+    // deferred, ADR-125).
+    const targetId = ensureWebsocketChannelNode(
+      ctx.graph,
+      span.service,
+      span.websocketChannel,
+    )
+    const result = upsertObservedEdge(
+      ctx.graph,
+      EdgeType.CONNECTS_TO,
       observedSource(),
       targetId,
       ts,

--- a/packages/core/src/otel.ts
+++ b/packages/core/src/otel.ts
@@ -78,6 +78,16 @@ export interface ParsedSpan {
   rpcSystem?: string
   rpcService?: string
   rpcMethod?: string
+  // WebSocket channel (OTel HTTP semconv). A WebSocket connection opens with an
+  // HTTP upgrade handshake: a SERVER `GET` whose `Upgrade` request header names
+  // `websocket`. That single span is the only reliable OBSERVED signal a channel
+  // exists — the message frames afterwards ride the socket, not more spans. This
+  // field carries the channel path off that upgrade span (`http.route` when the
+  // router templated it, else `url.path` / `http.target`), and is set only when
+  // the upgrade header is present. handleSpan reads it to mint a
+  // WebSocketChannelNode and an OBSERVED `CONNECTS_TO` edge from the serving
+  // service to it. See docs/contracts/otel-ingest.md §WebSocket channels.
+  websocketChannel?: string
   // 0 = UNSET, 1 = OK, 2 = ERROR per OTLP. We only care that 2 means error.
   statusCode?: number
   errorMessage?: string
@@ -288,6 +298,50 @@ function messagingDestinationOf(
   return undefined
 }
 
+// True when the span's `Upgrade` request header names `websocket`. OTel HTTP
+// instrumentation captures configured request headers as `http.request.header.<key>`
+// with the key lower-cased and the value an array of strings (one per header
+// occurrence); older SDKs may write a bare string. A WebSocket handshake carries
+// `Upgrade: websocket`, so any element equal to `websocket` (case-insensitive)
+// marks the upgrade. Returns false when the header is absent — a plain `GET`
+// route span never mints a channel.
+function hasWebsocketUpgradeHeader(attrs: Record<string, AttributeValue>): boolean {
+  const v = attrs['http.request.header.upgrade']
+  const matches = (s: unknown): boolean =>
+    typeof s === 'string' && s.trim().toLowerCase() === 'websocket'
+  if (Array.isArray(v)) return v.some(matches)
+  return matches(v)
+}
+
+// The channel path an upgrade span opens onto. Prefer the templated route
+// (`http.route`, e.g. `/ws/:room`) so high-cardinality connection paths collapse
+// onto one channel node; fall back to the concrete request path (`url.path`, the
+// SC v1.21+ name, or the legacy `http.target`) with any query string trimmed.
+// Returns undefined when nothing carries a path — the branch then falls through
+// rather than minting a channel keyed on an empty string.
+function websocketChannelPathOf(attrs: Record<string, AttributeValue>): string | undefined {
+  const route = attrs['http.route']
+  if (typeof route === 'string' && route.length > 0) return route
+  for (const key of ['url.path', 'http.target']) {
+    const v = attrs[key]
+    if (typeof v === 'string' && v.length > 0) {
+      const q = v.indexOf('?')
+      const path = q === -1 ? v : v.slice(0, q)
+      if (path.length > 0) return path
+    }
+  }
+  return undefined
+}
+
+// The WebSocket channel this span serves, or undefined. Set only on the HTTP
+// upgrade handshake span — a request carrying `Upgrade: websocket` — so a plain
+// HTTP route span is never mistaken for a channel. See docs/contracts/otel-ingest.md
+// §WebSocket channels.
+function websocketChannelOf(attrs: Record<string, AttributeValue>): string | undefined {
+  if (!hasWebsocketUpgradeHeader(attrs)) return undefined
+  return websocketChannelPathOf(attrs)
+}
+
 export function parseOtlpRequest(body: OtlpTracesRequest): ParsedSpan[] {
   const out: ParsedSpan[] = []
   for (const rs of body.resourceSpans ?? []) {
@@ -352,6 +406,7 @@ export function parseOtlpRequest(body: OtlpTracesRequest): ParsedSpan[] {
             (attrs['rpc.method'] as string).length > 0
               ? (attrs['rpc.method'] as string)
               : undefined,
+          websocketChannel: websocketChannelOf(attrs),
           statusCode: span.status?.code,
           errorMessage: span.status?.message,
           exception: extractExceptionFromEvents(span.events),

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -98,6 +98,11 @@ export function embedText(node: GraphNode): string {
       if (rpcMethod) parts.push(`rpcMethod=${rpcMethod}`)
       break
     }
+    case 'WebSocketChannelNode': {
+      const channel = (node as { channel?: string }).channel
+      if (channel) parts.push(`channel=${channel}`)
+      break
+    }
     default:
       break
   }

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -1464,6 +1464,37 @@
               "_literal": "GrpcMethodNode"
             }
           }
+        },
+        "WebSocketChannelNode": {
+          "_object": {
+            "channel": "_string",
+            "discoveredVia": {
+              "_optional": {
+                "_enum": [
+                  "merged",
+                  "otel",
+                  "static"
+                ]
+              }
+            },
+            "id": "_string",
+            "line": {
+              "_optional": {
+                "_number": [
+                  "int",
+                  "min"
+                ]
+              }
+            },
+            "name": "_string",
+            "path": {
+              "_optional": "_string"
+            },
+            "service": "_string",
+            "type": {
+              "_literal": "WebSocketChannelNode"
+            }
+          }
         }
       }
     }
@@ -1478,7 +1509,8 @@
       "GrpcMethodNode",
       "InfraNode",
       "RouteNode",
-      "ServiceNode"
+      "ServiceNode",
+      "WebSocketChannelNode"
     ]
   },
   "PolicyFileSchema": {
@@ -1538,7 +1570,8 @@
                             "GrpcMethodNode",
                             "InfraNode",
                             "RouteNode",
-                            "ServiceNode"
+                            "ServiceNode",
+                            "WebSocketChannelNode"
                           ]
                         },
                         "toNodeType": {
@@ -1551,7 +1584,8 @@
                             "GrpcMethodNode",
                             "InfraNode",
                             "RouteNode",
-                            "ServiceNode"
+                            "ServiceNode",
+                            "WebSocketChannelNode"
                           ]
                         },
                         "type": {
@@ -1636,7 +1670,8 @@
                             "GrpcMethodNode",
                             "InfraNode",
                             "RouteNode",
-                            "ServiceNode"
+                            "ServiceNode",
+                            "WebSocketChannelNode"
                           ]
                         },
                         "type": {
@@ -1670,7 +1705,8 @@
                             "GrpcMethodNode",
                             "InfraNode",
                             "RouteNode",
-                            "ServiceNode"
+                            "ServiceNode",
+                            "WebSocketChannelNode"
                           ]
                         },
                         "type": {

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -18,6 +18,8 @@ import {
   type GraphNode,
   type GraphQLOperationNode,
   type GrpcMethodNode,
+  websocketChannelId,
+  type WebSocketChannelNode,
   NodeType,
   Provenance,
 } from '@neat.is/types'
@@ -2530,5 +2532,187 @@ describe('handleSpan gRPC method spans (#616)', () => {
       if ((a as { type: string }).type === NodeType.GrpcMethodNode) methodNodes++
     })
     expect(methodNodes).toBe(0)
+  })
+})
+
+// ── WebSocket channel spans (#617, ADR-125) ────────────────────────────────
+// A WebSocket app used to produce no OBSERVED topology at all: only
+// message-handler errors surfaced, as incidents, and the channels themselves
+// stayed invisible. The one span that reliably marks a channel is the HTTP
+// upgrade handshake that opens it: a SERVER `GET` carrying `Upgrade: websocket`
+// and the connection path. handleSpan mints a per-channel WebSocketChannelNode
+// and an OBSERVED `service ──CONNECTS_TO──▶ ws-channel` edge — reusing the
+// connection edge, not a new edge type. The node is OBSERVED-only; the edge
+// carries `lastObserved` and decays OBSERVED → STALE on CONNECTS_TO's threshold.
+describe('handleSpan WebSocket channel spans (#617)', () => {
+  let tmpDir: string
+  let ctx: IngestContext
+
+  beforeEach(async () => {
+    resetParentSpanCache()
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-ws-'))
+    ctx = { graph: newGraph(), errorsPath: path.join(tmpDir, 'errors.ndjson') }
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+    resetParentSpanCache()
+  })
+
+  // A real HTTP upgrade span: SERVER kind (2), a `GET` carrying
+  // `Upgrade: websocket`, the templated channel path, and a code.* call site for
+  // the handler file. otel.ts derives `websocketChannel` from these attrs; the
+  // fixture sets it directly the way parseOtlpRequest would.
+  function wsSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
+    return {
+      service: 'service-a',
+      traceId: 'trace-ws',
+      spanId: 'span-ws',
+      name: 'GET /chat',
+      kind: 2, // SERVER
+      startTimeUnixNano: '0',
+      endTimeUnixNano: '0',
+      durationNanos: 0n,
+      env: 'unknown',
+      attributes: {
+        'http.request.method': 'GET',
+        'http.request.header.upgrade': ['websocket'],
+        'http.route': '/chat',
+        'code.filepath': '/var/task/src/ws/chat.ts',
+        'code.lineno': 12,
+        'code.function': 'onConnect',
+      },
+      websocketChannel: '/chat',
+      statusCode: 0,
+      ...overrides,
+    }
+  }
+
+  it('mints a file-grained OBSERVED CONNECTS_TO edge from the serving service to the channel node', async () => {
+    // The extractor already parsed the handler file the channel runs in.
+    ensureFileNode(ctx.graph, 'service-a', 'service:service-a', 'src/ws/chat.ts')
+
+    await handleSpan(ctx, wsSpan())
+
+    const channelId = websocketChannelId('service-a', '/chat')
+    expect(channelId).toBe('ws:service-a:/chat')
+    expect(ctx.graph.hasNode(channelId)).toBe(true)
+    const ch = ctx.graph.getNodeAttributes(channelId) as WebSocketChannelNode
+    expect(ch.type).toBe(NodeType.WebSocketChannelNode)
+    expect(ch.name).toBe('/chat')
+    expect(ch.service).toBe('service-a')
+    expect(ch.channel).toBe('/chat')
+    expect(ch.discoveredVia).toBe('otel')
+    // OBSERVED-only — no static twin, so path/line stay absent, never fabricated.
+    expect(ch.path).toBeUndefined()
+    expect(ch.line).toBeUndefined()
+
+    // The edge reuses CONNECTS_TO (no new edge type) and originates from the
+    // handler's FileNode at the exact call site, fused onto the EXTRACTED path.
+    const fileNodeId = fileId('service-a', 'src/ws/chat.ts')
+    const edgeId = `${EdgeType.CONNECTS_TO}:OBSERVED:${fileNodeId}->${channelId}`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.type).toBe(EdgeType.CONNECTS_TO)
+    expect(edge.source).toBe(fileNodeId)
+    expect(edge.target).toBe(channelId)
+    expect(edge.evidence?.file).toBe('src/ws/chat.ts')
+    expect(edge.evidence?.line).toBe(12)
+  })
+
+  it('keys a distinct node per channel path, scoped to the serving service', async () => {
+    await handleSpan(ctx, wsSpan())
+    await handleSpan(
+      ctx,
+      wsSpan({
+        spanId: 'span-ws-2',
+        name: 'GET /notifications',
+        attributes: {
+          'http.request.method': 'GET',
+          'http.request.header.upgrade': ['websocket'],
+          'http.route': '/notifications',
+        },
+        websocketChannel: '/notifications',
+      }),
+    )
+
+    const chatId = websocketChannelId('service-a', '/chat')
+    const notifId = websocketChannelId('service-a', '/notifications')
+    const channelNodes: string[] = []
+    ctx.graph.forEachNode((id, a) => {
+      if ((a as { type: string }).type === NodeType.WebSocketChannelNode) channelNodes.push(id)
+    })
+    expect(new Set(channelNodes)).toEqual(new Set([chatId, notifId]))
+  })
+
+  it('stays service-level when the upgrade span carries no call site', async () => {
+    await handleSpan(
+      ctx,
+      wsSpan({
+        attributes: {
+          'http.request.method': 'GET',
+          'http.request.header.upgrade': ['websocket'],
+          'http.route': '/chat',
+        },
+      }),
+    )
+    const channelId = websocketChannelId('service-a', '/chat')
+    const edgeId = `${EdgeType.CONNECTS_TO}:OBSERVED:service:service-a->${channelId}`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.source).toBe('service:service-a')
+    expect(edge.evidence).toBeUndefined()
+  })
+
+  it('mints no channel node from the CLIENT side — client-side attribution is deferred', async () => {
+    await handleSpan(ctx, wsSpan({ kind: 3 })) // CLIENT
+    let channelNodes = 0
+    ctx.graph.forEachNode((_id, a) => {
+      if ((a as { type: string }).type === NodeType.WebSocketChannelNode) channelNodes++
+    })
+    expect(channelNodes).toBe(0)
+  })
+
+  it('mints no channel node when the span carries no WebSocket channel', async () => {
+    // A plain GET route span (no Upgrade header) never derives a channel.
+    await handleSpan(
+      ctx,
+      wsSpan({
+        websocketChannel: undefined,
+        attributes: { 'http.request.method': 'GET', 'http.route': '/chat' },
+      }),
+    )
+    let channelNodes = 0
+    ctx.graph.forEachNode((_id, a) => {
+      if ((a as { type: string }).type === NodeType.WebSocketChannelNode) channelNodes++
+    })
+    expect(channelNodes).toBe(0)
+  })
+
+  it('decays the channel CONNECTS_TO edge OBSERVED → STALE past the CONNECTS_TO threshold', async () => {
+    // No call site here so the edge stays service-level with a deterministic id.
+    await handleSpan(
+      ctx,
+      wsSpan({
+        attributes: {
+          'http.request.method': 'GET',
+          'http.request.header.upgrade': ['websocket'],
+          'http.route': '/chat',
+        },
+      }),
+    )
+    const channelId = websocketChannelId('service-a', '/chat')
+    const edgeId = `${EdgeType.CONNECTS_TO}:OBSERVED:service:service-a->${channelId}`
+    expect(ctx.graph.hasEdge(edgeId)).toBe(true)
+    // Freshly observed — still OBSERVED right after the upgrade span.
+    expect((ctx.graph.getEdgeAttributes(edgeId) as GraphEdge).provenance).toBe(Provenance.OBSERVED)
+
+    // The channel goes quiet: five hours later, past CONNECTS_TO's 4h default.
+    const now = Date.now() + 5 * 60 * 60 * 1000
+    const result = await markStaleEdges(ctx.graph, { now })
+    expect(result.count).toBe(1)
+    const decayed = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(decayed.provenance).toBe(Provenance.STALE)
   })
 })

--- a/packages/core/test/otel.test.ts
+++ b/packages/core/test/otel.test.ts
@@ -161,6 +161,49 @@ describe('parseOtlpRequest', () => {
     expect(spans[0].messagingDestination).toBeUndefined()
   })
 
+  it('derives the WebSocket channel from an HTTP upgrade span (#617)', () => {
+    // A real upgrade handshake: SERVER `GET` with `Upgrade: websocket` (captured
+    // as an array-valued request header) and the templated route.
+    const spans = parseOtlpRequest({
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [{ key: 'service.name', value: { stringValue: 'chat-api' } }],
+          },
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  traceId: 't',
+                  spanId: 's',
+                  name: 'GET /chat',
+                  kind: 2,
+                  startTimeUnixNano: '0',
+                  endTimeUnixNano: '0',
+                  attributes: [
+                    { key: 'http.request.method', value: { stringValue: 'GET' } },
+                    {
+                      key: 'http.request.header.upgrade',
+                      value: { arrayValue: { values: [{ stringValue: 'websocket' }] } },
+                    },
+                    { key: 'http.route', value: { stringValue: '/chat' } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    expect(spans[0].websocketChannel).toBe('/chat')
+  })
+
+  it('leaves websocketChannel undefined on a plain HTTP span with no upgrade header', () => {
+    // The SAMPLE_BODY GET /data span is a normal route, not a handshake.
+    const spans = parseOtlpRequest(SAMPLE_BODY)
+    expect(spans[0].websocketChannel).toBeUndefined()
+  })
+
   it('preserves the full attribute bag', () => {
     const spans = parseOtlpRequest(SAMPLE_BODY)
     expect(spans[0].attributes['http.method']).toBe('GET')

--- a/packages/core/test/websocket-channel-divergence.test.ts
+++ b/packages/core/test/websocket-channel-divergence.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { MultiDirectedGraph } from 'graphology'
+import { computeDivergences } from '../src/divergences.js'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  databaseId,
+  websocketChannelId,
+  type GraphEdge,
+  type GraphNode,
+} from '@neat.is/types'
+import type { NeatGraph } from '../src/graph.js'
+
+// A WebSocket channel is OBSERVED-only by design (ADR-125): it is minted from the
+// HTTP upgrade span and has no static twin to fuse with. Its edge is a
+// `CONNECTS_TO`, which lives in the missing-extracted allowlist — so without a
+// target-type exclusion an OBSERVED-only `service ──CONNECTS_TO──▶ ws-channel`
+// would flag a spurious `missing-extracted`. This proves the exclusion is real
+// and targeted: the channel is suppressed, a plain observed-only DB edge is not.
+describe('WebSocket channel missing-extracted exclusion (#617, ADR-125)', () => {
+  function graphWithService(): NeatGraph {
+    const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    g.addNode('service:service-a', {
+      id: 'service:service-a',
+      type: NodeType.ServiceNode,
+      name: 'service-a',
+      language: 'javascript',
+    })
+    return g
+  }
+
+  it('does not flag an OBSERVED-only CONNECTS_TO onto a WebSocket channel as missing-extracted', () => {
+    const g = graphWithService()
+    const channelId = websocketChannelId('service-a', '/chat')
+    g.addNode(channelId, {
+      id: channelId,
+      type: NodeType.WebSocketChannelNode,
+      name: '/chat',
+      service: 'service-a',
+      channel: '/chat',
+      discoveredVia: 'otel',
+    } as GraphNode)
+    const edgeId = `${EdgeType.CONNECTS_TO}:OBSERVED:service:service-a->${channelId}`
+    g.addEdgeWithKey(edgeId, 'service:service-a', channelId, {
+      id: edgeId,
+      source: 'service:service-a',
+      target: channelId,
+      type: EdgeType.CONNECTS_TO,
+      provenance: Provenance.OBSERVED,
+      lastObserved: new Date().toISOString(),
+    })
+
+    const { divergences } = computeDivergences(g)
+    const onChannel = divergences.filter(
+      (d) => d.type === 'missing-extracted' && d.target === channelId,
+    )
+    expect(onChannel).toHaveLength(0)
+  })
+
+  it('still flags an OBSERVED-only CONNECTS_TO onto a real database node (control)', () => {
+    const g = graphWithService()
+    const dbId = databaseId('payments-host')
+    g.addNode(dbId, {
+      id: dbId,
+      type: NodeType.DatabaseNode,
+      name: 'payments-host',
+      engine: 'postgresql',
+      engineVersion: 'unknown',
+      compatibleDrivers: [],
+      host: 'payments-host',
+      discoveredVia: 'otel',
+    } as GraphNode)
+    const edgeId = `${EdgeType.CONNECTS_TO}:OBSERVED:service:service-a->${dbId}`
+    g.addEdgeWithKey(edgeId, 'service:service-a', dbId, {
+      id: edgeId,
+      source: 'service:service-a',
+      target: dbId,
+      type: EdgeType.CONNECTS_TO,
+      provenance: Provenance.OBSERVED,
+      lastObserved: new Date().toISOString(),
+    })
+
+    const { divergences } = computeDivergences(g)
+    const onDb = divergences.filter(
+      (d) => d.type === 'missing-extracted' && d.target === dbId,
+    )
+    expect(onDb).toHaveLength(1)
+  })
+})

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -64,6 +64,19 @@ export const NodeType = {
   // one fuse onto the same node into a two-sided divergence. See
   // docs/contracts/otel-ingest.md and docs/contracts/static-extraction.md.
   GrpcMethodNode: 'GrpcMethodNode',
+  // A live WebSocket channel — the path/channel a client connects to — at
+  // (service, channel) granularity (ADR-125). A WebSocket app used to produce no
+  // OBSERVED topology at all: only message-handler errors surfaced, as incidents,
+  // and the channels themselves stayed invisible. This node recovers the
+  // channel-level topology from the HTTP upgrade span that opens the connection —
+  // a SERVER `GET` carrying the WebSocket path. It is minted OBSERVED-only: a
+  // WebSocket channel is known from observation, never from static extraction, so
+  // there is no declared twin to fuse with. The edge onto it reuses the existing
+  // `CONNECTS_TO` (`service ──CONNECTS_TO──▶ ws-channel`) as an observed-liveness
+  // edge that carries `lastObserved` and decays OBSERVED → STALE on CONNECTS_TO's
+  // own staleness threshold when the channel goes quiet. See
+  // docs/contracts/otel-ingest.md.
+  WebSocketChannelNode: 'WebSocketChannelNode',
 } as const
 
 export type NodeTypeValue = (typeof NodeType)[keyof typeof NodeType]
@@ -83,4 +96,5 @@ export const NodeTypeSchema = z.enum([
   NodeType.RouteNode,
   NodeType.GraphQLOperationNode,
   NodeType.GrpcMethodNode,
+  NodeType.WebSocketChannelNode,
 ])

--- a/packages/types/src/identity.ts
+++ b/packages/types/src/identity.ts
@@ -16,6 +16,7 @@ const FILE_PREFIX = 'file:'
 const ROUTE_PREFIX = 'route:'
 const GRAPHQL_OP_PREFIX = 'graphql:'
 const GRPC_METHOD_PREFIX = 'grpc:'
+const WEBSOCKET_CHANNEL_PREFIX = 'ws:'
 
 // ServiceNode id: `service:<name>` for env-unknown nodes (the default,
 // produced by static extraction or by ingest when the span carries no env
@@ -242,6 +243,36 @@ export function parseGrpcMethodId(
   const rpcMethod = rest.slice(slash + 1)
   if (rpcService.length === 0 || rpcMethod.length === 0) return null
   return { rpcService, rpcMethod }
+}
+
+// WebSocketChannelNode id: `ws:<service>:<channel>` (ADR-125). The `service`
+// segment is the serving service's manifest name, matching the FileNode /
+// RouteNode / GraphQLOperationNode convention. Unlike the gRPC id — which keys on
+// the globally-unique fully-qualified `rpc.service` — a WebSocket channel path
+// (`/chat`, `/socket.io`) carries no package qualifier and is not unique across a
+// mesh, so it is scoped to the serving service exactly as a route path is. The
+// channel is a server-side artifact of a package, not an environment, so the id
+// is env-unscoped like FileNode / RouteNode. The `channel` follows the first
+// colon after the prefix; a service name carries no colon, so a channel path that
+// itself contains a colon stays intact on the channel side.
+export function websocketChannelId(service: string, channel: string): string {
+  return `${WEBSOCKET_CHANNEL_PREFIX}${service}:${channel}`
+}
+
+// Parse a WebSocket channel id into its (service, channel) tuple. Returns null
+// when the input isn't a WebSocket channel id. Splits on the first colon after
+// the prefix — the service name carries no colon, the channel is the remainder.
+export function parseWebsocketChannelId(
+  id: string,
+): { service: string; channel: string } | null {
+  if (!id.startsWith(WEBSOCKET_CHANNEL_PREFIX)) return null
+  const rest = id.slice(WEBSOCKET_CHANNEL_PREFIX.length)
+  const colon = rest.indexOf(':')
+  if (colon === -1) return null
+  const service = rest.slice(0, colon)
+  const channel = rest.slice(colon + 1)
+  if (service.length === 0 || channel.length === 0) return null
+  return { service, channel }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/types/src/nodes.ts
+++ b/packages/types/src/nodes.ts
@@ -239,6 +239,34 @@ export const GrpcMethodNodeSchema = z.object({
 })
 export type GrpcMethodNode = z.infer<typeof GrpcMethodNodeSchema>
 
+// WebSocketChannelNode — a live WebSocket channel at (service, channel)
+// granularity (ADR-125 / docs/contracts/otel-ingest.md). A WebSocket app used to
+// produce no OBSERVED topology — only message-handler errors, as incidents —
+// leaving the channels themselves invisible. This node recovers the channel-level
+// topology from the HTTP upgrade span that opens the connection (a SERVER `GET`
+// carrying `Upgrade: websocket` and the WebSocket path). Identified by
+// `websocketChannelId(service, channel)` → `ws:<service>:<channel>`. `service` is
+// the serving service; `channel` is the connection path/channel (`/chat`,
+// `/socket.io`), mirrored into `name` for the shared node-name convention. It is
+// minted OBSERVED-only: a WebSocket channel is known from observation, never from
+// static extraction, so — unlike RouteNode / GraphQLOperationNode / GrpcMethodNode
+// — there is no declared twin to fuse with and no static producer to fill in
+// `path` / `line`. Those stay optional and absent in this cut, never fabricated
+// (file-awareness.md §6). The edge onto it reuses the existing `CONNECTS_TO` — an
+// observed-liveness edge that carries `lastObserved` and decays OBSERVED → STALE
+// on CONNECTS_TO's own staleness threshold when the channel goes quiet.
+export const WebSocketChannelNodeSchema = z.object({
+  id: z.string(),
+  type: z.literal(NodeType.WebSocketChannelNode),
+  name: z.string(),
+  service: z.string(),
+  channel: z.string(),
+  path: z.string().optional(),
+  line: z.number().int().nonnegative().optional(),
+  discoveredVia: DiscoveredViaSchema.optional(),
+})
+export type WebSocketChannelNode = z.infer<typeof WebSocketChannelNodeSchema>
+
 export const GraphNodeSchema = z.discriminatedUnion('type', [
   ServiceNodeSchema,
   DatabaseNodeSchema,
@@ -249,5 +277,6 @@ export const GraphNodeSchema = z.discriminatedUnion('type', [
   RouteNodeSchema,
   GraphQLOperationNodeSchema,
   GrpcMethodNodeSchema,
+  WebSocketChannelNodeSchema,
 ])
 export type GraphNode = z.infer<typeof GraphNodeSchema>

--- a/packages/types/test/schemas.test.ts
+++ b/packages/types/test/schemas.test.ts
@@ -25,12 +25,14 @@ describe('runtime constants', () => {
     // IMPORTS joined with the import graph (ADR-092).
     expect(Object.values(EdgeType)).toHaveLength(9)
   })
-  it('NodeType has 9 values', () => {
+  it('NodeType has 10 values', () => {
     // FileNode joined the set with the file-first graph (ADR-089); RouteNode
     // joined with server-route extraction (ADR-119); GraphQLOperationNode joined
     // with operation-grain GraphQL observation (ADR-122); GrpcMethodNode joined
-    // with method-grain gRPC observation + `.proto` extraction (ADR-123).
-    expect(Object.values(NodeType)).toHaveLength(9)
+    // with method-grain gRPC observation + `.proto` extraction (ADR-123);
+    // WebSocketChannelNode joined with channel-grain WebSocket observation
+    // (ADR-125), minted OBSERVED-only from the HTTP upgrade span.
+    expect(Object.values(NodeType)).toHaveLength(10)
   })
 })
 


### PR DESCRIPTION
A WebSocket app currently produces no OBSERVED topology at all — only the odd message-handler error surfaces as an incident, and the channels a client actually connects to stay invisible. After the HTTP upgrade handshake the traffic rides the socket and stops producing spans, so there is nothing left to observe at message grain.

This gives WebSocket services a **channel-grain, OBSERVED-only** topology, minted from the one span that reliably names a channel: the HTTP upgrade handshake — a SERVER `GET` carrying `Upgrade: websocket` and the connection path.

What it does:

- **New node, channel grain.** `WebSocketChannelNode` at `(service, channel)` grain, id `ws:<service>:<channel>`, scoped to the serving service like a route (a WS path is not globally unique). It is the tenth `NodeType`.
- **Reuses `CONNECTS_TO` — no new edge type.** The serving service connects to the channel over the existing `CONNECTS_TO` edge, the same connection verb a service already has to a datastore. A channel's whole meaning is liveness, so that fits.
- **Decays to STALE.** The edge carries `lastObserved` and decays `OBSERVED → STALE` on `CONNECTS_TO`'s own staleness threshold, via the daemon staleness loop — no new threshold.
- **OBSERVED-only, honestly.** A channel is known from observation, never from static extraction, so the node has no declared twin and its `path` / `line` stay absent rather than fabricated. File-grained through the same `code.*` call-site path as every other OBSERVED edge; service-level when there is no call site.
- **Excluded from `missing-extracted`.** Because the node is observed-only by design, an observed-only `CONNECTS_TO` onto it would trip a false `missing-extracted` divergence. Channel targets are excluded from that check — mirroring the existing `CONTAINS` exclusion, keyed on the target node type.

Tests cover the real upgrade-span shape (node + file-grained OBSERVED `CONNECTS_TO`), the staleness decay, and the divergence exclusion; the schema snapshot grows additively (NodeType count 9 → 10).

**Heads-up on the ADR number.** The task assigned this decision ADR-124, but #654 (Connectors plane) merged to `main` first and already occupies ADR-124 across `docs/contracts.md`, `connectors.md`, and `otel-ingest.md`. To avoid a duplicate ADR number in the repo, this branch cites **ADR-125** for the WebSocket decision. If you'd rather keep 124 for WebSocket and renumber connectors, it's a one-line find-replace — flagging so you can decide when you file the ADR.

Refs #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)