### PR TITLE
Implement the Railway connector (ADR-127)

### DIFF
--- a/docs/contracts/connectors.md
+++ b/docs/contracts/connectors.md
@@ -4,7 +4,7 @@ description: The connectors plane — a second OBSERVED ingestion path (pull) al
 governs:
   - "packages/core/src/connectors/**"
 adr: [ADR-124]
-enforcement: [review]
+enforcement: [lint, review]
 ---
 
 # Connectors contract
@@ -59,6 +59,6 @@ A connector's config/broker state holds the credential. The graph records existe
 
 ## Enforcement
 
-`enforcement: [review]` — this is a review-only contract for now: no connector code has landed yet (this contract lands with ADR-124, ahead of the `neatd` implementation), so there is nothing for a lint assertion to check yet. Once the first provider (Supabase) ships, a `contracts.test.ts` assertion should check the provider-interface shape (§1) and the credential-in-config-not-snapshot rule (§6) mechanically, and this contract's enforcement tag should move to `[lint, review]`. Flagged here rather than deferred silently, per `contract-enforcement.md` §3.
+`enforcement: [lint, review]`. **Lint:** `contracts.test.ts`'s "Connectors plane contract (ADR-124)" block checks the provider-interface shape (§1 — `ObservedConnector`/`ConnectorContext`/`ObservedSignal` declared as specified) and the credential-in-config-not-snapshot rule (§6 — `credentials` never appears on the same line as a graph mutation call in `connectors/**`) mechanically, plus a scoped regression guard that `connectors/index.ts` never mutates the graph directly (ADR-030). **Review:** everything else — the passive/ambient discipline (§2), the two-credential-profile split (§3), and each provider's own fusion pattern (§4) — stays a human call until a provider's `poll()`/mapping code gives it something concrete to check against.
 
 Full rationale: [ADR-124](../decisions.md#adr-124--the-supabase-connector-and-the-connectors-plane).

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -1,0 +1,239 @@
+// Connectors plane — the provider-agnostic pull/map/fuse pipeline
+// (docs/contracts/connectors.md, docs/connectors/README.md, ADR-124).
+//
+// A provider module (packages/core/src/connectors/<provider>/, none shipped
+// yet) owns exactly two things: fetching `ObservedSignal[]` off its own API
+// (`ObservedConnector.poll`) and mapping a signal's targetKind/targetName to
+// a NEAT node id (the `resolveTarget` callback below). Everything after that
+// — resolving a static call site, minting the OBSERVED edge — is written
+// once, here, and is identical for every provider: a connector-sourced edge
+// and a span-sourced edge carry the same provenance and land through the
+// same mutation primitives OTel ingest uses (README.md's opening paragraph).
+//
+// Mutation authority (ADR-030 — see contracts.test.ts's "Lifecycle contract"
+// audit): only ingest.ts and extract/* may call a graph mutator directly.
+// This module never does — every node/edge write below goes through an
+// ingest.ts primitive (`ensureServiceNode`, `ensureObservedFileNode`,
+// `upsertObservedEdge`), exported for exactly this reuse. A future
+// provider's own target-node creation (a Supabase table InfraNode, say)
+// belongs in ingest.ts too, for the same reason — this module only ever
+// calls into it, never mutates the graph itself.
+
+import type { EdgeTypeValue } from '@neat.is/types'
+import type { NeatGraph } from '../graph.js'
+import {
+  ensureObservedFileNode,
+  ensureServiceNode,
+  reconcileObservedRelPath,
+  upsertObservedEdge,
+  type CallSite,
+} from '../ingest.js'
+import type { ConnectorContext, ObservedConnector, ObservedSignal } from './types.js'
+
+export type {
+  ConnectorCallSite,
+  ConnectorContext,
+  ObservedConnector,
+  ObservedSignal,
+} from './types.js'
+
+// env-unscoped, matching the sentinel identity.ts uses for "no deployment
+// signal" (ADR-074 §2) — a connector signal carries no
+// deployment.environment(.name) the way an OTel span might.
+const NO_ENV = 'unknown'
+
+/**
+ * What a provider's target-resolution step hands back for one signal. The
+ * generic pipeline needs both endpoints of the edge it's about to mint:
+ *
+ * - `serviceName` is the NEAT manifest service whose code produced the
+ *   signal — the edge's source. The shared pipeline turns it into a plain
+ *   ServiceNode id, or a FileNode id once the fuse step below resolves the
+ *   signal's callSite against it.
+ * - `targetNodeId` is the id the provider's own mapping already resolved —
+ *   an `infraId(...)` sub-resource, a RouteNode, a ServiceNode, whatever
+ *   (see each provider's docs/connectors/<provider>.md §Fusion).
+ *
+ * Returning `null` skips the signal honestly: an unresolvable target never
+ * fabricates a node or edge (the same discipline file-awareness.md §6
+ * states for OTel ingest).
+ */
+export interface ResolvedConnectorTarget {
+  targetNodeId: string
+  serviceName: string
+  edgeType: EdgeTypeValue
+}
+
+export type ResolveConnectorTarget = (
+  signal: ObservedSignal,
+  ctx: ConnectorContext,
+) => ResolvedConnectorTarget | null
+
+export interface ConnectorPollResult {
+  // Signals connector.poll() returned this tick.
+  signalCount: number
+  // Fresh OBSERVED edges minted.
+  edgesCreated: number
+  // Existing OBSERVED edges whose signal block advanced.
+  edgesUpdated: number
+  // Signals that resolved to no target (resolveTarget returned null, or the
+  // resolved target/service node doesn't exist in the graph yet) — dropped
+  // honestly rather than minting a fabricated edge.
+  unresolved: number
+}
+
+/**
+ * One poll cycle: fetch, map, fuse, mint. Pure with respect to `ctx` — the
+ * caller (`startConnectorPollLoop` below, or a one-shot `neat sync`) owns
+ * advancing `ctx.since` between calls.
+ */
+export async function runConnectorPoll(
+  connector: ObservedConnector,
+  ctx: ConnectorContext,
+  graph: NeatGraph,
+  resolveTarget: ResolveConnectorTarget,
+): Promise<ConnectorPollResult> {
+  const signals = await connector.poll(ctx)
+  let edgesCreated = 0
+  let edgesUpdated = 0
+  let unresolved = 0
+
+  for (const signal of signals) {
+    const resolved = resolveTarget(signal, ctx)
+    if (!resolved) {
+      unresolved++
+      continue
+    }
+
+    // Same shape ingest.ts's handleSpan uses for every span: auto-create a
+    // minimal ServiceNode the first time this service is seen so the edge
+    // upsert below always has a source endpoint, even for a service the
+    // static extractor hasn't reached (or never will, in an OTel-less setup).
+    const serviceNodeId = ensureServiceNode(graph, resolved.serviceName, NO_ENV)
+
+    // File-grain fusion when the signal carries a call site, through the
+    // same reconcileObservedRelPath path OTel ingest uses (file-awareness.md
+    // §4) — service-level, honestly, when it doesn't (§6, never fabricated).
+    const callSite: CallSite | undefined = signal.callSite
+      ? { relPath: signal.callSite.file, line: signal.callSite.line }
+      : undefined
+    const sourceId = callSite
+      ? ensureObservedFileNode(graph, resolved.serviceName, serviceNodeId, callSite)
+      : serviceNodeId
+    const evidence = callSite
+      ? {
+          file: reconcileObservedRelPath(graph, resolved.serviceName, callSite.relPath),
+          line: callSite.line,
+        }
+      : undefined
+
+    // upsertObservedEdge increments its signal block by exactly one call per
+    // invocation — the right unit for a single span, but a connector signal
+    // is already an aggregate over the whole poll window (`callCount` calls,
+    // `errorCount` of them failing). Replay it that many times so the
+    // edge's spanCount/errorCount — and the confidence grade derived from
+    // them, ADR-066 — land the same as if `callCount` individual spans had
+    // arrived, rather than undercounting a batched signal down to +1.
+    const calls = Math.trunc(signal.callCount)
+    if (calls < 1) continue // nothing observed this window — not even a miss
+    const errors = Math.min(Math.max(Math.trunc(signal.errorCount), 0), calls)
+
+    let created = false
+    let ok = true
+    for (let i = 0; i < calls; i++) {
+      const result = upsertObservedEdge(
+        graph,
+        resolved.edgeType,
+        sourceId,
+        resolved.targetNodeId,
+        signal.lastObservedIso,
+        i < errors,
+        evidence,
+      )
+      if (!result) {
+        // Target node doesn't exist yet — an extractor gap (supabase.md
+        // §Static extractor gap documents exactly this case) or a provider
+        // that hasn't minted it. Honest miss, not a crash.
+        ok = false
+        break
+      }
+      if (i === 0) created = result.created
+    }
+    if (!ok) {
+      unresolved++
+      continue
+    }
+    if (created) edgesCreated++
+    else edgesUpdated++
+  }
+
+  return { signalCount: signals.length, edgesCreated, edgesUpdated, unresolved }
+}
+
+export interface ConnectorPollLoopOptions {
+  intervalMs?: number
+  onError?: (err: unknown) => void
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 60_000
+
+/**
+ * Recurring wrapper around `runConnectorPoll` — the same setInterval +
+ * unref + try/catch + stop-closure shape `startStalenessLoop` (ingest.ts)
+ * already uses for the daemon's per-project background tasks, reused here
+ * rather than reinvented. `daemon.ts` wires this in exactly where it wires
+ * `startStalenessLoop`, tearing both down together per project slot.
+ *
+ * Advances `since` to the tick's own start time after every successful
+ * poll — the next tick asks the provider for "since last tick" rather than
+ * replaying. A tick that throws logs and leaves `since` where it was, so a
+ * transient provider outage doesn't silently skip the gap once it recovers.
+ */
+export function startConnectorPollLoop(
+  connector: ObservedConnector,
+  ctx: ConnectorContext,
+  graph: NeatGraph,
+  resolveTarget: ResolveConnectorTarget,
+  options: ConnectorPollLoopOptions = {},
+): () => void {
+  let stopped = false
+  let since = ctx.since
+  const intervalMs = options.intervalMs ?? DEFAULT_POLL_INTERVAL_MS
+  const onError =
+    options.onError ??
+    ((err: unknown) => console.error(`[neatd] connector poll failed (${connector.provider})`, err))
+
+  const tick = (): void => {
+    if (stopped) return
+    void (async () => {
+      const tickStartedAt = new Date().toISOString()
+      try {
+        await runConnectorPoll(connector, { ...ctx, since }, graph, resolveTarget)
+        since = tickStartedAt
+      } catch (err) {
+        onError(err)
+      }
+    })()
+  }
+
+  const interval = setInterval(tick, intervalMs)
+  if (typeof interval.unref === 'function') interval.unref()
+  return () => {
+    stopped = true
+    clearInterval(interval)
+  }
+}
+
+/**
+ * One project's registered connector, ready for `daemon.ts` to poll on an
+ * interval. Deliberately thin — no config-loading or credential-broker logic
+ * lives here (that's provider- and profile-specific, later work per
+ * docs/contracts/connectors.md §3); this is just the seam a daemon slot
+ * wires a connector through.
+ */
+export interface ConnectorRegistration {
+  connector: ObservedConnector
+  credentials: Record<string, unknown>
+  resolveTarget: ResolveConnectorTarget
+  intervalMs?: number
+}

--- a/packages/core/src/connectors/railway/client.ts
+++ b/packages/core/src/connectors/railway/client.ts
@@ -1,0 +1,184 @@
+// Railway GraphQL client — the fetch half of this connector's poll() (ADR-127,
+// docs/connectors/railway.md). Passive and ambient only (docs/contracts/
+// connectors.md §2): two read-only queries, never a mutation, never a
+// synthetic request to keep the connection warm.
+
+import type { RailwayConnectorConfig, RailwayHttpLogEntry, RailwayNetworkFlowLogEntry } from './types.js'
+
+export const DEFAULT_RAILWAY_API_URL = 'https://backboard.railway.com/graphql/v2'
+
+// docs/connectors/railway.md §"Out of scope for this cut" flags the
+// neighbouring plan-tier question the same way: Railway's docs don't publish
+// a retention/lookback window for httpLogs/networkFlowLogs as of this
+// writing. 24h is a conservative default pending a live project confirming
+// the real cap — never an unbounded full-history query regardless
+// (docs/contracts/connectors.md §"Poll cadence and backfill").
+export const DEFAULT_MAX_LOOKBACK_MS = 24 * 60 * 60 * 1000
+export const DEFAULT_LOG_LIMIT = 1000
+
+interface RailwayGraphQLError {
+  message: string
+}
+
+interface RailwayGraphQLResponse<T> {
+  data?: T
+  errors?: RailwayGraphQLError[]
+}
+
+// A Project-Access-Token is the credential ADR-127 scopes this connector to
+// (docs/connectors/railway.md §Scope) — both local and hosted profiles carry
+// it the same way (docs/contracts/connectors.md §3). Read from
+// `ConnectorContext.credentials` at poll time, never logged, never written
+// into a node/edge (contract §6).
+export function readRailwayToken(credentials: Record<string, unknown>): string {
+  const token = credentials.token
+  if (typeof token !== 'string' || token.length === 0) {
+    throw new Error(
+      'Railway connector requires ctx.credentials.token (a Project-Access-Token or account Bearer token)',
+    )
+  }
+  return token
+}
+
+async function railwayGraphQL<T>(
+  apiUrl: string,
+  token: string,
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(apiUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      // docs.railway.com/integrations/api/graphql-overview confirms
+      // `Authorization: Bearer <token>` for an account/workspace token;
+      // Railway also documents a dedicated `Project-Access-Token: <token>`
+      // header for the project-scoped token ADR-127 targets specifically.
+      // This connector sends the Bearer form — needs-endpoint-testing
+      // whether a live Project-Access-Token requires the dedicated header
+      // instead once this poller runs against a real project.
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ query, variables }),
+  })
+  if (!res.ok) {
+    throw new Error(`Railway GraphQL request failed: ${res.status} ${res.statusText}`)
+  }
+  const body = (await res.json()) as RailwayGraphQLResponse<T>
+  if (body.errors && body.errors.length > 0) {
+    throw new Error(`Railway GraphQL errors: ${body.errors.map((e) => e.message).join('; ')}`)
+  }
+  if (!body.data) throw new Error('Railway GraphQL response carried no data')
+  return body.data
+}
+
+// See types.ts's "raw provider response shapes" header — the query shape
+// below is the closest documented approximation, flagged
+// needs-endpoint-testing, not a live-confirmed schema.
+const HTTP_LOGS_QUERY = `
+  query HttpLogs(
+    $environmentId: String!
+    $serviceId: String!
+    $startDate: String!
+    $endDate: String!
+    $limit: Int
+  ) {
+    httpLogs(
+      environmentId: $environmentId
+      serviceId: $serviceId
+      startDate: $startDate
+      endDate: $endDate
+      limit: $limit
+    ) {
+      timestamp
+      method
+      path
+      httpStatus
+      totalDuration
+      requestId
+      deploymentId
+      edgeRegion
+    }
+  }
+`
+
+const NETWORK_FLOW_LOGS_QUERY = `
+  query NetworkFlowLogs(
+    $environmentId: String!
+    $serviceId: String!
+    $startDate: String!
+    $endDate: String!
+    $limit: Int
+  ) {
+    networkFlowLogs(
+      environmentId: $environmentId
+      serviceId: $serviceId
+      startDate: $startDate
+      endDate: $endDate
+      limit: $limit
+    ) {
+      timestamp
+      peerServiceId
+      peerKind
+      direction
+      byteCount
+      packetCount
+      dropCause
+    }
+  }
+`
+
+export async function fetchRailwayHttpLogs(
+  config: RailwayConnectorConfig,
+  token: string,
+  startDate: string,
+  endDate: string,
+): Promise<RailwayHttpLogEntry[]> {
+  const data = await railwayGraphQL<{ httpLogs: RailwayHttpLogEntry[] }>(
+    config.apiUrl ?? DEFAULT_RAILWAY_API_URL,
+    token,
+    HTTP_LOGS_QUERY,
+    {
+      environmentId: config.environmentId,
+      serviceId: config.serviceId,
+      startDate,
+      endDate,
+      limit: config.limit ?? DEFAULT_LOG_LIMIT,
+    },
+  )
+  return data.httpLogs
+}
+
+export async function fetchRailwayNetworkFlowLogs(
+  config: RailwayConnectorConfig,
+  token: string,
+  startDate: string,
+  endDate: string,
+): Promise<RailwayNetworkFlowLogEntry[]> {
+  const data = await railwayGraphQL<{ networkFlowLogs: RailwayNetworkFlowLogEntry[] }>(
+    config.apiUrl ?? DEFAULT_RAILWAY_API_URL,
+    token,
+    NETWORK_FLOW_LOGS_QUERY,
+    {
+      environmentId: config.environmentId,
+      serviceId: config.serviceId,
+      startDate,
+      endDate,
+      limit: config.limit ?? DEFAULT_LOG_LIMIT,
+    },
+  )
+  return data.networkFlowLogs
+}
+
+// `since` bounded by the provider's max lookback window (docs/contracts/
+// connectors.md §"Poll cadence and backfill") — a gap wider than the window
+// (a laptop off for a week) backfills from `now - maxLookbackMs`, never an
+// unbounded full-history replay. An absent or unparseable `since` (no prior
+// poll) gets the same treatment as too-old a `since`.
+export function boundedRailwayStartDate(since: string | undefined, now: Date, maxLookbackMs: number): string {
+  const floor = new Date(now.getTime() - maxLookbackMs)
+  if (!since) return floor.toISOString()
+  const sinceMs = new Date(since).getTime()
+  if (Number.isNaN(sinceMs)) return floor.toISOString()
+  return sinceMs < floor.getTime() ? floor.toISOString() : new Date(sinceMs).toISOString()
+}

