### PR TITLE
Fix a calendar-flaky test in the Railway connector

### DIFF
--- a/packages/core/test/connectors-railway.test.ts
+++ b/packages/core/test/connectors-railway.test.ts
@@ -334,7 +334,7 @@ describe('Railway connector — end-to-end poll() against fixture GraphQL respon
     expect(connectsToEdge.signal?.errorCount).toBe(1)
   })
 
-  it('bounds the query window to since when provided, and to maxLookbackMs otherwise', async () => {
+  it('passes since through unchanged when it is within the lookback window', async () => {
     let capturedVariables: Record<string, unknown> | undefined
     globalThis.fetch = (async (_url: string, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body)) as {
@@ -350,13 +350,47 @@ describe('Railway connector — end-to-end poll() against fixture GraphQL respon
 
     const graph = newGraph()
     const connector = createRailwayConnector(graph, config())
-    const since = '2026-07-03T09:00:00.000Z'
+    // An hour ago, computed at test-run time - not a hardcoded calendar date.
+    // DEFAULT_MAX_LOOKBACK_MS is 24h, so this always lands inside the window
+    // regardless of which day the suite runs, unlike a fixed ISO string.
+    const since = new Date(Date.now() - 60 * 60 * 1000).toISOString()
 
     await connector.poll(baseCtx({ since }))
 
     expect(capturedVariables?.startDate).toBe(since)
     expect(capturedVariables?.environmentId).toBe('env-abc123')
     expect(capturedVariables?.serviceId).toBe(RAILWAY_SERVICE_ID)
+  })
+
+  it('bounds since to maxLookbackMs when the gap is too wide, or when since is absent', async () => {
+    let capturedVariables: Record<string, unknown> | undefined
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        query: string
+        variables: Record<string, unknown>
+      }
+      capturedVariables = body.variables
+      const data = body.query.includes('httpLogs')
+        ? { httpLogs: [] }
+        : { networkFlowLogs: [] }
+      return new Response(JSON.stringify({ data }), { status: 200 })
+    }) as typeof globalThis.fetch
+
+    const graph = newGraph()
+    const connector = createRailwayConnector(graph, config())
+    const beforeMs = Date.now()
+
+    // A since well outside the 24h default lookback (a laptop off for a week).
+    const staleSince = new Date(beforeMs - 7 * 24 * 60 * 60 * 1000).toISOString()
+    await connector.poll(baseCtx({ since: staleSince }))
+    const staleStartMs = new Date(capturedVariables?.startDate as string).getTime()
+    expect(staleStartMs).toBeGreaterThan(new Date(staleSince).getTime())
+    expect(beforeMs - staleStartMs).toBeLessThanOrEqual(24 * 60 * 60 * 1000 + 5000)
+
+    // No since at all (first poll ever) gets the same floor treatment.
+    await connector.poll(baseCtx({ since: undefined }))
+    const absentStartMs = new Date(capturedVariables?.startDate as string).getTime()
+    expect(beforeMs - absentStartMs).toBeLessThanOrEqual(24 * 60 * 60 * 1000 + 5000)
   })
 
   it('requires ctx.credentials.token and never lets it reach a graph mutation', async () => {


### PR DESCRIPTION
boundedRailwayStartDate's own capping logic is correct - it bounds `since` to `now - maxLookbackMs` (24h) when the gap is too wide, exactly as documented. The test asserting the passthrough case hardcoded `since` as a fixed calendar date, which only stayed inside the 24h window on the day the test was written - it started failing CI as soon as the calendar moved past that window (surfaced by an unrelated PR's CI run, not caused by it).

Fix: compute `since` relative to `Date.now()` at test-run time instead of a fixed string, and add real coverage for the "since absent, or since too old" floor case the test's own name already promised ("...and to maxLookbackMs otherwise") but never actually exercised.

Refs #679

## Test plan

- [x] `npx vitest run --root packages/core packages/core/test/connectors-railway.test.ts` - 11 passed
- [x] `npx vitest run --root packages/core` - 66 files, 1300 passed / 2 skipped / 5 todo