### PR TITLE
Add the bounded logs store and GET /logs endpoint (ADR-132)

### DIFF
--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -3,7 +3,7 @@ name: rest-api
 description: Routes dual-mount at /X and /projects/:project/X per ADR-026. JSON errors. Live graphology only — no graph.json reads at request time. Inbound bodies are Zod-validated. Outbound responses are always JSON objects (never bare arrays) per ADR-061's envelope rule.
 governs:
   - "packages/core/src/api.ts"
-adr: [ADR-040, ADR-026, ADR-061, ADR-110, ADR-116]
+adr: [ADR-040, ADR-026, ADR-061, ADR-110, ADR-116, ADR-132]
 enforcement: [lint, review]
 ---
 
@@ -46,6 +46,7 @@ Bare arrays from REST endpoints are a contract violation. Why: an object can gro
 | `GET /incidents/:nodeId` | recent ErrorEvents filtered to a node | `{ count, total, events: ErrorEvent[] }` |
 | `GET /graph/incident-history/:nodeId` | same handler as `/incidents/:nodeId`, under the graph-query name that mirrors the MCP `get_incident_history` tool (ADR-116) | `{ count, total, events: ErrorEvent[] }` |
 | `GET /stale-events?limit=N&edgeType=X` | recent STALE transitions | `{ count, total, events: StaleEvent[] }` |
+| `GET /logs?source=X&service=Y&limit=N&since=Z` | recent `LogEntry` records from the bounded per-`(project, source)` store — `source` repeatable, defaults to all (ADR-132) | `{ count, total, logs: LogEntry[] }` |
 | `GET /policies` | parsed `policy.json` | `{ version, policies: Policy[] }` |
 | `GET /policies/violations?severity=X&policyId=X` | current violations, filterable | `{ violations: PolicyViolation[] }` |
 | `GET /policies/applicable?node=X` | soft guardrail (ADR-108): policies that govern a node, matched by direct subject/region. Informs, never blocks | `{ node, applicable: ApplicablePolicy[] }` |

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -24,6 +24,11 @@ import {
 } from './extend/index.js'
 import { computeDivergences } from './divergences.js'
 import {
+  LOGS_QUERY_DEFAULT_LIMIT,
+  LOGS_QUERY_MAX_LIMIT,
+  queryLogEntries,
+} from './logs-store.js'
+import {
   evaluateAllPolicies,
   loadPolicyFile,
   PolicyViolationsLog,
@@ -408,6 +413,38 @@ function registerRoutes(scope: FastifyInstance, ctx: RouteContext): void {
     const limit = req.query.limit ? Number(req.query.limit) : 50
     const sliced = ordered.slice(0, Number.isFinite(limit) && limit > 0 ? limit : 50)
     return { count: sliced.length, total, events: sliced }
+  })
+
+  // Logs surface (docs/contracts/logs.md, ADR-132). Reads the bounded
+  // per-(project, source) ring buffer in logs-store.ts — the only REST
+  // surface allowed to; MCP's get_logs and the CLI's `neat logs` are meant
+  // to call this endpoint rather than the store directly. `source` is
+  // repeatable (?source=supabase&source=railway); `service`/`since` filter
+  // before the `limit` cap, so `total` reflects the filtered-but-unlimited
+  // size per the ADR-061 envelope rule.
+  scope.get<{
+    Params: { project?: string }
+    Querystring: { source?: string | string[]; service?: string; limit?: string; since?: string }
+  }>('/logs', async (req, reply) => {
+    const proj = resolveProject(registry, req, reply, ctx.bootstrap, ctx.singleProject)
+    if (!proj) return
+    const rawSource = req.query.source
+    const sources =
+      rawSource === undefined ? undefined : Array.isArray(rawSource) ? rawSource : [rawSource]
+    const filtered = queryLogEntries({
+      projectName: proj.name,
+      ...(sources && sources.length > 0 ? { source: sources } : {}),
+      ...(req.query.service ? { service: req.query.service } : {}),
+      ...(req.query.since ? { since: req.query.since } : {}),
+    })
+    const total = filtered.length
+    const limit = req.query.limit ? Number(req.query.limit) : LOGS_QUERY_DEFAULT_LIMIT
+    const safeLimit =
+      Number.isFinite(limit) && limit > 0
+        ? Math.min(limit, LOGS_QUERY_MAX_LIMIT)
+        : LOGS_QUERY_DEFAULT_LIMIT
+    const sliced = filtered.slice(0, safeLimit)
+    return { count: sliced.length, total, logs: sliced }
   })
 
   // One handler, two paths: `/incidents/:nodeId` is the original REST name and