--- a/packages/core/src/connectors/railway/index.ts
+++ b/packages/core/src/connectors/railway/index.ts
@@ -1,0 +1,315 @@
+// Railway connector (ADR-127, docs/connectors/railway.md) — the second
+// connectors-plane provider after the shared pull/map/fuse scaffold
+// (ADR-124, connectors/index.ts). Railway names nothing in application code:
+// the signal comes entirely from Railway's own edge/ingress layer (httpLogs)
+// and L4 flow records (networkFlowLogs), so fusion binds onto the RouteNode
+// `extract/routes.ts` already builds — the same node an OBSERVED server span
+// would fuse onto if the app were OTel-instrumented — rather than a
+// client-SDK call site the way the Supabase connector design does.
+
+import type { RouteNode } from '@neat.is/types'
+import { EdgeType, NodeType, serviceId } from '@neat.is/types'
+import type { NeatGraph } from '../../graph.js'
+import { normalizePathTemplate } from '../../extract/routes.js'
+import type {
+  ConnectorCallSite,
+  ConnectorContext,
+  ObservedConnector,
+  ObservedSignal,
+  ResolveConnectorTarget,
+} from '../index.js'
+import type { RailwayConnectorConfig, RailwayHttpLogEntry, RailwayNetworkFlowLogEntry } from './types.js'
+import {
+  DEFAULT_MAX_LOOKBACK_MS,
+  boundedRailwayStartDate,
+  fetchRailwayHttpLogs,
+  fetchRailwayNetworkFlowLogs,
+  readRailwayToken,
+} from './client.js'
+
+export type { RailwayConnectorConfig, RailwayHttpLogEntry, RailwayNetworkFlowLogEntry } from './types.js'
+export { DEFAULT_RAILWAY_API_URL } from './client.js'
+
+// A signal's `targetKind` for this provider (README.md's "provider's own
+// vocabulary" — connectors/index.ts never inspects these strings itself):
+//
+// - 'route'           — the record's (method, path) normalised onto an
+//                        existing RouteNode (extract/routes.ts). targetName
+//                        already carries that RouteNode's own graph id.
+// - 'unmatched-route' — no RouteNode resolved. See createRailwayResolveTarget
+//                        below for why this drops honestly rather than
+//                        fabricating a target.
+// - 'peer-service'    — a networkFlowLogs record naming another Railway
+//                        service. targetName carries the raw Railway
+//                        peerServiceId, resolved through config.serviceNameById.
+const ROUTE_TARGET_KIND = 'route'
+const UNMATCHED_ROUTE_TARGET_KIND = 'unmatched-route'
+const PEER_SERVICE_TARGET_KIND = 'peer-service'
+
+// ── route index (read-only graph query) ────────────────────────────────────
+//
+// Mirrors extract/calls/route-match.ts's own buildRouteIndex/findRoute — not
+// imported, since neither is exported from that module (only
+// normalizePathTemplate is, which this file reuses directly rather than
+// re-deriving the path-template normalisation rules). This is the
+// connectors-plane side of the same (method, normalised-path) matching
+// route-match.ts already does for a client call site, applied here to
+// Railway's own edge-observed (method, path) pairs instead of a parsed HTTP
+// client call (docs/connectors/railway.md §Fusion).
+
+interface RailwayRouteIndexEntry {
+  method: string
+  normalizedPath: string
+  routeNodeId: string
+  path: string
+  line?: number
+}
+
+export function buildRailwayRouteIndex(graph: NeatGraph, serviceName: string): RailwayRouteIndexEntry[] {
+  const out: RailwayRouteIndexEntry[] = []
+  graph.forEachNode((_id, attrs) => {
+    const node = attrs as unknown as { type?: string }
+    if (node.type !== NodeType.RouteNode) return
+    const route = attrs as unknown as RouteNode
+    if (route.service !== serviceName) return
+    out.push({
+      method: route.method.toUpperCase(),
+      normalizedPath: normalizePathTemplate(route.pathTemplate),
+      routeNodeId: route.id,
+      path: route.path,
+      line: route.line,
+    })
+  })
+  return out
+}
+
+// httpLogs always carries a concrete method (unlike a statically parsed
+// client call site, which sometimes can't determine one) — so unlike
+// route-match.ts's findRoute, there's no "caller method unknown" passthrough
+// case, only the route's own `ALL` wildcard.
+function findRailwayRoute(
+  entries: RailwayRouteIndexEntry[],
+  method: string,
+  normalizedPath: string,
+): RailwayRouteIndexEntry | undefined {
+  return entries.find(
+    (e) => e.normalizedPath === normalizedPath && (e.method === 'ALL' || e.method === method),
+  )
+}
+
+function bucketKey(method: string, normalizedPath: string): string {
+  return `${method} ${normalizedPath}`
+}
+
+function isHttpErrorStatus(status: number): boolean {
+  return status >= 400
+}
+
+interface SignalBucket {
+  callCount: number
+  errorCount: number
+  lastObservedIso: string
+  targetKind: string
+  targetName: string
+  callSite?: ConnectorCallSite
+}
+
+function upsertBucket(
+  buckets: Map<string, SignalBucket>,
+  key: string,
+  isError: boolean,
+  timestamp: string,
+  build: () => Omit<SignalBucket, 'callCount' | 'errorCount' | 'lastObservedIso'>,
+): void {
+  const existing = buckets.get(key)
+  if (existing) {
+    existing.callCount += 1
+    if (isError) existing.errorCount += 1
+    if (timestamp > existing.lastObservedIso) existing.lastObservedIso = timestamp
+    return
+  }
+  buckets.set(key, { callCount: 1, errorCount: isError ? 1 : 0, lastObservedIso: timestamp, ...build() })
+}
+
+// ── httpLogs → ObservedSignal[] ─────────────────────────────────────────────
+//
+// Route-grain fusion (docs/connectors/railway.md §Fusion): normalise each
+// record's `path` the same way route-match.ts normalises a client call
+// site's URL path, then match against the polled service's own RouteNodes.
+// A match carries the matched RouteNode's own `path`/`line` as this signal's
+// callSite — reconciled onto the EXTRACTED service-relative path
+// (connectors/index.ts's shared fuse step) the same way every other OBSERVED
+// surface in NEAT lands file-grained, because that path IS the extracted
+// path a static pass already walked (routes.ts's own file:line).
+export function mapRailwayHttpLogsToSignals(
+  entries: RailwayHttpLogEntry[],
+  routeIndex: RailwayRouteIndexEntry[],
+): ObservedSignal[] {
+  const buckets = new Map<string, SignalBucket>()
+
+  for (const entry of entries) {
+    const method = entry.method.toUpperCase()
+    const normalizedPath = normalizePathTemplate(entry.path)
+    const match = findRailwayRoute(routeIndex, method, normalizedPath)
+    const isError = isHttpErrorStatus(entry.httpStatus)
+
+    if (match) {
+      upsertBucket(buckets, `route:${match.routeNodeId}`, isError, entry.timestamp, () => ({
+        targetKind: ROUTE_TARGET_KIND,
+        targetName: match.routeNodeId,
+        // RouteNode.line is optional in the schema (packages/types/src/
+        // nodes.ts) even though routes.ts always sets it today — skip the
+        // callSite rather than fabricate a line when it's ever absent
+        // (file-awareness.md §6).
+        ...(match.line !== undefined ? { callSite: { file: match.path, line: match.line } } : {}),
+      }))
+    } else {
+      // No RouteNode resolves — the app's framework/router isn't one
+      // routes.ts recognises yet, or the path doesn't match any declared
+      // template. See createRailwayResolveTarget below for why this
+      // targetKind always resolves to null (an honest "unresolved" miss)
+      // rather than a fabricated target.
+      upsertBucket(
+        buckets,
+        `unmatched:${bucketKey(method, normalizedPath)}`,
+        isError,
+        entry.timestamp,
+        () => ({
+          targetKind: UNMATCHED_ROUTE_TARGET_KIND,
+          targetName: bucketKey(method, normalizedPath),
+        }),
+      )
+    }
+  }
+
+  return [...buckets.values()].map((b) => ({
+    targetKind: b.targetKind,
+    targetName: b.targetName,
+    callCount: b.callCount,
+    errorCount: b.errorCount,
+    lastObservedIso: b.lastObservedIso,
+    ...(b.callSite ? { callSite: b.callSite } : {}),
+  }))
+}
+
+// ── networkFlowLogs → ObservedSignal[] ──────────────────────────────────────
+//
+// Service-dependency signal, independent of any route (docs/connectors/
+// railway.md §Fusion — "independent of whether any route resolves for the
+// traffic that produced the flow"). A record with no `peerServiceId` names
+// no Railway-internal peer (public internet egress, say) and is dropped
+// honestly — never guessed at.
+export function mapRailwayNetworkFlowLogsToSignals(
+  entries: RailwayNetworkFlowLogEntry[],
+): ObservedSignal[] {
+  const buckets = new Map<string, SignalBucket>()
+
+  for (const entry of entries) {
+    if (!entry.peerServiceId) continue
+    const isError = entry.dropCause !== null && entry.dropCause !== ''
+    upsertBucket(buckets, entry.peerServiceId, isError, entry.timestamp, () => ({
+      targetKind: PEER_SERVICE_TARGET_KIND,
+      targetName: entry.peerServiceId as string,
+    }))
+  }
+
+  return [...buckets.values()].map((b) => ({
+    targetKind: b.targetKind,
+    targetName: b.targetName,
+    callCount: b.callCount,
+    errorCount: b.errorCount,
+    lastObservedIso: b.lastObservedIso,
+  }))
+}
+
+// ── target resolution (README.md pipeline step 2 — provider-specific) ──────
+//
+// A pure function of (signal, ctx, config) — no graph access, unlike
+// poll()/the route index above, which need a read-only graph query to match
+// against existing RouteNodes. That matching already happened in poll();
+// resolveTarget's job here is only the id-shape mapping README.md describes
+// ("targetKind/targetName → NEAT node id").
+export function createRailwayResolveTarget(config: RailwayConnectorConfig): ResolveConnectorTarget {
+  return (signal: ObservedSignal) => {
+    const serviceName = config.serviceNameById[config.serviceId]
+    // This connector's own polled service has no configured mapping — a
+    // config error, not something to guess past (docs/connectors/railway.md
+    // §Fusion, "resolved once, never guessed").
+    if (!serviceName) return null
+
+    if (signal.targetKind === ROUTE_TARGET_KIND) {
+      // targetName is already the exact RouteNode graph id poll()'s route
+      // index resolved — this is the two-sided divergence's OBSERVED half,
+      // landing on the same node the EXTRACTED client↔route CALLS edge
+      // (route-match.ts, ADR-119) and a future OBSERVED server span (#576)
+      // would.
+      return { targetNodeId: signal.targetName, serviceName, edgeType: EdgeType.CALLS }
+    }
+
+    if (signal.targetKind === PEER_SERVICE_TARGET_KIND) {
+      const peerName = config.serviceNameById[signal.targetName]
+      // Unmapped peer serviceId — dropped honestly rather than guessed
+      // (docs/connectors/railway.md §Fusion). A future config update adding
+      // the mapping picks this traffic up on the next poll; it never
+      // fabricates a peer identity in the meantime.
+      if (!peerName) return null
+      return { targetNodeId: serviceId(peerName), serviceName, edgeType: EdgeType.CONNECTS_TO }
+    }
+
+    // UNMATCHED_ROUTE_TARGET_KIND (and anything else unrecognised): no
+    // RouteNode resolved for this traffic, and the scaffold's shared pipeline
+    // (connectors/index.ts) has no primitive to auto-vivify one the way
+    // ensureGraphqlOperationNode/ensureGrpcMethodNode do for an OTel span
+    // (ingest.ts) — those exist on the OTLP-ingest path, not on
+    // ResolveConnectorTarget's (signal, ctx) => ResolvedConnectorTarget
+    // shape, which only names an id, never creates one. Even if it could:
+    // RouteNode.path is a required field (packages/types/src/nodes.ts)
+    // naming the real source location a static extractor found — a
+    // Railway-observed route with no static match has no honest value to
+    // put there, so minting one here would fabricate provenance
+    // (file-awareness.md §6). Returning null routes this through the
+    // scaffold's own honest-miss path (ConnectorPollResult.unresolved)
+    // instead of forcing an edge. See this PR's description for the gap
+    // this leaves open: a route Railway observes but no static extractor
+    // recognises today produces no missing-extracted divergence via this
+    // connector, pending either a scaffold extension (observed-first target
+    // creation, mirroring the OTel-ingest pattern) or a product decision on
+    // how to represent it without fabricating a path.
+    return null
+  }
+}
+
+// ── connector ────────────────────────────────────────────────────────────────
+//
+// Constructed with a `graph` reference so poll() can read (never mutate,
+// per ADR-030 mutation authority — every write this connector's signals
+// eventually cause flows back through connectors/index.ts's ingest.ts
+// primitives, not through this module) the polled service's existing
+// RouteNodes to match httpLogs against, the same read-only access
+// extract/calls/route-match.ts already has to the graph for the identical
+// purpose on the static-extraction side.
+export function createRailwayConnector(graph: NeatGraph, config: RailwayConnectorConfig): ObservedConnector {
+  return {
+    provider: 'railway',
+    async poll(ctx: ConnectorContext): Promise<ObservedSignal[]> {
+      const token = readRailwayToken(ctx.credentials)
+      const now = new Date()
+      const maxLookbackMs = config.maxLookbackMs ?? DEFAULT_MAX_LOOKBACK_MS
+      const startDate = boundedRailwayStartDate(ctx.since, now, maxLookbackMs)
+      const endDate = now.toISOString()
+
+      const [httpLogs, flowLogs] = await Promise.all([
+        fetchRailwayHttpLogs(config, token, startDate, endDate),
+        fetchRailwayNetworkFlowLogs(config, token, startDate, endDate),
+      ])
+
+      const serviceName = config.serviceNameById[config.serviceId]
+      const routeIndex = serviceName ? buildRailwayRouteIndex(graph, serviceName) : []
+
+      return [
+        ...mapRailwayHttpLogsToSignals(httpLogs, routeIndex),
+        ...mapRailwayNetworkFlowLogsToSignals(flowLogs),
+      ]
+    },
+  }
+}

