### PR TITLE
Add the Logs page to the web shell (ADR-132)

### DIFF
--- a/packages/web/app/api/logs/route.ts
+++ b/packages/web/app/api/logs/route.ts
@@ -1,0 +1,17 @@
+import { proxyProfile } from '../../../lib/proxy'
+import { FIXTURE_LOGS } from '../../../lib/fixtures'
+
+// ADR-101 — logs come from the selected profile's daemon at the ROOT
+// (`/logs`, no `/projects/:name` prefix). `source`/`service`/`limit`/`since`
+// are forwarded through unchanged — `source` repeatable — so the REST
+// endpoint, MCP's get_logs, and the CLI's neat logs all filter on the same
+// query semantics (docs/contracts/logs.md §6, ADR-132).
+export async function GET(request: Request): Promise<Response> {
+  const url = new URL(request.url)
+  const forwarded = new URLSearchParams()
+  for (const key of ['source', 'service', 'limit', 'since']) {
+    for (const value of url.searchParams.getAll(key)) forwarded.append(key, value)
+  }
+  const qs = forwarded.toString()
+  return proxyProfile(request, `/logs${qs ? `?${qs}` : ''}`, () => Response.json(FIXTURE_LOGS))
+}

--- a/packages/web/app/components/AppShell.tsx
+++ b/packages/web/app/components/AppShell.tsx
@@ -12,6 +12,7 @@ import { DebugPanel } from './DebugPanel'
 import { Toaster } from './Toaster'
 import { CommandPalette } from './CommandPalette'
 import { PoliciesPage } from './PoliciesPage'
+import { LogsPage } from './LogsPage'
 import { StubPage } from './StubPage'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -215,6 +216,8 @@ export function AppShell() {
                   onNodeSelect={setSelectedNodeId}
                   onNavigateGraph={() => setActivePage('graph')}
                 />
+              ) : activePage === 'logs' ? (
+                <LogsPage project={project} />
               ) : (
                 <StubPage id={activePage} />
               )}