--- a/packages/core/src/logs-store.ts
+++ b/packages/core/src/logs-store.ts
@@ -1,0 +1,123 @@
+import type { LogEntry } from '@neat.is/types'
+
+// Bounded per-(projectName, source) ring buffer for LogEntry records
+// (docs/contracts/logs.md Rule 4, ADR-132). Fully in-memory, no
+// persistence — a daemon restart loses the buffer, the same trade-off NEAT
+// already accepts for the live graph between snapshots. Every pair owns its
+// own array, so a burst from one source can never evict another pair's
+// entries.
+
+// Default cap: the last 1,000 entries, and nothing older than 24h — both
+// bounds apply independently (see `prune` below), whichever trips first for
+// a given entry.
+export const LOGS_STORE_MAX_ENTRIES = 1000
+export const LOGS_STORE_MAX_AGE_MS = 24 * 60 * 60 * 1000
+
+// GET /logs query-param defaults. Exported so the REST route (api.ts) and
+// any future direct caller (MCP's get_logs) share one definition of "sane
+// max" rather than each picking their own number.
+export const LOGS_QUERY_DEFAULT_LIMIT = 100
+export const LOGS_QUERY_MAX_LIMIT = 1000
+
+const buffers = new Map<string, LogEntry[]>()
+
+// Separator chosen so an ordinary project name or source string can't
+// collide two distinct (projectName, source) pairs onto the same key —
+// neither a NEAT project name nor a `source` value (logs.md Rule 1's fixed
+// set, extended one string per future connector) is expected to contain it.
+const KEY_SEP = '::'
+
+function bufferKey(projectName: string, source: string): string {
+  return `${projectName}${KEY_SEP}${source}`
+}
+
+function sourcesForProject(projectName: string): string[] {
+  const prefix = `${projectName}${KEY_SEP}`
+  const sources: string[] = []
+  for (const key of buffers.keys()) {
+    if (key.startsWith(prefix)) sources.push(key.slice(prefix.length))
+  }
+  return sources
+}
+
+// Drops entries older than the age cap, then trims to the count cap. Both
+// run every append so a buffer never grows past 1,000 elements even
+// mid-burst, and a slow, quiet source still ages its old entries out even
+// though it never fills the count cap.
+function prune(entries: LogEntry[], now: number): LogEntry[] {
+  const cutoff = now - LOGS_STORE_MAX_AGE_MS
+  let pruned = entries.filter((e) => {
+    const t = Date.parse(e.timestamp)
+    // A timestamp that fails to parse can't be judged stale — fail open
+    // rather than silently dropping a malformed-but-real entry.
+    return Number.isNaN(t) || t >= cutoff
+  })
+  if (pruned.length > LOGS_STORE_MAX_ENTRIES) {
+    pruned = pruned.slice(pruned.length - LOGS_STORE_MAX_ENTRIES)
+  }
+  return pruned
+}
+
+export function appendLogEntry(entry: LogEntry): void {
+  const key = bufferKey(entry.projectName, entry.source)
+  const existing = buffers.get(key) ?? []
+  existing.push(entry)
+  buffers.set(key, prune(existing, Date.now()))
+}
+
+export interface QueryLogEntriesOptions {
+  projectName: string
+  // Repeatable per logs.md §5 — when omitted, every source this project has
+  // ever written an entry under is included.
+  source?: string[]
+  service?: string
+  limit?: number
+  // ISO8601 lower bound, inclusive, matched against each entry's own
+  // `timestamp` (not append time).
+  since?: string
+}
+
+// Newest-first, merged across every matching source bucket for the
+// project, then service/since filtered. `limit` is applied last so a
+// direct caller (a future MCP get_logs, or a test) can ask for a bounded
+// slice without redoing the REST layer's separate total/count bookkeeping;
+// the REST route itself calls this once unlimited (for `total`) and slices
+// the result itself so `total` reflects the filtered-but-unlimited size.
+export function queryLogEntries(opts: QueryLogEntriesOptions): LogEntry[] {
+  const { projectName, source, service, since, limit } = opts
+  const sources = source && source.length > 0 ? source : sourcesForProject(projectName)
+
+  let merged: LogEntry[] = []
+  for (const src of sources) {
+    const buf = buffers.get(bufferKey(projectName, src))
+    if (buf) merged = merged.concat(buf)
+  }
+
+  if (service) {
+    merged = merged.filter((e) => e.serviceName === service)
+  }
+
+  if (since) {
+    const sinceMs = Date.parse(since)
+    if (!Number.isNaN(sinceMs)) {
+      merged = merged.filter((e) => {
+        const t = Date.parse(e.timestamp)
+        return Number.isNaN(t) || t >= sinceMs
+      })
+    }
+  }
+
+  merged.sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+
+  if (typeof limit === 'number' && Number.isFinite(limit) && limit >= 0) {
+    return merged.slice(0, limit)
+  }
+  return merged
+}
+
+// Test seam. The store is a module-level singleton with no persistence —
+// tests that append fixture entries need a way back to empty between
+// cases, the same shape `resetGraph()` gives the in-memory graph.
+export function resetLogsStore(): void {
+  buffers.clear()
+}