--- a/packages/core/src/connectors/railway/types.ts
+++ b/packages/core/src/connectors/railway/types.ts
@@ -1,0 +1,91 @@
+// Railway connector — provider-specific types (docs/connectors/railway.md,
+// ADR-127). Second connectors-plane provider after the Supabase scaffold
+// (ADR-124); ADR-127's own scope note applies here too: Railway is SaaS-only,
+// so there is no self-hosted-vs-Cloud branch to carry through these types the
+// way a future Supabase self-hosted cut might need.
+
+/**
+ * Config resolved once at connector setup (docs/connectors/railway.md
+ * §Fusion, "resolved once, never guessed") — never re-derived from a Railway
+ * API response at poll time.
+ */
+export interface RailwayConnectorConfig {
+  // Railway's GraphQL endpoint. Defaults to the public API
+  // (docs.railway.com/integrations/api/graphql-overview confirms
+  // `https://backboard.railway.com/graphql/v2`); overridable for tests and
+  // any self-hosted proxy in front of it.
+  apiUrl?: string
+  // The Railway environment httpLogs/networkFlowLogs are scoped to — both
+  // surfaces are environment-scoped per docs.railway.com/cli/logs (a
+  // Project-Access-Token is itself minted per environment, not per account —
+  // docs/connectors/railway.md §Scope).
+  environmentId: string
+  // The Railway serviceId this connector instance polls httpLogs for. Railway
+  // names a service by its own GraphQL id, which carries no relationship to
+  // NEAT's manifest-derived `serviceId(name)` (packages/types/src/identity.ts)
+  // — the two are different naming authorities with no shared source of
+  // truth (docs/connectors/railway.md §Fusion, "Service identity mapping").
+  serviceId: string
+  // Explicit map from a Railway serviceId — this connector's own `serviceId`
+  // above, and any peer serviceId a networkFlowLogs record's `peerServiceId`
+  // names — to the NEAT manifest service name that resolves `serviceId(name)`.
+  // Supplied once at connector setup; never inferred or pattern-matched from
+  // a Railway API response (docs/connectors/railway.md §Fusion).
+  serviceNameById: Record<string, string>
+  // Bounded lookback cap in ms for a first poll (no prior `since`) or a gap
+  // wider than this window. Railway's docs don't publish a retention/lookback
+  // cap for httpLogs/networkFlowLogs as of this writing
+  // (docs/connectors/railway.md flags the neighbouring "plan-tier" question
+  // the same way) — this is a conservative chosen default, not a
+  // provider-confirmed value. Overridable once a live project confirms the
+  // real window (docs/contracts/connectors.md §"Poll cadence and backfill").
+  maxLookbackMs?: number
+  // Max rows requested per query. Same "needs-endpoint-testing" caveat as
+  // the lookback cap — Railway's own pagination shape for these two queries
+  // isn't confirmed (docs/connectors/railway.md §1).
+  limit?: number
+}
+
+// ── raw provider response shapes ────────────────────────────────────────────
+//
+// NEEDS-ENDPOINT-TESTING (docs/connectors/railway.md §1 / §2): the field
+// names below are sourced from Railway's own published log-explorer
+// attribute list (docs.railway.com/cli/logs — the `@method`/`@path`/...
+// filter keys, confirmed to map 1:1 onto camelCase JSON field names the docs
+// show verbatim), not from a live GraphQL schema introspection — this
+// sandbox has no live Railway project/token to introspect against. Whether
+// `httpLogs`/`networkFlowLogs` are literal top-level query names, or a
+// filtered view over the confirmed `deploymentLogs`/`environmentLogs`
+// queries, could not be confirmed without hitting `railway.com/graphiql`
+// with a real token. Build this poller against a live Railway project before
+// treating the shape below as locked, exactly as railway.md's own
+// "needs-endpoint-testing" notes ask for every other unconfirmed surface.
+
+/** One row of `httpLogs` — Railway's edge/ingress per-request record. */
+export interface RailwayHttpLogEntry {
+  timestamp: string
+  method: string
+  path: string
+  httpStatus: number
+  totalDuration: number
+  requestId: string
+  deploymentId: string
+  edgeRegion: string
+}
+
+/** One row of `networkFlowLogs` — an L4 flow record between two services. */
+export interface RailwayNetworkFlowLogEntry {
+  timestamp: string
+  // Null when the peer isn't another Railway service on the same project
+  // (public internet egress, say) — dropped honestly rather than guessed
+  // (docs/connectors/railway.md §Fusion).
+  peerServiceId: string | null
+  peerKind: string | null
+  direction: string | null
+  byteCount: number | null
+  packetCount: number | null
+  // Non-null names why a flow was dropped (Railway's `@drop_cause` /
+  // `dropCause` field) — the closest signal networkFlowLogs carries to an
+  // "error" on a connection with no HTTP status of its own.
+  dropCause: string | null
+}

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -1,0 +1,81 @@
+// Connectors plane — provider-agnostic types (docs/contracts/connectors.md,
+// docs/connectors/README.md, ADR-124).
+//
+// OTLP ingest has had exactly one path onto the OBSERVED layer: an app
+// pushing spans it was instrumented to emit. A connector is the second path
+// — a provider that already runs its own server-side telemetry (a hosted
+// Postgres platform's query stats, a hosting platform's request logs) gets
+// pulled from instead, so OBSERVED edges exist with zero app instrumentation.
+//
+// This file declares the one shape every provider implements. The
+// provider-specific fetch + target-resolution logic lives under
+// packages/core/src/connectors/<provider>/ — none shipped yet; this PR is
+// the shared pull/map/fuse scaffold those provider modules plug into
+// (Supabase first, per ADR-124; Railway/Firebase/Cloudflare designs are
+// merged as prose-only docs and land their own connector modules next).
+
+/**
+ * A connector implements exactly one method. Everything downstream of
+ * `poll()` — resolving a static call site, minting the OBSERVED edge — is
+ * shared, generic code in connectors/index.ts.
+ */
+export interface ObservedConnector {
+  readonly provider: string
+  poll(ctx: ConnectorContext): Promise<ObservedSignal[]>
+}
+
+/**
+ * Everything a connector's `poll()` needs, resolved once at connector setup
+ * — never re-derived at poll time.
+ *
+ * `credentials` is opaque here on purpose: its shape is entirely provider-
+ * and profile-defined (local vs hosted — docs/contracts/connectors.md §3).
+ * It flows through to `poll()` only. Never log it, never write it into a
+ * node or edge, never let it reach the graph snapshot (contract §6, and the
+ * `.env`-contents rule docs/contracts.md Rule 4 already states for local
+ * config).
+ */
+export interface ConnectorContext {
+  // Absolute path to the project root being polled — the same anchor
+  // `reconcileObservedRelPath` (ingest.ts) uses to fuse a signal's callSite
+  // onto the EXTRACTED service-relative path.
+  projectDir: string
+  credentials: Record<string, unknown>
+  // ISO8601 — the last successful poll's high-water mark. A connector must
+  // treat an absent `since` as "no prior poll", bounded by whatever lookback
+  // window the provider's own API caps (README.md §Poll cadence and
+  // backfill) — never an unbounded full-history query.
+  since?: string
+}
+
+/**
+ * `file:line` the provider's own signal carries, when it does (rare — see
+ * docs/connectors/README.md §Provider interface, which notes this is
+ * "usually resolved by the mapping layer below, not here"). Reconciled onto
+ * the EXTRACTED service-relative path by the shared fuse step the same way
+ * an OTel span's call site is (file-awareness.md §4).
+ */
+export interface ConnectorCallSite {
+  file: string
+  line: number
+}
+
+/**
+ * One provider-agnostic observation. `targetKind`/`targetName` are the
+ * provider's own vocabulary (`'supabase-table'`/`'orders'`,
+ * `'route'`/`'GET /users/:id'`, ...) — resolving that pair to a NEAT node id
+ * is the one genuinely provider-specific step (README.md's pipeline
+ * diagram), supplied to `runConnectorPoll` (connectors/index.ts) as a
+ * `resolveTarget` callback. Everything downstream of that resolution — file
+ * grain fusion, OBSERVED mint — is shared.
+ */
+export interface ObservedSignal {
+  targetKind: string
+  targetName: string
+  callCount: number
+  errorCount: number
+  // The provider's own event time — never poll-arrival time (README.md
+  // §Poll cadence and backfill).
+  lastObservedIso: string
+  callSite?: ConnectorCallSite
+}

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -45,6 +45,7 @@ import { buildApi } from './api.js'
 import { buildOtelReceiver, listenSteppingOtlp } from './otel.js'
 import { attachGraphToEventBus } from './events.js'
 import { handleSpan, makeErrorSpanWriter, startStalenessLoop } from './ingest.js'
