### PR TITLE
Add the native OTLP logs receiver (ADR-132)

### DIFF
--- a/packages/core/proto/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/packages/core/proto/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -1,0 +1,31 @@
+// Copyright 2020, OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bundled from https://github.com/open-telemetry/opentelemetry-proto.
+syntax = "proto3";
+
+package opentelemetry.proto.collector.logs.v1;
+
+import "opentelemetry/proto/logs/v1/logs.proto";
+
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.collector.logs.v1";
+option java_outer_classname = "LogsServiceProto";
+option go_package = "go.opentelemetry.io/proto/otlp/collector/logs/v1";
+
+service LogsService {
+  rpc Export(ExportLogsServiceRequest) returns (ExportLogsServiceResponse) {}
+}
+
+message ExportLogsServiceRequest {
+  repeated opentelemetry.proto.logs.v1.ResourceLogs resource_logs = 1;
+}
+
+message ExportLogsServiceResponse {
+  ExportLogsPartialSuccess partial_success = 1;
+}
+
+message ExportLogsPartialSuccess {
+  int64 rejected_log_records = 1;
+  string error_message = 2;
+}

--- a/packages/core/proto/opentelemetry/proto/logs/v1/logs.proto
+++ b/packages/core/proto/opentelemetry/proto/logs/v1/logs.proto
@@ -1,0 +1,80 @@
+// Copyright 2020, OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bundled from https://github.com/open-telemetry/opentelemetry-proto.
+syntax = "proto3";
+
+package opentelemetry.proto.logs.v1;
+
+import "opentelemetry/proto/common/v1/common.proto";
+import "opentelemetry/proto/resource/v1/resource.proto";
+
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.logs.v1";
+option java_outer_classname = "LogsProto";
+option go_package = "go.opentelemetry.io/proto/otlp/logs/v1";
+
+message LogsData {
+  repeated ResourceLogs resource_logs = 1;
+}
+
+message ResourceLogs {
+  reserved 1000;
+  opentelemetry.proto.resource.v1.Resource resource = 1;
+  repeated ScopeLogs scope_logs = 2;
+  string schema_url = 3;
+}
+
+message ScopeLogs {
+  opentelemetry.proto.common.v1.InstrumentationScope scope = 1;
+  repeated LogRecord log_records = 2;
+  string schema_url = 3;
+}
+
+enum SeverityNumber {
+  SEVERITY_NUMBER_UNSPECIFIED = 0;
+  SEVERITY_NUMBER_TRACE = 1;
+  SEVERITY_NUMBER_TRACE2 = 2;
+  SEVERITY_NUMBER_TRACE3 = 3;
+  SEVERITY_NUMBER_TRACE4 = 4;
+  SEVERITY_NUMBER_DEBUG = 5;
+  SEVERITY_NUMBER_DEBUG2 = 6;
+  SEVERITY_NUMBER_DEBUG3 = 7;
+  SEVERITY_NUMBER_DEBUG4 = 8;
+  SEVERITY_NUMBER_INFO = 9;
+  SEVERITY_NUMBER_INFO2 = 10;
+  SEVERITY_NUMBER_INFO3 = 11;
+  SEVERITY_NUMBER_INFO4 = 12;
+  SEVERITY_NUMBER_WARN = 13;
+  SEVERITY_NUMBER_WARN2 = 14;
+  SEVERITY_NUMBER_WARN3 = 15;
+  SEVERITY_NUMBER_WARN4 = 16;
+  SEVERITY_NUMBER_ERROR = 17;
+  SEVERITY_NUMBER_ERROR2 = 18;
+  SEVERITY_NUMBER_ERROR3 = 19;
+  SEVERITY_NUMBER_ERROR4 = 20;
+  SEVERITY_NUMBER_FATAL = 21;
+  SEVERITY_NUMBER_FATAL2 = 22;
+  SEVERITY_NUMBER_FATAL3 = 23;
+  SEVERITY_NUMBER_FATAL4 = 24;
+}
+
+enum LogRecordFlags {
+  LOG_RECORD_FLAGS_DO_NOT_USE = 0;
+  LOG_RECORD_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
+}
+
+message LogRecord {
+  reserved 4;
+  fixed64 time_unix_nano = 1;
+  fixed64 observed_time_unix_nano = 11;
+  SeverityNumber severity_number = 2;
+  string severity_text = 3;
+  opentelemetry.proto.common.v1.AnyValue body = 5;
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 6;
+  uint32 dropped_attributes_count = 7;
+  fixed32 flags = 8;
+  bytes trace_id = 9;
+  bytes span_id = 10;
+  string event_name = 12;
+}

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -43,6 +43,8 @@ import { loadGraphFromDisk, saveGraphToDisk, startPersistLoop } from './persist.
 import { Projects, pathsForProject, type ProjectPaths } from './projects.js'
 import { buildApi } from './api.js'
 import { buildOtelReceiver, listenSteppingOtlp } from './otel.js'
+import { registerOtelLogsRoutes, type ParsedLogRecord } from './otel-logs.js'
+import { appendLogEntry } from './logs-store.js'
 import { attachGraphToEventBus } from './events.js'
 import { handleSpan, makeErrorSpanWriter, startStalenessLoop } from './ingest.js'
 import { startConnectorPollLoop, type ConnectorRegistration } from './connectors/index.js'
@@ -1115,6 +1117,59 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
           await makeErrorSpanWriter(slot.paths.errorsPath, slot.graph, slot.entry.path)(span)
         },
       })
+
+      // /v1/logs (ADR-132, docs/contracts/logs.md). Mounted onto the same
+      // Fastify app — and therefore the same OTLP port — as /v1/traces
+      // above, registered before listenSteppingOtlp binds it below so the
+      // routes exist by the time the socket opens. Reusing project routing
+      // (resolveTargetSlot / resolveSlotByName, the exact functions the
+      // trace receiver above uses) rather than reinventing it for logs — a
+      // log record's service.name resolves to a project the same way a
+      // span's does. The one wording nuance: a dropped/unrouted log record
+      // still logs and records itself through warnDroppedSpan /
+      // recordUnroutedSpan, so the diagnostic line and errors.ndjson
+      // `reason` field say "span" even when what was actually dropped is a
+      // log record — cosmetic, not a data-correctness issue, and reusing the
+      // real routing logic outweighs a wording fix that would require
+      // duplicating the broken/unrouted bookkeeping those closures already
+      // own.
+      //
+      // This receiver never touches NeatGraph: no node is looked up, none is
+      // created. `serviceName` rides onto the LogEntry as a plain string —
+      // per otel-ingest.md's ADR-132 section, a log naming an unseen service
+      // auto-creates nothing.
+      function toLogEntry(projectName: string, record: ParsedLogRecord) {
+        appendLogEntry({
+          id: record.id,
+          projectName,
+          source: 'native',
+          serviceName: record.serviceName,
+          timestamp: record.timestamp,
+          severity: record.severity,
+          message: record.message,
+          attributes:
+            Object.keys(record.attributes).length > 0 ? record.attributes : undefined,
+        })
+      }
+      registerOtelLogsRoutes(otlpApp, {
+        onLogRecord: async (record) => {
+          const traceId = typeof record.attributes.trace_id === 'string'
+            ? record.attributes.trace_id
+            : undefined
+          const slot = await resolveTargetSlot(record.serviceName, traceId)
+          if (!slot) return
+          toLogEntry(slot.entry.name, record)
+        },
+        onProjectLogRecord: async (project, record) => {
+          const traceId = typeof record.attributes.trace_id === 'string'
+            ? record.attributes.trace_id
+            : undefined
+          const slot = await resolveSlotByName(project, record.serviceName, traceId)
+          if (!slot) return
+          toLogEntry(slot.entry.name, record)
+        },
+      })
+
       // A held OTLP port steps to the next free one rather than crashing the
       // daemon (daemon.md §Binding). The recorded daemon.json port below reads
       // back from otlpAddress, so a stepped port is what otel-init resolves.