--- a/packages/core/test/logs-api.test.ts
+++ b/packages/core/test/logs-api.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+import type { LogEntry } from '@neat.is/types'
+import { LogsResponseSchema } from '@neat.is/types'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { buildApi } from '../src/api.js'
+import { appendLogEntry, resetLogsStore } from '../src/logs-store.js'
+
+function iso(offsetMs: number): string {
+  return new Date(Date.now() + offsetMs).toISOString()
+}
+
+function entry(overrides: Partial<LogEntry> & { id: string }): LogEntry {
+  return {
+    projectName: 'default',
+    source: 'native',
+    timestamp: iso(0),
+    message: 'hello',
+    ...overrides,
+  }
+}
+
+describe('GET /logs', () => {
+  let app: FastifyInstance
+
+  beforeEach(async () => {
+    resetLogsStore()
+    resetGraph()
+    app = await buildApi({ graph: getGraph() })
+  })
+
+  afterEach(async () => {
+    await app.close()
+    resetLogsStore()
+  })
+
+  it('returns a wrapped empty list when the store has nothing for the project', async () => {
+    const res = await app.inject({ method: 'GET', url: '/logs' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ count: 0, total: 0, logs: [] })
+  })
+
+  it('returns entries newest-first with the ADR-061 envelope shape', async () => {
+    appendLogEntry(entry({ id: '1', message: 'first', timestamp: iso(-2000) }))
+    appendLogEntry(entry({ id: '2', message: 'second', timestamp: iso(-1000) }))
+
+    const res = await app.inject({ method: 'GET', url: '/logs' })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.count).toBe(2)
+    expect(body.total).toBe(2)
+    expect(body.logs.map((l: LogEntry) => l.id)).toEqual(['2', '1'])
+
+    const parsed = LogsResponseSchema.safeParse(body)
+    expect(parsed.success, parsed.success ? '' : JSON.stringify(parsed.error.format())).toBe(true)
+  })
+
+  it('is dual-mounted at /logs and /projects/:project/logs', async () => {
+    appendLogEntry(entry({ id: '1' }))
+    const root = await app.inject({ method: 'GET', url: '/logs' })
+    const prefixed = await app.inject({ method: 'GET', url: '/projects/default/logs' })
+    expect(root.statusCode).toBe(200)
+    expect(prefixed.statusCode).toBe(200)
+    expect(root.json()).toEqual(prefixed.json())
+  })
+
+  it('filters by source, repeatable via ?source=a&source=b', async () => {
+    appendLogEntry(entry({ id: 'n1', source: 'native' }))
+    appendLogEntry(entry({ id: 's1', source: 'supabase' }))
+    appendLogEntry(entry({ id: 'r1', source: 'railway' }))
+
+    const onlyNative = await app.inject({ method: 'GET', url: '/logs?source=native' })
+    expect(onlyNative.json().logs.map((l: LogEntry) => l.id)).toEqual(['n1'])
+
+    const two = await app.inject({ method: 'GET', url: '/logs?source=native&source=supabase' })
+    expect(two.json().logs.map((l: LogEntry) => l.id).sort()).toEqual(['n1', 's1'])
+    expect(two.json().total).toBe(2)
+
+    const all = await app.inject({ method: 'GET', url: '/logs' })
+    expect(all.json().total).toBe(3)
+  })
+
+  it('filters by service', async () => {
+    appendLogEntry(entry({ id: 'a', serviceName: 'checkout' }))
+    appendLogEntry(entry({ id: 'b', serviceName: 'billing' }))
+    const res = await app.inject({ method: 'GET', url: '/logs?service=checkout' })
+    const body = res.json()
+    expect(body.logs.map((l: LogEntry) => l.id)).toEqual(['a'])
+    expect(body.total).toBe(1)
+  })
+
+  it('filters by since', async () => {
+    appendLogEntry(entry({ id: 'old', timestamp: iso(-3000) }))
+    appendLogEntry(entry({ id: 'new', timestamp: iso(-1000) }))
+    const res = await app.inject({
+      method: 'GET',
+      url: `/logs?since=${encodeURIComponent(iso(-2000))}`,
+    })
+    const body = res.json()
+    expect(body.logs.map((l: LogEntry) => l.id)).toEqual(['new'])
+    expect(body.total).toBe(1)
+  })
+
+  it('caps `logs` at `limit` while `total` reflects the unlimited filtered count', async () => {
+    appendLogEntry(entry({ id: '1', timestamp: iso(-3000) }))
+    appendLogEntry(entry({ id: '2', timestamp: iso(-2000) }))
+    appendLogEntry(entry({ id: '3', timestamp: iso(-1000) }))
+
+    const res = await app.inject({ method: 'GET', url: '/logs?limit=2' })
+    const body = res.json()
+    expect(body.count).toBe(2)
+    expect(body.total).toBe(3)
+    expect(body.logs.map((l: LogEntry) => l.id)).toEqual(['3', '2'])
+  })
+
+  it('caps an oversized limit at the sane max rather than returning everything', async () => {
+    for (let i = 0; i < 20; i++) {
+      appendLogEntry(entry({ id: `e${i}`, timestamp: iso(-1000 * (20 - i)) }))
+    }
+    const res = await app.inject({ method: 'GET', url: '/logs?limit=1000000' })
+    const body = res.json()
+    expect(body.total).toBe(20)
+    expect(body.count).toBe(20)
+    expect(body.logs.length).toBeLessThanOrEqual(1000)
+  })
+
+  it('keeps entries from other projects out of the default-project read', async () => {
+    appendLogEntry(entry({ id: 'other', projectName: 'other-project' }))
+    const res = await app.inject({ method: 'GET', url: '/logs' })
+    expect(res.json()).toEqual({ count: 0, total: 0, logs: [] })
+  })
+})

