### PR TITLE
Connectors plane: shared pull/map/fuse scaffold

### DIFF
--- a/docs/contracts/connectors.md
+++ b/docs/contracts/connectors.md
@@ -4,7 +4,7 @@ description: The connectors plane — a second OBSERVED ingestion path (pull) al
 governs:
   - "packages/core/src/connectors/**"
 adr: [ADR-124]
-enforcement: [review]
+enforcement: [lint, review]
 ---
 
 # Connectors contract
@@ -59,6 +59,6 @@ A connector's config/broker state holds the credential. The graph records existe
 
 ## Enforcement
 
-`enforcement: [review]` — this is a review-only contract for now: no connector code has landed yet (this contract lands with ADR-124, ahead of the `neatd` implementation), so there is nothing for a lint assertion to check yet. Once the first provider (Supabase) ships, a `contracts.test.ts` assertion should check the provider-interface shape (§1) and the credential-in-config-not-snapshot rule (§6) mechanically, and this contract's enforcement tag should move to `[lint, review]`. Flagged here rather than deferred silently, per `contract-enforcement.md` §3.
+`enforcement: [lint, review]`. **Lint:** `contracts.test.ts`'s "Connectors plane contract (ADR-124)" block checks the provider-interface shape (§1 — `ObservedConnector`/`ConnectorContext`/`ObservedSignal` declared as specified) and the credential-in-config-not-snapshot rule (§6 — `credentials` never appears on the same line as a graph mutation call in `connectors/**`) mechanically, plus a scoped regression guard that `connectors/index.ts` never mutates the graph directly (ADR-030). **Review:** everything else — the passive/ambient discipline (§2), the two-credential-profile split (§3), and each provider's own fusion pattern (§4) — stays a human call until a provider's `poll()`/mapping code gives it something concrete to check against.
 
 Full rationale: [ADR-124](../decisions.md#adr-124--the-supabase-connector-and-the-connectors-plane).

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -1,0 +1,239 @@
+// Connectors plane — the provider-agnostic pull/map/fuse pipeline
+// (docs/contracts/connectors.md, docs/connectors/README.md, ADR-124).
+//
+// A provider module (packages/core/src/connectors/<provider>/, none shipped
+// yet) owns exactly two things: fetching `ObservedSignal[]` off its own API
+// (`ObservedConnector.poll`) and mapping a signal's targetKind/targetName to
+// a NEAT node id (the `resolveTarget` callback below). Everything after that
+// — resolving a static call site, minting the OBSERVED edge — is written
+// once, here, and is identical for every provider: a connector-sourced edge
+// and a span-sourced edge carry the same provenance and land through the
+// same mutation primitives OTel ingest uses (README.md's opening paragraph).
+//
+// Mutation authority (ADR-030 — see contracts.test.ts's "Lifecycle contract"
+// audit): only ingest.ts and extract/* may call a graph mutator directly.
+// This module never does — every node/edge write below goes through an
+// ingest.ts primitive (`ensureServiceNode`, `ensureObservedFileNode`,
+// `upsertObservedEdge`), exported for exactly this reuse. A future
+// provider's own target-node creation (a Supabase table InfraNode, say)
+// belongs in ingest.ts too, for the same reason — this module only ever
+// calls into it, never mutates the graph itself.
+
+import type { EdgeTypeValue } from '@neat.is/types'
+import type { NeatGraph } from '../graph.js'
+import {
+  ensureObservedFileNode,
+  ensureServiceNode,
+  reconcileObservedRelPath,
+  upsertObservedEdge,
+  type CallSite,
+} from '../ingest.js'
+import type { ConnectorContext, ObservedConnector, ObservedSignal } from './types.js'
+
+export type {
+  ConnectorCallSite,
+  ConnectorContext,
+  ObservedConnector,
+  ObservedSignal,
+} from './types.js'
+
+// env-unscoped, matching the sentinel identity.ts uses for "no deployment
+// signal" (ADR-074 §2) — a connector signal carries no
+// deployment.environment(.name) the way an OTel span might.
+const NO_ENV = 'unknown'
+
+/**
+ * What a provider's target-resolution step hands back for one signal. The
+ * generic pipeline needs both endpoints of the edge it's about to mint:
+ *
+ * - `serviceName` is the NEAT manifest service whose code produced the
+ *   signal — the edge's source. The shared pipeline turns it into a plain
+ *   ServiceNode id, or a FileNode id once the fuse step below resolves the
+ *   signal's callSite against it.
+ * - `targetNodeId` is the id the provider's own mapping already resolved —
+ *   an `infraId(...)` sub-resource, a RouteNode, a ServiceNode, whatever
+ *   (see each provider's docs/connectors/<provider>.md §Fusion).
+ *
+ * Returning `null` skips the signal honestly: an unresolvable target never
+ * fabricates a node or edge (the same discipline file-awareness.md §6
+ * states for OTel ingest).
+ */
+export interface ResolvedConnectorTarget {
+  targetNodeId: string
+  serviceName: string
+  edgeType: EdgeTypeValue
+}
+
+export type ResolveConnectorTarget = (
+  signal: ObservedSignal,
+  ctx: ConnectorContext,
+) => ResolvedConnectorTarget | null
+
+export interface ConnectorPollResult {
+  // Signals connector.poll() returned this tick.
+  signalCount: number
+  // Fresh OBSERVED edges minted.
+  edgesCreated: number
+  // Existing OBSERVED edges whose signal block advanced.
+  edgesUpdated: number
+  // Signals that resolved to no target (resolveTarget returned null, or the
+  // resolved target/service node doesn't exist in the graph yet) — dropped
+  // honestly rather than minting a fabricated edge.
+  unresolved: number
+}
+
+/**
+ * One poll cycle: fetch, map, fuse, mint. Pure with respect to `ctx` — the
+ * caller (`startConnectorPollLoop` below, or a one-shot `neat sync`) owns
+ * advancing `ctx.since` between calls.
+ */
+export async function runConnectorPoll(
+  connector: ObservedConnector,
+  ctx: ConnectorContext,
+  graph: NeatGraph,
+  resolveTarget: ResolveConnectorTarget,
+): Promise<ConnectorPollResult> {
+  const signals = await connector.poll(ctx)
+  let edgesCreated = 0
+  let edgesUpdated = 0
+  let unresolved = 0
+
+  for (const signal of signals) {
+    const resolved = resolveTarget(signal, ctx)
+    if (!resolved) {
+      unresolved++
+      continue
+    }
+
+    // Same shape ingest.ts's handleSpan uses for every span: auto-create a
+    // minimal ServiceNode the first time this service is seen so the edge
+    // upsert below always has a source endpoint, even for a service the
+    // static extractor hasn't reached (or never will, in an OTel-less setup).
+    const serviceNodeId = ensureServiceNode(graph, resolved.serviceName, NO_ENV)
+
+    // File-grain fusion when the signal carries a call site, through the
+    // same reconcileObservedRelPath path OTel ingest uses (file-awareness.md
+    // §4) — service-level, honestly, when it doesn't (§6, never fabricated).
+    const callSite: CallSite | undefined = signal.callSite
+      ? { relPath: signal.callSite.file, line: signal.callSite.line }
+      : undefined
+    const sourceId = callSite
+      ? ensureObservedFileNode(graph, resolved.serviceName, serviceNodeId, callSite)
+      : serviceNodeId
+    const evidence = callSite
+      ? {
+          file: reconcileObservedRelPath(graph, resolved.serviceName, callSite.relPath),
+          line: callSite.line,
+        }
+      : undefined
+
+    // upsertObservedEdge increments its signal block by exactly one call per
+    // invocation — the right unit for a single span, but a connector signal
+    // is already an aggregate over the whole poll window (`callCount` calls,
+    // `errorCount` of them failing). Replay it that many times so the
+    // edge's spanCount/errorCount — and the confidence grade derived from
+    // them, ADR-066 — land the same as if `callCount` individual spans had
+    // arrived, rather than undercounting a batched signal down to +1.
+    const calls = Math.trunc(signal.callCount)
+    if (calls < 1) continue // nothing observed this window — not even a miss
+    const errors = Math.min(Math.max(Math.trunc(signal.errorCount), 0), calls)
+
+    let created = false
+    let ok = true
+    for (let i = 0; i < calls; i++) {
+      const result = upsertObservedEdge(
+        graph,
+        resolved.edgeType,
+        sourceId,
+        resolved.targetNodeId,
+        signal.lastObservedIso,
+        i < errors,
+        evidence,
+      )
+      if (!result) {
+        // Target node doesn't exist yet — an extractor gap (supabase.md
+        // §Static extractor gap documents exactly this case) or a provider
+        // that hasn't minted it. Honest miss, not a crash.
+        ok = false
+        break
+      }
+      if (i === 0) created = result.created
+    }
+    if (!ok) {
+      unresolved++
+      continue
+    }
+    if (created) edgesCreated++
+    else edgesUpdated++
+  }
+
+  return { signalCount: signals.length, edgesCreated, edgesUpdated, unresolved }
+}
+
+export interface ConnectorPollLoopOptions {
+  intervalMs?: number
+  onError?: (err: unknown) => void
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 60_000
+
+/**
+ * Recurring wrapper around `runConnectorPoll` — the same setInterval +
+ * unref + try/catch + stop-closure shape `startStalenessLoop` (ingest.ts)
+ * already uses for the daemon's per-project background tasks, reused here
+ * rather than reinvented. `daemon.ts` wires this in exactly where it wires
+ * `startStalenessLoop`, tearing both down together per project slot.
+ *
+ * Advances `since` to the tick's own start time after every successful
+ * poll — the next tick asks the provider for "since last tick" rather than
+ * replaying. A tick that throws logs and leaves `since` where it was, so a
+ * transient provider outage doesn't silently skip the gap once it recovers.
+ */
+export function startConnectorPollLoop(
+  connector: ObservedConnector,
+  ctx: ConnectorContext,
+  graph: NeatGraph,
+  resolveTarget: ResolveConnectorTarget,
+  options: ConnectorPollLoopOptions = {},
+): () => void {
+  let stopped = false
+  let since = ctx.since
+  const intervalMs = options.intervalMs ?? DEFAULT_POLL_INTERVAL_MS
+  const onError =
+    options.onError ??
+    ((err: unknown) => console.error(`[neatd] connector poll failed (${connector.provider})`, err))
+
+  const tick = (): void => {
+    if (stopped) return
+    void (async () => {
+      const tickStartedAt = new Date().toISOString()
+      try {
+        await runConnectorPoll(connector, { ...ctx, since }, graph, resolveTarget)
+        since = tickStartedAt
+      } catch (err) {
+        onError(err)
+      }
+    })()
+  }
+
+  const interval = setInterval(tick, intervalMs)
+  if (typeof interval.unref === 'function') interval.unref()
+  return () => {
+    stopped = true
+    clearInterval(interval)
+  }
+}
+
+/**
+ * One project's registered connector, ready for `daemon.ts` to poll on an
+ * interval. Deliberately thin — no config-loading or credential-broker logic
+ * lives here (that's provider- and profile-specific, later work per
+ * docs/contracts/connectors.md §3); this is just the seam a daemon slot
+ * wires a connector through.
+ */
+export interface ConnectorRegistration {
+  connector: ObservedConnector
+  credentials: Record<string, unknown>
+  resolveTarget: ResolveConnectorTarget
+  intervalMs?: number
+}

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -1,0 +1,81 @@
+// Connectors plane — provider-agnostic types (docs/contracts/connectors.md,
+// docs/connectors/README.md, ADR-124).
+//
+// OTLP ingest has had exactly one path onto the OBSERVED layer: an app
+// pushing spans it was instrumented to emit. A connector is the second path
+// — a provider that already runs its own server-side telemetry (a hosted
+// Postgres platform's query stats, a hosting platform's request logs) gets
+// pulled from instead, so OBSERVED edges exist with zero app instrumentation.
+//
+// This file declares the one shape every provider implements. The
+// provider-specific fetch + target-resolution logic lives under
+// packages/core/src/connectors/<provider>/ — none shipped yet; this PR is
+// the shared pull/map/fuse scaffold those provider modules plug into
+// (Supabase first, per ADR-124; Railway/Firebase/Cloudflare designs are
+// merged as prose-only docs and land their own connector modules next).
+
+/**
+ * A connector implements exactly one method. Everything downstream of
+ * `poll()` — resolving a static call site, minting the OBSERVED edge — is
+ * shared, generic code in connectors/index.ts.
+ */
+export interface ObservedConnector {
+  readonly provider: string
+  poll(ctx: ConnectorContext): Promise<ObservedSignal[]>
+}
+
+/**
+ * Everything a connector's `poll()` needs, resolved once at connector setup
+ * — never re-derived at poll time.
+ *
+ * `credentials` is opaque here on purpose: its shape is entirely provider-
+ * and profile-defined (local vs hosted — docs/contracts/connectors.md §3).
+ * It flows through to `poll()` only. Never log it, never write it into a
+ * node or edge, never let it reach the graph snapshot (contract §6, and the
+ * `.env`-contents rule docs/contracts.md Rule 4 already states for local
+ * config).
+ */
+export interface ConnectorContext {
+  // Absolute path to the project root being polled — the same anchor
+  // `reconcileObservedRelPath` (ingest.ts) uses to fuse a signal's callSite
+  // onto the EXTRACTED service-relative path.
+  projectDir: string
+  credentials: Record<string, unknown>
+  // ISO8601 — the last successful poll's high-water mark. A connector must
+  // treat an absent `since` as "no prior poll", bounded by whatever lookback
+  // window the provider's own API caps (README.md §Poll cadence and
+  // backfill) — never an unbounded full-history query.
+  since?: string
+}
+
+/**
+ * `file:line` the provider's own signal carries, when it does (rare — see
+ * docs/connectors/README.md §Provider interface, which notes this is
+ * "usually resolved by the mapping layer below, not here"). Reconciled onto
+ * the EXTRACTED service-relative path by the shared fuse step the same way
+ * an OTel span's call site is (file-awareness.md §4).
+ */
+export interface ConnectorCallSite {
+  file: string
+  line: number
+}
+
+/**
+ * One provider-agnostic observation. `targetKind`/`targetName` are the
+ * provider's own vocabulary (`'supabase-table'`/`'orders'`,
+ * `'route'`/`'GET /users/:id'`, ...) — resolving that pair to a NEAT node id
+ * is the one genuinely provider-specific step (README.md's pipeline
+ * diagram), supplied to `runConnectorPoll` (connectors/index.ts) as a
+ * `resolveTarget` callback. Everything downstream of that resolution — file
+ * grain fusion, OBSERVED mint — is shared.
+ */
+export interface ObservedSignal {
+  targetKind: string
+  targetName: string
+  callCount: number
+  errorCount: number
+  // The provider's own event time — never poll-arrival time (README.md
+  // §Poll cadence and backfill).
+  lastObservedIso: string
+  callSite?: ConnectorCallSite
+}

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -45,6 +45,7 @@ import { buildApi } from './api.js'
 import { buildOtelReceiver, listenSteppingOtlp } from './otel.js'
 import { attachGraphToEventBus } from './events.js'
 import { handleSpan, makeErrorSpanWriter, startStalenessLoop } from './ingest.js'
+import { startConnectorPollLoop, type ConnectorRegistration } from './connectors/index.js'
 import {
   listProjects,
   pruneRegistry,
@@ -247,6 +248,14 @@ export interface DaemonOptions {
   // exercise daemon slots without needing the listeners). Production
   // `neatd start` never sets this.
   bindListeners?: boolean
+  // Connectors plane (docs/contracts/connectors.md, ADR-124) — pull-based
+  // OBSERVED connectors polled on an interval alongside every project this
+  // daemon bootstraps, the same way every project gets the staleness loop.
+  // Applied identically to every project slot; there is no per-project
+  // config-loading here yet (that's provider-specific, later work) — a
+  // caller wanting project-scoped connectors runs a separate `startDaemon`
+  // per project (the single-project ADR-096 mode is the common case).
+  connectors?: ConnectorRegistration[]
 }
 
 export interface ProjectSlot {
@@ -261,6 +270,11 @@ export interface ProjectSlot {
   // STALE instead of sitting live forever. Must be stopped alongside
   // stopPersist so no interval leaks when the slot is torn down or replaced.
   stopStaleness: () => void
+  // Stops every connector poll loop registered for this slot (connectors/
+  // index.ts's startConnectorPollLoop, one per opts.connectors entry). Same
+  // lifecycle as stopStaleness — must run alongside it wherever the slot is
+  // torn down or replaced.
+  stopConnectors: () => void
   // #475 — removes the event-bus listeners attachGraphToEventBus installed
   // on this slot's graph. No-op for broken slots. Must run wherever the slot
   // is torn down or replaced, or a reloaded slot's old graph keeps emitting.
@@ -281,6 +295,11 @@ function teardownSlot(slot: ProjectSlot): void {
   }
   try {
     slot.stopStaleness()
+  } catch {
+    // best-effort
+  }
+  try {
+    slot.stopConnectors()
   } catch {
     // best-effort
   }
@@ -466,7 +485,10 @@ function spanBelongsToSingleProject(
   )
 }
 
-async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
+async function bootstrapProject(
+  entry: RegistryEntry,
+  connectors: ConnectorRegistration[] = [],
+): Promise<ProjectSlot> {
   const paths = pathsForProject(entry.name, path.join(entry.path, 'neat-out'))
 
   // Path missing on disk → mark broken and surface the reason. Daemon
@@ -487,6 +509,7 @@ async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
       paths,
       stopPersist: () => {},
       stopStaleness: () => {},
+      stopConnectors: () => {},
       detachEvents: () => {},
       status: 'broken',
       errorReason: (err as Error).message,
@@ -523,6 +546,21 @@ async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
       staleEventsPath: paths.staleEventsPath,
       project: entry.name,
     })
+    // Connectors plane (docs/contracts/connectors.md, ADR-124) — one poll
+    // loop per registered connector, same interval-loop shape as the
+    // staleness loop above and torn down alongside it (teardownSlot).
+    const stopFns = connectors.map((registration) =>
+      startConnectorPollLoop(
+        registration.connector,
+        { projectDir: entry.path, credentials: registration.credentials },
+        graph,
+        registration.resolveTarget,
+        { intervalMs: registration.intervalMs },
+      ),
+    )
+    const stopConnectors = (): void => {
+      for (const stop of stopFns) stop()
+    }
     await touchLastSeen(entry.name).catch(() => {})
 
     return {
@@ -532,6 +570,7 @@ async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
       paths,
       stopPersist,
       stopStaleness,
+      stopConnectors,
       detachEvents,
       status: 'active',
     }
@@ -724,7 +763,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
   // the new slot status so callers can decide whether to deliver the span.
   async function tryRecoverSlot(entry: RegistryEntry): Promise<ProjectSlot> {
     try {
-      const fresh = await bootstrapProject(entry)
+      const fresh = await bootstrapProject(entry, opts.connectors ?? [])
       // The slot being replaced must release its graph's bus listeners
       // (#475) — a stale attach on the prior graph would double-emit.
       const prior = slots.get(entry.name)
@@ -751,7 +790,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
     bootstrapStatus.set(entry.name, 'bootstrapping')
     bootstrapStartedAt.set(entry.name, Date.now())
     try {
-      const slot = await bootstrapProject(entry)
+      const slot = await bootstrapProject(entry, opts.connectors ?? [])
       // Same replacement rule as tryRecoverSlot (#475).
       const prior = slots.get(entry.name)
       if (prior) teardownSlot(prior)

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -488,7 +488,12 @@ function relPathForRuntimeFile(
   return p.length > 0 ? p : null
 }
 
-interface CallSite {
+// Exported so the connectors plane (packages/core/src/connectors/index.ts,
+// docs/contracts/connectors.md) can build one from a signal's own callSite —
+// a connector's file:line comes from the provider's telemetry rather than an
+// OTel span's code.* attributes, but reconciles onto the same EXTRACTED
+// FileNode through the same primitives below.
+export interface CallSite {
   relPath: string
   line?: number
   fn?: string
@@ -615,7 +620,7 @@ function callSiteFromSpan(
 // carrying extra leading directories the anchor couldn't strip — reuse the
 // extractor's path so both layers key the same node. No match means the file is
 // genuinely OTel-only; the honest runtime path stands (never fabricated, §6).
-function reconcileObservedRelPath(
+export function reconcileObservedRelPath(
   graph: NeatGraph,
   serviceName: string,
   relPath: string,
@@ -646,7 +651,7 @@ function reconcileObservedRelPath(
 // STALE when traffic quiets (markStaleEdges skips edges without lastObserved),
 // and divergence detection skips CONTAINS so an OTel-only file node doesn't
 // surface as a missing-extracted finding.
-function ensureObservedFileNode(
+export function ensureObservedFileNode(
   graph: NeatGraph,
   serviceName: string,
   serviceNodeId: string,
@@ -1041,7 +1046,11 @@ export function frontierIdFor(host: string): string {
 // `language: 'unknown'` is the contract's specified placeholder (ADR-033). When
 // static extraction later produces a ServiceNode at the same id, addServiceNodes
 // merges and flips discoveredVia to 'merged' rather than overwriting.
-function ensureServiceNode(
+// Exported for the connectors plane (connectors/index.ts) — a connector
+// signal needs the same auto-vivified ServiceNode any OTel span gets before
+// an edge upsert, since a connector-sourced service may never have been
+// statically extracted or seen a span yet.
+export function ensureServiceNode(
   graph: NeatGraph,
   serviceName: string,
   env: string,
@@ -1130,12 +1139,16 @@ function ensureFrontierNode(graph: NeatGraph, host: string, ts: string): string 
   return id
 }
 
-interface UpsertResult {
+// Exported so the connectors plane (connectors/index.ts) mints edges through
+// the identical primitive OTel ingest uses — a connector-sourced edge and a
+// span-sourced edge are meant to be indistinguishable to traversal,
+// divergence, and staleness (docs/connectors/README.md).
+export interface UpsertResult {
   edge: GraphEdge
   created: boolean
 }
 
-function upsertObservedEdge(
+export function upsertObservedEdge(
   graph: NeatGraph,
   type: EdgeTypeValue,
   source: string,

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -13582,3 +13582,62 @@ describe('Contract enforcement tags (ADR-104)', () => {
     expect(unknown, `${file} names unknown enforcement pillar(s): ${unknown.join(', ')}`).toEqual([])
   })
 })
+
+// ──────────────────────────────────────────────────────────────────────────
+// Connectors plane (ADR-124) — mechanical checks for the two things
+// docs/contracts/connectors.md §Enforcement names as ready to lock down now
+// that the shared scaffold has landed: the provider-interface shape (§1) and
+// the credential-in-config-not-snapshot rule (§6). The contract itself still
+// reads `enforcement: [review]` — these are additive regression guards, not
+// a claim that every connectors.md rule is mechanically checked yet (the
+// per-provider fusion rules in §4 have no code to check until a provider's
+// poll()/mapping lands).
+// ──────────────────────────────────────────────────────────────────────────
+describe('Connectors plane contract (ADR-124)', () => {
+  const CONNECTORS_SRC = join(CORE_SRC, 'connectors')
+
+  it('docs/contracts/connectors.md governs packages/core/src/connectors/**', () => {
+    const src = readFileSync(join(__dirname, '../../../../docs/contracts/connectors.md'), 'utf8')
+    expect(src).toMatch(/governs:/)
+    expect(src).toMatch(/packages\/core\/src\/connectors\/\*\*/)
+  })
+
+  it('§1 — ObservedConnector/ConnectorContext/ObservedSignal are declared with the spec\'s shape', () => {
+    const src = readFileSync(join(CONNECTORS_SRC, 'types.ts'), 'utf8')
+    expect(src).toMatch(/interface ObservedConnector/)
+    expect(src).toMatch(/readonly provider: string/)
+    expect(src).toMatch(/poll\(ctx: ConnectorContext\): Promise<ObservedSignal\[\]>/)
+    expect(src).toMatch(/interface ConnectorContext/)
+    expect(src).toMatch(/interface ObservedSignal/)
+  })
+
+  it('§6 — ConnectorContext.credentials never lands on the same line as a graph mutation call', () => {
+    // Not a full data-flow analysis — a line-level guard against the
+    // obvious regression (a credential literal stuffed into a node/edge
+    // attribute object at the mutation call site). Mirrors the grep-grade
+    // audits the rest of this file already relies on (Rule 16, Rule 8).
+    const offenders: string[] = []
+    const mutators = /\b(graph|g)\.(addNode|addEdge|addEdgeWithKey|addDirectedEdge|addDirectedEdgeWithKey|replaceNodeAttributes|replaceEdgeAttributes|mergeNodeAttributes|mergeEdgeAttributes)\s*\(/
+    for (const file of walkSrc(CONNECTORS_SRC)) {
+      readFileSync(file, 'utf8')
+        .split('\n')
+        .forEach((line, i) => {
+          if (/credentials/.test(line) && mutators.test(line)) {
+            offenders.push(`${file}:${i + 1}: ${line.trim()}`)
+          }
+        })
+    }
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
+
+  it('connectors/index.ts never mutates the graph directly (ADR-030 mutation authority, scoped regression guard)', () => {
+    // The generic "Lifecycle contract" audit above already covers all of
+    // core/src; this pins the same expectation specifically for the
+    // connectors plane so a regression here reads as a connectors-contract
+    // failure, not a buried line in the ADR-030 sweep.
+    const src = readFileSync(join(CONNECTORS_SRC, 'index.ts'), 'utf8')
+    const mutators =
+      /\b(graph|g)\.(addNode|addEdge|addEdgeWithKey|addDirectedEdge|addDirectedEdgeWithKey|dropNode|dropEdge|replaceNodeAttributes|replaceEdgeAttributes|mergeNodeAttributes|mergeEdgeAttributes)\s*\(/
+    expect(mutators.test(src)).toBe(false)
+  })
+})

--- a/packages/core/test/connectors.test.ts
+++ b/packages/core/test/connectors.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest'
+import { MultiDirectedGraph } from 'graphology'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  fileId,
+  infraId,
+  observedEdgeId,
+  serviceId,
+  type FileNode,
+  type GraphEdge,
+  type GraphNode,
+  type InfraNode,
+  type ServiceNode,
+} from '@neat.is/types'
+import {
+  runConnectorPoll,
+  type ConnectorContext,
+  type ObservedConnector,
+  type ObservedSignal,
+  type ResolveConnectorTarget,
+} from '../src/connectors/index.js'
+import type { NeatGraph } from '../src/graph.js'
+
+const SERVICE = 'orders-api'
+const TABLE_TARGET = infraId('supabase-table', 'proj-ref/orders')
+const RPC_TARGET = infraId('supabase-rpc', 'proj-ref/get_totals')
+
+function newGraph(): NeatGraph {
+  const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+  const service: ServiceNode = {
+    id: serviceId(SERVICE),
+    type: NodeType.ServiceNode,
+    name: SERVICE,
+    language: 'javascript',
+  }
+  g.addNode(service.id, service)
+
+  // EXTRACTED FileNode a static extractor already minted — the trailing
+  // segment reconcileObservedRelPath must match against a connector
+  // signal's own (unanchored) callSite path.
+  const file: FileNode = {
+    id: fileId(SERVICE, 'src/db/orders.ts'),
+    type: NodeType.FileNode,
+    service: SERVICE,
+    path: 'src/db/orders.ts',
+    language: 'typescript',
+  }
+  g.addNode(file.id, file)
+
+  const table: InfraNode = {
+    id: TABLE_TARGET,
+    type: NodeType.InfraNode,
+    name: 'proj-ref/orders',
+    provider: 'supabase',
+    kind: 'supabase-table',
+  }
+  g.addNode(table.id, table)
+
+  const rpc: InfraNode = {
+    id: RPC_TARGET,
+    type: NodeType.InfraNode,
+    name: 'proj-ref/get_totals',
+    provider: 'supabase',
+    kind: 'supabase-rpc',
+  }
+  g.addNode(rpc.id, rpc)
+
+  return g
+}
+
+// A trivial in-memory test double — not a real provider. Real poll()
+// implementations (Supabase, Railway, Firebase, Cloudflare) are out of
+// scope for this scaffold; this fake only exercises the pull/map/fuse
+// pipeline the four provider designs will plug into.
+class FakeConnector implements ObservedConnector {
+  readonly provider = 'fake'
+  constructor(private readonly signals: ObservedSignal[]) {}
+  async poll(_ctx: ConnectorContext): Promise<ObservedSignal[]> {
+    return this.signals
+  }
+}
+
+const resolveTarget: ResolveConnectorTarget = (signal) => {
+  if (signal.targetKind === 'supabase-table') {
+    return {
+      targetNodeId: infraId('supabase-table', signal.targetName),
+      serviceName: SERVICE,
+      edgeType: EdgeType.CALLS,
+    }
+  }
+  if (signal.targetKind === 'supabase-rpc') {
+    return {
+      targetNodeId: infraId('supabase-rpc', signal.targetName),
+      serviceName: SERVICE,
+      edgeType: EdgeType.CALLS,
+    }
+  }
+  return null
+}
+
+function baseCtx(): ConnectorContext {
+  return { projectDir: '/repo/orders-api', credentials: {} }
+}
+
+describe('connectors plane — runConnectorPoll (docs/contracts/connectors.md)', () => {
+  it('mints an OBSERVED edge, file-grained, when the signal carries a callSite', async () => {
+    const graph = newGraph()
+    const signal: ObservedSignal = {
+      targetKind: 'supabase-table',
+      targetName: 'proj-ref/orders',
+      callCount: 5,
+      errorCount: 1,
+      lastObservedIso: '2026-07-03T12:00:00.000Z',
+      // Unanchored leading segment ("app/") the extractor's own path
+      // ("src/db/orders.ts") doesn't carry — reconcileObservedRelPath must
+      // recover it via trailing-suffix match, same as an OTel call site.
+      callSite: { file: 'app/src/db/orders.ts', line: 42 },
+    }
+    const connector = new FakeConnector([signal])
+
+    const result = await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
+
+    expect(result).toEqual({
+      signalCount: 1,
+      edgesCreated: 1,
+      edgesUpdated: 0,
+      unresolved: 0,
+    })
+
+    const fileNodeId = fileId(SERVICE, 'src/db/orders.ts')
+    const edgeId = observedEdgeId(fileNodeId, TABLE_TARGET, EdgeType.CALLS)
+    expect(graph.hasEdge(edgeId)).toBe(true)
+
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.source).toBe(fileNodeId)
+    expect(edge.target).toBe(TABLE_TARGET)
+    // callCount=5/errorCount=1 replay as 5 upserts (1 erroring) — the same
+    // signal.spanCount/errorCount shape a burst of 5 individual spans would
+    // produce, not a flat +1 per signal.
+    expect(edge.signal?.spanCount).toBe(5)
+    expect(edge.signal?.errorCount).toBe(1)
+    expect(edge.evidence).toEqual({ file: 'src/db/orders.ts', line: 42 })
+
+    // The edge id and its endpoints were built via the identity helpers
+    // (observedEdgeId / fileId / infraId), never a hand-rolled template
+    // literal — contracts.test.ts's Rule 16 / Rule 2 audits cover this at
+    // the source level; this assertion pins the same expectation for the
+    // connectors path specifically.
+    expect(edgeId).toBe(`CALLS:OBSERVED:${fileNodeId}->${TABLE_TARGET}`)
+  })
+
+  it('falls back to a service-level edge when the signal carries no callSite', async () => {
+    const graph = newGraph()
+    const signal: ObservedSignal = {
+      targetKind: 'supabase-rpc',
+      targetName: 'proj-ref/get_totals',
+      callCount: 2,
+      errorCount: 0,
+      lastObservedIso: '2026-07-03T12:05:00.000Z',
+    }
+    const connector = new FakeConnector([signal])
+
+    const result = await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
+
+    expect(result).toEqual({
+      signalCount: 1,
+      edgesCreated: 1,
+      edgesUpdated: 0,
+      unresolved: 0,
+    })
+
+    const serviceNodeId = serviceId(SERVICE)
+    const edgeId = observedEdgeId(serviceNodeId, RPC_TARGET, EdgeType.CALLS)
+    expect(graph.hasEdge(edgeId)).toBe(true)
+
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.source).toBe(serviceNodeId)
+    expect(edge.evidence).toBeUndefined()
+    expect(edge.signal?.spanCount).toBe(2)
+    expect(edge.signal?.errorCount).toBe(0)
+
+    // No FileNode should have been created for this fallback path.
+    expect(graph.hasNode(fileId(SERVICE, 'src/db/get_totals.ts'))).toBe(false)
+  })
+
+  it('an unresolved signal is dropped honestly, never fabricated', async () => {
+    const graph = newGraph()
+    const signal: ObservedSignal = {
+      targetKind: 'supabase-storage', // resolveTarget above knows nothing of this kind
+      targetName: 'proj-ref/avatars',
+      callCount: 3,
+      errorCount: 0,
+      lastObservedIso: '2026-07-03T12:10:00.000Z',
+    }
+    const connector = new FakeConnector([signal])
+
+    const result = await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
+
+    expect(result).toEqual({
+      signalCount: 1,
+      edgesCreated: 0,
+      edgesUpdated: 0,
+      unresolved: 1,
+    })
+  })
+
+  it('re-polling the same signal updates the existing edge instead of minting a twin', async () => {
+    const graph = newGraph()
+    const signal: ObservedSignal = {
+      targetKind: 'supabase-rpc',
+      targetName: 'proj-ref/get_totals',
+      callCount: 1,
+      errorCount: 0,
+      lastObservedIso: '2026-07-03T12:05:00.000Z',
+    }
+    const connector = new FakeConnector([signal])
+
+    await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
+    const second = await runConnectorPoll(
+      connector,
+      { ...baseCtx(), since: '2026-07-03T12:05:00.000Z' },
+      graph,
+      resolveTarget,
+    )
+
+    expect(second).toEqual({
+      signalCount: 1,
+      edgesCreated: 0,
+      edgesUpdated: 1,
+      unresolved: 0,
+    })
+
+    const edgeId = observedEdgeId(serviceId(SERVICE), RPC_TARGET, EdgeType.CALLS)
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.signal?.spanCount).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `packages/core/src/connectors/types.ts` (`ObservedConnector`, `ConnectorContext`, `ObservedSignal`) and `packages/core/src/connectors/index.ts` (`runConnectorPoll`, `startConnectorPollLoop`, `ConnectorRegistration`, `ResolvedConnectorTarget`, `ResolveConnectorTarget`) — the shared pull/map/fuse pipeline the Supabase, Railway, Firebase, and Cloudflare connector designs (docs/connectors/{supabase,railway,firebase,cloudflare}.md) all plug into. No provider's `poll()` logic lands here; that's each provider's own PR against this scaffold.
- The pipeline mints edges through the same `upsertObservedEdge`/`reconcileObservedRelPath`/`ensureObservedFileNode`/`ensureServiceNode` primitives OTel ingest already uses (now exported from `ingest.ts` for reuse) — file-grained when a signal carries a call site, service-level fallback otherwise, exactly the discipline `otel-ingest.md` and `connectors.md` §4 describe. A signal's `callCount`/`errorCount` is an aggregate over the poll window, so the pipeline replays it through `upsertObservedEdge` that many times rather than flattening a burst down to a single `+1`.
- `connectors/index.ts` never calls a graph mutator directly — every write goes through an `ingest.ts` primitive, respecting the ADR-030 mutation-authority rule.
- `daemon.ts` gets a minimal hook (`DaemonOptions.connectors`) so a project's daemon can register connectors and poll them on an interval, using the identical setInterval/unref/stop-closure shape `startStalenessLoop` already runs, torn down alongside it in `teardownSlot`.
- `contracts.test.ts` gains a "Connectors plane contract (ADR-124)" block that mechanically checks the provider-interface shape (§1) and the credentials-never-reach-the-snapshot rule (§6); `docs/contracts/connectors.md` moves from `enforcement: [review]` to `[lint, review]` to match.

## Test plan

- [x] `npm run build --workspace @neat.is/types`
- [x] `npx turbo build --filter=@neat.is/core^...`
- [x] `npm run build --workspace @neat.is/core` (DTS builds clean — confirms every newly-exported type is actually exported)
- [x] `npx vitest run --root packages/core` — 63 files, 1257 passed / 2 skipped / 5 todo (baseline 723 passed in `contracts.test.ts` + this PR's 4 new tests there + 4 new tests in the new `connectors.test.ts`)
- [x] `npx turbo lint --filter=@neat.is/core` — clean (one pre-existing, unrelated warning in `orchestrator.ts`)

Refs #664