--- a/packages/web/app/components/LogsPage.tsx
+++ b/packages/web/app/components/LogsPage.tsx
@@ -1,0 +1,202 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { LogEntry, LogSource } from '@neat.is/types'
+import { authedFetch } from '../../lib/authed-fetch'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+
+// ---------------------------------------------------------------------------
+// Logs page (docs/contracts/logs.md, ADR-132).
+//
+// One unified feed — native OTel logs and every OCloud connector
+// (Supabase/Railway/Firebase/Cloudflare/Vercel) — read through the single
+// REST surface, GET /logs (proxied here at /api/logs). The source filter
+// sets the exact same `source` query param MCP's get_logs and the CLI's
+// `neat logs` use (contract §6) — no separate filter vocabulary invented for
+// the frontend.
+//
+// Follows the Policies page's shape: an AppShell-embedded list/table view
+// fed the resolved `project` as a prop (the shell owns profile resolution),
+// styled with the shared `.page-*` list/table chrome (globals.css — "generic
+// list/table page chrome (Policies + stubs)").
+// ---------------------------------------------------------------------------
+
+interface LogsPageProps {
+  project: string | null
+}
+
+interface LogsResponse {
+  count: number
+  total: number
+  logs: LogEntry[]
+}
+
+const SOURCE_FILTERS: { id: LogSource; label: string }[] = [
+  { id: 'native', label: 'Native' },
+  { id: 'supabase', label: 'Supabase' },
+  { id: 'railway', label: 'Railway' },
+  { id: 'firebase', label: 'Firebase' },
+  { id: 'cloudflare', label: 'Cloudflare' },
+  { id: 'vercel', label: 'Vercel' },
+]
+
+const SEVERITY_VARIANT: Record<string, 'destructive' | 'outline' | 'secondary' | 'ghost'> = {
+  error: 'destructive',
+  warn: 'outline',
+  warning: 'outline',
+  info: 'secondary',
+  debug: 'ghost',
+}
+
+const LOGS_LIMIT = 200
+
+function formatTs(iso: string): string {
+  try {
+    const d = new Date(iso)
+    return d.toLocaleDateString() + ' ' + d.toTimeString().slice(0, 8)
+  } catch {
+    return iso
+  }
+}
+
+export function LogsPage({ project }: LogsPageProps) {
+  // Repeatable `source` — the same multi-value semantics the REST endpoint,
+  // MCP, and the CLI share (docs/contracts/logs.md §6). Empty = no filter =
+  // "All".
+  const [sources, setSources] = useState<LogSource[]>([])
+  const [data, setData] = useState<LogsResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Idle until a project resolves (#461) — mirrors PoliciesPage/IncidentsClient.
+  useEffect(() => {
+    if (!project) {
+      setData(null)
+      setError(null)
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setError(null)
+    const params = new URLSearchParams({ project, limit: String(LOGS_LIMIT) })
+    for (const s of sources) params.append('source', s)
+    authedFetch(`/api/logs?${params.toString()}`)
+      .then((r) => r.json())
+      .then((d: LogsResponse) => {
+        setData(d)
+        setLoading(false)
+      })
+      .catch(() => {
+        setError('could not load logs')
+        setLoading(false)
+      })
+  }, [project, sources])
+
+  function toggleSource(id: LogSource): void {
+    setSources((prev) => (prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id]))
+  }
+
+  return (
+    <div className="page-scroll">
+      <header className="page-head">
+        <h1 className="page-title">Logs</h1>
+        <p className="page-sub">
+          The native OTel logs receiver and every connected connector, merged into one
+          feed. Filtering by source sets the same query param MCP&apos;s <code>get_logs</code>{' '}
+          and the CLI&apos;s <code>neat logs</code> use.
+        </p>
+      </header>
+
+      <section className="page-section">
+        <div className="page-section-head">
+          <h2>Source</h2>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant={sources.length === 0 ? 'secondary' : 'outline'}
+            size="sm"
+            aria-pressed={sources.length === 0}
+            onClick={() => setSources([])}
+          >
+            All
+          </Button>
+          {SOURCE_FILTERS.map((f) => (
+            <Button
+              key={f.id}
+              variant={sources.includes(f.id) ? 'secondary' : 'outline'}
+              size="sm"
+              aria-pressed={sources.includes(f.id)}
+              onClick={() => toggleSource(f.id)}
+            >
+              {f.label}
+            </Button>
+          ))}
+        </div>
+      </section>
+
+      <section className="page-section">
+        <div className="page-section-head">
+          <h2>
+            {data
+              ? `${data.total} total — showing ${data.logs.length}`
+              : loading
+                ? 'loading'
+                : 'recent logs'}
+          </h2>
+        </div>
+
+        {loading && <div className="page-empty">loading logs…</div>}
+
+        {!loading && !error && !project && (
+          <div className="page-empty">no project registered</div>
+        )}
+
+        {error && (
+          <div className="page-empty" style={{ color: 'var(--destructive)' }}>
+            failed to load: {error}
+          </div>
+        )}
+
+        {!loading && !error && project && data && data.logs.length === 0 && (
+          <div className="page-empty">
+            no logs recorded{sources.length > 0 ? ' for the selected source' : ''}
+          </div>
+        )}
+
+        {!loading && !error && data && data.logs.length > 0 && (
+          <table className="page-table">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Source</th>
+                <th>Service</th>
+                <th>Severity</th>
+                <th>Message</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.logs.map((log) => (
+                <tr key={log.id}>
+                  <td className="td-mono">{formatTs(log.timestamp)}</td>
+                  <td className="td-mono">{log.source}</td>
+                  <td className="td-mono">{log.serviceName ?? '—'}</td>
+                  <td>
+                    {log.severity ? (
+                      <Badge variant={SEVERITY_VARIANT[log.severity] ?? 'outline'}>
+                        {log.severity}
+                      </Badge>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
+                  <td className="td-msg">{log.message}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/packages/web/app/components/PageSidebar.tsx
+++ b/packages/web/app/components/PageSidebar.tsx
@@ -7,6 +7,7 @@ import {
   SearchIcon,
   SettingsIcon,
   ShuffleIcon,
+  LogsIcon,
 } from 'lucide-react'
 import {
   Sidebar,
@@ -34,6 +35,7 @@ const ICONS: Record<NavId, React.ComponentType<{ className?: string }>> = {
   divergences: ShuffleIcon,
   policies: ShieldIcon,
   incidents: TriangleAlertIcon,
+  logs: LogsIcon,
   find: SearchIcon,
   settings: SettingsIcon,
 }

--- a/packages/web/audit/09-gaps-and-stubs.md
+++ b/packages/web/audit/09-gaps-and-stubs.md
@@ -46,6 +46,7 @@ When code state changes, this file changes in lockstep.
 | Policies | wired | Violation view (live) + enforcement preview. |
 | Divergences | disabled | Sibling page, progressive; rendered disabled with "soon" affordance. |
 | Incidents | disabled | Sibling page, progressive; rendered disabled with "soon" affordance. |
+| Logs | wired | Native OTel + connector logs, one feed; source filter chips (docs/contracts/logs.md, ADR-132). |
 | Find | disabled | ⌘K palette is the Find surface today; a full page is progressive. |
 | Settings | disabled | Sibling page, progressive; rendered disabled with "soon" affordance. |
 

--- a/packages/web/lib/fixtures.ts
+++ b/packages/web/lib/fixtures.ts
@@ -89,6 +89,51 @@ export const FIXTURE_PROFILES = [
 
 export const FIXTURE_VIOLATIONS = { violations: [] }
 
+// ADR-132 — the logs surface's DEMO fixture. One entry per source so the
+// filter chips have something to narrow down in a fixture-only session.
+export const FIXTURE_LOGS = {
+  count: 4,
+  total: 4,
+  logs: [
+    {
+      id: 'log-1',
+      projectName: 'demo',
+      source: 'native' as const,
+      serviceName: 'checkout',
+      timestamp: new Date(Date.now() - 1000 * 60 * 3).toISOString(),
+      severity: 'error',
+      message: 'unhandled rejection in POST /charge — payments-db connection refused',
+    },
+    {
+      id: 'log-2',
+      projectName: 'demo',
+      source: 'supabase' as const,
+      serviceName: 'auth',
+      timestamp: new Date(Date.now() - 1000 * 60 * 9).toISOString(),
+      severity: 'warn',
+      message: 'row-level security policy denied a read on public.users',
+    },
+    {
+      id: 'log-3',
+      projectName: 'demo',
+      source: 'railway' as const,
+      serviceName: 'notifications',
+      timestamp: new Date(Date.now() - 1000 * 60 * 22).toISOString(),
+      severity: 'info',
+      message: 'deploy succeeded — notifications@1.1.0',
+    },
+    {
+      id: 'log-4',
+      projectName: 'demo',
+      source: 'native' as const,
+      serviceName: 'api-gateway',
+      timestamp: new Date(Date.now() - 1000 * 60 * 41).toISOString(),
+      severity: 'debug',
+      message: 'cache miss for key session:9f21 — falling through to auth service',
+    },
+  ],
+}
+
 // A node's searchable / display name. FileNodes carry `path` rather than
 // `name`, so fall back to it (then to the id) — keeps search file-aware.
 function fixtureNodeLabel(n: { name?: string; path?: string; id: string }): string {

--- a/packages/web/lib/nav.ts
+++ b/packages/web/lib/nav.ts
@@ -16,6 +16,7 @@ export type NavId =
   | 'divergences'
   | 'policies'
   | 'incidents'
+  | 'logs'
   | 'find'
   | 'settings'
 
@@ -62,6 +63,12 @@ export const NAV_GROUPS: { label: string; items: NavItem[] }[] = [
         label: 'Incidents',
         hint: 'OTel error events',
         kind: 'todo',
+      },
+      {
+        id: 'logs',
+        label: 'Logs',
+        hint: 'Native OTel logs and every connector, one bounded feed (ADR-132)',
+        kind: 'page',
       },
     ],
   },

--- a/packages/web/test/logs-page.test.tsx
+++ b/packages/web/test/logs-page.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// docs/contracts/logs.md, ADR-132 — the Logs page reads GET /logs (proxied at
+// /api/logs) and its source filter chips set the same `source` query param
+// MCP's get_logs and the CLI's neat logs use. Mirrors the state-machine
+// coverage cold-load-gating.test.tsx applies to IncidentsClient: idle while
+// unresolved, loading, populated, empty, and error.
+
+import { LogsPage } from '../app/components/LogsPage'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+const SAMPLE_LOGS = {
+  count: 2,
+  total: 2,
+  logs: [
+    {
+      id: 'log-a',
+      projectName: 'alpha',
+      source: 'native',
+      serviceName: 'checkout',
+      timestamp: new Date('2026-01-01T00:00:00Z').toISOString(),
+      severity: 'error',
+      message: 'connection refused',
+    },
+    {
+      id: 'log-b',
+      projectName: 'alpha',
+      source: 'supabase',
+      serviceName: 'auth',
+      timestamp: new Date('2026-01-01T00:01:00Z').toISOString(),
+      severity: 'info',
+      message: 'row read ok',
+    },
+  ],
+}
+
+describe('LogsPage', () => {
+  const fetchCalls: string[] = []
+
+  beforeEach(() => {
+    fetchCalls.length = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        fetchCalls.push(url)
+        if (url.includes('/api/logs')) return jsonResponse(SAMPLE_LOGS)
+        return jsonResponse({})
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('fires nothing while project is null (#461 gate)', async () => {
+    render(<LogsPage project={null} />)
+    await new Promise((r) => setTimeout(r, 30))
+    expect(fetchCalls).toEqual([])
+    expect(screen.getByText('no project registered')).toBeInTheDocument()
+  })
+
+  it('fetches /api/logs once a project resolves and renders the rows', async () => {
+    render(<LogsPage project="alpha" />)
+    await waitFor(() => {
+      expect(fetchCalls.some((u) => u.includes('/api/logs?project=alpha&limit=200'))).toBe(true)
+    })
+    await waitFor(() => {
+      expect(screen.getByText('connection refused')).toBeInTheDocument()
+      expect(screen.getByText('row read ok')).toBeInTheDocument()
+    })
+  })
+
+  it('clicking a source chip sets the same `source` query param the REST/MCP/CLI surfaces share', async () => {
+    const user = userEvent.setup()
+    render(<LogsPage project="alpha" />)
+    await waitFor(() => {
+      expect(fetchCalls.some((u) => u.includes('/api/logs?project=alpha&limit=200'))).toBe(true)
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Supabase' }))
+
+    await waitFor(() => {
+      expect(fetchCalls.some((u) => u.includes('source=supabase'))).toBe(true)
+    })
+    // toggling back off drops the param again
+    await user.click(screen.getByRole('button', { name: 'Supabase' }))
+    await waitFor(() => {
+      const last = fetchCalls[fetchCalls.length - 1]
+      expect(last.includes('source=supabase')).toBe(false)
+    })
+  })
+
+  it('shows the empty state when the daemon returns no logs', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ count: 0, total: 0, logs: [] })),
+    )
+    render(<LogsPage project="alpha" />)
+    await waitFor(() => {
+      expect(screen.getByText('no logs recorded')).toBeInTheDocument()
+    })
+  })
+
+  it('shows an error state when the daemon is unreachable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down')
+      }),
+    )
+    render(<LogsPage project="alpha" />)
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load/)).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
Refs #692. Builds on #690 (the logs store + REST endpoint) — this PR's diff will shrink once #690 merges and this gets retargeted to main.

## What this does

Adds a Logs page to the web shell: a list/table view of recent `LogEntry` records (time, source, service, severity, message) fetched from `GET /logs` (proxied through `/api/logs`, same per-daemon-profile pattern every other page uses), with a source filter — chips for All / Native / Supabase / Railway / Firebase / Cloudflare / Vercel — that sets the same `source` query param MCP's `get_logs` and the CLI's `neat logs` read, per `docs/contracts/logs.md` §6.

## A judgment call worth flagging

The task pointed at `packages/web/app/incidents/` as the template to mirror, including "how it's wired into the sidebar." Turned out incidents isn't currently reachable from the live sidebar — `lib/nav.ts` marks it `kind: 'todo'` and the only link to the standalone `/incidents` route lived in `Rail.tsx`, which the GUI redo (#549) stopped mounting. So today it's a real page with no way to get to it from the shell.

Given the actual goal is a page a user can reach, I built Logs the way the one page that *is* currently live and sidebar-wired works — Policies (`PoliciesPage.tsx`) — as an AppShell-embedded component that takes the already-resolved `project` as a prop, rather than a standalone route re-deriving its own profile resolution. `globals.css` already has a comment marking its `.page-*` classes as "generic list/table page chrome (Policies + stubs)," which reads like this was the intended landing spot for the next page in this set. I pulled the loading/empty/error state granularity from Incidents (it's more thorough than Policies') and the visual chrome from Policies.

Net effect: Logs is a new sidebar entry (`kind: 'page'`), wired live, reachable in one click, and shows up in the ⌘K palette for free (it reads off the same nav list).

## Test plan

- [x] `npm run build --workspace @neat.is/types`
- [x] `npx turbo build --filter=@neat.is/core^...`
- [x] `npm run build --workspace @neat.is/web`
- [x] `npm run test --workspace @neat.is/web` — 60/60 passing, including 5 new tests for the Logs page (null-project gate, fetch + render, source-chip filter round-trip, empty state, error state)
- [x] `npm run lint --workspace @neat.is/web` — clean
- [x] `packages/core`'s `contracts.test.ts` "Web shell completeness" (ADR-056) suite — 37/37 passing (audit doc updated in lockstep with the new sidebar entry)
- [ ] Visual verification — not done. No browser tooling available in this environment; build/type/lint/test passing is not the same as confirming it renders correctly.