--- a/packages/core/test/logs-store.test.ts
+++ b/packages/core/test/logs-store.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { LogEntry } from '@neat.is/types'
+import {
+  appendLogEntry,
+  queryLogEntries,
+  resetLogsStore,
+  LOGS_STORE_MAX_ENTRIES,
+} from '../src/logs-store.js'
+
+// Every fixture timestamp is relative to `Date.now()` at test-run time — the
+// store's age-based eviction (24h) is judged against the real wall clock, so
+// hardcoded absolute dates would silently start failing once the calendar
+// moves far enough past them.
+function iso(offsetMs: number): string {
+  return new Date(Date.now() + offsetMs).toISOString()
+}
+
+function entry(overrides: Partial<LogEntry> & { id: string }): LogEntry {
+  return {
+    projectName: 'default',
+    source: 'native',
+    timestamp: iso(0),
+    message: 'hello',
+    ...overrides,
+  }
+}
+
+describe('logs-store', () => {
+  beforeEach(() => {
+    resetLogsStore()
+  })
+
+  it('appends and returns entries newest-first', () => {
+    appendLogEntry(entry({ id: '1', message: 'first', timestamp: iso(-2000) }))
+    appendLogEntry(entry({ id: '2', message: 'second', timestamp: iso(-1000) }))
+    const result = queryLogEntries({ projectName: 'default' })
+    expect(result.map((e) => e.id)).toEqual(['2', '1'])
+  })
+
+  it("keeps projects isolated — querying one project never returns another project's entries", () => {
+    appendLogEntry(entry({ id: 'a', projectName: 'alpha' }))
+    appendLogEntry(entry({ id: 'b', projectName: 'beta' }))
+    expect(queryLogEntries({ projectName: 'alpha' }).map((e) => e.id)).toEqual(['a'])
+    expect(queryLogEntries({ projectName: 'beta' }).map((e) => e.id)).toEqual(['b'])
+  })
+
+  it("a burst from one source never evicts another source's entries for the same project", () => {
+    // Fill the railway buffer past its count cap — each entry a millisecond
+    // apart, all well within the 24h age window.
+    const burst = LOGS_STORE_MAX_ENTRIES + 50
+    for (let i = 0; i < burst; i++) {
+      appendLogEntry(
+        entry({
+          id: `railway-${i}`,
+          source: 'railway',
+          timestamp: iso(-1000 * (burst - i)),
+        }),
+      )
+    }
+    // One quiet supabase entry, appended once.
+    appendLogEntry(entry({ id: 'supabase-1', source: 'supabase', message: 'quiet' }))
+
+    const railwayEntries = queryLogEntries({ projectName: 'default', source: ['railway'] })
+    const supabaseEntries = queryLogEntries({ projectName: 'default', source: ['supabase'] })
+
+    // railway's buffer is capped at the count bound...
+    expect(railwayEntries.length).toBe(LOGS_STORE_MAX_ENTRIES)
+    // ...but the noisy railway burst didn't touch supabase's own buffer.
+    expect(supabaseEntries.map((e) => e.id)).toEqual(['supabase-1'])
+  })
+
+  it('evicts entries older than the 24h age cap', () => {
+    appendLogEntry(entry({ id: 'stale', timestamp: iso(-25 * 60 * 60 * 1000) }))
+    appendLogEntry(entry({ id: 'recent', timestamp: iso(0) }))
+    const result = queryLogEntries({ projectName: 'default' })
+    expect(result.map((e) => e.id)).toEqual(['recent'])
+  })
+
+  it('filters by source (repeatable) — omitting it merges every source', () => {
+    appendLogEntry(entry({ id: 'n1', source: 'native' }))
+    appendLogEntry(entry({ id: 's1', source: 'supabase' }))
+    appendLogEntry(entry({ id: 'r1', source: 'railway' }))
+
+    const onlyNative = queryLogEntries({ projectName: 'default', source: ['native'] })
+    expect(onlyNative.map((e) => e.id)).toEqual(['n1'])
+
+    const nativeAndSupabase = queryLogEntries({
+      projectName: 'default',
+      source: ['native', 'supabase'],
+    })
+    expect(nativeAndSupabase.map((e) => e.id).sort()).toEqual(['n1', 's1'])
+
+    const all = queryLogEntries({ projectName: 'default' })
+    expect(all.map((e) => e.id).sort()).toEqual(['n1', 'r1', 's1'])
+  })
+
+  it('filters by service', () => {
+    appendLogEntry(entry({ id: 'a', serviceName: 'checkout' }))
+    appendLogEntry(entry({ id: 'b', serviceName: 'billing' }))
+    appendLogEntry(entry({ id: 'c' }))
+    const result = queryLogEntries({ projectName: 'default', service: 'checkout' })
+    expect(result.map((e) => e.id)).toEqual(['a'])
+  })
+
+  it("filters by since (inclusive lower bound on the entry's own timestamp)", () => {
+    appendLogEntry(entry({ id: 'old', timestamp: iso(-3000) }))
+    appendLogEntry(entry({ id: 'boundary', timestamp: iso(-2000) }))
+    appendLogEntry(entry({ id: 'new', timestamp: iso(-1000) }))
+    const result = queryLogEntries({ projectName: 'default', since: iso(-2000) })
+    expect(result.map((e) => e.id).sort()).toEqual(['boundary', 'new'])
+  })
+
+  it('applies limit last, after sorting newest-first', () => {
+    appendLogEntry(entry({ id: '1', timestamp: iso(-3000) }))
+    appendLogEntry(entry({ id: '2', timestamp: iso(-2000) }))
+    appendLogEntry(entry({ id: '3', timestamp: iso(-1000) }))
+    const result = queryLogEntries({ projectName: 'default', limit: 2 })
+    expect(result.map((e) => e.id)).toEqual(['3', '2'])
+  })
+
+  it('returns an empty array for a project with no entries', () => {
+    expect(queryLogEntries({ projectName: 'nope' })).toEqual([])
+  })
+})

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -61,3 +61,38 @@ export const StaleEventSchema = z.object({
   transitionedAt: z.string(),
 })
 export type StaleEvent = z.infer<typeof StaleEventSchema>
