### PR TITLE
MCP get_logs tool + CLI neat logs verb (ADR-132)

### DIFF
--- a/packages/core/src/cli-client.ts
+++ b/packages/core/src/cli-client.ts
@@ -21,6 +21,7 @@ import type {
   GraphEdge,
   GraphNode,
   HypotheticalAction,
+  LogEntry,
   ObservedDependenciesResult,
   PolicyViolation,
   RootCauseResult,
@@ -749,6 +750,66 @@ export async function runDivergences(
     block: blockLines.join('\n'),
     confidence: maxConfidence,
     provenance: 'composite (EXTRACTED + OBSERVED)',
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// logs (ADR-132) — the eleventh verb. Thin client over GET /logs, the one
+// data path the logs store is read through (docs/contracts/logs.md §5).
+// Mirrors the MCP get_logs tool.
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface LogsInput {
+  // Repeatable — filters to one or more of the fixed source set. Omit for
+  // every source the project has written an entry under.
+  source?: string[]
+  service?: string
+  limit?: number
+  // ISO8601 lower bound, matched against each entry's own timestamp.
+  since?: string
+  project?: string
+}
+
+interface LogsQueryResponse {
+  count: number
+  total: number
+  logs: LogEntry[]
+}
+
+function formatLogLine(e: LogEntry): string {
+  const sev = (e.severity ?? 'info').toUpperCase()
+  const svc = e.serviceName ? ` [${e.serviceName}]` : ''
+  return `  ${e.timestamp} ${sev} (${e.source})${svc} — ${e.message}`
+}
+
+export async function runLogs(client: HttpClient, input: LogsInput): Promise<VerbResult> {
+  const params = new URLSearchParams()
+  if (input.source) {
+    for (const s of input.source) params.append('source', s)
+  }
+  if (input.service) params.set('service', input.service)
+  if (input.limit !== undefined) params.set('limit', String(input.limit))
+  if (input.since) params.set('since', input.since)
+  const qs = params.size > 0 ? `?${params.toString()}` : ''
+
+  const body = await client.get<LogsQueryResponse>(projectPath(input.project, `/logs${qs}`))
+  const logs = body.logs
+  if (logs.length === 0) {
+    return {
+      summary:
+        input.source && input.source.length > 0
+          ? `No log entries recorded for source${input.source.length === 1 ? '' : 's'} ${input.source.join(', ')}.`
+          : 'No log entries recorded.',
+    }
+  }
+  const blockLines = logs.map(formatLogLine)
+  const sourceBit = input.source && input.source.length > 0 ? ` from ${input.source.join(', ')}` : ''
+  return {
+    summary: `${logs.length} log entr${logs.length === 1 ? 'y' : 'ies'} returned (${body.total} total match${body.total === 1 ? '' : 'es'})${sourceBit}.`,
+    block: blockLines.join('\n'),
+    // Log entries are raw observation records, not graph edges — there's no
+    // per-result confidence or EXTRACTED/OBSERVED provenance to report here,
+    // the same n/a case runDiff's non-empty result already takes.
   }
 }
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -42,7 +42,7 @@ import {
 } from './installers/index.js'
 import { runOrchestrator } from './orchestrator.js'
 import { runSync } from './cli-verbs.js'
-import { DivergenceTypeSchema, type DivergenceType } from '@neat.is/types'
+import { DivergenceTypeSchema, LogSourceSchema, type DivergenceType } from '@neat.is/types'
 import {
   createHttpClient,
   exitCodeForError,
@@ -56,6 +56,7 @@ import {
   runDiff,
   runDivergences,
   runIncidents,
+  runLogs,
   runObservedDependencies,
   runPolicies,
   runRootCause,
@@ -193,6 +194,10 @@ export function usage(): void {
   console.log('  divergences                      Where code (EXTRACTED) and production (OBSERVED) disagree.')
   console.log('                                   Flags: --type <list>, --min-confidence <0..1>, --node <id>')
   console.log(`                                   example: ${neat} divergences --min-confidence 0.7`)
+  console.log('  logs                             Recent log entries — native OTLP logs + connector OCloud logs.')
+  console.log('                                   Flags: --source <name> (repeatable, or comma-separated),')
+  console.log('                                          --service <name>, --limit N, --since <date>')
+  console.log(`                                   example: ${neat} logs --source supabase --source railway --limit 50`)
   console.log('')
   console.log('flags:')
   console.log('  --project <name>   Name the project this command targets. Default: "default".')
@@ -238,6 +243,11 @@ interface ParsedArgs {
   // `neat sync` (ADR-074 §1) — remote daemon URL + bearer token.
   to: string | null
   token: string | null
+  // `neat logs` (ADR-132). --source is repeatable — each occurrence (and each
+  // comma-separated segment within one occurrence) appends to this array
+  // rather than overwriting, unlike the single-value STRING_FLAGS fields.
+  source: string[]
+  service: string | null
   positional: string[]
 }
 
@@ -259,6 +269,7 @@ const STRING_FLAGS = [
   ['--min-confidence', 'minConfidence'],
   ['--to', 'to'],
   ['--token', 'token'],
+  ['--service', 'service'],
 ] as const
 
 function parseArgs(rest: string[]): ParsedArgs {
@@ -286,6 +297,8 @@ function parseArgs(rest: string[]): ParsedArgs {
     minConfidence: null,
     to: null,
     token: null,
+    source: [],
+    service: null,
     positional: [],
   }
   for (let i = 0; i < rest.length; i++) {
@@ -301,6 +314,24 @@ function parseArgs(rest: string[]): ParsedArgs {
     if (arg === '--verbose') { out.verbose = true; continue }
     if (arg === '--print-config') { out.printConfig = true; continue }
     if (arg === '--json') { out.json = true; continue }
+
+    // `--source` is repeatable (ADR-132): `--source supabase --source
+    // railway`, or one occurrence with comma-separated values — either
+    // shape appends to the array rather than overwriting.
+    if (arg === '--source' || arg.startsWith('--source=')) {
+      const value = arg === '--source' ? rest[i + 1] : arg.slice('--source='.length)
+      if (arg === '--source') {
+        if (value === undefined) {
+          console.error('neat: --source requires a value')
+          process.exit(2)
+        }
+        i++
+      }
+      for (const part of (value as string).split(',').map((s) => s.trim()).filter((s) => s.length > 0)) {
+        out.source.push(part)
+      }
+      continue
+    }
 
     // String/number flags via the shared table.
     let matched = false
@@ -1015,7 +1046,7 @@ export async function main(): Promise<void> {
   }
 
   // ── Query verbs (ADR-050) ────────────────────────────────────────────
-  // The nine verbs mirror the MCP tool allowlist. Same multi-project
+  // The eleven verbs mirror the MCP tool allowlist. Same multi-project
   // routing, same three-part response shape (summary + block + footer),
   // exit codes branch on misuse vs server error vs daemon-down.
   if (QUERY_VERBS.has(cmd)) {
@@ -1074,6 +1105,8 @@ export const QUERY_VERBS: Set<string> = new Set([
   'policies',
   // Tenth verb (ADR-060) — amends ADR-050's locked allowlist of nine.
   'divergences',
+  // Eleventh verb (ADR-132) — the unified logs surface.
+  'logs',
 ])
 
 // ADR-050 #2: --project flag → NEAT_PROJECT env → undefined (server's
@@ -1338,6 +1371,31 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
         ...(typeFilter ? { type: typeFilter } : {}),
         ...(parsed.minConfidence !== null ? { minConfidence: parsed.minConfidence } : {}),
         ...(parsed.node ? { node: parsed.node } : {}),
+        ...(project ? { project } : {}),
+      })
+      break
+    }
+    case 'logs': {
+      let sourceFilter: string[] | undefined
+      if (parsed.source.length > 0) {
+        const out: string[] = []
+        for (const s of parsed.source) {
+          const r = LogSourceSchema.safeParse(s)
+          if (!r.success) {
+            console.error(
+              `neat logs: unknown --source "${s}". allowed: ${LogSourceSchema.options.join(', ')}`,
+            )
+            return 2
+          }
+          out.push(r.data)
+        }
+        sourceFilter = out
+      }
+      makeWork = (project) => runLogs(client, {
+        ...(sourceFilter ? { source: sourceFilter } : {}),
+        ...(parsed.service ? { service: parsed.service } : {}),
+        ...(parsed.limit !== null ? { limit: parsed.limit } : {}),
+        ...(parsed.since ? { since: parsed.since } : {}),
         ...(project ? { project } : {}),
       })
       break

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -6236,6 +6236,8 @@ describe('CLI surface contract (ADR-050)', () => {
     check_policies: 'policies',
     // Tenth pairing added by ADR-060 — the thesis surface.
     get_divergences: 'divergences',
+    // Eleventh pairing added by ADR-132 — the unified logs surface.
+    get_logs: 'logs',
   } as const
 
   it('every MCP tool from ADR-039 has a corresponding `neat <verb>` registered (ADR-050 #1)', async () => {
@@ -8310,9 +8312,10 @@ describe('Divergence query (ADR-060)', () => {
   it('neat divergences is registered as the tenth CLI verb — extends ADR-050 allowlist (ADR-060 #4 — amendment)', async () => {
     const { QUERY_VERBS } = await import('../../src/cli.js')
     expect(QUERY_VERBS.has('divergences')).toBe(true)
-    // Confirms the verb is part of the ten-mirror map captured by the
-    // earlier ADR-050 contract test.
-    expect(QUERY_VERBS.size).toBe(10)
+    // Confirms the verb is part of the eleven-mirror map captured by the
+    // earlier ADR-050 contract test — divergences was the tenth addition,
+    // logs (ADR-132) is the eleventh.
+    expect(QUERY_VERBS.size).toBe(11)
   })
 
   it('neat divergences --json emits machine-readable DivergenceResult (ADR-060 #4)', async () => {
@@ -8369,6 +8372,117 @@ describe('Divergence query (ADR-060)', () => {
     expect(url).toContain('type=missing-observed%2Cmissing-extracted')
     expect(url).toContain('minConfidence=0.6')
     expect(url).toContain('node=service%3Acheckout')
+  })
+
+  // ── get_logs / neat logs (ADR-132) — the unified logs surface ──────────
+
+  it('get_logs is registered via the @neat.is/types manifest (ADR-132)', () => {
+    const indexTs = readFileSync(join(MCP_SRC, 'index.ts'), 'utf8')
+    expect(indexTs).toMatch(/registerTool\(\s*['"]get_logs['"]/)
+  })
+
+  it('get_logs MCP response is three-part: NL summary + structured block + footer, n/a confidence/provenance (ADR-132)', async () => {
+    const { getLogs } = await import('../../../mcp/src/tools.js')
+    const stubClient = {
+      async get<T>(): Promise<T> {
+        return {
+          count: 1,
+          total: 1,
+          logs: [
+            {
+              id: 'log-1',
+              projectName: 'default',
+              source: 'native',
+              serviceName: 'checkout',
+              timestamp: '2026-07-03T11:30:00.000Z',
+              severity: 'error',
+              message: 'payment capture failed',
+            },
+          ],
+        } as unknown as T
+      },
+    }
+    const result = await getLogs(stubClient, {})
+    const text = (result.content[0] as { text: string }).text
+    const sections = text.split('\n\n')
+    expect(sections.length).toBeGreaterThanOrEqual(3)
+    // Logs are raw observation records, not graph edges — no per-result
+    // confidence/provenance to report, per the contract's n/a convention.
+    expect(sections[sections.length - 1]).toMatch(/confidence: n\/a · provenance: n\/a/)
+  })
+
+  it('neat logs is registered as the eleventh CLI verb — extends ADR-050 allowlist (ADR-132 amendment)', async () => {
+    const { QUERY_VERBS } = await import('../../src/cli.js')
+    expect(QUERY_VERBS.has('logs')).toBe(true)
+  })
+
+  it('neat logs --json emits the three-part machine-readable shape (ADR-132)', async () => {
+    const { runLogs, formatJson } = await import('../../src/cli-client.js')
+    const stubClient = {
+      async get<T>(): Promise<T> {
+        return {
+          count: 1,
+          total: 1,
+          logs: [
+            {
+              id: 'log-1',
+              projectName: 'default',
+              source: 'supabase',
+              timestamp: '2026-07-03T11:00:00.000Z',
+              severity: 'warn',
+              message: 'connection pool near limit',
+            },
+          ],
+        } as unknown as T
+      },
+    }
+    const result = await runLogs(stubClient, {})
+    const parsed = JSON.parse(formatJson(result)) as Record<string, unknown>
+    expect(parsed.summary).toMatch(/1 log entry returned/)
+    expect(parsed.confidence).toBeNull()
+    expect(parsed.provenance).toBeNull()
+  })
+
+  it('neat logs --source (repeatable), --service, --limit, --since propagate to GET /logs (ADR-132)', async () => {
+    const { runLogs } = await import('../../src/cli-client.js')
+    const captured: string[] = []
+    const stubClient = {
+      async get<T>(path: string): Promise<T> {
+        captured.push(path)
+        return { count: 0, total: 0, logs: [] } as unknown as T
+      },
+    }
+    await runLogs(stubClient, {
+      source: ['supabase', 'railway'],
+      service: 'checkout',
+      limit: 25,
+      since: '2026-07-01T00:00:00.000Z',
+      project: 'alpha',
+    })
+    const url = captured[0]!
+    expect(url).toContain('/projects/alpha/logs')
+    expect(url).toContain('source=supabase')
+    expect(url).toContain('source=railway')
+    expect(url).toContain('service=checkout')
+    expect(url).toContain('limit=25')
+    expect(url).toContain('since=2026-07-01T00%3A00%3A00.000Z')
+  })
+
+  it('neat logs rejects an unknown --source before any network call (misuse, exit 2)', async () => {
+    const { parseArgs, runQueryVerb } = await import('../../src/cli.js')
+    const prevErr = console.error
+    let stderrBuf = ''
+    console.error = (...args: unknown[]) => {
+      stderrBuf += args.join(' ') + '\n'
+    }
+    try {
+      const parsed = parseArgs(['--source', 'not-a-real-source'])
+      const code = await runQueryVerb('logs', parsed)
+      expect(code).toBe(2)
+      expect(stderrBuf).toMatch(/unknown --source/)
+    } finally {
+      console.error = prevErr
+    }
   })
 
   it('computeDivergences detects missing-observed: EXTRACTED edge without OBSERVED counterpart (ADR-060 #5)', async () => {

--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -1,6 +1,6 @@
 # @neat.is/mcp
 
-The NEAT MCP server. Stdio JSON-RPC, sixteen tools and two resources, talks to a running `@neat.is/core` instance over HTTP. The tool surface is single-sourced from `MCP_TOOL_NAMES` in `@neat.is/types` (ADR-091) — ten read-only graph queries plus six `/neat extend` tools.
+The NEAT MCP server. Stdio JSON-RPC, seventeen tools and two resources, talks to a running `@neat.is/core` instance over HTTP. The tool surface is single-sourced from `MCP_TOOL_NAMES` in `@neat.is/types` (ADR-091) — eleven read-only graph/log queries plus six `/neat extend` tools.
 
 ## When to use these tools
 
@@ -20,6 +20,7 @@ Rule of thumb: if the question would take more than two file reads to answer fro
 | "What changed since the last snapshot?"              | `get_graph_diff`           |
 | "Which integrations have gone quiet?"                | `get_recent_stale_edges`   |
 | "Any policy violations right now?"                   | `check_policies`           |
+| "What did this service log around the incident?"     | `get_logs`                 |
 
 If a tool returns "not found" or empty, check that core is running (`curl $NEAT_CORE_URL/health`) before falling back to source reads.
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,6 +7,7 @@ import {
   CheckPoliciesScopeSchema,
   DivergenceTypeSchema,
   HypotheticalActionSchema,
+  LogSourceSchema,
   type MCPToolName,
 } from '@neat.is/types'
 import { resolveBaseUrl } from './base-url.js'
@@ -19,6 +20,7 @@ import {
   getDivergences,
   getGraphDiff,
   getIncidentHistory,
+  getLogs,
   getObservedDependencies,
   getRecentStaleEdges,
   getRootCause,
@@ -209,6 +211,33 @@ registerTool(
   },
   async (input) =>
     getDivergences(client, { ...input, project: projectFor(input) }),
+)
+
+registerTool(
+  'get_logs',
+  'Return recent log entries — native OTLP logs and connector-sourced OCloud logs (Supabase/Railway/Firebase/Cloudflare/Vercel) — from the unified per-project logs surface, newest first. Use this to see what a service actually logged around an incident, or to scope to one provider.',
+  {
+    source: z
+      .array(LogSourceSchema)
+      .optional()
+      .describe(
+        'Filter to one or more sources: native, supabase, railway, firebase, cloudflare, vercel. Omit for every source.',
+      ),
+    service: z.string().optional().describe('Filter to logs from this service name'),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(1000)
+      .optional()
+      .describe('Max entries to return (default 100, max 1000)'),
+    since: z
+      .string()
+      .optional()
+      .describe('ISO8601 lower bound — only entries at or after this timestamp'),
+    project: projectField,
+  },
+  async (input) => getLogs(client, { ...input, project: projectFor(input) }),
 )
 
 registerTool(

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -15,6 +15,7 @@ import type {
   GraphEdge,
   GraphNode,
   HypotheticalAction,
+  LogEntry,
   ObservedDependenciesResult,
   PolicyViolation,
   RootCauseResult,
@@ -512,6 +513,69 @@ export async function getRecentStaleEdges(
       block: blockLines.join('\n'),
       // STALE by definition — every event is a transition into STALE.
       provenance: Provenance.STALE,
+    })
+  } catch (err) {
+    return formatErrorResponse(`Error talking to neat-core: ${(err as Error).message}`)
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// get_logs (ADR-132) — thin client over GET /logs, the one data path the
+// logs store is read through (docs/contracts/logs.md §5). No graph.json,
+// no logs-store.ts import — REST only, same as every other tool here.
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface LogsInput {
+  // Repeatable — filters to one or more of the fixed source set. Omit for
+  // every source the project has written an entry under.
+  source?: string[]
+  service?: string
+  limit?: number
+  // ISO8601 lower bound, matched against each entry's own timestamp.
+  since?: string
+  project?: string
+}
+
+interface LogsQueryResponse {
+  count: number
+  total: number
+  logs: LogEntry[]
+}
+
+function formatLogLine(e: LogEntry): string {
+  const sev = (e.severity ?? 'info').toUpperCase()
+  const svc = e.serviceName ? ` [${e.serviceName}]` : ''
+  return `  ${e.timestamp} ${sev} (${e.source})${svc} — ${e.message}`
+}
+
+export async function getLogs(client: HttpClient, input: LogsInput): Promise<ToolResponse> {
+  const params = new URLSearchParams()
+  if (input.source) {
+    for (const s of input.source) params.append('source', s)
+  }
+  if (input.service) params.set('service', input.service)
+  if (input.limit !== undefined) params.set('limit', String(input.limit))
+  if (input.since) params.set('since', input.since)
+  const qs = params.size > 0 ? `?${params.toString()}` : ''
+
+  try {
+    const body = await client.get<LogsQueryResponse>(projectPath(input.project, `/logs${qs}`))
+    const logs = body.logs
+    if (logs.length === 0) {
+      return formatEmptyResponse(
+        input.source && input.source.length > 0
+          ? `No log entries recorded for source${input.source.length === 1 ? '' : 's'} ${input.source.join(', ')}.`
+          : 'No log entries recorded.',
+      )
+    }
+    const blockLines = logs.map(formatLogLine)
+    const sourceBit = input.source && input.source.length > 0 ? ` from ${input.source.join(', ')}` : ''
+    return formatToolResponse({
+      summary: `${logs.length} log entr${logs.length === 1 ? 'y' : 'ies'} returned (${body.total} total match${body.total === 1 ? '' : 'es'})${sourceBit}.`,
+      block: blockLines.join('\n'),
+      // Log entries are raw observation records, not graph edges — there's no
+      // per-result confidence or EXTRACTED/OBSERVED provenance to report here,
+      // the same n/a case get_graph_diff's non-empty result already takes.
     })
   } catch (err) {
     return formatErrorResponse(`Error talking to neat-core: ${(err as Error).message}`)

--- a/packages/mcp/test/stdio-smoke.test.ts
+++ b/packages/mcp/test/stdio-smoke.test.ts
@@ -68,12 +68,12 @@ describe('MCP server stdio smoke', () => {
     expect(info?.name).toBe('neat')
   })
 
-  it('lists exactly the manifest tool surface (all 16 names)', async () => {
+  it('lists exactly the manifest tool surface (all 17 names)', async () => {
     const { tools } = await client.listTools()
     const names = tools.map((t) => t.name).sort()
     expect(names).toEqual([...MCP_TOOL_NAMES].sort())
-    // The manifest is 16 today (ten read tools + six extend tools).
-    expect(names).toHaveLength(16)
+    // The manifest is 17 today (eleven read tools + six extend tools).
+    expect(names).toHaveLength(17)
   })
 
   it('drives a read wrapper to the core and surfaces the unreachable core as isError', async () => {

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -7,6 +7,7 @@ import {
   getDependencies,
   getGraphDiff,
   getIncidentHistory,
+  getLogs,
   getObservedDependencies,
   getRecentStaleEdges,
   getRootCause,
@@ -641,6 +642,86 @@ describe('getRecentStaleEdges', () => {
   })
 })
 
+describe('getLogs', () => {
+  it('formats a list of log entries newest-first', async () => {
+    const { client, capture } = clientFor({
+      '/logs': {
+        count: 2,
+        total: 2,
+        logs: [
+          {
+            id: 'log-2',
+            projectName: 'default',
+            source: 'native',
+            serviceName: 'checkout',
+            timestamp: '2026-07-03T11:30:00.000Z',
+            severity: 'error',
+            message: 'payment capture failed',
+          },
+          {
+            id: 'log-1',
+            projectName: 'default',
+            source: 'supabase',
+            timestamp: '2026-07-03T11:00:00.000Z',
+            severity: 'warn',
+            message: 'connection pool near limit',
+          },
+        ],
+      },
+    })
+    const res = await getLogs(client, {})
+    const out = res.content[0].text
+    expect(out).toContain('2 log entries returned (2 total match')
+    expect(out).toContain('ERROR (native) [checkout] — payment capture failed')
+    expect(out).toContain('WARN (supabase) — connection pool near limit')
+    // Logs are raw observation records — no per-result confidence/provenance,
+    // the same n/a case get_graph_diff's non-empty result takes.
+    expect(out).toMatch(/confidence: n\/a · provenance: n\/a/)
+    expect(capture.paths[0]).toBe('/logs')
+  })
+
+  it('returns a friendly empty message', async () => {
+    const { client } = clientFor({
+      '/logs': { count: 0, total: 0, logs: [] },
+    })
+    const res = await getLogs(client, {})
+    expect(res.content[0].text).toContain('No log entries recorded.')
+  })
+
+  it('returns a source-scoped empty message', async () => {
+    const { client } = clientFor({
+      '/logs?source=railway': { count: 0, total: 0, logs: [] },
+    })
+    const res = await getLogs(client, { source: ['railway'] })
+    expect(res.content[0].text).toContain('No log entries recorded for source railway.')
+  })
+
+  it('passes source (repeatable), service, limit, since as query params', async () => {
+    const { client, capture } = clientFor({
+      '/logs?source=supabase&source=railway&service=checkout&limit=10&since=2026-07-01T00:00:00.000Z':
+        { count: 0, total: 0, logs: [] },
+    })
+    await getLogs(client, {
+      source: ['supabase', 'railway'],
+      service: 'checkout',
+      limit: 10,
+      since: '2026-07-01T00:00:00.000Z',
+    })
+    expect(capture.paths[0]).toContain('source=supabase')
+    expect(capture.paths[0]).toContain('source=railway')
+    expect(capture.paths[0]).toContain('service=checkout')
+    expect(capture.paths[0]).toContain('limit=10')
+    expect(capture.paths[0]).toContain('since=2026-07-01T00%3A00%3A00.000Z')
+  })
+
+  it('surfaces transport errors', async () => {
+    const client = errorClient(new Error('ECONNREFUSED'))
+    const res = await getLogs(client, {})
+    expect(res.isError).toBe(true)
+    expect(res.content[0].text).toContain('Error talking to neat-core')
+  })
+})
+
 describe('project routing', () => {
   it('threads project through every tool URL when set', async () => {
     const { client, capture } = clientFor({
@@ -679,6 +760,7 @@ describe('project routing', () => {
         changed: { nodes: [], edges: [] },
       },
       '/projects/alpha/stale-events': { count: 0, total: 0, events: [] },
+      '/projects/alpha/logs': { count: 0, total: 0, logs: [] },
     })
 
     await getRootCause(client, { errorNode: 'database:payments-db', project: 'alpha' })
@@ -689,6 +771,7 @@ describe('project routing', () => {
     await semanticSearch(client, { query: 'foo', project: 'alpha' })
     await getGraphDiff(client, { againstSnapshot: 'snap.json', project: 'alpha' })
     await getRecentStaleEdges(client, { project: 'alpha' })
+    await getLogs(client, { project: 'alpha' })
 
     for (const p of capture.paths) {
       expect(p.startsWith('/projects/alpha/')).toBe(true)

--- a/packages/types/src/mcp-tools.ts
+++ b/packages/types/src/mcp-tools.ts
@@ -13,6 +13,8 @@ export const MCP_TOOL_NAMES = [
   'get_recent_stale_edges',
   'check_policies',
   'get_divergences',
+  // Unified logs surface (ADR-132, #691) — reads GET /logs over REST.
+  'get_logs',
   // Six /neat extend tools (ADR-081, ADR-086, #387).
   'neat_list_uninstrumented',
   'neat_lookup_instrumentation',


### PR DESCRIPTION
Refs #691. Builds on #690 (the logs store + REST endpoint) — this PR's diff will shrink once #690 merges and this gets retargeted to main.

## What this adds

- MCP `get_logs(source?, service?, limit?, since?)` tool, registered in `MCP_TOOL_NAMES` and `packages/mcp/src/index.ts` following the exact pattern every other tool uses. REST-only — calls `GET /logs` through the shared `HttpClient`, never reads `logs-store.ts` or `graph.json` directly.
- CLI `neat logs [--source <name>] [--service <name>] [--limit N] [--since <date>]`, the eleventh query verb. `--source` is repeatable (`--source supabase --source railway`) and also accepts one comma-separated value for convenience.
- Both go through the existing three-part response shape (NL summary + structured block + confidence/provenance footer). Log entries aren't graph edges, so there's no OBSERVED/EXTRACTED provenance or confidence to report — the footer reads `n/a · n/a`, the same case `get_graph_diff`'s non-empty result already takes.
- Human and `--json` output for the CLI verb both route through the existing `formatHuman`/`formatJson` helpers, unchanged.

## Judgment calls

- `--source` repeatable vs comma-separated: implemented both. The contract text says "repeatable," so each `--source` occurrence accumulates; a single occurrence with commas also splits and accumulates, since that's a nice-to-have and free to support given the parsing already needed comma-splitting for `--type`/divergences.
- CLI `--json`: kept the same three-part `{ summary, block, confidence, provenance }` envelope every other verb's `--json` uses (per `cli-surface.md`'s "same three sections as named fields" rule), rather than passing through the raw REST `{ count, total, logs }` envelope. That raw envelope is what `GET /logs` itself returns and what MCP/CLI/frontend all read from — it isn't the CLI's own `--json` output shape, which is locked to the three-part format for every other verb (`incidents`, `stale-edges`, `divergences`, etc). Keeping `logs` consistent with that precedent.

## Contract test updates

`docs/contracts/cli-surface.md` and `docs/contracts/logs.md` already state an eleven-verb CLI surface with `logs` as the eleventh verb, and MCP tool manifest is explicitly "not count-locked" per `mcp-tools.md`. Updated the two places that had the old counts hardcoded:
- `packages/core/test/audits/contracts.test.ts`: `MCP_TOOLS_TO_VERBS` gains `get_logs: 'logs'`; `QUERY_VERBS.size` assertion moves from 10 to 11. Added dedicated coverage for `get_logs`/`neat logs` (manifest registration, three-part response with n/a footer, repeatable `--source` + other filters propagating to REST, misuse exit code for an unknown `--source`).
- `packages/mcp/test/stdio-smoke.test.ts`: manifest tool count moves from 16 to 17.

## Test plan

- [x] `npm run build --workspace @neat.is/types`
- [x] `npx turbo build --filter=@neat.is/core^...`
- [x] `npm run build --workspace @neat.is/mcp`
- [x] `npx vitest run --root packages/core` — 70/70 files, 1362 passed, 2 skipped, 5 todo (pre-existing)
- [x] `npx vitest run --root packages/mcp` — 5/5 files, 94 passed
- [x] `npx turbo lint` on the touched packages — clean (one pre-existing unrelated warning in `orchestrator.ts`)
- [x] Manual end-to-end smoke: stub REST server + `packages/core/dist/cli.cjs logs` (human + `--json`, repeatable and comma-separated `--source`, misuse exit code 2) and `packages/mcp/dist/index.cjs` over stdio JSON-RPC calling `get_logs` — all confirmed working, including that repeated/comma `--source` values reach the server as `?source=a&source=b`.

Do not merge — leaving open for review.