### PR TITLE
Bump to v0.4.26

### DIFF
--- a/packages/claude-skill/package.json
+++ b/packages/claude-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/claude-skill",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "description": "Claude Code skill drop-in for NEAT — wires the @neat.is/mcp server into Claude's MCP config",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/core",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "description": "NEAT graph engine: tree-sitter extraction, OTel ingest, REST API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -51,7 +51,7 @@
     "@fastify/cors": "^10.0.0",
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
-    "@neat.is/types": "^0.4.25",
+    "@neat.is/types": "^0.4.26",
     "chokidar": "^4.0.3",
     "fastify": "^5.0.0",
     "graphology": "^0.25.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/mcp",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "description": "NEAT MCP server: exposes graph queries to AI agents over stdio",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@neat.is/types": "^0.4.25",
+    "@neat.is/types": "^0.4.26",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/neat.is/package.json
+++ b/packages/neat.is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neat.is",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "description": "NEAT — live semantic graph of a software system, queryable from AI agents over MCP. Install once, get the neat / neatd / neat-mcp CLIs.",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -26,9 +26,9 @@
     "README.md"
   ],
   "dependencies": {
-    "@neat.is/core": "^0.4.25",
-    "@neat.is/mcp": "^0.4.25",
-    "@neat.is/claude-skill": "^0.4.25",
-    "@neat.is/web": "^0.4.25"
+    "@neat.is/core": "^0.4.26",
+    "@neat.is/mcp": "^0.4.26",
+    "@neat.is/claude-skill": "^0.4.26",
+    "@neat.is/web": "^0.4.26"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/types",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "description": "Shared Zod schemas, types, and runtime constants for NEAT",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/web",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "description": "NEAT web shell — minimal Next.js app fronting the core API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
-    "@neat.is/types": "^0.4.25",
+    "@neat.is/types": "^0.4.26",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cytoscape": "^3.33.3",


### PR DESCRIPTION
Version bump for the v0.4.26 release, per docs/runbook-publish.md. Lockstep bump across the six version-locked packages (types, core, mcp, claude-skill, web, neat.is) plus their cross-package dep pins. @neat.is/instrumentation-registry stays on its own 1.0.0 line, untouched.

What's shipping in this release: the connectors plane (a second OBSERVED ingestion path, pull, alongside OTLP) with Supabase's design and four more providers built out - Vercel (an edge-runtime installer path, not a connector), Railway, Firebase, and Cloudflare Workers/Pages - plus the shared pull/map/fuse scaffold they all build on.

No behavior change beyond the version numbers themselves in this diff.