--- a/packages/core/src/otel-logs.ts
+++ b/packages/core/src/otel-logs.ts
@@ -1,0 +1,591 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { randomUUID } from 'node:crypto'
+import Fastify, { type FastifyInstance } from 'fastify'
+import protobuf from 'protobufjs'
+import { mountBearerAuth } from './auth.js'
+
+// OTLP/HTTP logs receiver (ADR-132, docs/contracts/logs.md, the
+// otel-ingest.md "sibling /v1/logs receiver" amendment). Structurally this
+// is `otel.ts`'s `/v1/traces` receiver retargeted at the OTLP *logs* signal:
+// same JSON + protobuf content-type dispatch, same bearer-token gate, same
+// non-blocking-receiver shape. The one deliberate difference is the
+// destination — this module never touches `NeatGraph`. It only ever
+// produces `ParsedLogRecord`s for a caller-supplied handler to turn into
+// `LogEntry`s via `logs-store.ts`'s `appendLogEntry`. No node is minted, no
+// edge is minted, no graph is read.
+
+export interface ParsedLogRecord {
+  // Synthetic — OTLP log records carry no wire-level identity the way a span
+  // carries `(traceId, spanId)`. Most structured-logger output has neither a
+  // trace nor a span attached, so `randomUUID()` (already the codebase's
+  // convention — see connectors/cloudflare/client.ts) is the honest choice
+  // over fabricating one from fields that are frequently absent.
+  id: string
+  // `resource.attributes['service.name']`. Left undefined when the resource
+  // didn't carry one — unlike a span, a log record mints nothing and needs
+  // no service to route against, so there's no pressure to fall back to a
+  // placeholder like span parsing's `'unidentified'`.
+  serviceName?: string
+  resourceServiceNamePresent?: boolean
+  // ISO8601. Always set: `timeUnixNano` when present, else
+  // `observedTimeUnixNano` (the proto's own documented fallback order),
+  // else wall-clock as a last resort so a record is never dropped merely for
+  // missing every timestamp signal.
+  timestamp: string
+  // Normalized 'debug' | 'info' | 'warn' | 'error'. Undefined when neither
+  // `severityNumber` nor `severityText` yields a signal.
+  severity?: string
+  message: string
+  // The log record's own attributes, flattened, plus (when present)
+  // `trace_id` / `span_id` as a cross-reference back to the trace that
+  // produced it. `code.filepath` / `code.lineno`, when the SDK stamped them,
+  // ride through here unchanged — no special-casing needed since they're
+  // ordinary OTLP attributes.
+  attributes: Record<string, unknown>
+}
+
+export type LogRecordHandler = (record: ParsedLogRecord) => void | Promise<void>
+// Project-scoped variant, mirroring otel.ts's ProjectSpanHandler — used by
+// `/projects/:project/v1/logs` once the URL already names the project.
+export type ProjectLogRecordHandler = (
+  project: string,
+  record: ParsedLogRecord,
+) => void | Promise<void>
+
+interface OtlpAnyValue {
+  stringValue?: string
+  intValue?: string | number
+  doubleValue?: number
+  boolValue?: boolean
+  arrayValue?: { values?: OtlpAnyValue[] }
+  kvlistValue?: { values?: OtlpKeyValue[] }
+  bytesValue?: string
+}
+
+interface OtlpKeyValue {
+  key: string
+  value?: OtlpAnyValue
+}
+
+interface OtlpLogRecord {
+  timeUnixNano?: string
+  observedTimeUnixNano?: string
+  severityNumber?: number
+  severityText?: string
+  body?: OtlpAnyValue
+  attributes?: OtlpKeyValue[]
+  traceId?: string
+  spanId?: string
+}
+
+interface OtlpScopeLogs {
+  logRecords?: OtlpLogRecord[]
+}
+
+interface OtlpResourceLogs {
+  resource?: { attributes?: OtlpKeyValue[] }
+  scopeLogs?: OtlpScopeLogs[]
+}
+
+export interface OtlpLogsRequest {
+  resourceLogs?: OtlpResourceLogs[]
+}
+
+function flattenAnyValue(v: OtlpAnyValue | undefined): unknown {
+  if (!v) return null
+  if (v.stringValue !== undefined) return v.stringValue
+  if (v.boolValue !== undefined) return v.boolValue
+  if (v.intValue !== undefined) {
+    return typeof v.intValue === 'string' ? Number(v.intValue) : v.intValue
+  }
+  if (v.doubleValue !== undefined) return v.doubleValue
+  if (v.arrayValue?.values) return v.arrayValue.values.map((x) => flattenAnyValue(x))
+  if (v.kvlistValue?.values) {
+    const out: Record<string, unknown> = {}
+    for (const kv of v.kvlistValue.values) {
+      if (kv.key) out[kv.key] = flattenAnyValue(kv.value)
+    }
+    return out
+  }
+  if (v.bytesValue !== undefined) return v.bytesValue
+  return null
+}
+
+function attrsToRecord(attrs: OtlpKeyValue[] | undefined): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  if (!attrs) return out
+  for (const kv of attrs) {
+    if (kv.key) out[kv.key] = flattenAnyValue(kv.value)
+  }
+  return out
+}
+
+// `body` is an `AnyValue` (docs/contracts/otel-ingest.md's ADR-132 section).
+// Structured loggers overwhelmingly emit a plain string body; anything else
+// (a numeric/bool body, or a structured object a logger chose to attach as
+// the body rather than as attributes) is stringified rather than dropped.
+function messageFromBody(body: OtlpAnyValue | undefined): string {
+  if (!body) return ''
+  if (body.stringValue !== undefined) return body.stringValue
+  const flattened = flattenAnyValue(body)
+  if (flattened === null || flattened === undefined) return ''
+  if (typeof flattened === 'string') return flattened
+  try {
+    return JSON.stringify(flattened)
+  } catch {
+    return String(flattened)
+  }
+}
+
+// OTel's SeverityNumber buckets (1-4 TRACE, 5-8 DEBUG, 9-12 INFO, 13-16
+// WARN, 17-20 ERROR, 21-24 FATAL). `LogEntry.severity` only has four
+// buckets, so TRACE folds into 'debug' and FATAL folds into 'error' — the
+// nearest neighbour in each case, and consistent with how most log
+// frontends collapse a finer OTel scale onto a four-level one.
+function severityFromNumber(n: number | undefined): string | undefined {
+  if (typeof n !== 'number' || n <= 0) return undefined
+  if (n >= 17) return 'error'
+  if (n >= 13) return 'warn'
+  if (n >= 9) return 'info'
+  return 'debug'
+}
+
+const SEVERITY_TEXT_PATTERNS: ReadonlyArray<[RegExp, string]> = [
+  [/^(fatal|critical|crit|panic|error|err)/i, 'error'],
+  [/^warn/i, 'warn'],
+  [/^(info|notice|log)/i, 'info'],
+  [/^(trace|debug)/i, 'debug'],
+]
+
+function severityFromText(t: string | undefined): string | undefined {
+  if (!t) return undefined
+  const trimmed = t.trim()
+  for (const [re, sev] of SEVERITY_TEXT_PATTERNS) {
+    if (re.test(trimmed)) return sev
+  }
+  return undefined
+}
+
+// `severityNumber` is the canonical, spec-defined numeric signal — prefer it
+// when present. `severityText` (the log-library's own level string) is the
+// fallback for producers that only set the text form.
+function normalizeSeverity(
+  severityNumber: number | undefined,
+  severityText: string | undefined,
+): string | undefined {
+  return severityFromNumber(severityNumber) ?? severityFromText(severityText)
+}
+
+// Same conversion `otel.ts` uses for `startTimeUnixNano`, duplicated locally
+// rather than imported — logs.md/otel-ingest.md govern this file
+// independently of otel.ts, and the conversion itself is a two-line, ADR-free
+// utility not worth a cross-file dependency for.
+function isoFromUnixNano(nanos: string | undefined): string | undefined {
+  if (!nanos || nanos === '0') return undefined
+  try {
+    const ms = Number(BigInt(nanos) / 1_000_000n)
+    if (!Number.isFinite(ms)) return undefined
+    return new Date(ms).toISOString()
+  } catch {
+    return undefined
+  }
+}
+
+// time_unix_nano first, observed_time_unix_nano second (the proto's own
+// documented recommendation), wall-clock last. A record is never dropped
+// merely for missing every timestamp signal — the honest fallback mirrors
+// `pickEnv`'s literal-'unknown' pattern in otel.ts rather than fabricating a
+// span-time-shaped value from nothing.
+function timestampOf(record: OtlpLogRecord): string {
+  return (
+    isoFromUnixNano(record.timeUnixNano) ??
+    isoFromUnixNano(record.observedTimeUnixNano) ??
+    new Date().toISOString()
+  )
+}
+
+export function parseOtlpLogsRequest(body: OtlpLogsRequest): ParsedLogRecord[] {
+  const out: ParsedLogRecord[] = []
+  for (const rl of body.resourceLogs ?? []) {
+    const resourceAttrs = attrsToRecord(rl.resource?.attributes)
+    const rawServiceName = resourceAttrs['service.name']
+    const resourceServiceNamePresent =
+      typeof rawServiceName === 'string' && rawServiceName.length > 0
+    const serviceName = resourceServiceNamePresent ? (rawServiceName as string) : undefined
+
+    for (const sl of rl.scopeLogs ?? []) {
+      for (const lr of sl.logRecords ?? []) {
+        const attributes = attrsToRecord(lr.attributes)
+        // Cross-reference back to the trace this log line was written
+        // during, when the SDK correlated the two (docs/contracts/
+        // otel-ingest.md's ADR-132 section). Carried in the free-form
+        // attribute bag — `LogEntry` has no dedicated field for either.
+        if (lr.traceId) attributes.trace_id = lr.traceId
+        if (lr.spanId) attributes.span_id = lr.spanId
+
+        out.push({
+          id: randomUUID(),
+          serviceName,
+          resourceServiceNamePresent,
+          timestamp: timestampOf(lr),
+          severity: normalizeSeverity(lr.severityNumber, lr.severityText),
+          message: messageFromBody(lr.body),
+          attributes,
+        })
+      }
+    }
+  }
+  return out
+}
+
+// ── protobuf decode (application/x-protobuf) ────────────────────────────────
+//
+// Mirrors otel.ts's ExportTraceServiceRequest decoder against the bundled
+// logs proto tree (packages/core/proto/opentelemetry/proto/{logs,collector/
+// logs}/v1/*.proto — added alongside this receiver; the trace-only proto
+// tree otel.ts already bundles doesn't cover the logs signal, a distinct
+// OTLP message family). `keepCase: true` decodes snake_case field names, so
+// the result is reshaped onto the same camelCase shape parseOtlpLogsRequest
+// already understands — the same two-step decode-then-reshape otel-grpc.ts
+// uses for the gRPC trace path.
+
+interface ProtoAnyValue {
+  string_value?: string
+  bool_value?: boolean
+  int_value?: string | number
+  double_value?: number
+  array_value?: { values?: ProtoAnyValue[] }
+  kvlist_value?: { values?: ProtoKeyValue[] }
+  bytes_value?: Buffer | Uint8Array
+}
+
+interface ProtoKeyValue {
+  key?: string
+  value?: ProtoAnyValue
+}
+
+interface ProtoLogRecord {
+  time_unix_nano?: string | number
+  observed_time_unix_nano?: string | number
+  severity_number?: number
+  severity_text?: string
+  body?: ProtoAnyValue
+  attributes?: ProtoKeyValue[]
+  trace_id?: Buffer | Uint8Array
+  span_id?: Buffer | Uint8Array
+}
+
+interface ProtoScopeLogs {
+  log_records?: ProtoLogRecord[]
+}
+
+interface ProtoResourceLogs {
+  resource?: { attributes?: ProtoKeyValue[] }
+  scope_logs?: ProtoScopeLogs[]
+}
+
+interface ProtoExportLogsServiceRequest {
+  resource_logs?: ProtoResourceLogs[]
+}
+
+// Bytes fields (trace_id/span_id) arrive as Buffer/Uint8Array under the
+// default toObject() decode; hex-encode for consistency with the JSON wire
+// format's hex string convention (same fix #468 applied to span IDs).
+function bytesToHex(buf: Buffer | Uint8Array | undefined): string | undefined {
+  if (!buf) return undefined
+  if (Buffer.isBuffer(buf)) return buf.toString('hex')
+  if (buf instanceof Uint8Array) return Buffer.from(buf).toString('hex')
+  return undefined
+}
+
+function reshapeAnyValue(v: ProtoAnyValue | undefined): OtlpAnyValue | undefined {
+  if (!v) return undefined
+  return {
+    stringValue: v.string_value,
+    boolValue: v.bool_value,
+    intValue: v.int_value,
+    doubleValue: v.double_value,
+    arrayValue: v.array_value
+      ? { values: (v.array_value.values ?? []).map((x) => reshapeAnyValue(x)) as OtlpAnyValue[] }
+      : undefined,
+    kvlistValue: v.kvlist_value
+      ? { values: reshapeKeyValues(v.kvlist_value.values) }
+      : undefined,
+    bytesValue: bytesToHex(v.bytes_value),
+  }
+}
+
+function reshapeKeyValues(attrs: ProtoKeyValue[] | undefined): OtlpKeyValue[] {
+  return (attrs ?? []).map((kv) => ({ key: kv.key ?? '', value: reshapeAnyValue(kv.value) }))
+}
+
+function nanosToString(n: string | number | undefined): string | undefined {
+  if (n === undefined || n === null) return undefined
+  return typeof n === 'string' ? n : String(n)
+}
+
+function reshapeLogsRequest(decoded: ProtoExportLogsServiceRequest): OtlpLogsRequest {
+  return {
+    resourceLogs: (decoded.resource_logs ?? []).map((rl) => ({
+      resource: rl.resource ? { attributes: reshapeKeyValues(rl.resource.attributes) } : undefined,
+      scopeLogs: (rl.scope_logs ?? []).map((sl) => ({
+        logRecords: (sl.log_records ?? []).map((lr) => ({
+          timeUnixNano: nanosToString(lr.time_unix_nano),
+          observedTimeUnixNano: nanosToString(lr.observed_time_unix_nano),
+          severityNumber: lr.severity_number,
+          severityText: lr.severity_text,
+          body: reshapeAnyValue(lr.body),
+          attributes: reshapeKeyValues(lr.attributes),
+          traceId: bytesToHex(lr.trace_id),
+          spanId: bytesToHex(lr.span_id),
+        })),
+      })),
+    })),
+  }
+}
+
+let exportLogsServiceRequestType: protobuf.Type | null = null
+let exportLogsServiceResponseType: protobuf.Type | null = null
+
+function loadLogsProtoRoot(): protobuf.Root {
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  const protoRoot = path.resolve(here, '..', 'proto')
+  const root = new protobuf.Root()
+  root.resolvePath = (_origin, target) => path.resolve(protoRoot, target)
+  root.loadSync('opentelemetry/proto/collector/logs/v1/logs_service.proto', { keepCase: true })
+  return root
+}
+
+function loadLogsProtobufDecoder(): protobuf.Type {
+  if (exportLogsServiceRequestType) return exportLogsServiceRequestType
+  const root = loadLogsProtoRoot()
+  exportLogsServiceRequestType = root.lookupType(
+    'opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest',
+  )
+  return exportLogsServiceRequestType
+}
+
+function loadLogsProtobufResponseEncoder(): protobuf.Type {
+  if (exportLogsServiceResponseType) return exportLogsServiceResponseType
+  const root = loadLogsProtoRoot()
+  exportLogsServiceResponseType = root.lookupType(
+    'opentelemetry.proto.collector.logs.v1.ExportLogsServiceResponse',
+  )
+  return exportLogsServiceResponseType
+}
+
+let cachedLogsProtobufResponseBody: Buffer | null = null
+
+function encodeLogsProtobufResponseBody(): Buffer {
+  if (cachedLogsProtobufResponseBody) return cachedLogsProtobufResponseBody
+  const Type = loadLogsProtobufResponseEncoder()
+  const msg = Type.create({})
+  const encoded = Type.encode(msg).finish()
+  cachedLogsProtobufResponseBody = Buffer.from(encoded)
+  return cachedLogsProtobufResponseBody
+}
+
+function decodeProtobufLogsBody(buf: Buffer): OtlpLogsRequest {
+  const Type = loadLogsProtobufDecoder()
+  const decoded = Type.toObject(Type.decode(buf), {
+    longs: String,
+    enums: Number,
+  }) as ProtoExportLogsServiceRequest
+  return reshapeLogsRequest(decoded)
+}
+
+// ── Fastify wiring ───────────────────────────────────────────────────────────
+
+export interface RegisterOtelLogsRoutesOptions {
+  onLogRecord: LogRecordHandler
+  // Project-scoped route (`/projects/:project/v1/logs`). When unset, that
+  // route still exists but falls through to `onLogRecord` — same fallback
+  // shape as otel.ts's `onProjectSpan`.
+  onProjectLogRecord?: ProjectLogRecordHandler
+  bodyLimit?: number
+}
+
+export interface OtelLogsRoutes {
+  // Test seam — resolves once every record enqueued so far has reached its
+  // handler. Production code never awaits this.
+  flushPending: () => Promise<void>
+}
+
+async function readOtlpLogsBody(
+  req: import('fastify').FastifyRequest,
+): Promise<
+  | { ok: true; body: OtlpLogsRequest; flavor: 'json' | 'protobuf' }
+  | { ok: false; code: 400 | 415; error: string }
+> {
+  const ct = (req.headers['content-type'] ?? '').toString().split(';')[0]!.trim().toLowerCase()
+  if (ct === 'application/x-protobuf') {
+    try {
+      const body = decodeProtobufLogsBody(req.body as Buffer)
+      return { ok: true, body, flavor: 'protobuf' }
+    } catch (err) {
+      return { ok: false, code: 400, error: `protobuf decode failed: ${(err as Error).message}` }
+    }
+  }
+  if (!ct || ct === 'application/json') {
+    return { ok: true, body: (req.body ?? {}) as OtlpLogsRequest, flavor: 'json' }
+  }
+  return { ok: false, code: 415, error: `unsupported content-type: ${ct}` }
+}
+
+function sendOtlpLogsSuccess(
+  reply: import('fastify').FastifyReply,
+  flavor: 'json' | 'protobuf',
+): unknown {
+  if (flavor === 'protobuf') {
+    const buf = encodeLogsProtobufResponseBody()
+    return reply.code(200).header('content-type', 'application/x-protobuf').send(buf)
+  }
+  return reply.code(200).header('content-type', 'application/json').send({ partialSuccess: {} })
+}
+
+// Registers `/v1/logs` and `/projects/:project/v1/logs` onto an existing
+// Fastify instance. This is the seam daemon.ts uses to mount the logs
+// receiver onto the same app (and therefore the same port) the `/v1/traces`
+// receiver already binds — OTLP's own convention is one collector endpoint
+// serving every signal on distinct paths, and reusing the app means reusing
+// its already-mounted bearer-auth hook for free rather than standing up a
+// second port with its own auth and its own daemon.json bookkeeping.
+//
+// Registers the `application/x-protobuf` content-type parser only if the app
+// doesn't already have one (buildOtelReceiver's `/v1/traces` app registers
+// it first when both receivers share an instance; a bare app built for
+// testing this module in isolation won't have it yet).
+export function registerOtelLogsRoutes(
+  app: FastifyInstance,
+  opts: RegisterOtelLogsRoutesOptions,
+): OtelLogsRoutes {
+  const bodyLimit = opts.bodyLimit ?? 16 * 1024 * 1024
+  if (!app.hasContentTypeParser('application/x-protobuf')) {
+    app.addContentTypeParser(
+      'application/x-protobuf',
+      { parseAs: 'buffer', bodyLimit },
+      (_req, body, done) => {
+        done(null, body)
+      },
+    )
+  }
+
+  // Non-blocking append. `appendLogEntry` (logs-store.ts) is a synchronous,
+  // in-memory push + prune with no I/O — unlike graph mutation, there's no
+  // real backpressure risk in calling it inline before replying. The
+  // queue/drain shape below is kept anyway, for three reasons: it makes the
+  // "the sender is never blocked on the mutation" invariant literally true
+  // rather than true only by the mutation's current speed; it gives tests
+  // the same `flushPending()` seam every other OTLP receiver in this
+  // codebase already exposes; and it means a future change to the store
+  // (persistence, a slower sink) doesn't require touching the receiver
+  // shape. This is a judgment call, not a requirement — appendLogEntry's own
+  // synchronous cost is negligible either way.
+  const queue: ParsedLogRecord[] = []
+  let draining = false
+  let drainPromise: Promise<void> = Promise.resolve()
+  const drain = async (): Promise<void> => {
+    if (draining) return
+    draining = true
+    try {
+      while (queue.length > 0) {
+        const record = queue.shift()!
+        try {
+          await opts.onLogRecord(record)
+        } catch (err) {
+          console.warn(`[neat] otel-logs handler error: ${(err as Error).message}`)
+        }
+      }
+    } finally {
+      draining = false
+    }
+  }
+  const enqueue = (records: ParsedLogRecord[]): void => {
+    if (records.length === 0) return
+    for (const r of records) queue.push(r)
+    drainPromise = drainPromise.then(() => drain())
+  }
+
+  const projectQueue: Array<{ project: string; record: ParsedLogRecord }> = []
+  let projectDraining = false
+  let projectDrainPromise: Promise<void> = Promise.resolve()
+  const drainProject = async (): Promise<void> => {
+    if (projectDraining) return
+    projectDraining = true
+    try {
+      while (projectQueue.length > 0) {
+        const { project, record } = projectQueue.shift()!
+        try {
+          if (opts.onProjectLogRecord) {
+            await opts.onProjectLogRecord(project, record)
+          } else {
+            await opts.onLogRecord(record)
+          }
+        } catch (err) {
+          console.warn(`[neat] otel-logs handler error: ${(err as Error).message}`)
+        }
+      }
+    } finally {
+      projectDraining = false
+    }
+  }
+  const enqueueProject = (project: string, records: ParsedLogRecord[]): void => {
+    if (records.length === 0) return
+    for (const r of records) projectQueue.push({ project, record: r })
+    projectDrainPromise = projectDrainPromise.then(() => drainProject())
+  }
+
+  app.post('/v1/logs', async (req, reply) => {
+    const result = await readOtlpLogsBody(req)
+    if (!result.ok) return reply.code(result.code).send({ error: result.error })
+    enqueue(parseOtlpLogsRequest(result.body))
+    return sendOtlpLogsSuccess(reply, result.flavor)
+  })
+
+  app.post<{ Params: { project: string } }>('/projects/:project/v1/logs', async (req, reply) => {
+    const result = await readOtlpLogsBody(req)
+    if (!result.ok) return reply.code(result.code).send({ error: result.error })
+    enqueueProject(req.params.project, parseOtlpLogsRequest(result.body))
+    return sendOtlpLogsSuccess(reply, result.flavor)
+  })
+
+  return {
+    flushPending: async () => {
+      while (queue.length > 0 || draining || projectQueue.length > 0 || projectDraining) {
+        await Promise.all([drainPromise, projectDrainPromise])
+      }
+    },
+  }
+}
+
+export interface BuildOtelLogsReceiverOptions extends RegisterOtelLogsRoutesOptions {
+  // ADR-073 §4 — same bearer gate as `/v1/traces` (`NEAT_OTEL_TOKEN`).
+  authToken?: string
+  trustProxy?: boolean
+}
+
+// Standalone receiver — its own Fastify app, own bearer auth, own `/health`,
+// own protobuf content-type parser. Exists for tests and any caller that
+// wants an independent `/v1/logs` server rather than mounting onto an
+// existing OTLP app; daemon.ts instead calls `registerOtelLogsRoutes`
+// directly against the already-built `/v1/traces` app so both receivers
+// share one port.
+export async function buildOtelLogsReceiver(
+  opts: BuildOtelLogsReceiverOptions,
+): Promise<FastifyInstance & OtelLogsRoutes> {
+  const app = Fastify({
+    logger: false,
+    bodyLimit: opts.bodyLimit ?? 16 * 1024 * 1024,
+  })
+
+  mountBearerAuth(app, { token: opts.authToken, trustProxy: opts.trustProxy })
+
+  app.get('/health', async () => ({ ok: true }))
+
+  const routes = registerOtelLogsRoutes(app, opts)
+
+  const decorated = app as unknown as FastifyInstance & OtelLogsRoutes
+  decorated.flushPending = routes.flushPending
+  return decorated
+}

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -4,6 +4,8 @@ import { buildApi } from './api.js'
 import { extractFromDirectory } from './extract.js'
 import { loadGraphFromDisk, startPersistLoop } from './persist.js'
 import { buildOtelReceiver } from './otel.js'