+import { startConnectorPollLoop, type ConnectorRegistration } from './connectors/index.js'
 import {
   listProjects,
   pruneRegistry,
@@ -247,6 +248,14 @@ export interface DaemonOptions {
   // exercise daemon slots without needing the listeners). Production
   // `neatd start` never sets this.
   bindListeners?: boolean
+  // Connectors plane (docs/contracts/connectors.md, ADR-124) — pull-based
+  // OBSERVED connectors polled on an interval alongside every project this
+  // daemon bootstraps, the same way every project gets the staleness loop.
+  // Applied identically to every project slot; there is no per-project
+  // config-loading here yet (that's provider-specific, later work) — a
+  // caller wanting project-scoped connectors runs a separate `startDaemon`
+  // per project (the single-project ADR-096 mode is the common case).
+  connectors?: ConnectorRegistration[]
 }
 
 export interface ProjectSlot {
@@ -261,6 +270,11 @@ export interface ProjectSlot {
   // STALE instead of sitting live forever. Must be stopped alongside
   // stopPersist so no interval leaks when the slot is torn down or replaced.
   stopStaleness: () => void
+  // Stops every connector poll loop registered for this slot (connectors/
+  // index.ts's startConnectorPollLoop, one per opts.connectors entry). Same
+  // lifecycle as stopStaleness — must run alongside it wherever the slot is
+  // torn down or replaced.
+  stopConnectors: () => void
   // #475 — removes the event-bus listeners attachGraphToEventBus installed
   // on this slot's graph. No-op for broken slots. Must run wherever the slot
   // is torn down or replaced, or a reloaded slot's old graph keeps emitting.
@@ -281,6 +295,11 @@ function teardownSlot(slot: ProjectSlot): void {
   }
   try {
     slot.stopStaleness()
+  } catch {
+    // best-effort
+  }
+  try {
+    slot.stopConnectors()
   } catch {
     // best-effort
   }
@@ -466,7 +485,10 @@ function spanBelongsToSingleProject(
   )
 }
 
-async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
+async function bootstrapProject(
+  entry: RegistryEntry,
+  connectors: ConnectorRegistration[] = [],
+): Promise<ProjectSlot> {
   const paths = pathsForProject(entry.name, path.join(entry.path, 'neat-out'))
 
   // Path missing on disk → mark broken and surface the reason. Daemon
@@ -487,6 +509,7 @@ async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
       paths,
       stopPersist: () => {},
       stopStaleness: () => {},
+      stopConnectors: () => {},
       detachEvents: () => {},
       status: 'broken',
       errorReason: (err as Error).message,
@@ -523,6 +546,21 @@ async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
       staleEventsPath: paths.staleEventsPath,
       project: entry.name,
     })
+    // Connectors plane (docs/contracts/connectors.md, ADR-124) — one poll
+    // loop per registered connector, same interval-loop shape as the
+    // staleness loop above and torn down alongside it (teardownSlot).
+    const stopFns = connectors.map((registration) =>
+      startConnectorPollLoop(
+        registration.connector,
+        { projectDir: entry.path, credentials: registration.credentials },
+        graph,
+        registration.resolveTarget,
+        { intervalMs: registration.intervalMs },
+      ),
+    )
+    const stopConnectors = (): void => {
+      for (const stop of stopFns) stop()
+    }
     await touchLastSeen(entry.name).catch(() => {})
 
     return {
@@ -532,6 +570,7 @@ async function bootstrapProject(entry: RegistryEntry): Promise<ProjectSlot> {
       paths,
       stopPersist,
       stopStaleness,
+      stopConnectors,
       detachEvents,
       status: 'active',
     }
@@ -724,7 +763,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
   // the new slot status so callers can decide whether to deliver the span.
   async function tryRecoverSlot(entry: RegistryEntry): Promise<ProjectSlot> {
     try {
-      const fresh = await bootstrapProject(entry)
+      const fresh = await bootstrapProject(entry, opts.connectors ?? [])
       // The slot being replaced must release its graph's bus listeners
       // (#475) — a stale attach on the prior graph would double-emit.
       const prior = slots.get(entry.name)
@@ -751,7 +790,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
     bootstrapStatus.set(entry.name, 'bootstrapping')
     bootstrapStartedAt.set(entry.name, Date.now())
     try {
-      const slot = await bootstrapProject(entry)
+      const slot = await bootstrapProject(entry, opts.connectors ?? [])
       // Same replacement rule as tryRecoverSlot (#475).
       const prior = slots.get(entry.name)
       if (prior) teardownSlot(prior)

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -488,7 +488,12 @@ function relPathForRuntimeFile(
   return p.length > 0 ? p : null
 }
 
-interface CallSite {
+// Exported so the connectors plane (packages/core/src/connectors/index.ts,
+// docs/contracts/connectors.md) can build one from a signal's own callSite —
+// a connector's file:line comes from the provider's telemetry rather than an
+// OTel span's code.* attributes, but reconciles onto the same EXTRACTED
+// FileNode through the same primitives below.
+export interface CallSite {
   relPath: string
   line?: number
   fn?: string
@@ -615,7 +620,7 @@ function callSiteFromSpan(
 // carrying extra leading directories the anchor couldn't strip — reuse the
 // extractor's path so both layers key the same node. No match means the file is
 // genuinely OTel-only; the honest runtime path stands (never fabricated, §6).
-function reconcileObservedRelPath(
+export function reconcileObservedRelPath(
   graph: NeatGraph,
   serviceName: string,
   relPath: string,
@@ -646,7 +651,7 @@ function reconcileObservedRelPath(
 // STALE when traffic quiets (markStaleEdges skips edges without lastObserved),
 // and divergence detection skips CONTAINS so an OTel-only file node doesn't
 // surface as a missing-extracted finding.
-function ensureObservedFileNode(
+export function ensureObservedFileNode(
   graph: NeatGraph,
   serviceName: string,
   serviceNodeId: string,
@@ -1041,7 +1046,11 @@ export function frontierIdFor(host: string): string {
 // `language: 'unknown'` is the contract's specified placeholder (ADR-033). When
 // static extraction later produces a ServiceNode at the same id, addServiceNodes
 // merges and flips discoveredVia to 'merged' rather than overwriting.
-function ensureServiceNode(
+// Exported for the connectors plane (connectors/index.ts) — a connector
+// signal needs the same auto-vivified ServiceNode any OTel span gets before
+// an edge upsert, since a connector-sourced service may never have been
+// statically extracted or seen a span yet.
+export function ensureServiceNode(
   graph: NeatGraph,
   serviceName: string,
   env: string,
@@ -1130,12 +1139,16 @@ function ensureFrontierNode(graph: NeatGraph, host: string, ts: string): string 
   return id
 }
 
-interface UpsertResult {
+// Exported so the connectors plane (connectors/index.ts) mints edges through
+// the identical primitive OTel ingest uses — a connector-sourced edge and a
+// span-sourced edge are meant to be indistinguishable to traversal,
+// divergence, and staleness (docs/connectors/README.md).
+export interface UpsertResult {
   edge: GraphEdge
   created: boolean
 }
 
-function upsertObservedEdge(
+export function upsertObservedEdge(
   graph: NeatGraph,
   type: EdgeTypeValue,
   source: string,

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -13582,3 +13582,62 @@ describe('Contract enforcement tags (ADR-104)', () => {
     expect(unknown, `${file} names unknown enforcement pillar(s): ${unknown.join(', ')}`).toEqual([])
   })
 })
+
+// ──────────────────────────────────────────────────────────────────────────
+// Connectors plane (ADR-124) — mechanical checks for the two things
+// docs/contracts/connectors.md §Enforcement names as ready to lock down now
+// that the shared scaffold has landed: the provider-interface shape (§1) and
+// the credential-in-config-not-snapshot rule (§6). The contract itself still
+// reads `enforcement: [review]` — these are additive regression guards, not
+// a claim that every connectors.md rule is mechanically checked yet (the
+// per-provider fusion rules in §4 have no code to check until a provider's
+// poll()/mapping lands).
+// ──────────────────────────────────────────────────────────────────────────
+describe('Connectors plane contract (ADR-124)', () => {
+  const CONNECTORS_SRC = join(CORE_SRC, 'connectors')
+
+  it('docs/contracts/connectors.md governs packages/core/src/connectors/**', () => {
+    const src = readFileSync(join(__dirname, '../../../../docs/contracts/connectors.md'), 'utf8')
+    expect(src).toMatch(/governs:/)
+    expect(src).toMatch(/packages\/core\/src\/connectors\/\*\*/)
+  })
+
+  it('§1 — ObservedConnector/ConnectorContext/ObservedSignal are declared with the spec\'s shape', () => {
+    const src = readFileSync(join(CONNECTORS_SRC, 'types.ts'), 'utf8')
+    expect(src).toMatch(/interface ObservedConnector/)
+    expect(src).toMatch(/readonly provider: string/)
+    expect(src).toMatch(/poll\(ctx: ConnectorContext\): Promise<ObservedSignal\[\]>/)
+    expect(src).toMatch(/interface ConnectorContext/)
+    expect(src).toMatch(/interface ObservedSignal/)
+  })
+
+  it('§6 — ConnectorContext.credentials never lands on the same line as a graph mutation call', () => {
+    // Not a full data-flow analysis — a line-level guard against the
+    // obvious regression (a credential literal stuffed into a node/edge
+    // attribute object at the mutation call site). Mirrors the grep-grade
+    // audits the rest of this file already relies on (Rule 16, Rule 8).
+    const offenders: string[] = []
+    const mutators = /\b(graph|g)\.(addNode|addEdge|addEdgeWithKey|addDirectedEdge|addDirectedEdgeWithKey|replaceNodeAttributes|replaceEdgeAttributes|mergeNodeAttributes|mergeEdgeAttributes)\s*\(/
+    for (const file of walkSrc(CONNECTORS_SRC)) {
+      readFileSync(file, 'utf8')
+        .split('\n')
+        .forEach((line, i) => {
+          if (/credentials/.test(line) && mutators.test(line)) {
+            offenders.push(`${file}:${i + 1}: ${line.trim()}`)
+          }
+        })
+    }
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
+
+  it('connectors/index.ts never mutates the graph directly (ADR-030 mutation authority, scoped regression guard)', () => {
+    // The generic "Lifecycle contract" audit above already covers all of
+    // core/src; this pins the same expectation specifically for the
+    // connectors plane so a regression here reads as a connectors-contract
+    // failure, not a buried line in the ADR-030 sweep.
+    const src = readFileSync(join(CONNECTORS_SRC, 'index.ts'), 'utf8')
+    const mutators =
+      /\b(graph|g)\.(addNode|addEdge|addEdgeWithKey|addDirectedEdge|addDirectedEdgeWithKey|dropNode|dropEdge|replaceNodeAttributes|replaceEdgeAttributes|mergeNodeAttributes|mergeEdgeAttributes)\s*\(/
+    expect(mutators.test(src)).toBe(false)
+  })
+})

--- a/packages/core/test/connectors-railway.test.ts
+++ b/packages/core/test/connectors-railway.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { MultiDirectedGraph } from 'graphology'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  fileId,
+  observedEdgeId,
+  routeId,
+  serviceId,
+  type FileNode,
+  type GraphEdge,
+  type GraphNode,
+  type RouteNode,
+  type ServiceNode,
+} from '@neat.is/types'
+import { runConnectorPoll, type ConnectorContext } from '../src/connectors/index.js'
+import type { NeatGraph } from '../src/graph.js'
+import {
+  buildRailwayRouteIndex,
+  createRailwayConnector,
+  createRailwayResolveTarget,
+  mapRailwayHttpLogsToSignals,
+  mapRailwayNetworkFlowLogsToSignals,
+  type RailwayConnectorConfig,
+  type RailwayHttpLogEntry,
+  type RailwayNetworkFlowLogEntry,
+} from '../src/connectors/railway/index.js'
+import httpLogsFixture from './fixtures/railway/http-logs.json' with { type: 'json' }
+import networkFlowLogsFixture from './fixtures/railway/network-flow-logs.json' with { type: 'json' }
+
+// Fixtures below mirror Railway's own documented field names for these two
+// log families (docs.railway.com/cli/logs, fetched 2026-07-03): httpLogs
+// carries `method`/`path`/`httpStatus`/`totalDuration`/`requestId`/
+// `deploymentId`/`edgeRegion` (a subset of the full attribute list that
+// page documents — the fields docs/connectors/railway.md's own §1 names as
+// what this connector needs); networkFlowLogs carries `peerServiceId` +
+// byte/packet counts + `dropCause`. Per docs/contracts/connectors.md §5,
+// these are the closest-documented real provider response shapes available
+// without live GraphiQL introspection against an actual Railway project —
+// see the "needs-endpoint-testing" comments in
+// packages/core/src/connectors/railway/types.ts for exactly what remains
+// unconfirmed (whether httpLogs/networkFlowLogs are literal top-level query
+// names, the pagination shape, and any provider-side rate limit).
+
+const RAILWAY_SERVICE_ID = 'railway-svc-orders'
+const RAILWAY_PEER_SERVICE_ID = 'railway-svc-billing'
+const NEAT_SERVICE = 'orders-api'
+const NEAT_PEER_SERVICE = 'billing-api'
+
+function config(overrides: Partial<RailwayConnectorConfig> = {}): RailwayConnectorConfig {
+  return {
+    environmentId: 'env-abc123',
+    serviceId: RAILWAY_SERVICE_ID,
+    serviceNameById: {
+      [RAILWAY_SERVICE_ID]: NEAT_SERVICE,
+      [RAILWAY_PEER_SERVICE_ID]: NEAT_PEER_SERVICE,
+    },
+    ...overrides,
+  }
+}
+
+function newGraph(): NeatGraph {
+  const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+
+  const service: ServiceNode = {
+    id: serviceId(NEAT_SERVICE),
+    type: NodeType.ServiceNode,
+    name: NEAT_SERVICE,
+    language: 'typescript',
+  }
+  g.addNode(service.id, service)
+
+  const peer: ServiceNode = {
+    id: serviceId(NEAT_PEER_SERVICE),
+    type: NodeType.ServiceNode,
+    name: NEAT_PEER_SERVICE,
+    language: 'typescript',
+  }
+  g.addNode(peer.id, peer)
+
+  // EXTRACTED FileNode a static extractor already minted for the file the
+  // routes below are declared in — the same fusion target
+  // reconcileObservedRelPath resolves onto (file-awareness.md §4).
+  const file: FileNode = {
+    id: fileId(NEAT_SERVICE, 'src/routes/users.ts'),
+    type: NodeType.FileNode,
+    service: NEAT_SERVICE,
+    path: 'src/routes/users.ts',
+    language: 'typescript',
+  }
+  g.addNode(file.id, file)
+
+  const getUser: RouteNode = {
+    id: routeId(NEAT_SERVICE, 'GET', '/users/:id'),
+    type: NodeType.RouteNode,
+    name: 'GET /users/:id',
+    service: NEAT_SERVICE,
+    method: 'GET',
+    pathTemplate: '/users/:id',
+    path: 'src/routes/users.ts',
+    line: 10,
+    framework: 'express',
+    discoveredVia: 'static',
+  }
+  g.addNode(getUser.id, getUser)
+
+  const createUser: RouteNode = {
+    id: routeId(NEAT_SERVICE, 'POST', '/users'),
+    type: NodeType.RouteNode,
+    name: 'POST /users',
+    service: NEAT_SERVICE,
+    method: 'POST',
+    pathTemplate: '/users',
+    path: 'src/routes/users.ts',
+    line: 20,
+    framework: 'express',
+    discoveredVia: 'static',
+  }
+  g.addNode(createUser.id, createUser)
+
+  return g
+}
+
+function baseCtx(overrides: Partial<ConnectorContext> = {}): ConnectorContext {
+  return {
+    projectDir: '/repo/orders-api',
+    credentials: { token: 'test-project-access-token' },
+    ...overrides,
+  }
+}
+
+describe('Railway connector — httpLogs/networkFlowLogs → ObservedSignal mapping (ADR-127)', () => {
+  it('normalizes and matches httpLogs entries onto existing RouteNodes, aggregating by route', () => {
+    const graph = newGraph()
+    const routeIndex = buildRailwayRouteIndex(graph, NEAT_SERVICE)
+
+    const signals = mapRailwayHttpLogsToSignals(httpLogsFixture as RailwayHttpLogEntry[], routeIndex)
+
+    // /users/42, /users/17, /users/999 all normalise to /users/:param and
+    // match the declared GET /users/:id route — one aggregated signal, not
+    // three, with the 500 counted as the error.
+    const getUserRoute = routeId(NEAT_SERVICE, 'GET', '/users/:id')
+    const getUserSignal = signals.find((s) => s.targetKind === 'route' && s.targetName === getUserRoute)
+    expect(getUserSignal).toBeDefined()
+    expect(getUserSignal?.callCount).toBe(3)
+    expect(getUserSignal?.errorCount).toBe(1)
+    expect(getUserSignal?.lastObservedIso).toBe('2026-07-03T10:00:05.000Z')
+    expect(getUserSignal?.callSite).toEqual({ file: 'src/routes/users.ts', line: 10 })
+
+    const createUserRoute = routeId(NEAT_SERVICE, 'POST', '/users')
+    const createUserSignal = signals.find(
+      (s) => s.targetKind === 'route' && s.targetName === createUserRoute,
+    )
+    expect(createUserSignal).toBeDefined()
+    expect(createUserSignal?.callCount).toBe(1)
+    expect(createUserSignal?.errorCount).toBe(0)
+    expect(createUserSignal?.callSite).toEqual({ file: 'src/routes/users.ts', line: 20 })
+  })
+
+  it('falls back to an honest unmatched-route signal when no static route resolves', () => {
+    const graph = newGraph()
+    const routeIndex = buildRailwayRouteIndex(graph, NEAT_SERVICE)
+
+    const signals = mapRailwayHttpLogsToSignals(httpLogsFixture as RailwayHttpLogEntry[], routeIndex)
+
+    const unmatched = signals.find((s) => s.targetKind === 'unmatched-route')
+    expect(unmatched).toBeDefined()
+    expect(unmatched?.targetName).toBe('GET /internal/healthz')
+    expect(unmatched?.callCount).toBe(1)
+    expect(unmatched?.callSite).toBeUndefined()
+
+    // createRailwayResolveTarget must drop this honestly (never fabricate a
+    // RouteNode target — RouteNode.path is a required, real source location,
+    // packages/types/src/nodes.ts) rather than mint anything for it.
+    const resolveTarget = createRailwayResolveTarget(config())
+    expect(resolveTarget(unmatched!, baseCtx())).toBeNull()
+  })
+
+  it('maps networkFlowLogs into a peer-service signal, dropping entries with no peer identity', () => {
+    const signals = mapRailwayNetworkFlowLogsToSignals(
+      networkFlowLogsFixture as RailwayNetworkFlowLogEntry[],
+    )
+
+    expect(signals).toHaveLength(1)
+    const [peerSignal] = signals
+    expect(peerSignal.targetKind).toBe('peer-service')
+    expect(peerSignal.targetName).toBe(RAILWAY_PEER_SERVICE_ID)
+    expect(peerSignal.callCount).toBe(2)
+    // One of the two flow rows carries a non-null dropCause.
+    expect(peerSignal.errorCount).toBe(1)
+    expect(peerSignal.lastObservedIso).toBe('2026-07-03T10:00:04.000Z')
+  })
+})
+
+describe('Railway connector — createRailwayResolveTarget (ADR-127)', () => {
+  it('resolves a matched route signal to the RouteNode with a CALLS edge', () => {
+    const resolveTarget = createRailwayResolveTarget(config())
+    const routeNodeId = routeId(NEAT_SERVICE, 'GET', '/users/:id')
+
+    const resolved = resolveTarget(
+      {
+        targetKind: 'route',
+        targetName: routeNodeId,
+        callCount: 3,
+        errorCount: 1,
+        lastObservedIso: '2026-07-03T10:00:05.000Z',
+        callSite: { file: 'src/routes/users.ts', line: 10 },
+      },
+      baseCtx(),
+    )
+
+    expect(resolved).toEqual({
+      targetNodeId: routeNodeId,
+      serviceName: NEAT_SERVICE,
+      edgeType: EdgeType.CALLS,
+    })
+  })
+
+  it('resolves a mapped peer-service signal to a CONNECTS_TO edge between ServiceNodes', () => {
+    const resolveTarget = createRailwayResolveTarget(config())
+
+    const resolved = resolveTarget(
+      {
+        targetKind: 'peer-service',
+        targetName: RAILWAY_PEER_SERVICE_ID,
+        callCount: 2,
+        errorCount: 1,
+        lastObservedIso: '2026-07-03T10:00:04.000Z',
+      },
+      baseCtx(),
+    )
+
+    expect(resolved).toEqual({
+      targetNodeId: serviceId(NEAT_PEER_SERVICE),
+      serviceName: NEAT_SERVICE,
+      edgeType: EdgeType.CONNECTS_TO,
+    })
+  })
+
+  it('drops an unmapped peer serviceId honestly rather than guessing', () => {
+    const resolveTarget = createRailwayResolveTarget(config())
+
+    const resolved = resolveTarget(
+      {
+        targetKind: 'peer-service',
+        targetName: 'railway-svc-unknown',
+        callCount: 1,
+        errorCount: 0,
+        lastObservedIso: '2026-07-03T10:00:04.000Z',
+      },
+      baseCtx(),
+    )
+
+    expect(resolved).toBeNull()
+  })
+})
+
+describe('Railway connector — end-to-end poll() against fixture GraphQL responses (docs/contracts/connectors.md §5)', () => {
+  let realFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    realFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = realFetch
+  })
+
+  function stubRailwayGraphQL(): void {
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { query: string }
+      const isHttpLogs = body.query.includes('httpLogs')
+      const data = isHttpLogs
+        ? { httpLogs: httpLogsFixture }
+        : { networkFlowLogs: networkFlowLogsFixture }
+      return new Response(JSON.stringify({ data }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }) as typeof globalThis.fetch
+  }
+
+  it('poll() fetches both queries and maps them into ObservedSignal[]', async () => {
+    stubRailwayGraphQL()
+    const graph = newGraph()
+    const connector = createRailwayConnector(graph, config())
+
+    const signals = await connector.poll(baseCtx())
+
+    const routeSignals = signals.filter((s) => s.targetKind === 'route')
+    const unmatchedSignals = signals.filter((s) => s.targetKind === 'unmatched-route')
+    const peerSignals = signals.filter((s) => s.targetKind === 'peer-service')
+    expect(routeSignals).toHaveLength(2)
+    expect(unmatchedSignals).toHaveLength(1)
+    expect(peerSignals).toHaveLength(1)
+  })
+
+  it('mints file-grained OBSERVED CALLS + CONNECTS_TO edges through runConnectorPoll', async () => {
+    stubRailwayGraphQL()
+    const graph = newGraph()
+    const connector = createRailwayConnector(graph, config())
+    const resolveTarget = createRailwayResolveTarget(config())
+
+    const result = await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
+
+    // 2 matched routes + 1 peer-service resolve; the unmatched-route signal
+    // drops honestly.
+    expect(result.edgesCreated).toBe(3)
+    expect(result.unresolved).toBe(1)
+
+    const fileNodeId = fileId(NEAT_SERVICE, 'src/routes/users.ts')
+    const getUserEdgeId = observedEdgeId(
+      fileNodeId,
+      routeId(NEAT_SERVICE, 'GET', '/users/:id'),
+      EdgeType.CALLS,
+    )
+    expect(graph.hasEdge(getUserEdgeId)).toBe(true)
+    const getUserEdge = graph.getEdgeAttributes(getUserEdgeId) as GraphEdge
+    expect(getUserEdge.provenance).toBe(Provenance.OBSERVED)
+    expect(getUserEdge.signal?.spanCount).toBe(3)
+    expect(getUserEdge.signal?.errorCount).toBe(1)
+    expect(getUserEdge.evidence).toEqual({ file: 'src/routes/users.ts', line: 10 })
+
+    const connectsToId = observedEdgeId(
+      serviceId(NEAT_SERVICE),
+      serviceId(NEAT_PEER_SERVICE),
+      EdgeType.CONNECTS_TO,
+    )
+    expect(graph.hasEdge(connectsToId)).toBe(true)
+    const connectsToEdge = graph.getEdgeAttributes(connectsToId) as GraphEdge
+    expect(connectsToEdge.provenance).toBe(Provenance.OBSERVED)
+    expect(connectsToEdge.signal?.spanCount).toBe(2)
+    expect(connectsToEdge.signal?.errorCount).toBe(1)
+  })
+
+  it('bounds the query window to since when provided, and to maxLookbackMs otherwise', async () => {
+    let capturedVariables: Record<string, unknown> | undefined
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        query: string
+        variables: Record<string, unknown>
+      }
+      capturedVariables = body.variables
+      const data = body.query.includes('httpLogs')
+        ? { httpLogs: [] }
+        : { networkFlowLogs: [] }
+      return new Response(JSON.stringify({ data }), { status: 200 })
+    }) as typeof globalThis.fetch
+
+    const graph = newGraph()
+    const connector = createRailwayConnector(graph, config())
+    const since = '2026-07-03T09:00:00.000Z'
+
+    await connector.poll(baseCtx({ since }))
+
+    expect(capturedVariables?.startDate).toBe(since)
+    expect(capturedVariables?.environmentId).toBe('env-abc123')
+    expect(capturedVariables?.serviceId).toBe(RAILWAY_SERVICE_ID)
+  })
+
+  it('requires ctx.credentials.token and never lets it reach a graph mutation', async () => {
+    const graph = newGraph()
+    const connector = createRailwayConnector(graph, config())
+
+    await expect(connector.poll(baseCtx({ credentials: {} }))).rejects.toThrow(/credentials\.token/)
+  })
+})

--- a/packages/core/test/connectors.test.ts
+++ b/packages/core/test/connectors.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest'
+import { MultiDirectedGraph } from 'graphology'
+import {
+  EdgeType,
+  NodeType,
+  Provenance,
+  fileId,
+  infraId,
+  observedEdgeId,
+  serviceId,
+  type FileNode,
+  type GraphEdge,
+  type GraphNode,
+  type InfraNode,
+  type ServiceNode,
+} from '@neat.is/types'
+import {
+  runConnectorPoll,
+  type ConnectorContext,
+  type ObservedConnector,
+  type ObservedSignal,
+  type ResolveConnectorTarget,
+} from '../src/connectors/index.js'
+import type { NeatGraph } from '../src/graph.js'
+
+const SERVICE = 'orders-api'
+const TABLE_TARGET = infraId('supabase-table', 'proj-ref/orders')
+const RPC_TARGET = infraId('supabase-rpc', 'proj-ref/get_totals')
+
+function newGraph(): NeatGraph {
+  const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+  const service: ServiceNode = {
+    id: serviceId(SERVICE),
+    type: NodeType.ServiceNode,
+    name: SERVICE,
+    language: 'javascript',
+  }
+  g.addNode(service.id, service)
+
+  // EXTRACTED FileNode a static extractor already minted — the trailing
+  // segment reconcileObservedRelPath must match against a connector
+  // signal's own (unanchored) callSite path.
+  const file: FileNode = {
+    id: fileId(SERVICE, 'src/db/orders.ts'),
+    type: NodeType.FileNode,
+    service: SERVICE,
+    path: 'src/db/orders.ts',
+    language: 'typescript',
+  }
+  g.addNode(file.id, file)
+
+  const table: InfraNode = {
+    id: TABLE_TARGET,
+    type: NodeType.InfraNode,
+    name: 'proj-ref/orders',
+    provider: 'supabase',
+    kind: 'supabase-table',
+  }
+  g.addNode(table.id, table)
+
+  const rpc: InfraNode = {
+    id: RPC_TARGET,
+    type: NodeType.InfraNode,
+    name: 'proj-ref/get_totals',
+    provider: 'supabase',
+    kind: 'supabase-rpc',
+  }
+  g.addNode(rpc.id, rpc)
+
+  return g
+}
+
+// A trivial in-memory test double — not a real provider. Real poll()
+// implementations (Supabase, Railway, Firebase, Cloudflare) are out of
+// scope for this scaffold; this fake only exercises the pull/map/fuse
+// pipeline the four provider designs will plug into.
+class FakeConnector implements ObservedConnector {
+  readonly provider = 'fake'
+  constructor(private readonly signals: ObservedSignal[]) {}
+  async poll(_ctx: ConnectorContext): Promise<ObservedSignal[]> {
+    return this.signals
+  }
+}
+
+const resolveTarget: ResolveConnectorTarget = (signal) => {
+  if (signal.targetKind === 'supabase-table') {
+    return {
+      targetNodeId: infraId('supabase-table', signal.targetName),
+      serviceName: SERVICE,
+      edgeType: EdgeType.CALLS,
+    }
+  }
+  if (signal.targetKind === 'supabase-rpc') {
+    return {
+      targetNodeId: infraId('supabase-rpc', signal.targetName),
+      serviceName: SERVICE,
+      edgeType: EdgeType.CALLS,
+    }
+  }
+  return null
+}
+
+function baseCtx(): ConnectorContext {
+  return { projectDir: '/repo/orders-api', credentials: {} }
+}
+
+describe('connectors plane — runConnectorPoll (docs/contracts/connectors.md)', () => {
+  it('mints an OBSERVED edge, file-grained, when the signal carries a callSite', async () => {
+    const graph = newGraph()
+    const signal: ObservedSignal = {
+      targetKind: 'supabase-table',
+      targetName: 'proj-ref/orders',
+      callCount: 5,
+      errorCount: 1,
+      lastObservedIso: '2026-07-03T12:00:00.000Z',
+      // Unanchored leading segment ("app/") the extractor's own path
+      // ("src/db/orders.ts") doesn't carry — reconcileObservedRelPath must
+      // recover it via trailing-suffix match, same as an OTel call site.
+      callSite: { file: 'app/src/db/orders.ts', line: 42 },
+    }
+    const connector = new FakeConnector([signal])
+
+    const result = await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
+
+    expect(result).toEqual({
+      signalCount: 1,
+      edgesCreated: 1,
+      edgesUpdated: 0,
+      unresolved: 0,
+    })
+
+    const fileNodeId = fileId(SERVICE, 'src/db/orders.ts')
+    const edgeId = observedEdgeId(fileNodeId, TABLE_TARGET, EdgeType.CALLS)
+    expect(graph.hasEdge(edgeId)).toBe(true)
+
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.source).toBe(fileNodeId)
+    expect(edge.target).toBe(TABLE_TARGET)
+    // callCount=5/errorCount=1 replay as 5 upserts (1 erroring) — the same
+    // signal.spanCount/errorCount shape a burst of 5 individual spans would
+    // produce, not a flat +1 per signal.
+    expect(edge.signal?.spanCount).toBe(5)
+    expect(edge.signal?.errorCount).toBe(1)
+    expect(edge.evidence).toEqual({ file: 'src/db/orders.ts', line: 42 })
+
+    // The edge id and its endpoints were built via the identity helpers
+    // (observedEdgeId / fileId / infraId), never a hand-rolled template
+    // literal — contracts.test.ts's Rule 16 / Rule 2 audits cover this at
+    // the source level; this assertion pins the same expectation for the
+    // connectors path specifically.
+    expect(edgeId).toBe(`CALLS:OBSERVED:${fileNodeId}->${TABLE_TARGET}`)
+  })
+
+  it('falls back to a service-level edge when the signal carries no callSite', async () => {
+    const graph = newGraph()
+    const signal: ObservedSignal = {
+      targetKind: 'supabase-rpc',
+      targetName: 'proj-ref/get_totals',
+      callCount: 2,
+      errorCount: 0,
+      lastObservedIso: '2026-07-03T12:05:00.000Z',
+    }
+    const connector = new FakeConnector([signal])
+
+    const result = await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
+
+    expect(result).toEqual({
+      signalCount: 1,
+      edgesCreated: 1,
+      edgesUpdated: 0,
+      unresolved: 0,
+    })
+
+    const serviceNodeId = serviceId(SERVICE)
+    const edgeId = observedEdgeId(serviceNodeId, RPC_TARGET, EdgeType.CALLS)
+    expect(graph.hasEdge(edgeId)).toBe(true)
+
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe(Provenance.OBSERVED)
+    expect(edge.source).toBe(serviceNodeId)
+    expect(edge.evidence).toBeUndefined()
+    expect(edge.signal?.spanCount).toBe(2)
+    expect(edge.signal?.errorCount).toBe(0)
+
+    // No FileNode should have been created for this fallback path.
+    expect(graph.hasNode(fileId(SERVICE, 'src/db/get_totals.ts'))).toBe(false)
+  })
+
+  it('an unresolved signal is dropped honestly, never fabricated', async () => {
+    const graph = newGraph()
+    const signal: ObservedSignal = {
+      targetKind: 'supabase-storage', // resolveTarget above knows nothing of this kind
+      targetName: 'proj-ref/avatars',
+      callCount: 3,
+      errorCount: 0,
+      lastObservedIso: '2026-07-03T12:10:00.000Z',
+    }
+    const connector = new FakeConnector([signal])
+
+    const result = await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
+
+    expect(result).toEqual({
+      signalCount: 1,
+      edgesCreated: 0,
+      edgesUpdated: 0,
+      unresolved: 1,
+    })
+  })
+
+  it('re-polling the same signal updates the existing edge instead of minting a twin', async () => {
+    const graph = newGraph()
+    const signal: ObservedSignal = {
+      targetKind: 'supabase-rpc',
+      targetName: 'proj-ref/get_totals',
+      callCount: 1,
+      errorCount: 0,
+      lastObservedIso: '2026-07-03T12:05:00.000Z',
+    }
+    const connector = new FakeConnector([signal])
+
+    await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
+    const second = await runConnectorPoll(
+      connector,
+      { ...baseCtx(), since: '2026-07-03T12:05:00.000Z' },
+      graph,
+      resolveTarget,
+    )
+
+    expect(second).toEqual({
+      signalCount: 1,
+      edgesCreated: 0,
+      edgesUpdated: 1,
+      unresolved: 0,
+    })
+
+    const edgeId = observedEdgeId(serviceId(SERVICE), RPC_TARGET, EdgeType.CALLS)
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.signal?.spanCount).toBe(2)
+  })
+})

--- a/packages/core/test/fixtures/railway/http-logs.json
+++ b/packages/core/test/fixtures/railway/http-logs.json
@@ -1,0 +1,52 @@
+[
+  {
+    "timestamp": "2026-07-03T10:00:01.000Z",
+    "method": "GET",
+    "path": "/users/42",
+    "httpStatus": 200,
+    "totalDuration": 45,
+    "requestId": "req_01HXYZ0001",
+    "deploymentId": "dep_9f8e7d6c",
+    "edgeRegion": "us-west1"
+  },
+  {
+    "timestamp": "2026-07-03T10:00:03.000Z",
+    "method": "GET",
+    "path": "/users/17",
+    "httpStatus": 200,
+    "totalDuration": 38,
+    "requestId": "req_01HXYZ0002",
+    "deploymentId": "dep_9f8e7d6c",
+    "edgeRegion": "us-west1"
+  },
+  {
+    "timestamp": "2026-07-03T10:00:05.000Z",
+    "method": "GET",
+    "path": "/users/999",
+    "httpStatus": 500,
+    "totalDuration": 812,
+    "requestId": "req_01HXYZ0003",
+    "deploymentId": "dep_9f8e7d6c",
+    "edgeRegion": "us-west1"
+  },
+  {
+    "timestamp": "2026-07-03T10:00:07.000Z",
+    "method": "POST",
+    "path": "/users",
+    "httpStatus": 201,
+    "totalDuration": 61,
+    "requestId": "req_01HXYZ0004",
+    "deploymentId": "dep_9f8e7d6c",
+    "edgeRegion": "us-west1"
+  },
+  {
+    "timestamp": "2026-07-03T10:00:09.000Z",
+    "method": "GET",
+    "path": "/internal/healthz",
+    "httpStatus": 200,
+    "totalDuration": 4,
+    "requestId": "req_01HXYZ0005",
+    "deploymentId": "dep_9f8e7d6c",
+    "edgeRegion": "us-west1"
+  }
+]

--- a/packages/core/test/fixtures/railway/network-flow-logs.json
+++ b/packages/core/test/fixtures/railway/network-flow-logs.json
@@ -1,0 +1,29 @@
+[
+  {
+    "timestamp": "2026-07-03T10:00:02.000Z",
+    "peerServiceId": "railway-svc-billing",
+    "peerKind": "internal",
+    "direction": "egress",
+    "byteCount": 4820,
+    "packetCount": 12,
+    "dropCause": null
+  },
+  {
+    "timestamp": "2026-07-03T10:00:04.000Z",
+    "peerServiceId": "railway-svc-billing",
+    "peerKind": "internal",
+    "direction": "egress",
+    "byteCount": 1290,
+    "packetCount": 4,
+    "dropCause": "policy-deny"
+  },
+  {
+    "timestamp": "2026-07-03T10:00:06.000Z",
+    "peerServiceId": null,
+    "peerKind": "external",
+    "direction": "egress",
+    "byteCount": 660,
+    "packetCount": 2,
+    "dropCause": null
+  }
+]


### PR DESCRIPTION
Refs #670. Builds on #665 (the connectors-plane scaffold) — this PR's diff will shrink to just the Railway-specific code once #665 merges and this gets retargeted to main.

## What this builds

`packages/core/src/connectors/railway/` — the second connectors-plane provider, per `docs/connectors/railway.md` (ADR-127):

- `client.ts` — the GraphQL fetch half: queries Railway's API (`backboard.railway.com/graphql/v2`, Bearer auth) for `httpLogs` and `networkFlowLogs` since the connector's last high-water mark, bounded by a conservative lookback cap (Railway's docs don't publish a retention window for these queries).
- `index.ts` — the mapping half: normalizes each `httpLogs` record's path with `extract/routes.ts`'s `normalizePathTemplate` (the same normalization `route-match.ts` already uses for cross-service contract matching — not reinvented), matches it against the polled service's existing `RouteNode`s (a small read-only route index, mirroring `route-match.ts`'s own private `buildRouteIndex`/`findRoute`, which aren't exported), and mints a route-grained `CALLS` signal. A match carries the `RouteNode`'s own declared `path`/`line` as the signal's callSite, so the edge lands file-grained through the scaffold's existing fuse step — the same file a static extractor already found, not a new one. `networkFlowLogs` maps directly onto a `CONNECTS_TO` signal between the two Railway services a flow record's `peerServiceId` names.
- `types.ts` — `RailwayConnectorConfig` (environment/service ids, the explicit Railway-serviceId → NEAT-service-name mapping ADR-127 requires be resolved once and never guessed, lookback/limit knobs) and the raw provider response shapes.

## On the schema

I fetched Railway's docs before writing the query (`docs.railway.com/integrations/api`, `/graphql-overview`, `/cli/logs`) rather than inventing field names. Their public API reference confirms the endpoint, Bearer auth, and Relay-style pagination shape, but doesn't spell out `httpLogs`/`networkFlowLogs` as GraphQL query names directly. The field names I used (`method`, `path`, `httpStatus`, `totalDuration`, `requestId`, `deploymentId`, `edgeRegion` for HTTP; `peerServiceId`, `byteCount`, `packetCount`, `dropCause` for flow logs) come from Railway's log-explorer attribute documentation, which does list them verbatim and lines up with what `railway.md` predicted. I could not confirm live via GraphiQL introspection (no live Railway project/token in this environment), so the query shape in `client.ts` is flagged `needs-endpoint-testing` in comments, same as the design doc already flags for this whole surface — it should be built against a real Railway project before being treated as locked.

## Interface gap worth flagging

The scaffold's `ResolveConnectorTarget` returns an existing node id — it has no way to auto-vivify a new target node the way `ensureGraphqlOperationNode`/`ensureGrpcMethodNode` do on the OTel-ingest path. That's fine for the `CONNECTS_TO` case (both `ServiceNode`s already exist or get auto-created by the shared pipeline), but it means an `httpLogs` record whose path matches no static `RouteNode` can't mint a `missing-extracted`-eligible node today — `RouteNode.path` is a required field naming a real source location, and there's no honest value to put there for a route no static extractor found. This connector drops that case honestly through the scaffold's own `unresolved` counter rather than fabricating a path or working around it. Closing this gap would need either a scaffold extension (an observed-first `ensureRouteNode` mirroring the OTel-ingest pattern) or a product call on how to represent it — flagging here rather than guessing.

## Tests

`packages/core/test/connectors-railway.test.ts` + fixtures under `test/fixtures/railway/`, matching Railway's documented field shapes (cited inline, `docs.railway.com/cli/logs`) per `docs/contracts/connectors.md` §5. Covers: multiple `httpLogs` entries collapsing onto one matched route signal (aggregated call/error counts), a path with no static match falling back honestly, `networkFlowLogs` mapping to a `CONNECTS_TO` signal while dropping a peerless entry, target resolution for all three signal kinds (including an unmapped peer serviceId dropping honestly), and an end-to-end `poll()` → `runConnectorPoll()` run against stubbed fetch responses that lands real edges in the graph.

## Verification

- `npm install`
- `npm run build --workspace @neat.is/types`
- `npx turbo build --filter=@neat.is/core^...`
- `npx vitest run --root packages/core` — 64 files, 1267 passed, 2 skipped, 5 todo (all green; the only flake I saw, `otlp-port-step.test.ts`, is a pre-existing port-binding timing test unrelated to this change and passes cleanly in isolation)