+
+// The one shape every log producer emits (docs/contracts/logs.md Rule 1,
+// ADR-132) — a native OTLP `/v1/logs` receiver (source: 'native') and each
+// connector's provider-specific mapping layer (source: '<provider>') both
+// produce this. `logs-store.ts` holds these in a bounded per-(project,
+// source) ring buffer; GET /logs is the only REST surface that reads it.
+// `source` is extensible the same way the connector provider dispatch table
+// grows one entry per provider.
+export const LogSourceSchema = z.enum([
+  'native',
+  'supabase',
+  'railway',
+  'firebase',
+  'cloudflare',
+  'vercel',
+])
+export type LogSource = z.infer<typeof LogSourceSchema>
+
+export const LogEntrySchema = z.object({
+  id: z.string(),
+  projectName: z.string(),
+  source: LogSourceSchema,
+  serviceName: z.string().optional(),
+  nodeId: z.string().optional(),
+  // ISO8601, the event's own time — never ingest/poll time.
+  timestamp: z.string().datetime(),
+  // Normalized upstream to 'debug' | 'info' | 'warn' | 'error' by whichever
+  // producer wrote the entry; kept as a plain string here rather than a
+  // locked enum because normalization is a producer concern, not this
+  // schema's.
+  severity: z.string().optional(),
+  message: z.string(),
+  attributes: z.record(z.string(), z.unknown()).optional(),
+})
+export type LogEntry = z.infer<typeof LogEntrySchema>