+import { registerOtelLogsRoutes } from './otel-logs.js'
+import { appendLogEntry } from './logs-store.js'
 import { startOtelGrpcReceiver } from './otel-grpc.js'
 import { makeSpanHandler, startStalenessLoop } from './ingest.js'
 import { buildSearchIndex } from './search.js'
@@ -108,6 +110,24 @@ async function main(): Promise<void> {
       onSpan,
       authToken: auth.otelToken,
       trustProxy: auth.trustProxy,
+    })
+    // /v1/logs (ADR-132) — single-project mode has no routing ambiguity, so
+    // every record lands in DEFAULT_PROJECT directly. Never touches the
+    // graph; only appendLogEntry (logs-store.ts).
+    registerOtelLogsRoutes(otelApp, {
+      onLogRecord: (record) => {
+        appendLogEntry({
+          id: record.id,
+          projectName: DEFAULT_PROJECT,
+          source: 'native',
+          serviceName: record.serviceName,
+          timestamp: record.timestamp,
+          severity: record.severity,
+          message: record.message,
+          attributes:
+            Object.keys(record.attributes).length > 0 ? record.attributes : undefined,
+        })
+      },
     })
     await otelApp.listen({ port: otelPort, host })
     console.log(`neat-core OTLP receiver on http://${host}:${otelPort}/v1/traces`)

