### PR TITLE
Implement the Cloudflare Workers/Pages connector, v1 whole-file grain (ADR-129)

### DIFF
--- a/docs/contracts/connectors.md
+++ b/docs/contracts/connectors.md
@@ -4,7 +4,7 @@ description: The connectors plane — a second OBSERVED ingestion path (pull) al
 governs:
   - "packages/core/src/connectors/**"
 adr: [ADR-124]
-enforcement: [review]
+enforcement: [lint, review]
 ---
 
 # Connectors contract
@@ -59,6 +59,6 @@ A connector's config/broker state holds the credential. The graph records existe
 
 ## Enforcement
 
-`enforcement: [review]` — this is a review-only contract for now: no connector code has landed yet (this contract lands with ADR-124, ahead of the `neatd` implementation), so there is nothing for a lint assertion to check yet. Once the first provider (Supabase) ships, a `contracts.test.ts` assertion should check the provider-interface shape (§1) and the credential-in-config-not-snapshot rule (§6) mechanically, and this contract's enforcement tag should move to `[lint, review]`. Flagged here rather than deferred silently, per `contract-enforcement.md` §3.
+`enforcement: [lint, review]`. **Lint:** `contracts.test.ts`'s "Connectors plane contract (ADR-124)" block checks the provider-interface shape (§1 — `ObservedConnector`/`ConnectorContext`/`ObservedSignal` declared as specified) and the credential-in-config-not-snapshot rule (§6 — `credentials` never appears on the same line as a graph mutation call in `connectors/**`) mechanically, plus a scoped regression guard that `connectors/index.ts` never mutates the graph directly (ADR-030). **Review:** everything else — the passive/ambient discipline (§2), the two-credential-profile split (§3), and each provider's own fusion pattern (§4) — stays a human call until a provider's `poll()`/mapping code gives it something concrete to check against.
 
 Full rationale: [ADR-124](../decisions.md#adr-124--the-supabase-connector-and-the-connectors-plane).

--- a/packages/core/src/connectors/cloudflare/client.ts
+++ b/packages/core/src/connectors/cloudflare/client.ts
@@ -1,0 +1,76 @@
+// Workers Observability Telemetry Query API client (docs/connectors/cloudflare.md
+// §Surfaces used #1). Read-only, ambient — this issues exactly one query per
+// poll tick against telemetry Cloudflare already collects when a Worker
+// deploys with `observability.enabled`; it never issues a synthetic request
+// to the Worker itself (connectors.md §2).
+
+import { randomUUID } from 'node:crypto'
+import type { ConnectorContext } from '../types.js'
+import type { CloudflareConnectorConfig, CloudflareTelemetryEvent, CloudflareTelemetryQueryResponse } from './types.js'
+
+const DEFAULT_BASE_URL = 'https://api.cloudflare.com/client/v4'
+
+// The API's own per-response event cap isn't documented (needs-endpoint-
+// testing, docs/connectors/cloudflare.md); this is a conservative default
+// kept well under any plausible limit, overridable per connector config.
+const DEFAULT_EVENT_LIMIT = 1000
+
+export interface TelemetryWindow {
+  fromMs: number
+  toMs: number
+}
+
+// `fetchImpl` defaults to the platform global (Node 20 ships `fetch`) and is
+// the seam tests inject a fake response through — dependency injection, not
+// a production mock (contracts.md Rule 5 / connectors.md §5 only bar mocks
+// on the runtime poll path itself).
+export async function queryWorkerInvocations(
+  ctx: ConnectorContext,
+  config: CloudflareConnectorConfig,
+  window: TelemetryWindow,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CloudflareTelemetryEvent[]> {
+  const token = ctx.credentials.apiToken
+  if (typeof token !== 'string' || token.length === 0) {
+    throw new Error('cloudflare connector: ctx.credentials.apiToken must be a non-empty string')
+  }
+
+  const baseUrl = config.baseUrl ?? DEFAULT_BASE_URL
+  const url = `${baseUrl}/accounts/${config.accountId}/workers/observability/telemetry/query`
+
+  const body = {
+    // Cloudflare's schema requires an identifier per query even for an
+    // ad-hoc, unsaved one — a fresh id per tick, never reused.
+    queryId: `neat-connector-${randomUUID()}`,
+    timeframe: { from: window.fromMs, to: window.toMs },
+    view: 'events',
+    limit: config.eventLimit ?? DEFAULT_EVENT_LIMIT,
+    // Execute without persisting — this is a read, not a saved query
+    // (connectors.md §2's "never writes on the read path" applies to
+    // Cloudflare's own query-history state too).
+    dry: true,
+  }
+
+  const res = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!res.ok) {
+    throw new Error(
+      `cloudflare connector: telemetry query failed (${res.status} ${res.statusText})`,
+    )
+  }
+
+  const payload = (await res.json()) as CloudflareTelemetryQueryResponse
+  if (!payload.success) {
+    const message = payload.errors?.map((e) => e.message).join('; ') || 'unknown error'
+    throw new Error(`cloudflare connector: telemetry query returned an error (${message})`)
+  }
+
+  return payload.result?.events?.events ?? []
+}

--- a/packages/core/src/connectors/cloudflare/connector.ts
+++ b/packages/core/src/connectors/cloudflare/connector.ts
@@ -1,0 +1,77 @@
+// The Cloudflare Workers/Pages connector (docs/connectors/cloudflare.md,
+// ADR-129). Owns the two provider-specific steps README.md's pipeline
+// diagram assigns to `connectors/<provider>/`: fetching signals off
+// Cloudflare's own API (`poll`, via client.ts + map.ts) and mapping a
+// signal's targetKind/targetName to a NEAT node id
+// (`createCloudflareResolveTarget`). Everything downstream — resolving a
+// static call site, minting the OBSERVED edge — is the shared pipeline in
+// connectors/index.ts; this module never mutates the graph itself.
+
+import { EdgeType, fileId } from '@neat.is/types'
+import type { ResolveConnectorTarget, ResolvedConnectorTarget } from '../index.js'
+import type { ConnectorContext, ObservedConnector } from '../types.js'
+import { queryWorkerInvocations } from './client.js'
+import { mapEventToSignal } from './map.js'
+import { CLOUDFLARE_TARGET_KIND, type CloudflareConnectorConfig, type CloudflareObservedSignal } from './types.js'
+
+// Cloudflare's docs don't confirm the Telemetry Query API's own max lookback
+// window (docs/connectors/cloudflare.md needs-endpoint-testing); a
+// conservative hour, same discipline connectors.md's "Poll cadence and
+// backfill" requires of every provider — a gap larger than this backfills
+// from `now - maxLookbackMs`, never an unbounded full-history query.
+const DEFAULT_MAX_LOOKBACK_MS = 60 * 60 * 1000
+
+function resolveFromMs(since: string | undefined, maxLookbackMs: number | undefined): number {
+  const cap = maxLookbackMs ?? DEFAULT_MAX_LOOKBACK_MS
+  const now = Date.now()
+  const floor = now - cap
+  if (!since) return floor
+  const parsed = Date.parse(since)
+  if (Number.isNaN(parsed)) return floor
+  return Math.max(parsed, floor)
+}
+
+export class CloudflareConnector implements ObservedConnector {
+  readonly provider = 'cloudflare'
+
+  constructor(private readonly config: CloudflareConnectorConfig) {}
+
+  async poll(ctx: ConnectorContext): Promise<CloudflareObservedSignal[]> {
+    const toMs = Date.now()
+    const fromMs = resolveFromMs(ctx.since, this.config.maxLookbackMs)
+    const events = await queryWorkerInvocations(ctx, this.config, { fromMs, toMs })
+
+    const signals: CloudflareObservedSignal[] = []
+    for (const event of events) {
+      const signal = mapEventToSignal(event)
+      if (signal) signals.push(signal)
+    }
+    return signals
+  }
+}
+
+// Provider-specific target resolution (README.md's pipeline step 2). Per
+// docs/connectors/cloudflare.md §Fusion, the signal's target is the Worker's
+// single entry FileNode — not the caller, since this API carries no caller
+// identity at all, only "this script was invoked". The edge that results,
+// `service --CALLS--> entryFile`, mirrors the WebSocket channel precedent
+// (ADR-125): a liveness signal minted from a service onto its own child node,
+// reusing an existing edge verb rather than inventing one for "this file got
+// reached" (connectors.md §4's fusion identity applies the same way here as
+// it does when a future extractor recognizes the same Worker's routes).
+//
+// A script with no entry in `config.workers` resolves to `null` — an honest
+// miss (connectors.md's own "never fabricates a node or edge" discipline),
+// not a guess at which service/file it might belong to.
+export function createCloudflareResolveTarget(config: CloudflareConnectorConfig): ResolveConnectorTarget {
+  return (signal): ResolvedConnectorTarget | null => {
+    if (signal.targetKind !== CLOUDFLARE_TARGET_KIND) return null
+    const mapping = config.workers[signal.targetName]
+    if (!mapping) return null
+    return {
+      targetNodeId: fileId(mapping.service, mapping.entryFile),
+      serviceName: mapping.service,
+      edgeType: EdgeType.CALLS,
+    }
+  }
+}

--- a/packages/core/src/connectors/cloudflare/index.ts
+++ b/packages/core/src/connectors/cloudflare/index.ts
@@ -1,0 +1,18 @@
+// Cloudflare Workers/Pages connector (docs/connectors/cloudflare.md, ADR-129).
+// v1 ships at whole-file grain, deliberately — see connector.ts and map.ts
+// for why. Re-exports the module's public surface for daemon/CLI wiring and
+// for tests.
+
+export { CloudflareConnector, createCloudflareResolveTarget } from './connector.js'
+export { queryWorkerInvocations, type TelemetryWindow } from './client.js'
+export { mapEventToSignal, parseHttpMethodFromTrigger } from './map.js'
+export {
+  CLOUDFLARE_TARGET_KIND,
+  type CloudflareConnectorConfig,
+  type CloudflareObservedSignal,
+  type CloudflareTelemetryEvent,
+  type CloudflareTelemetryEventMetadata,
+  type CloudflareTelemetryQueryResponse,
+  type CloudflareTelemetryWorkersMetadata,
+  type CloudflareWorkerMapping,
+} from './types.js'

--- a/packages/core/src/connectors/cloudflare/map.ts
+++ b/packages/core/src/connectors/cloudflare/map.ts
@@ -1,0 +1,80 @@
+// Maps one Telemetry Query API invocation record to an ObservedSignal at
+// whole-file grain (docs/connectors/cloudflare.md §Fusion, ADR-129).
+//
+// The only route-shaped field this API exposes is `$metadata.trigger`
+// ("GET /users", "POST /orders", or a non-HTTP trigger like "queue message").
+// v1 parses the leading HTTP method token off it for metadata only — the
+// remainder is never matched against a route table, because no static route
+// recognizer exists yet for the in-Worker router shapes (Hono, itty-router,
+// manual `fetch(request)` dispatch) that would make such a match meaningful
+// (design doc's §Static extractor gap). A trigger that isn't HTTP-shaped
+// (cron, queue, alarm, ...) carries no method to parse and is out of scope
+// for this cut (§Out of scope) — dropped here, honestly, rather than
+// fabricating a method or forcing it through as an unresolvable signal.
+
+import { CLOUDFLARE_TARGET_KIND, type CloudflareObservedSignal, type CloudflareTelemetryEvent } from './types.js'
+
+// The HTTP methods a `trigger` string's leading token can actually name
+// (RFC 7231 + CONNECT/TRACE). A closed vocabulary, the same discipline
+// routes.ts's own ROUTER_METHODS set applies to router registrations, so a
+// non-HTTP trigger ("queue message", a cron expression, "scheduled") never
+// misparses its own leading word as a method.
+const HTTP_METHODS = new Set([
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'HEAD',
+  'OPTIONS',
+  'TRACE',
+  'CONNECT',
+])
+
+const LEADING_TOKEN_RE = /^(\S+)\s+\S/
+
+export function parseHttpMethodFromTrigger(trigger: string | undefined): string | null {
+  if (!trigger) return null
+  const match = LEADING_TOKEN_RE.exec(trigger.trim())
+  const token = match?.[1]
+  if (!token) return null
+  const method = token.toUpperCase()
+  return HTTP_METHODS.has(method) ? method : null
+}
+
+// 5xx is treated as the unambiguous failure threshold for this connector's
+// own errorCount, mirroring the span-derived `isError` convention elsewhere
+// in ingest.ts (a bare 4xx is often correct app behavior — an auth probe, a
+// conditional fetch — and isn't held against the edge's own error tally).
+const ERROR_STATUS_THRESHOLD = 500
+
+export function mapEventToSignal(event: CloudflareTelemetryEvent): CloudflareObservedSignal | null {
+  const metadata = event.$metadata
+  const workers = event.$workers
+
+  const method = parseHttpMethodFromTrigger(metadata?.trigger)
+  if (!method) return null
+
+  // `$workers.scriptName` and `$metadata.service` are both documented as
+  // "Worker script name" — prefer the Workers-Runtime-specific field when
+  // present, fall back to the always-present metadata field.
+  const scriptName = workers?.scriptName ?? metadata?.service
+  if (!scriptName) return null
+
+  const timestampMs = event.timestamp ?? metadata?.startTime
+  if (typeof timestampMs !== 'number' || !Number.isFinite(timestampMs)) return null
+
+  const statusCode = metadata?.statusCode
+  const isError = typeof statusCode === 'number' && statusCode >= ERROR_STATUS_THRESHOLD
+
+  return {
+    targetKind: CLOUDFLARE_TARGET_KIND,
+    targetName: scriptName,
+    callCount: 1,
+    errorCount: isError ? 1 : 0,
+    lastObservedIso: new Date(timestampMs).toISOString(),
+    method,
+    ...(typeof statusCode === 'number' ? { statusCode } : {}),
+    ...(typeof metadata?.duration === 'number' ? { duration: metadata.duration } : {}),
+  }
+}

--- a/packages/core/src/connectors/cloudflare/types.ts
+++ b/packages/core/src/connectors/cloudflare/types.ts
@@ -1,0 +1,117 @@
+// Cloudflare Workers/Pages connector — provider-specific shapes
+// (docs/connectors/cloudflare.md, ADR-129). v1 ships at whole-file grain: no
+// route table, no Hono/itty-router recognizer — see the design doc's
+// §Static extractor gap for why, and packages/core/src/extract/routes.ts is
+// untouched by this cut.
+
+import type { ObservedSignal } from '../types.js'
+
+// Provider vocabulary for ObservedSignal.targetKind (connectors.md §1 — "the
+// provider's own vocabulary", same shape as Supabase's 'supabase-table' /
+// 'supabase-rpc').
+export const CLOUDFLARE_TARGET_KIND = 'cloudflare-worker-invocation'
+
+// One Cloudflare Worker/Pages script's mapping onto a NEAT service + file.
+// Cloudflare's own telemetry only ever names the script (`$workers.scriptName`
+// / `$metadata.service`) — it has no idea which repo, service, or file that
+// script's code lives in. That mapping is genuinely not inferrable from the
+// telemetry itself, so it's supplied here, once, at connector-configuration
+// time (docs/connectors/cloudflare.md §Fusion): `service` is the NEAT
+// manifest name (package.json#name) the design doc says gets paired against
+// the Worker's `wrangler.toml`/`wrangler.jsonc` `name` field, and `entryFile`
+// is the service-relative path to the file containing
+// `export default { fetch(request, env, ctx) { ... } }`, resolved from that
+// same manifest's `main` field the same way NEAT's Node installer already
+// resolves an entry point.
+export interface CloudflareWorkerMapping {
+  service: string
+  entryFile: string
+}
+
+export interface CloudflareConnectorConfig {
+  accountId: string
+  // Cloudflare script name → the NEAT service/file it maps to. One connector
+  // instance covers every Worker/Pages script in one Cloudflare account's
+  // telemetry; scripts with no entry here are honestly unresolved rather than
+  // guessed at (see createCloudflareResolveTarget in connector.ts).
+  workers: Record<string, CloudflareWorkerMapping>
+  // Cap on how far an absent `since` backfills, ms. Cloudflare's docs don't
+  // confirm the Telemetry Query API's own max lookback window
+  // (docs/connectors/cloudflare.md flags this needs-endpoint-testing); default
+  // below is a conservative hour, capped the same way connectors.md's
+  // "Poll cadence and backfill" section requires for every provider.
+  maxLookbackMs?: number
+  // Events requested per query. The API's own per-response cap isn't
+  // documented either; kept well under any plausible limit until a live
+  // check confirms one. Pagination (the `offset` cursor) isn't implemented in
+  // v1 — same needs-endpoint-testing gap, since the docs surveyed don't spell
+  // out the cursor's exact semantics.
+  eventLimit?: number
+  // Override for tests; defaults to Cloudflare's real API host.
+  baseUrl?: string
+}
+
+// --- Workers Observability Telemetry Query API response shapes ---
+//
+// Confirmed against
+// developers.cloudflare.com/api/resources/workers/subresources/observability/subresources/telemetry/methods/query/
+// (fetched 2026-07-03) rather than assumed. Only the fields this connector
+// actually reads are typed here — the live response carries substantially
+// more (the `traces`/`calculations`/`invocations` views, per-event
+// diagnostics-channel data, etc.) that v1 has no use for.
+//
+// Two fields name the Worker script per event: `$metadata.service` (present
+// on every event type) and `$workers.scriptName` (present only when the
+// `$workers` sub-object is, i.e. for genuine Workers Runtime events). Both
+// are documented as "Worker script name" — map.ts prefers `$workers.scriptName`
+// when present and falls back to `$metadata.service`.
+export interface CloudflareTelemetryEventMetadata {
+  service?: string
+  trigger?: string
+  url?: string
+  statusCode?: number
+  duration?: number
+  traceDuration?: number
+  startTime?: number
+  endTime?: number
+}
+
+export interface CloudflareTelemetryWorkersMetadata {
+  eventType?: string
+  scriptName?: string
+  outcome?: string
+}
+
+export interface CloudflareTelemetryEvent {
+  timestamp?: number
+  dataset?: string
+  $metadata?: CloudflareTelemetryEventMetadata
+  $workers?: CloudflareTelemetryWorkersMetadata
+}
+
+export interface CloudflareTelemetryQueryResponse {
+  success: boolean
+  errors?: { message: string }[]
+  messages?: { message: string }[]
+  result?: {
+    events?: {
+      count?: number
+      events: CloudflareTelemetryEvent[]
+    }
+  }
+}
+
+// ObservedSignal, widened with the fields this connector's own mapping step
+// carries for metadata/testing purposes — `method` (parsed from `trigger`),
+// `statusCode`, `duration`. None of these are read by the generic
+// connectors pipeline (connectors/index.ts only consumes the base
+// ObservedSignal shape); they exist so map.ts's own output — and, through
+// it, `CloudflareConnector.poll()` — stays inspectable for exactly what
+// docs/connectors/cloudflare.md promises: "parses only the HTTP method token
+// off the front of trigger ... for edge metadata — no attempt to match the
+// remainder against a route table".
+export interface CloudflareObservedSignal extends ObservedSignal {
+  method: string
+  statusCode?: number
+  duration?: number
+}

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -1,0 +1,239 @@
+// Connectors plane — the provider-agnostic pull/map/fuse pipeline
+// (docs/contracts/connectors.md, docs/connectors/README.md, ADR-124).
+//
+// A provider module (packages/core/src/connectors/<provider>/, none shipped
+// yet) owns exactly two things: fetching `ObservedSignal[]` off its own API
+// (`ObservedConnector.poll`) and mapping a signal's targetKind/targetName to
+// a NEAT node id (the `resolveTarget` callback below). Everything after that
+// — resolving a static call site, minting the OBSERVED edge — is written
+// once, here, and is identical for every provider: a connector-sourced edge
+// and a span-sourced edge carry the same provenance and land through the
+// same mutation primitives OTel ingest uses (README.md's opening paragraph).
+//
+// Mutation authority (ADR-030 — see contracts.test.ts's "Lifecycle contract"
+// audit): only ingest.ts and extract/* may call a graph mutator directly.
+// This module never does — every node/edge write below goes through an
+// ingest.ts primitive (`ensureServiceNode`, `ensureObservedFileNode`,
+// `upsertObservedEdge`), exported for exactly this reuse. A future
+// provider's own target-node creation (a Supabase table InfraNode, say)
+// belongs in ingest.ts too, for the same reason — this module only ever
+// calls into it, never mutates the graph itself.
+
+import type { EdgeTypeValue } from '@neat.is/types'
+import type { NeatGraph } from '../graph.js'
+import {
+  ensureObservedFileNode,
+  ensureServiceNode,
+  reconcileObservedRelPath,
+  upsertObservedEdge,
+  type CallSite,
+} from '../ingest.js'
+import type { ConnectorContext, ObservedConnector, ObservedSignal } from './types.js'
+
+export type {
+  ConnectorCallSite,
+  ConnectorContext,
+  ObservedConnector,
+  ObservedSignal,
+} from './types.js'
+
+// env-unscoped, matching the sentinel identity.ts uses for "no deployment
+// signal" (ADR-074 §2) — a connector signal carries no
+// deployment.environment(.name) the way an OTel span might.
+const NO_ENV = 'unknown'
+
+/**
+ * What a provider's target-resolution step hands back for one signal. The
+ * generic pipeline needs both endpoints of the edge it's about to mint:
+ *
+ * - `serviceName` is the NEAT manifest service whose code produced the
+ *   signal — the edge's source. The shared pipeline turns it into a plain
+ *   ServiceNode id, or a FileNode id once the fuse step below resolves the
+ *   signal's callSite against it.
+ * - `targetNodeId` is the id the provider's own mapping already resolved —
+ *   an `infraId(...)` sub-resource, a RouteNode, a ServiceNode, whatever
+ *   (see each provider's docs/connectors/<provider>.md §Fusion).
+ *
+ * Returning `null` skips the signal honestly: an unresolvable target never
+ * fabricates a node or edge (the same discipline file-awareness.md §6
+ * states for OTel ingest).
+ */
+export interface ResolvedConnectorTarget {
+  targetNodeId: string
+  serviceName: string
+  edgeType: EdgeTypeValue
+}
+
+export type ResolveConnectorTarget = (
+  signal: ObservedSignal,
+  ctx: ConnectorContext,
+) => ResolvedConnectorTarget | null
+
+export interface ConnectorPollResult {
+  // Signals connector.poll() returned this tick.
+  signalCount: number
+  // Fresh OBSERVED edges minted.
+  edgesCreated: number
+  // Existing OBSERVED edges whose signal block advanced.
+  edgesUpdated: number
+  // Signals that resolved to no target (resolveTarget returned null, or the
+  // resolved target/service node doesn't exist in the graph yet) — dropped
+  // honestly rather than minting a fabricated edge.
+  unresolved: number
+}
+
+/**
+ * One poll cycle: fetch, map, fuse, mint. Pure with respect to `ctx` — the
+ * caller (`startConnectorPollLoop` below, or a one-shot `neat sync`) owns
+ * advancing `ctx.since` between calls.
+ */
+export async function runConnectorPoll(
+  connector: ObservedConnector,
+  ctx: ConnectorContext,
+  graph: NeatGraph,
+  resolveTarget: ResolveConnectorTarget,
+): Promise<ConnectorPollResult> {
+  const signals = await connector.poll(ctx)
+  let edgesCreated = 0
+  let edgesUpdated = 0
+  let unresolved = 0
+
+  for (const signal of signals) {
+    const resolved = resolveTarget(signal, ctx)
+    if (!resolved) {
+      unresolved++
+      continue
+    }
+
+    // Same shape ingest.ts's handleSpan uses for every span: auto-create a
+    // minimal ServiceNode the first time this service is seen so the edge
+    // upsert below always has a source endpoint, even for a service the
+    // static extractor hasn't reached (or never will, in an OTel-less setup).
+    const serviceNodeId = ensureServiceNode(graph, resolved.serviceName, NO_ENV)
+
+    // File-grain fusion when the signal carries a call site, through the
+    // same reconcileObservedRelPath path OTel ingest uses (file-awareness.md
+    // §4) — service-level, honestly, when it doesn't (§6, never fabricated).
+    const callSite: CallSite | undefined = signal.callSite
+      ? { relPath: signal.callSite.file, line: signal.callSite.line }
+      : undefined
+    const sourceId = callSite
+      ? ensureObservedFileNode(graph, resolved.serviceName, serviceNodeId, callSite)
+      : serviceNodeId
+    const evidence = callSite
+      ? {
+          file: reconcileObservedRelPath(graph, resolved.serviceName, callSite.relPath),
+          line: callSite.line,
+        }
+      : undefined
+
+    // upsertObservedEdge increments its signal block by exactly one call per
+    // invocation — the right unit for a single span, but a connector signal
+    // is already an aggregate over the whole poll window (`callCount` calls,
+    // `errorCount` of them failing). Replay it that many times so the
+    // edge's spanCount/errorCount — and the confidence grade derived from
+    // them, ADR-066 — land the same as if `callCount` individual spans had
+    // arrived, rather than undercounting a batched signal down to +1.
+    const calls = Math.trunc(signal.callCount)
+    if (calls < 1) continue // nothing observed this window — not even a miss
+    const errors = Math.min(Math.max(Math.trunc(signal.errorCount), 0), calls)
+
+    let created = false
+    let ok = true
+    for (let i = 0; i < calls; i++) {
+      const result = upsertObservedEdge(
+        graph,
+        resolved.edgeType,
+        sourceId,
+        resolved.targetNodeId,
+        signal.lastObservedIso,
+        i < errors,
+        evidence,
+      )
+      if (!result) {
+        // Target node doesn't exist yet — an extractor gap (supabase.md
+        // §Static extractor gap documents exactly this case) or a provider
+        // that hasn't minted it. Honest miss, not a crash.
+        ok = false
+        break
+      }
+      if (i === 0) created = result.created
+    }
+    if (!ok) {
+      unresolved++
+      continue
+    }
+    if (created) edgesCreated++
+    else edgesUpdated++
+  }
+
+  return { signalCount: signals.length, edgesCreated, edgesUpdated, unresolved }
+}
+
+export interface ConnectorPollLoopOptions {
+  intervalMs?: number
+  onError?: (err: unknown) => void
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 60_000
+
+/**
+ * Recurring wrapper around `runConnectorPoll` — the same setInterval +
+ * unref + try/catch + stop-closure shape `startStalenessLoop` (ingest.ts)
+ * already uses for the daemon's per-project background tasks, reused here
+ * rather than reinvented. `daemon.ts` wires this in exactly where it wires
+ * `startStalenessLoop`, tearing both down together per project slot.
+ *
+ * Advances `since` to the tick's own start time after every successful
+ * poll — the next tick asks the provider for "since last tick" rather than
+ * replaying. A tick that throws logs and leaves `since` where it was, so a
+ * transient provider outage doesn't silently skip the gap once it recovers.
+ */
+export function startConnectorPollLoop(
+  connector: ObservedConnector,
+  ctx: ConnectorContext,
+  graph: NeatGraph,
+  resolveTarget: ResolveConnectorTarget,
+  options: ConnectorPollLoopOptions = {},
+): () => void {
+  let stopped = false
+  let since = ctx.since
+  const intervalMs = options.intervalMs ?? DEFAULT_POLL_INTERVAL_MS
+  const onError =
+    options.onError ??
+    ((err: unknown) => console.error(`[neatd] connector poll failed (${connector.provider})`, err))
+
+  const tick = (): void => {
+    if (stopped) return
+    void (async () => {
+      const tickStartedAt = new Date().toISOString()
+      try {
+        await runConnectorPoll(connector, { ...ctx, since }, graph, resolveTarget)
+        since = tickStartedAt
+      } catch (err) {
+        onError(err)
+      }
+    })()
+  }
+
+  const interval = setInterval(tick, intervalMs)
+  if (typeof interval.unref === 'function') interval.unref()
+  return () => {
+    stopped = true
+    clearInterval(interval)
+  }
+}
+
+/**
+ * One project's registered connector, ready for `daemon.ts` to poll on an
+ * interval. Deliberately thin — no config-loading or credential-broker logic
+ * lives here (that's provider- and profile-specific, later work per
+ * docs/contracts/connectors.md §3); this is just the seam a daemon slot
+ * wires a connector through.
+ */
+export interface ConnectorRegistration {
+  connector: ObservedConnector
+  credentials: Record<string, unknown>
+  resolveTarget: ResolveConnectorTarget
+  intervalMs?: number
+}

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -1,0 +1,81 @@
+// Connectors plane — provider-agnostic types (docs/contracts/connectors.md,
+// docs/connectors/README.md, ADR-124).
+//
+// OTLP ingest has had exactly one path onto the OBSERVED layer: an app
+// pushing spans it was instrumented to emit. A connector is the second path
+// — a provider that already runs its own server-side telemetry (a hosted
+// Postgres platform's query stats, a hosting platform's request logs) gets
+// pulled from instead, so OBSERVED edges exist with zero app instrumentation.
+//
+// This file declares the one shape every provider implements. The
+// provider-specific fetch + target-resolution logic lives under
+// packages/core/src/connectors/<provider>/ — none shipped yet; this PR is
+// the shared pull/map/fuse scaffold those provider modules plug into
+// (Supabase first, per ADR-124; Railway/Firebase/Cloudflare designs are
+// merged as prose-only docs and land their own connector modules next).
+
+/**
+ * A connector implements exactly one method. Everything downstream of
+ * `poll()` — resolving a static call site, minting the OBSERVED edge — is
+ * shared, generic code in connectors/index.ts.
+ */
+export interface ObservedConnector {
+  readonly provider: string
+  poll(ctx: ConnectorContext): Promise<ObservedSignal[]>
+}
+
+/**
+ * Everything a connector's `poll()` needs, resolved once at connector setup
+ * — never re-derived at poll time.
+ *
+ * `credentials` is opaque here on purpose: its shape is entirely provider-
+ * and profile-defined (local vs hosted — docs/contracts/connectors.md §3).
+ * It flows through to `poll()` only. Never log it, never write it into a
+ * node or edge, never let it reach the graph snapshot (contract §6, and the
+ * `.env`-contents rule docs/contracts.md Rule 4 already states for local
+ * config).
+ */
+export interface ConnectorContext {
+  // Absolute path to the project root being polled — the same anchor
+  // `reconcileObservedRelPath` (ingest.ts) uses to fuse a signal's callSite
+  // onto the EXTRACTED service-relative path.
+  projectDir: string
+  credentials: Record<string, unknown>
+  // ISO8601 — the last successful poll's high-water mark. A connector must
+  // treat an absent `since` as "no prior poll", bounded by whatever lookback
+  // window the provider's own API caps (README.md §Poll cadence and
+  // backfill) — never an unbounded full-history query.
+  since?: string
+}
+
+/**
+ * `file:line` the provider's own signal carries, when it does (rare — see
+ * docs/connectors/README.md §Provider interface, which notes this is
+ * "usually resolved by the mapping layer below, not here"). Reconciled onto
+ * the EXTRACTED service-relative path by the shared fuse step the same way
+ * an OTel span's call site is (file-awareness.md §4).
+ */
+export interface ConnectorCallSite {
+  file: string
+  line: number
+}
+
+/**
+ * One provider-agnostic observation. `targetKind`/`targetName` are the
+ * provider's own vocabulary (`'supabase-table'`/`'orders'`,
+ * `'route'`/`'GET /users/:id'`, ...) — resolving that pair to a NEAT node id
+ * is the one genuinely provider-specific step (README.md's pipeline
+ * diagram), supplied to `runConnectorPoll` (connectors/index.ts) as a
+ * `resolveTarget` callback. Everything downstream of that resolution — file
+ * grain fusion, OBSERVED mint — is shared.
+ */
+export interface ObservedSignal {
+  targetKind: string
+  targetName: string
+  callCount: number
+  errorCount: number
+  // The provider's own event time — never poll-arrival time (README.md
+  // §Poll cadence and backfill).
+  lastObservedIso: string
+  callSite?: ConnectorCallSite
+}

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -45,6 +45,7 @@ import { buildApi } from './api.js'
 import { buildOtelReceiver, listenSteppingOtlp } from './otel.js'
 import { attachGraphToEventBus } from './events.js'
 import { handleSpan, makeErrorSpanWriter, startStalenessLoop } from './ingest.js'
+import { startConnectorPollLoop, type ConnectorRegistration } from './connectors/index.js'
 import {
   listProjects,
   pruneRegistry,
@@ -247,6 +248,14 @@ export interface DaemonOptions {
   // exercise daemon slots without needing the listeners). Production
   // `neatd start` never sets this.
   bindListeners?: boolean
+  // Connectors plane (docs/contracts/connectors.md, ADR-124) — pull-based
+  // OBSERVED connectors polled on an interval alongside every project this
+  // daemon bootstraps, the same way every project gets the staleness loop.
+  // Applied identically to every project slot; there is no per-project
+  // config-loading here yet (that's provider-specific, later work) — a
+  // caller wanting project-scoped connectors runs a separate `startDaemon`
+  // per project (the single-project ADR-096 mode is the common case).
+  connectors?: ConnectorRegistration[]
 }
 
 export interface ProjectSlot {
@@ -261,6 +270,11 @@ export interface ProjectSlot {
   // STALE instead of sitting live forever. Must be stopped alongside
   // stopPersist so no interval leaks when the slot is torn down or replaced.
   stopStaleness: () => void
+  // Stops every connector poll loop registered for this slot (connectors/
+  // index.ts's startConnectorPollLoop, one per opts.connectors entry). Same
+  // lifecycle as stopStaleness — must run alongside it wherever the slot is
+  // torn down or replaced.
+  stopConnectors: () => void
   // #475 — removes the event-bus listeners attachGraphToEventBus installed
   // on this slot's graph. No-op for broken slots. Must run wherever the slot
   // is torn down or replaced, or a reloaded slot's old graph keeps emitting.
@@ -281,6 +295,11 @@ function teardownSlot(slot: ProjectSlot): void {
   }
   try {
     slot.stopStaleness()
+  } catch {
+    // best-effort
+  }
+  try {
+    slot.stopConnectors()
   } catch {
     // best-effort
   }
@@ -466,7 +485,10 @@ function spanBelongsToSingleProject(
   )
 }
 
-async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
+async function bootstrapProject(
+  entry: RegistryEntry,
+  connectors: ConnectorRegistration[] = [],
+): Promise<ProjectSlot> {
   const paths = pathsForProject(entry.name, path.join(entry.path, 'neat-out'))
 
   // Path missing on disk → mark broken and surface the reason. Daemon
@@ -487,6 +509,7 @@ async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
       paths,
       stopPersist: () => {},
       stopStaleness: () => {},
+      stopConnectors: () => {},
       detachEvents: () => {},
       status: 'broken',
       errorReason: (err as Error).message,
@@ -523,6 +546,21 @@ async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
       staleEventsPath: paths.staleEventsPath,
       project: entry.name,
     })
+    // Connectors plane (docs/contracts/connectors.md, ADR-124) — one poll
+    // loop per registered connector, same interval-loop shape as the
+    // staleness loop above and torn down alongside it (teardownSlot).
+    const stopFns = connectors.map((registration) =>
+      startConnectorPollLoop(
+        registration.connector,
+        { projectDir: entry.path, credentials: registration.credentials },
+        graph,
+        registration.resolveTarget,
+        { intervalMs: registration.intervalMs },
+      ),
+    )
+    const stopConnectors = (): void => {
+      for (const stop of stopFns) stop()
+    }
     await touchLastSeen(entry.name).catch(() => {})
 
     return {
@@ -532,6 +570,7 @@ async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
       paths,
       stopPersist,
       stopStaleness,
+      stopConnectors,
       detachEvents,
       status: 'active',
     }
@@ -724,7 +763,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
   // the new slot status so callers can decide whether to deliver the span.
   async function tryRecoverSlot(entry: RegistryEntry): Promise<ProjectSlot> {
     try {
-      const fresh = await bootstrapProject(entry)
+      const fresh = await bootstrapProject(entry, opts.connectors ?? [])
       // The slot being replaced must release its graph's bus listeners
       // (#475) — a stale attach on the prior graph would double-emit.
       const prior = slots.get(entry.name)
@@ -751,7 +790,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
     bootstrapStatus.set(entry.name, 'bootstrapping')
     bootstrapStartedAt.set(entry.name, Date.now())
     try {
-      const slot = await bootstrapProject(entry)
+      const slot = await bootstrapProject(entry, opts.connectors ?? [])
       // Same replacement rule as tryRecoverSlot (#475).
       const prior = slots.get(entry.name)
       if (prior) teardownSlot(prior)

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -488,7 +488,12 @@ function relPathForRuntimeFile(
   return p.length > 0 ? p : null
 }
 
-interface CallSite {
+// Exported so the connectors plane (packages/core/src/connectors/index.ts,
+// docs/contracts/connectors.md) can build one from a signal's own callSite —
+// a connector's file:line comes from the provider's telemetry rather than an
+// OTel span's code.* attributes, but reconciles onto the same EXTRACTED
+// FileNode through the same primitives below.
+export interface CallSite {
   relPath: string
   line?: number
   fn?: string
@@ -615,7 +620,7 @@ function callSiteFromSpan(
 // carrying extra leading directories the anchor couldn't strip — reuse the
 // extractor's path so both layers key the same node. No match means the file is
 // genuinely OTel-only; the honest runtime path stands (never fabricated, §6).
-function reconcileObservedRelPath(
+export function reconcileObservedRelPath(
   graph: NeatGraph,
   serviceName: string,
   relPath: string,
@@ -646,7 +651,7 @@ function reconcileObservedRelPath(
 // STALE when traffic quiets (markStaleEdges skips edges without lastObserved),
 // and divergence detection skips CONTAINS so an OTel-only file node doesn't
 // surface as a missing-extracted finding.
-function ensureObservedFileNode(
+export function ensureObservedFileNode(
   graph: NeatGraph,
   serviceName: string,
   serviceNodeId: string,
@@ -1041,7 +1046,11 @@ export function frontierIdFor(host: string): string {
 // `language: 'unknown'` is the contract's specified placeholder (ADR-033). When
 // static extraction later produces a ServiceNode at the same id, addServiceNodes
 // merges and flips discoveredVia to 'merged' rather than overwriting.
-function ensureServiceNode(
+// Exported for the connectors plane (connectors/index.ts) — a connector
+// signal needs the same auto-vivified ServiceNode any OTel span gets before
+// an edge upsert, since a connector-sourced service may never have been
+// statically extracted or seen a span yet.
+export function ensureServiceNode(
   graph: NeatGraph,
   serviceName: string,
   env: string,
@@ -1130,12 +1139,16 @@ function ensureFrontierNode(graph: NeatGraph, host: string, ts: string): string 
   return id
 }
 
-interface UpsertResult {
+// Exported so the connectors plane (connectors/index.ts) mints edges through
+// the identical primitive OTel ingest uses — a connector-sourced edge and a
+// span-sourced edge are meant to be indistinguishable to traversal,
+// divergence, and staleness (docs/connectors/README.md).
+export interface UpsertResult {
   edge: GraphEdge
   created: boolean
 }
 
-function upsertObservedEdge(
+export function upsertObservedEdge(
   graph: NeatGraph,
   type: EdgeTypeValue,
   source: string,

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -13582,3 +13582,62 @@ describe('Contract enforcement tags (ADR-104)', () => {
     expect(unknown, `${file} names unknown enforcement pillar(s): ${unknown.join(', ')}`).toEqual([])
   })
 })
+
+// ──────────────────────────────────────────────────────────────────────────
+// Connectors plane (ADR-124) — mechanical checks for the two things
+// docs/contracts/connectors.md §Enforcement names as ready to lock down now
+// that the shared scaffold has landed: the provider-interface shape (§1) and
+// the credential-in-config-not-snapshot rule (§6). The contract itself still
+// reads `enforcement: [review]` — these are additive regression guards, not
+// a claim that every connectors.md rule is mechanically checked yet (the
+// per-provider fusion rules in §4 have no code to check until a provider's
+// poll()/mapping lands).
+// ──────────────────────────────────────────────────────────────────────────
+describe('Connectors plane contract (ADR-124)', () => {
+  const CONNECTORS_SRC = join(CORE_SRC, 'connectors')
+
+  it('docs/contracts/connectors.md governs packages/core/src/connectors/**', () => {
+    const src = readFileSync(join(__dirname, '../../../../docs/contracts/connectors.md'), 'utf8')
+    expect(src).toMatch(/governs:/)
+    expect(src).toMatch(/packages\/core\/src\/connectors\/\*\*/)
+  })
+
+  it('§1 — ObservedConnector/ConnectorContext/ObservedSignal are declared with the spec\'s shape', () => {
+    const src = readFileSync(join(CONNECTORS_SRC, 'types.ts'), 'utf8')
+    expect(src).toMatch(/interface ObservedConnector/)
+    expect(src).toMatch(/readonly provider: string/)
+    expect(src).toMatch(/poll\(ctx: ConnectorContext\): Promise<ObservedSignal\[\]>/)
+    expect(src).toMatch(/interface ConnectorContext/)
+    expect(src).toMatch(/interface ObservedSignal/)
+  })
+
+  it('§6 — ConnectorContext.credentials never lands on the same line as a graph mutation call', () => {
+    // Not a full data-flow analysis — a line-level guard against the
+    // obvious regression (a credential literal stuffed into a node/edge
+    // attribute object at the mutation call site). Mirrors the grep-grade
+    // audits the rest of this file already relies on (Rule 16, Rule 8).
+    const offenders: string[] = []
+    const mutators = /\b(graph|g)\.(addNode|addEdge|addEdgeWithKey|addDirectedEdge|addDirectedEdgeWithKey|replaceNodeAttributes|replaceEdgeAttributes|mergeNodeAttributes|mergeEdgeAttributes)\s*\(/
+    for (const file of walkSrc(CONNECTORS_SRC)) {
+      readFileSync(file, 'utf8')
+        .split('\n')
+        .forEach((line, i) => {
+          if (/credentials/.test(line) && mutators.test(line)) {
+            offenders.push(`${file}:${i + 1}: ${line.trim()}`)
+          }
+        })
+    }
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
+
+  it('connectors/index.ts never mutates the graph directly (ADR-030 mutation authority, scoped regression guard)', () => {
+    // The generic "Lifecycle contract" audit above already covers all of
+    // core/src; this pins the same expectation specifically for the
+    // connectors plane so a regression here reads as a connectors-contract
+    // failure, not a buried line in the ADR-030 sweep.
+    const src = readFileSync(join(CONNECTORS_SRC, 'index.ts'), 'utf8')
+    const mutators =
+      /\b(graph|g)\.(addNode|addEdge|addEdgeWithKey|addDirectedEdge|addDirectedEdgeWithKey|dropNode|dropEdge|replaceNodeAttributes|replaceEdgeAttributes|mergeNodeAttributes|mergeEdgeAttributes)\s*\(/
+    expect(mutators.test(src)).toBe(false)
+  })
+})

--- a/packages/core/test/connectors-cloudflare.test.ts
+++ b/packages/core/test/connectors-cloudflare.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi } from 'vitest'
+import { MultiDirectedGraph } from 'graphology'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  fileId,
+  observedEdgeId,
+  serviceId,
+  type FileNode,
+  type GraphEdge,
+  type GraphNode,
+  type ServiceNode,
+} from '@neat.is/types'
+import { runConnectorPoll, type ConnectorContext } from '../src/connectors/index.js'
+import type { NeatGraph } from '../src/graph.js'
+import {
+  CloudflareConnector,
+  createCloudflareResolveTarget,
+  mapEventToSignal,
+  parseHttpMethodFromTrigger,
+  queryWorkerInvocations,
+  type CloudflareConnectorConfig,
+  type CloudflareTelemetryEvent,
+  type CloudflareTelemetryQueryResponse,
+} from '../src/connectors/cloudflare/index.js'
+
+const SERVICE = 'orders-worker'
+const ENTRY_FILE = 'src/index.ts'
+
+// Fixture shape confirmed against Cloudflare's live API reference —
+// developers.cloudflare.com/api/resources/workers/subresources/observability/subresources/telemetry/methods/query/
+// (fetched 2026-07-03) — not invented. Three invocation records under the
+// `view: 'events'` response shape: an ok GET, a failing POST, and a queue
+// message (no HTTP trigger — out of scope per docs/connectors/cloudflare.md
+// §Out of scope, and must be dropped rather than mapped).
+const TELEMETRY_RESPONSE: CloudflareTelemetryQueryResponse = {
+  success: true,
+  messages: [{ message: 'Successful request' }],
+  result: {
+    events: {
+      count: 3,
+      events: [
+        {
+          timestamp: 1751566800000,
+          dataset: 'cloudflare-workers',
+          $metadata: {
+            service: SERVICE,
+            trigger: 'GET /users',
+            url: 'https://orders-worker.example.workers.dev/users',
+            statusCode: 200,
+            duration: 12.4,
+            traceDuration: 14.1,
+          },
+          $workers: {
+            eventType: 'fetch',
+            scriptName: SERVICE,
+            outcome: 'ok',
+          },
+        },
+        {
+          timestamp: 1751566801000,
+          dataset: 'cloudflare-workers',
+          $metadata: {
+            service: SERVICE,
+            trigger: 'POST /orders',
+            url: 'https://orders-worker.example.workers.dev/orders',
+            statusCode: 500,
+            duration: 340.2,
+          },
+          $workers: {
+            eventType: 'fetch',
+            scriptName: SERVICE,
+            outcome: 'exception',
+          },
+        },
+        {
+          timestamp: 1751566802000,
+          dataset: 'cloudflare-workers',
+          $metadata: {
+            service: SERVICE,
+            trigger: 'queue message',
+          },
+          $workers: {
+            eventType: 'queue',
+            scriptName: SERVICE,
+          },
+        },
+      ] satisfies CloudflareTelemetryEvent[],
+    },
+  },
+}
+
+function newGraph(): NeatGraph {
+  const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+  const service: ServiceNode = {
+    id: serviceId(SERVICE),
+    type: NodeType.ServiceNode,
+    name: SERVICE,
+    language: 'typescript',
+  }
+  g.addNode(service.id, service)
+
+  // EXTRACTED FileNode a static extractor already minted for the Worker's
+  // entry file — the file containing `export default { fetch }`.
+  const entry: FileNode = {
+    id: fileId(SERVICE, ENTRY_FILE),
+    type: NodeType.FileNode,
+    service: SERVICE,
+    path: ENTRY_FILE,
+    language: 'typescript',
+  }
+  g.addNode(entry.id, entry)
+
+  return g
+}
+
+function baseCtx(): ConnectorContext {
+  return { projectDir: '/repo/orders-worker', credentials: { apiToken: 'test-token' } }
+}
+
+function baseConfig(): CloudflareConnectorConfig {
+  return {
+    accountId: 'acct-123',
+    workers: {
+      [SERVICE]: { service: SERVICE, entryFile: ENTRY_FILE },
+    },
+  }
+}
+
+describe('parseHttpMethodFromTrigger', () => {
+  it('parses the leading HTTP method token off an HTTP-shaped trigger', () => {
+    expect(parseHttpMethodFromTrigger('GET /users')).toBe('GET')
+    expect(parseHttpMethodFromTrigger('post /orders')).toBe('POST')
+  })
+
+  it('returns null for a non-HTTP trigger (queue, cron, ...)', () => {
+    expect(parseHttpMethodFromTrigger('queue message')).toBeNull()
+    expect(parseHttpMethodFromTrigger(undefined)).toBeNull()
+  })
+})
+
+describe('mapEventToSignal (docs/connectors/cloudflare.md §Fusion)', () => {
+  it('maps an ok HTTP invocation to a whole-file-grain signal with the method parsed out of trigger', () => {
+    const signal = mapEventToSignal(TELEMETRY_RESPONSE.result!.events!.events[0])
+
+    expect(signal).not.toBeNull()
+    expect(signal!.targetName).toBe(SERVICE)
+    expect(signal!.method).toBe('GET')
+    expect(signal!.statusCode).toBe(200)
+    expect(signal!.duration).toBe(12.4)
+    expect(signal!.callCount).toBe(1)
+    expect(signal!.errorCount).toBe(0)
+    expect(signal!.lastObservedIso).toBe(new Date(1751566800000).toISOString())
+    // No route-matching attempt: the signal carries no path/route field at
+    // all, only the parsed method — confirms the mapper never touches the
+    // remainder of `trigger` beyond the leading method token.
+    expect(signal).not.toHaveProperty('route')
+    expect(signal).not.toHaveProperty('path')
+  })
+
+  it('maps a failing (5xx) HTTP invocation with errorCount 1', () => {
+    const signal = mapEventToSignal(TELEMETRY_RESPONSE.result!.events!.events[1])
+
+    expect(signal).not.toBeNull()
+    expect(signal!.method).toBe('POST')
+    expect(signal!.statusCode).toBe(500)
+    expect(signal!.errorCount).toBe(1)
+  })
+
+  it('drops a non-HTTP-triggered invocation (queue message) honestly, never fabricating a method', () => {
+    const signal = mapEventToSignal(TELEMETRY_RESPONSE.result!.events!.events[2])
+    expect(signal).toBeNull()
+  })
+
+  it('drops an event naming no script at all', () => {
+    const signal = mapEventToSignal({
+      timestamp: 1751566800000,
+      $metadata: { trigger: 'GET /users', statusCode: 200 },
+    })
+    expect(signal).toBeNull()
+  })
+})
+
+describe('queryWorkerInvocations', () => {
+  it('sends a bearer-token-authed query and returns the response events', async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(init!.body as string)
+      expect(body.timeframe).toEqual({ from: 1000, to: 2000 })
+      expect(body.view).toBe('events')
+      const headers = init!.headers as Record<string, string>
+      expect(headers.Authorization).toBe('Bearer test-token')
+      return new Response(JSON.stringify(TELEMETRY_RESPONSE), { status: 200 })
+    })
+
+    const events = await queryWorkerInvocations(
+      baseCtx(),
+      baseConfig(),
+      { fromMs: 1000, toMs: 2000 },
+      fetchImpl as unknown as typeof fetch,
+    )
+
+    expect(events).toHaveLength(3)
+    const [url] = fetchImpl.mock.calls[0]
+    expect(String(url)).toBe(
+      'https://api.cloudflare.com/client/v4/accounts/acct-123/workers/observability/telemetry/query',
+    )
+  })
+
+  it('throws when the response reports success: false', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ success: false, errors: [{ message: 'bad token' }] }),
+          { status: 200 },
+        ),
+    )
+
+    await expect(
+      queryWorkerInvocations(
+        baseCtx(),
+        baseConfig(),
+        { fromMs: 1000, toMs: 2000 },
+        fetchImpl as unknown as typeof fetch,
+      ),
+    ).rejects.toThrow(/bad token/)
+  })
+})
+
+describe('createCloudflareResolveTarget', () => {
+  it('resolves a mapped script to the Worker entry FileNode, service-sourced', () => {
+    const resolveTarget = createCloudflareResolveTarget(baseConfig())
+    const signal = mapEventToSignal(TELEMETRY_RESPONSE.result!.events!.events[0])!
+    const resolved = resolveTarget(signal, baseCtx())
+
+    expect(resolved).toEqual({
+      targetNodeId: fileId(SERVICE, ENTRY_FILE),
+      serviceName: SERVICE,
+      edgeType: EdgeType.CALLS,
+    })
+  })
+
+  it('returns null for a script with no configured mapping — honest miss, never guessed', () => {
+    const resolveTarget = createCloudflareResolveTarget(baseConfig())
+    const resolved = resolveTarget(
+      {
+        targetKind: 'cloudflare-worker-invocation',
+        targetName: 'some-other-worker',
+        callCount: 1,
+        errorCount: 0,
+        lastObservedIso: new Date().toISOString(),
+      },
+      baseCtx(),
+    )
+    expect(resolved).toBeNull()
+  })
+})
+
+describe('CloudflareConnector end-to-end via runConnectorPoll', () => {
+  it('mints one whole-file OBSERVED CALLS edge from two HTTP invocations, dropping the queue message', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify(TELEMETRY_RESPONSE), { status: 200 }))
+    const config = baseConfig()
+    const connector = new CloudflareConnector(config)
+    // Inject the fake fetch the same way queryWorkerInvocations exposes it —
+    // poll() itself doesn't take a fetchImpl, so exercise the connector via
+    // its own poll() by stubbing the global fetch for this call only.
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = fetchImpl as unknown as typeof fetch
+    try {
+      const graph = newGraph()
+      const resolveTarget = createCloudflareResolveTarget(config)
+      const result = await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
+
+      // 3 raw events in, 1 dropped (queue message) — 2 HTTP signals reach the
+      // pipeline; both resolve to the same whole-file target so one edge is
+      // created and the second call updates it rather than minting a twin.
+      expect(result).toEqual({
+        signalCount: 2,
+        edgesCreated: 1,
+        edgesUpdated: 1,
+        unresolved: 0,
+      })
+
+      const serviceNodeId = serviceId(SERVICE)
+      const entryFileId = fileId(SERVICE, ENTRY_FILE)
+      const edgeId = observedEdgeId(serviceNodeId, entryFileId, EdgeType.CALLS)
+      expect(graph.hasEdge(edgeId)).toBe(true)
+
+      const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+      expect(edge.provenance).toBe(Provenance.OBSERVED)
+      // Direction: the service (not an unknown external caller) is the
+      // source, the Worker's own entry FileNode is the target — the same
+      // "serving service → its own child node" shape the WebSocket channel
+      // connector-adjacent precedent uses (ADR-125), reusing CALLS the way
+      // that precedent reuses CONNECTS_TO.
+      expect(edge.source).toBe(serviceNodeId)
+      expect(edge.target).toBe(entryFileId)
+      // No callSite on either signal, so no file-grain fusion evidence — the
+      // edge lands directly on the pre-resolved whole-file target.
+      expect(edge.evidence).toBeUndefined()
+      // 2 invocations replayed (GET 200 + POST 500) — one error.
+      expect(edge.signal?.spanCount).toBe(2)
+      expect(edge.signal?.errorCount).toBe(1)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})

--- a/packages/core/test/connectors.test.ts
+++ b/packages/core/test/connectors.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest'
+import { MultiDirectedGraph } from 'graphology'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  fileId,
+  infraId,
+  observedEdgeId,
+  serviceId,
+  type FileNode,
+  type GraphEdge,
+  type GraphNode,
+  type InfraNode,
+  type ServiceNode,
+} from '@neat.is/types'
+import {
+  runConnectorPoll,
+  type ConnectorContext,
+  type ObservedConnector,
+  type ObservedSignal,
+  type ResolveConnectorTarget,
+} from '../src/connectors/index.js'
+import type { NeatGraph } from '../src/graph.js'
+
+const SERVICE = 'orders-api'
+const TABLE_TARGET = infraId('supabase-table', 'proj-ref/orders')
+const RPC_TARGET = infraId('supabase-rpc', 'proj-ref/get_totals')
+
+function newGraph(): NeatGraph {
+  const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+  const service: ServiceNode = {
+    id: serviceId(SERVICE),
+    type: NodeType.ServiceNode,
+    name: SERVICE,
+    language: 'javascript',
+  }
+  g.addNode(service.id, service)
+
+  // EXTRACTED FileNode a static extractor already minted — the trailing
+  // segment reconcileObservedRelPath must match against a connector
+  // signal's own (unanchored) callSite path.
+  const file: FileNode = {
+    id: fileId(SERVICE, 'src/db/orders.ts'),
+    type: NodeType.FileNode,
+    service: SERVICE,
+    path: 'src/db/orders.ts',
+    language: 'typescript',
+  }
+  g.addNode(file.id, file)
+
+  const table: InfraNode = {
+    id: TABLE_TARGET,
+    type: NodeType.InfraNode,
+    name: 'proj-ref/orders',
+    provider: 'supabase',
+    kind: 'supabase-table',
+  }
+  g.addNode(table.id, table)
+
+  const rpc: InfraNode = {
+    id: RPC_TARGET,
+    type: NodeType.InfraNode,
+    name: 'proj-ref/get_totals',
+    provider: 'supabase',
+    kind: 'supabase-rpc',
+  }
+  g.addNode(rpc.id, rpc)
+
+  return g
+}
+
+// A trivial in-memory test double — not a real provider. Real poll()
+// implementations (Supabase, Railway, Firebase, Cloudflare) are out of
+// scope for this scaffold; this fake only exercises the pull/map/fuse
+// pipeline the four provider designs will plug into.
+class FakeConnector implements ObservedConnector {
+  readonly provider = 'fake'
+  constructor(private readonly signals: ObservedSignal[]) {}
+  async poll(_ctx: ConnectorContext): Promise<ObservedSignal[]> {
+    return this.signals
+  }
+}
+
+const resolveTarget: ResolveConnectorTarget = (signal) => {
+  if (signal.targetKind === 'supabase-table') {
+    return {
+      targetNodeId: infraId('supabase-table', signal.targetName),
+      serviceName: SERVICE,
+      edgeType: EdgeType.CALLS,
+    }
+  }
+  if (signal.targetKind === 'supabase-rpc') {
+    return {
+      targetNodeId: infraId('supabase-rpc', signal.targetName),
+      serviceName: SERVICE,
+      edgeType: EdgeType.CALLS,
+    }
+  }
+  return null
+}
+
+function baseCtx(): ConnectorContext {
+  return { projectDir: '/repo/orders-api', credentials: {} }
+}
+
+describe('connectors plane — runConnectorPoll (docs/contracts/connectors.md)', () => {
+  it('mints an OBSERVED edge, file-grained, when the signal carries a callSite', async () => {
+    const graph = newGraph()
+    const signal: ObservedSignal = {
+      targetKind: 'supabase-table',
+      targetName: 'proj-ref/orders',
+      callCount: 5,
+      errorCount: 1,
+      lastObservedIso: '2026-07-03T12:00:00.000Z',
+      // Unanchored leading segment ("app/") the extractor's own path
+      // ("src/db/orders.ts") doesn't carry — reconcileObservedRelPath must
+      // recover it via trailing-suffix match, same as an OTel call site.
+      callSite: { file: 'app/src/db/orders.ts', line: 42 },
+    }
+    const connector = new FakeConnector([signal])
+
+    const result = await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
+
+    expect(result).toEqual({
+      signalCount: 1,
+      edgesCreated: 1,
+      edgesUpdated: 0,
+      unresolved: 0,
+    })
+
+    const fileNodeId = fileId(SERVICE, 'src/db/orders.ts')
+    const edgeId = observedEdgeId(fileNodeId, TABLE_TARGET, EdgeType.CALLS)
+    expect(graph.hasEdge(edgeId)).toBe(true)
+
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.source).toBe(fileNodeId)
+    expect(edge.target).toBe(TABLE_TARGET)
+    // callCount=5/errorCount=1 replay as 5 upserts (1 erroring) — the same
+    // signal.spanCount/errorCount shape a burst of 5 individual spans would
+    // produce, not a flat +1 per signal.
+    expect(edge.signal?.spanCount).toBe(5)
+    expect(edge.signal?.errorCount).toBe(1)
+    expect(edge.evidence).toEqual({ file: 'src/db/orders.ts', line: 42 })
+
+    // The edge id and its endpoints were built via the identity helpers
+    // (observedEdgeId / fileId / infraId), never a hand-rolled template
+    // literal — contracts.test.ts's Rule 16 / Rule 2 audits cover this at
+    // the source level; this assertion pins the same expectation for the
+    // connectors path specifically.
+    expect(edgeId).toBe(`CALLS:OBSERVED:${fileNodeId}->${TABLE_TARGET}`)
+  })
+
+  it('falls back to a service-level edge when the signal carries no callSite', async () => {
+    const graph = newGraph()
+    const signal: ObservedSignal = {
+      targetKind: 'supabase-rpc',
+      targetName: 'proj-ref/get_totals',
+      callCount: 2,
+      errorCount: 0,
+      lastObservedIso: '2026-07-03T12:05:00.000Z',
+    }
+    const connector = new FakeConnector([signal])
+
+    const result = await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
+
+    expect(result).toEqual({
+      signalCount: 1,
+      edgesCreated: 1,
+      edgesUpdated: 0,
+      unresolved: 0,
+    })
+
+    const serviceNodeId = serviceId(SERVICE)
+    const edgeId = observedEdgeId(serviceNodeId, RPC_TARGET, EdgeType.CALLS)
+    expect(graph.hasEdge(edgeId)).toBe(true)
+
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.source).toBe(serviceNodeId)
+    expect(edge.evidence).toBeUndefined()
+    expect(edge.signal?.spanCount).toBe(2)
+    expect(edge.signal?.errorCount).toBe(0)
+
+    // No FileNode should have been created for this fallback path.
+    expect(graph.hasNode(fileId(SERVICE, 'src/db/get_totals.ts'))).toBe(false)
+  })
+
+  it('an unresolved signal is dropped honestly, never fabricated', async () => {
+    const graph = newGraph()
+    const signal: ObservedSignal = {
+      targetKind: 'supabase-storage', // resolveTarget above knows nothing of this kind
+      targetName: 'proj-ref/avatars',
+      callCount: 3,
+      errorCount: 0,
+      lastObservedIso: '2026-07-03T12:10:00.000Z',
+    }
+    const connector = new FakeConnector([signal])
+
+    const result = await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
+
+    expect(result).toEqual({
+      signalCount: 1,
+      edgesCreated: 0,
+      edgesUpdated: 0,
+      unresolved: 1,
+    })
+  })
+
+  it('re-polling the same signal updates the existing edge instead of minting a twin', async () => {
+    const graph = newGraph()
+    const signal: ObservedSignal = {
+      targetKind: 'supabase-rpc',
+      targetName: 'proj-ref/get_totals',
+      callCount: 1,
+      errorCount: 0,
+      lastObservedIso: '2026-07-03T12:05:00.000Z',
+    }
+    const connector = new FakeConnector([signal])
+
+    await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
+    const second = await runConnectorPoll(
+      connector,
+      { ...baseCtx(), since: '2026-07-03T12:05:00.000Z' },
+      graph,
+      resolveTarget,
+    )
+
+    expect(second).toEqual({
+      signalCount: 1,
+      edgesCreated: 0,
+      edgesUpdated: 1,
+      unresolved: 0,
+    })
+
+    const edgeId = observedEdgeId(serviceId(SERVICE), RPC_TARGET, EdgeType.CALLS)
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.signal?.spanCount).toBe(2)
+  })
+})


### PR DESCRIPTION
Refs #666. Builds on #665 (the connectors-plane scaffold) — this PR's diff will shrink to just the Cloudflare-specific code once #665 merges and this gets retargeted to main.

Implements `packages/core/src/connectors/cloudflare/` per `docs/connectors/cloudflare.md` (ADR-129):

- `poll()` against the Workers Observability Telemetry Query API (`POST /accounts/{account_id}/workers/observability/telemetry/query`), API-token auth via `ConnectorContext.credentials`.
- Maps each invocation record to an `ObservedSignal` at whole-file grain — the HTTP method is parsed off the `trigger` string for metadata only, never matched against a route table. The signal resolves to the Worker's entry `FileNode`, mapped from a `scriptName -> {service, entryFile}` config table supplied at connector-configuration time (Cloudflare's telemetry only names the script, never a file path).
- The resulting edge is `service --CALLS--> entryFile` rather than the client-calls-provider shape Supabase's connector will use — this API carries no caller identity, only "this script ran" — mirroring how the WebSocket channel work mints a liveness edge from a service onto its own child node.
- `routes.ts` is untouched — zero diff, confirmed by `git diff --stat`.

Response shapes in `types.ts` and the test fixture in `connectors-cloudflare.test.ts` are taken from a live fetch of Cloudflare's actual API reference for this endpoint, not invented from memory — cited inline near the fixture.

## Test plan

- [x] `npm run build --workspace @neat.is/types`
- [x] `npx turbo build --filter=@neat.is/core^...`
- [x] `npm run build --workspace @neat.is/core`
- [x] `npx vitest run --root packages/core` — 64 test files, 1268 passed, 2 skipped, 5 todo (all pre-existing)
- [x] `npx tsc --noEmit` on core — no new errors (3 pre-existing errors unrelated to this change, present on the scaffold branch too)
- [x] `npm run lint --workspace @neat.is/core` — clean

Do not merge — leaving this open for review.