--- a/packages/types/src/responses.ts
+++ b/packages/types/src/responses.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { GraphEdgeSchema } from './edges.js'
 import { GraphNodeSchema } from './nodes.js'
-import { ErrorEventSchema, StaleEventSchema } from './events.js'
+import { ErrorEventSchema, LogEntrySchema, StaleEventSchema } from './events.js'
 import { PolicyViolationSchema } from './policy.js'
 import { RegistryEntrySchema } from './registry.js'
 
@@ -23,6 +23,17 @@ export type IncidentsResponse = z.infer<typeof IncidentsResponseSchema>
 
 export const StaleEventsResponseSchema = listEnvelope(StaleEventSchema)
 export type StaleEventsResponse = z.infer<typeof StaleEventsResponseSchema>
+
+// GET /logs response (docs/contracts/logs.md Rule 5, ADR-132). `total` is
+// the size of the filtered-but-unlimited collection (after source/service/
+// since filtering); `count` is the length of the returned, limit-capped
+// `logs` array.
+export const LogsResponseSchema = z.object({
+  count: z.number().int().nonnegative(),
+  total: z.number().int().nonnegative(),
+  logs: z.array(LogEntrySchema),
+})
+export type LogsResponse = z.infer<typeof LogsResponseSchema>
 
 export const PoliciesViolationsResponseSchema = z.object({
   violations: z.array(PolicyViolationSchema),


### PR DESCRIPTION
## Summary

First implementation slice of the unified logs surface designed in `docs/contracts/logs.md` (ADR-132).

- `LogEntry` (+ `LogSource`, `LogsResponse`) lands in `@neat.is/types`, next to `ErrorEvent`/`StaleEvent` — the same kind of cross-cutting shape every consumer reads.
- `packages/core/src/logs-store.ts`: an in-memory ring buffer capped independently on count (1,000) and age (24h) per `(projectName, source)` pair, so a noisy source never crowds out a quiet one. Exports `appendLogEntry`, `queryLogEntries`, `resetLogsStore`.
- `GET /logs` / `GET /projects/:project/logs`, dual-mounted per ADR-026 through the existing `registerRoutes` pattern. Filters: repeatable `source`, `service`, `limit` (capped at 1,000), `since`. Envelope: `{ count, total, logs }` per ADR-061.
- `docs/contracts/rest-api.md`'s canonical endpoint table gets the new row; ADR-132 joins its frontmatter `adr:` list.

Out of scope here, per `logs.md`'s own authority split — each lands as its own PR once this one's in:
- the native `/v1/logs` OTLP receiver (`otel-logs.ts`)
- each connector's `map.ts` emitting a `LogEntry` alongside its `ObservedSignal`
- MCP's `get_logs`, the CLI's `neat logs`, and the frontend Logs page

## Test plan

- [x] `npx vitest run --root packages/core` — 1356 passed, 2 skipped, 5 todo (one unrelated `otlp-port-step.test.ts` timeout reproduced as pre-existing flake under full-suite load; passes standalone and on a clean re-run)
- [x] `npx vitest run --root packages/types` — 31 passed
- [x] `packages/core/test/audits/contracts.test.ts` — 745 passed (includes the bidirectional `rest-api.md` ↔ `api.ts` endpoint-table check)
- [x] New: `packages/core/test/logs-store.test.ts` (9 tests) — per-(project, source) isolation, burst-doesn't-evict-sibling, 24h age eviction, source/service/since/limit filtering
- [x] New: `packages/core/test/logs-api.test.ts` (9 tests) — envelope shape via `LogsResponseSchema`, dual-mount, query-param filtering, limit-vs-total semantics
- [x] `eslint` clean on all touched/added files

Refs #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)