--- a/packages/core/src/watch.ts
+++ b/packages/core/src/watch.ts
@@ -28,6 +28,8 @@ import {
 } from './policy.js'
 import type { Policy } from '@neat.is/types'
 import { buildOtelReceiver, listenSteppingOtlp } from './otel.js'
+import { registerOtelLogsRoutes } from './otel-logs.js'
+import { appendLogEntry } from './logs-store.js'
 import {
   clearDaemonRecord,
   portFromListenAddress,
@@ -490,6 +492,23 @@ export async function startWatch(
   })
   const onErrorSpanSync = makeErrorSpanWriter(opts.errorsPath, graph, opts.scanPath)
   const otelHttp = await buildOtelReceiver({ onSpan, onErrorSpanSync })
+  // /v1/logs (ADR-132) — `neat watch` is single-project, so every record
+  // lands directly in this project's name; no service.name routing needed.
+  // Never touches the graph; only appendLogEntry (logs-store.ts).
+  registerOtelLogsRoutes(otelHttp, {
+    onLogRecord: (record) => {
+      appendLogEntry({
+        id: record.id,
+        projectName,
+        source: 'native',
+        serviceName: record.serviceName,
+        timestamp: record.timestamp,
+        severity: record.severity,
+        message: record.message,
+        attributes: Object.keys(record.attributes).length > 0 ? record.attributes : undefined,
+      })
+    },
+  })
   // A held OTLP port steps to the next free one rather than crashing the watch
   // process (daemon.md §Binding). The real bound port is what daemon.json
   // records below, so the instrumented app's otel-init resolves the right one.

--- a/packages/core/test/otel-logs.test.ts
+++ b/packages/core/test/otel-logs.test.ts
@@ -1,0 +1,581 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import protobuf from 'protobufjs'
+import type { FastifyInstance } from 'fastify'
+import { buildOtelReceiver } from '../src/otel.js'
+import {
+  buildOtelLogsReceiver,
+  registerOtelLogsRoutes,
+  parseOtlpLogsRequest,
+  type OtlpLogsRequest,
+  type ParsedLogRecord,
+} from '../src/otel-logs.js'
+import { appendLogEntry, queryLogEntries, resetLogsStore } from '../src/logs-store.js'
+import type { LogEntry } from '@neat.is/types'
+
+// Real OTLP/HTTP JSON shape (opentelemetry-proto's logs/v1/logs.proto +
+// collector/logs/v1/logs_service.proto — verified against the upstream
+// proto, not guessed). Three log records across two resources: a plain
+// info-level string body with a call site + trace/span cross-reference, an
+// error-level string body with no call site, and a non-string (int) body on
+// a second service to exercise the "other value kinds stringify" path.
+const SAMPLE_LOGS_BODY: OtlpLogsRequest = {
+  resourceLogs: [
+    {
+      resource: {
+        attributes: [{ key: 'service.name', value: { stringValue: 'service-a' } }],
+      },
+      scopeLogs: [
+        {
+          logRecords: [
+            {
+              timeUnixNano: '1749300000123000000',
+              severityNumber: 9,
+              severityText: 'INFO',
+              body: { stringValue: 'user signed in' },
+              attributes: [
+                { key: 'code.filepath', value: { stringValue: 'src/auth.ts' } },
+                { key: 'code.lineno', value: { intValue: '42' } },
+              ],
+              traceId: 'aabbccddeeff00112233445566778899',
+              spanId: '1111111111111111',
+            },
+            {
+              timeUnixNano: '1749300000456000000',
+              severityNumber: 17,
+              severityText: 'ERROR',
+              body: { stringValue: 'payment failed' },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      resource: {
+        attributes: [{ key: 'service.name', value: { stringValue: 'service-b' } }],
+      },
+      scopeLogs: [
+        {
+          logRecords: [
+            {
+              timeUnixNano: '1749300000789000000',
+              severityText: 'warn',
+              body: { intValue: '503' },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+describe('parseOtlpLogsRequest', () => {
+  it('flattens resource + scope + log record into a ParsedLogRecord list', () => {
+    const records = parseOtlpLogsRequest(SAMPLE_LOGS_BODY)
+    expect(records).toHaveLength(3)
+  })
+
+  it('extracts service.name from resource attributes', () => {
+    const records = parseOtlpLogsRequest(SAMPLE_LOGS_BODY)
+    expect(records[0].serviceName).toBe('service-a')
+    expect(records[1].serviceName).toBe('service-a')
+    expect(records[2].serviceName).toBe('service-b')
+  })
+
+  it('leaves serviceName undefined when the resource carries none — no ServiceNode fallback for logs', () => {
+    const records = parseOtlpLogsRequest({
+      resourceLogs: [
+        {
+          scopeLogs: [{ logRecords: [{ body: { stringValue: 'no resource at all' } }] }],
+        },
+      ],
+    })
+    expect(records[0].serviceName).toBeUndefined()
+    expect(records[0].resourceServiceNamePresent).toBe(false)
+  })
+
+  it('converts timeUnixNano to ISO8601', () => {
+    const records = parseOtlpLogsRequest(SAMPLE_LOGS_BODY)
+    expect(records[0].timestamp).toBe('2025-06-07T12:40:00.123Z')
+  })
+
+  it('falls back to wall-clock when no timestamp signal is present at all', () => {
+    const before = Date.now()
+    const records = parseOtlpLogsRequest({
+      resourceLogs: [{ scopeLogs: [{ logRecords: [{ body: { stringValue: 'no time' } }] }] }],
+    })
+    const after = Date.now()
+    const ts = Date.parse(records[0].timestamp)
+    expect(ts).toBeGreaterThanOrEqual(before)
+    expect(ts).toBeLessThanOrEqual(after)
+  })
+
+  it('normalizes severityNumber to the four-bucket scale, preferring it over severityText', () => {
+    const records = parseOtlpLogsRequest(SAMPLE_LOGS_BODY)
+    expect(records[0].severity).toBe('info') // 9 -> INFO bucket
+    expect(records[1].severity).toBe('error') // 17 -> ERROR bucket
+  })
+
+  it('falls back to severityText when severityNumber is absent', () => {
+    const records = parseOtlpLogsRequest(SAMPLE_LOGS_BODY)
+    expect(records[2].severity).toBe('warn')
+  })
+
+  it('folds TRACE into debug and FATAL into error (no dedicated buckets on LogEntry)', () => {
+    const records = parseOtlpLogsRequest({
+      resourceLogs: [
+        {
+          scopeLogs: [
+            {
+              logRecords: [
+                { severityNumber: 1, body: { stringValue: 'trace' } },
+                { severityNumber: 24, body: { stringValue: 'fatal4' } },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    expect(records[0].severity).toBe('debug')
+    expect(records[1].severity).toBe('error')
+  })
+
+  it('takes body.stringValue as the message', () => {
+    const records = parseOtlpLogsRequest(SAMPLE_LOGS_BODY)
+    expect(records[0].message).toBe('user signed in')
+    expect(records[1].message).toBe('payment failed')
+  })
+
+  it('stringifies a non-string body value kind rather than crashing', () => {
+    const records = parseOtlpLogsRequest(SAMPLE_LOGS_BODY)
+    expect(records[2].message).toBe('503')
+  })
+
+  it('handles a missing body without crashing', () => {
+    const records = parseOtlpLogsRequest({
+      resourceLogs: [{ scopeLogs: [{ logRecords: [{ severityText: 'info' }] }] }],
+    })
+    expect(records).toHaveLength(1)
+    expect(records[0].message).toBe('')
+  })
+
+  it('stringifies an array-valued body without crashing', () => {
+    const records = parseOtlpLogsRequest({
+      resourceLogs: [
+        {
+          scopeLogs: [
+            {
+              logRecords: [
+                {
+                  body: {
+                    arrayValue: {
+                      values: [{ stringValue: 'a' }, { intValue: '1' }, { boolValue: true }],
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    expect(() => JSON.parse(records[0].message)).not.toThrow()
+    expect(JSON.parse(records[0].message)).toEqual(['a', 1, true])
+  })
+
+  it('carries code.filepath / code.lineno through as ordinary attributes', () => {
+    const records = parseOtlpLogsRequest(SAMPLE_LOGS_BODY)
+    expect(records[0].attributes['code.filepath']).toBe('src/auth.ts')
+    expect(records[0].attributes['code.lineno']).toBe(42)
+  })
+
+  it('carries trace_id / span_id into attributes as a cross-reference when present', () => {
+    const records = parseOtlpLogsRequest(SAMPLE_LOGS_BODY)
+    expect(records[0].attributes.trace_id).toBe('aabbccddeeff00112233445566778899')
+    expect(records[0].attributes.span_id).toBe('1111111111111111')
+    // Second record on the same resource carries no traceId/spanId on the wire.
+    expect(records[1].attributes.trace_id).toBeUndefined()
+    expect(records[1].attributes.span_id).toBeUndefined()
+  })
+
+  it('assigns each record its own non-empty synthetic id', () => {
+    const records = parseOtlpLogsRequest(SAMPLE_LOGS_BODY)
+    const ids = records.map((r) => r.id)
+    expect(ids.every((id) => typeof id === 'string' && id.length > 0)).toBe(true)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('handles an empty payload without erroring', () => {
+    expect(parseOtlpLogsRequest({})).toEqual([])
+  })
+})
+
+describe('buildOtelLogsReceiver', () => {
+  let app: FastifyInstance
+  let collected: ParsedLogRecord[]
+
+  beforeEach(async () => {
+    collected = []
+    app = await buildOtelLogsReceiver({
+      onLogRecord: (r) => {
+        collected.push(r)
+      },
+    })
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('POST /v1/logs accepts JSON OTLP and dispatches each log record', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/logs',
+      headers: { 'content-type': 'application/json' },
+      payload: SAMPLE_LOGS_BODY,
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ partialSuccess: {} })
+    await (app as unknown as { flushPending: () => Promise<void> }).flushPending()
+    expect(collected).toHaveLength(3)
+    expect(collected[0].message).toBe('user signed in')
+  })
+
+  it('GET /health returns ok', async () => {
+    const res = await app.inject({ method: 'GET', url: '/health' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ ok: true })
+  })
+
+  it('handles an empty payload without erroring', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/logs',
+      headers: { 'content-type': 'application/json' },
+      payload: {},
+    })
+    expect(res.statusCode).toBe(200)
+    await (app as unknown as { flushPending: () => Promise<void> }).flushPending()
+    expect(collected).toEqual([])
+  })
+
+  it('returns 200 before a slow handler completes and drains it after (non-blocking append)', async () => {
+    await app.close()
+    const observed: string[] = []
+    const HANDLER_DELAY_MS = 200
+    app = await buildOtelLogsReceiver({
+      onLogRecord: async (r) => {
+        await new Promise((resolve) => setTimeout(resolve, HANDLER_DELAY_MS))
+        observed.push(r.message)
+      },
+    })
+    const start = Date.now()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/logs',
+      headers: { 'content-type': 'application/json' },
+      payload: SAMPLE_LOGS_BODY,
+    })
+    const replyMs = Date.now() - start
+    expect(res.statusCode).toBe(200)
+    expect(replyMs).toBeLessThan(HANDLER_DELAY_MS)
+    expect(observed).toEqual([])
+    await (app as unknown as { flushPending: () => Promise<void> }).flushPending()
+    expect(observed).toEqual(['user signed in', 'payment failed', '503'])
+  })
+
+  it('rejects unsupported content types with 415', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/logs',
+      headers: { 'content-type': 'application/xml' },
+      payload: '<not-otlp/>',
+    })
+    expect(res.statusCode).toBe(415)
+  })
+
+  it('returns 400 for malformed protobuf bodies', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/logs',
+      headers: { 'content-type': 'application/x-protobuf' },
+      payload: Buffer.from([0xff, 0xff, 0xff]),
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('decodes a valid application/x-protobuf body via the bundled logs .proto', async () => {
+    const here = path.dirname(fileURLToPath(import.meta.url))
+    const protoRoot = path.resolve(here, '..', 'proto')
+    const root = new protobuf.Root()
+    root.resolvePath = (_o, t) => path.resolve(protoRoot, t)
+    root.loadSync('opentelemetry/proto/collector/logs/v1/logs_service.proto', { keepCase: true })
+    const Type = root.lookupType('opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest')
+
+    const traceIdHex = 'aabbccddeeff00112233445566778899'
+    const spanIdHex = '1122334455667788'
+    const msg = Type.create({
+      resource_logs: [
+        {
+          resource: {
+            attributes: [{ key: 'service.name', value: { string_value: 'svc-proto-logs' } }],
+          },
+          scope_logs: [
+            {
+              log_records: [
+                {
+                  time_unix_nano: '1717777777123456789',
+                  severity_number: 17,
+                  severity_text: 'ERROR',
+                  body: { string_value: 'downstream call failed' },
+                  attributes: [
+                    { key: 'code.filepath', value: { string_value: 'src/handler.ts' } },
+                  ],
+                  trace_id: Buffer.from(traceIdHex, 'hex'),
+                  span_id: Buffer.from(spanIdHex, 'hex'),
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    const buf = Buffer.from(Type.encode(msg).finish())
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/logs',
+      headers: { 'content-type': 'application/x-protobuf' },
+      payload: buf,
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['content-type']).toBe('application/x-protobuf')
+
+    await (app as unknown as { flushPending: () => Promise<void> }).flushPending()
+    expect(collected).toHaveLength(1)
+    const parsed = collected[0]
+    expect(parsed.serviceName).toBe('svc-proto-logs')
+    expect(parsed.message).toBe('downstream call failed')
+    expect(parsed.severity).toBe('error')
+    expect(parsed.timestamp).toBe('2024-06-07T16:29:37.123Z')
+    expect(parsed.attributes['code.filepath']).toBe('src/handler.ts')
+    expect(parsed.attributes.trace_id).toBe(traceIdHex)
+    expect(parsed.attributes.span_id).toBe(spanIdHex)
+  })
+
+  it('project-scoped route dispatches to onProjectLogRecord when set', async () => {
+    await app.close()
+    const projectCollected: Array<{ project: string; message: string }> = []
+    app = await buildOtelLogsReceiver({
+      onLogRecord: () => {
+        throw new Error('should not be called when onProjectLogRecord is set')
+      },
+      onProjectLogRecord: (project, record) => {
+        projectCollected.push({ project, message: record.message })
+      },
+    })
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects/acme/v1/logs',
+      headers: { 'content-type': 'application/json' },
+      payload: SAMPLE_LOGS_BODY,
+    })
+    expect(res.statusCode).toBe(200)
+    await (app as unknown as { flushPending: () => Promise<void> }).flushPending()
+    expect(projectCollected).toHaveLength(3)
+    expect(projectCollected.every((p) => p.project === 'acme')).toBe(true)
+  })
+
+  it('project-scoped route falls back to onLogRecord when onProjectLogRecord is unset', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects/acme/v1/logs',
+      headers: { 'content-type': 'application/json' },
+      payload: SAMPLE_LOGS_BODY,
+    })
+    expect(res.statusCode).toBe(200)
+    await (app as unknown as { flushPending: () => Promise<void> }).flushPending()
+    expect(collected).toHaveLength(3)
+  })
+})
+
+describe('buildOtelLogsReceiver — bearer token gate (ADR-073 §4, same as /v1/traces)', () => {
+  let app: FastifyInstance
+
+  beforeEach(async () => {
+    app = await buildOtelLogsReceiver({
+      onLogRecord: () => {},
+      authToken: 'right-token',
+    })
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('rejects a request with no bearer', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/logs',
+      headers: { 'content-type': 'application/json' },
+      payload: SAMPLE_LOGS_BODY,
+    })
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('rejects a request with the wrong bearer', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/logs',
+      headers: {
+        'content-type': 'application/json',
+        authorization: 'Bearer wrong-token',
+      },
+      payload: SAMPLE_LOGS_BODY,
+    })
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('accepts a request with the correct bearer', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/logs',
+      headers: {
+        'content-type': 'application/json',
+        authorization: 'Bearer right-token',
+      },
+      payload: SAMPLE_LOGS_BODY,
+    })
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('/health stays unauthenticated', async () => {
+    const res = await app.inject({ method: 'GET', url: '/health' })
+    expect(res.statusCode).toBe(200)
+  })
+})
+
+// daemon.ts mounts /v1/logs onto the exact same Fastify app /v1/traces
+// already lives on (registerOtelLogsRoutes against buildOtelReceiver's
+// app), so both receivers share one port and one bearer-auth hook. This
+// proves that mounting doesn't collide on the protobuf content-type parser
+// (already registered by buildOtelReceiver) and that the shared auth hook
+// covers both paths.
+describe('registerOtelLogsRoutes — mounted onto the shared /v1/traces app (daemon.ts wiring shape)', () => {
+  let app: FastifyInstance
+  let logRecords: ParsedLogRecord[]
+
+  beforeEach(async () => {
+    logRecords = []
+    app = await buildOtelReceiver({
+      onSpan: () => {},
+      authToken: 'shared-token',
+    })
+    registerOtelLogsRoutes(app, {
+      onLogRecord: (r) => {
+        logRecords.push(r)
+      },
+    })
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('does not throw when the protobuf content-type parser is already registered', () => {
+    expect(app.hasContentTypeParser('application/x-protobuf')).toBe(true)
+  })
+
+  it('both /v1/traces and /v1/logs work on the one shared app', async () => {
+    const tracesRes = await app.inject({
+      method: 'POST',
+      url: '/v1/traces',
+      headers: {
+        'content-type': 'application/json',
+        authorization: 'Bearer shared-token',
+      },
+      payload: { resourceSpans: [] },
+    })
+    expect(tracesRes.statusCode).toBe(200)
+
+    const logsRes = await app.inject({
+      method: 'POST',
+      url: '/v1/logs',
+      headers: {
+        'content-type': 'application/json',
+        authorization: 'Bearer shared-token',
+      },
+      payload: SAMPLE_LOGS_BODY,
+    })
+    expect(logsRes.statusCode).toBe(200)
+    await (app as unknown as { flushPending: () => Promise<void> }).flushPending()
+    expect(logRecords).toHaveLength(3)
+  })
+
+  it('the shared bearer-auth hook covers /v1/logs too', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/logs',
+      headers: { 'content-type': 'application/json' },
+      payload: SAMPLE_LOGS_BODY,
+    })
+    expect(res.statusCode).toBe(401)
+  })
+})
+
+// End-to-end through the actual store — the receiver never touches
+// NeatGraph, so the only production sink for a ParsedLogRecord is
+// appendLogEntry (logs-store.ts). This exercises that full path.
+describe('otel-logs receiver -> appendLogEntry -> queryLogEntries', () => {
+  afterEach(() => {
+    resetLogsStore()
+  })
+
+  it('a JSON OTLP payload maps to LogEntrys retrievable from the store', async () => {
+    const app = await buildOtelLogsReceiver({
+      onLogRecord: (record) => {
+        const entry: LogEntry = {
+          id: record.id,
+          projectName: 'demo',
+          source: 'native',
+          serviceName: record.serviceName,
+          timestamp: record.timestamp,
+          severity: record.severity,
+          message: record.message,
+          attributes: Object.keys(record.attributes).length > 0 ? record.attributes : undefined,
+        }
+        appendLogEntry(entry)
+      },
+    })
+    // logs-store.ts prunes anything older than 24h on every append
+    // (LOGS_STORE_MAX_AGE_MS), so this integration test needs a live
+    // timestamp rather than SAMPLE_LOGS_BODY's fixed 2025 fixture dates —
+    // those are intentionally stable for the ISO-conversion assertions
+    // above, but would prune themselves out of the store immediately here.
+    const nowNanos = (BigInt(Date.now()) * 1_000_000n).toString()
+    const freshBody: OtlpLogsRequest = JSON.parse(
+      JSON.stringify(SAMPLE_LOGS_BODY).replaceAll(/"\d{19}"/g, `"${nowNanos}"`),
+    )
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/logs',
+      headers: { 'content-type': 'application/json' },
+      payload: freshBody,
+    })
+    expect(res.statusCode).toBe(200)
+    await (app as unknown as { flushPending: () => Promise<void> }).flushPending()
+    await app.close()
+
+    const stored = queryLogEntries({ projectName: 'demo' })
+    expect(stored).toHaveLength(3)
+    expect(stored.some((e) => e.message === 'user signed in' && e.serviceName === 'service-a')).toBe(true)
+    expect(stored.some((e) => e.message === 'payment failed' && e.severity === 'error')).toBe(true)
+    expect(stored.some((e) => e.message === '503' && e.serviceName === 'service-b')).toBe(true)
+    // Never a graph mutation — this is purely a store append. There's
+    // nothing to assert "absence of" against a graph here since this
+    // receiver is never handed one; the absence of any NeatGraph import in
+    // otel-logs.ts is the actual guarantee (see otel-ingest.md's ADR-132
+    // section).
+  })
+})


### PR DESCRIPTION
Refs #705. Builds on #690 (the logs store + REST endpoint) — this PR's diff will shrink once #690 merges and this gets retargeted to main.

## Summary

- `packages/core/src/otel-logs.ts` — the `/v1/logs` OTLP receiver. JSON and protobuf content-type dispatch (bundles `opentelemetry/proto/{logs,collector/logs}/v1/*.proto` alongside the traces proto tree `otel.ts` already carries — logs is a distinct OTLP message family, not covered by the trace protos). Same bearer-token gate (`NEAT_OTEL_TOKEN`) and non-blocking-receiver discipline as `/v1/traces`.
- Maps each `LogRecord` to a `LogEntry` (`source: 'native'`): `timeUnixNano`/`observedTimeUnixNano` → ISO8601 timestamp, `severityNumber`/`severityText` → normalized `debug`/`info`/`warn`/`error`, `body` → `message` (stringifies non-string `AnyValue` kinds rather than dropping them), `resource.attributes['service.name']` → `serviceName`. `trace_id`/`span_id` (when present) ride into the attribute bag as a cross-reference; `code.filepath`/`code.lineno` need no special handling since they're already ordinary OTLP attributes.
- Never touches `NeatGraph`. No node or edge is minted here, ever — the only production sink is `appendLogEntry` (logs-store.ts). An unseen `service.name` auto-creates nothing.
- Wired into `daemon.ts`, `server.ts`, and `watch.ts` alongside their existing `/v1/traces` receivers.

## Judgment calls

- **Same port as traces.** Rather than standing up a third OTLP port, `otel-logs.ts` exports `registerOtelLogsRoutes(app, opts)`, which mounts `/v1/logs` and `/projects/:project/v1/logs` onto the *same* Fastify app `/v1/traces` already binds — matching how a real OTLP collector endpoint serves every signal on one host:port with distinct paths. That app already has bearer auth mounted (from `buildOtelReceiver`), so logs inherit it for free instead of needing their own. `buildOtelLogsReceiver(opts)` (its own app, own auth, own `/health`) exists alongside it purely for standalone testing and any future caller that wants an independent logs-only server.
- **Project routing reuses the trace receiver's, verbatim.** `daemon.ts`'s `resolveTargetSlot`/`resolveSlotByName` (the same closures the trace receiver calls) resolve a log record's project by `service.name`, exactly like a span. One wording nuance from that reuse: a dropped/unrouted log record still logs through `warnDroppedSpan`/`recordUnroutedSpan`, so the diagnostic line and the `errors.ndjson` record say "span" even though what was dropped is a log record. Cosmetic — reusing the real broken/unrouted bookkeeping outweighed forking it for correct wording.
- **Non-blocking append, even though the append itself doesn't need it.** `appendLogEntry` (logs-store.ts) is a synchronous, in-memory push + prune — no I/O, negligible cost, no real backpressure risk. `otel-logs.ts` still runs it through the same queue/drain shape `otel.ts` uses for graph mutation, so the "sender is never blocked on the mutation" invariant holds literally rather than only by the mutation's current speed, and so tests get the same `flushPending()` seam every other OTLP receiver here exposes.
- **No graph lookup for `nodeId`.** `LogEntry.nodeId` stays unset — this receiver reads nothing off `NeatGraph`, matching the contract's "never touches NeatGraph" line literally rather than doing a minimal existence check.

## Tests

`packages/core/test/otel-logs.test.ts` — 33 new tests: `parseOtlpLogsRequest` against a real `ExportLogsServiceRequest` JSON shape (severity normalization both directions, missing/non-string body values, timestamp fallback, trace/span cross-reference, code.filepath passthrough), the JSON + protobuf receiver paths (bearer rejection, 415/400 handling, non-blocking reply-before-drain), project-scoped routing, mounting onto an app that already has `/v1/traces` (proves no protobuf-parser collision and shared auth), and a full receiver → `appendLogEntry` → `queryLogEntries` round trip.

`npx vitest run --root packages/core`: 1389 passed (baseline ~1356 + these 33), 2 skipped, 5 todo. `npx turbo build --filter=@neat.is/core^...` and `npm run build --workspace @neat.is/core` both clean. `npx eslint` clean on all touched files.