### PR TITLE
Connectors: emit a LogEntry alongside each ObservedSignal (ADR-132)

### DIFF
--- a/packages/core/src/connectors/cloudflare/connector.ts
+++ b/packages/core/src/connectors/cloudflare/connector.ts
@@ -7,11 +7,13 @@
 // static call site, minting the OBSERVED edge — is the shared pipeline in
 // connectors/index.ts; this module never mutates the graph itself.
 
+import path from 'node:path'
 import { EdgeType, fileId } from '@neat.is/types'
+import { appendLogEntry } from '../../logs-store.js'
 import type { ResolveConnectorTarget, ResolvedConnectorTarget } from '../index.js'
 import type { ConnectorContext, ObservedConnector } from '../types.js'
 import { queryWorkerInvocations } from './client.js'
-import { mapEventToSignal } from './map.js'
+import { mapEventToLogEntry, mapEventToSignal } from './map.js'
 import { CLOUDFLARE_TARGET_KIND, type CloudflareConnectorConfig, type CloudflareObservedSignal } from './types.js'
 
 // Cloudflare's docs don't confirm the Telemetry Query API's own max lookback
@@ -41,10 +43,17 @@ export class CloudflareConnector implements ObservedConnector {
     const fromMs = resolveFromMs(ctx.since, this.config.maxLookbackMs)
     const events = await queryWorkerInvocations(ctx, this.config, { fromMs, toMs })
 
+    // Raw-record retention alongside the graph-facing signal (docs/
+    // contracts/logs.md, connectors.md §7, ADR-132) — additive, never gates
+    // or alters the ObservedSignal[] this method returns.
+    const projectName = ctx.projectName ?? path.basename(ctx.projectDir)
+
     const signals: CloudflareObservedSignal[] = []
     for (const event of events) {
       const signal = mapEventToSignal(event)
       if (signal) signals.push(signal)
+      const logEntry = mapEventToLogEntry(event, this.config, projectName)
+      if (logEntry) appendLogEntry(logEntry)
     }
     return signals
   }

--- a/packages/core/src/connectors/cloudflare/index.ts
+++ b/packages/core/src/connectors/cloudflare/index.ts
@@ -5,7 +5,7 @@
 
 export { CloudflareConnector, createCloudflareResolveTarget } from './connector.js'
 export { queryWorkerInvocations, type TelemetryWindow } from './client.js'
-export { mapEventToSignal, parseHttpMethodFromTrigger } from './map.js'
+export { mapEventToLogEntry, mapEventToSignal, parseHttpMethodFromTrigger } from './map.js'
 export {
   CLOUDFLARE_TARGET_KIND,
   type CloudflareConnectorConfig,

--- a/packages/core/src/connectors/cloudflare/map.ts
+++ b/packages/core/src/connectors/cloudflare/map.ts
@@ -12,7 +12,14 @@
 // for this cut (§Out of scope) — dropped here, honestly, rather than
 // fabricating a method or forcing it through as an unresolvable signal.
 
-import { CLOUDFLARE_TARGET_KIND, type CloudflareObservedSignal, type CloudflareTelemetryEvent } from './types.js'
+import { randomUUID } from 'node:crypto'
+import { fileId, type LogEntry } from '@neat.is/types'
+import {
+  CLOUDFLARE_TARGET_KIND,
+  type CloudflareConnectorConfig,
+  type CloudflareObservedSignal,
+  type CloudflareTelemetryEvent,
+} from './types.js'
 
 // The HTTP methods a `trigger` string's leading token can actually name
 // (RFC 7231 + CONNECT/TRACE). A closed vocabulary, the same discipline
@@ -76,5 +83,63 @@ export function mapEventToSignal(event: CloudflareTelemetryEvent): CloudflareObs
     method,
     ...(typeof statusCode === 'number' ? { statusCode } : {}),
     ...(typeof metadata?.duration === 'number' ? { duration: metadata.duration } : {}),
+  }
+}
+
+function logSeverityForStatus(status: number | undefined): string {
+  if (typeof status !== 'number') return 'info'
+  if (status >= ERROR_STATUS_THRESHOLD) return 'error'
+  if (status >= 400) return 'warn'
+  return 'info'
+}
+
+// Maps one Telemetry Query API invocation record to a NEAT LogEntry
+// (docs/contracts/logs.md, connectors.md §7, ADR-129/ADR-132) — additive
+// alongside mapEventToSignal above, from the same raw event. Unlike the
+// signal path, this never drops a non-HTTP-triggered event (a queue
+// message, a cron tick): the graph-facing signal only has a use for
+// HTTP-shaped invocations, but log retention's job is showing what actually
+// happened, HTTP or not. serviceName/nodeId reuse the identical
+// `config.workers` lookup createCloudflareResolveTarget (connector.ts)
+// resolves a signal's target through — never a second mapping.
+export function mapEventToLogEntry(
+  event: CloudflareTelemetryEvent,
+  config: CloudflareConnectorConfig,
+  projectName: string,
+): LogEntry | null {
+  const metadata = event.$metadata
+  const workers = event.$workers
+  const scriptName = workers?.scriptName ?? metadata?.service
+  if (!scriptName) return null
+
+  const timestampMs = event.timestamp ?? metadata?.startTime
+  if (typeof timestampMs !== 'number' || !Number.isFinite(timestampMs)) return null
+
+  const mapping = config.workers[scriptName]
+  const trigger = metadata?.trigger ?? 'unknown trigger'
+  const statusCode = metadata?.statusCode
+  const message =
+    typeof statusCode === 'number'
+      ? `${trigger} → ${statusCode}${typeof metadata?.duration === 'number' ? ` (${metadata.duration}ms)` : ''}`
+      : trigger
+
+  return {
+    id: `cloudflare-${scriptName}-${timestampMs}-${randomUUID()}`,
+    projectName,
+    source: 'cloudflare',
+    ...(mapping ? { serviceName: mapping.service, nodeId: fileId(mapping.service, mapping.entryFile) } : {}),
+    timestamp: new Date(timestampMs).toISOString(),
+    severity: logSeverityForStatus(statusCode),
+    message,
+    attributes: {
+      scriptName,
+      ...(metadata?.trigger ? { trigger: metadata.trigger } : {}),
+      ...(typeof statusCode === 'number' ? { statusCode } : {}),
+      ...(typeof metadata?.duration === 'number' ? { duration: metadata.duration } : {}),
+      ...(typeof metadata?.traceDuration === 'number' ? { traceDuration: metadata.traceDuration } : {}),
+      ...(metadata?.url ? { url: metadata.url } : {}),
+      ...(workers?.eventType ? { eventType: workers.eventType } : {}),
+      ...(workers?.outcome ? { outcome: workers.outcome } : {}),
+    },
   }
 }

--- a/packages/core/src/connectors/firebase/index.ts
+++ b/packages/core/src/connectors/firebase/index.ts
@@ -15,26 +15,51 @@
 // connectors/index.ts pipeline; this module never touches the graph
 // directly (ADR-030).
 
+import path from 'node:path'
 import type { NeatGraph } from '../../graph.js'
+import { appendLogEntry } from '../../logs-store.js'
 import type { ConnectorContext, ObservedConnector, ObservedSignal } from '../types.js'
 import type { ResolveConnectorTarget } from '../index.js'
 import { fetchHttpRequestLogEntries, readFirebaseCredentials, DEFAULT_LOOKBACK_MS } from './logging-api.js'
-import { mapLogEntriesToSignals } from './map.js'
+import { mapLogEntriesToLogEntries, mapLogEntriesToSignals } from './map.js'
 import { createFirebaseResolveTarget, type FirebaseServiceMap } from './resolve.js'
 
 export type { FirebaseCredentials, FirebaseResourceType } from './logging-api.js'
 export type { FirebaseServiceMap } from './resolve.js'
 export { createFirebaseResolveTarget } from './resolve.js'
 export type { FirebaseTargetIdentity } from './map.js'
-export { mapLogEntryToSignal, mapLogEntriesToSignals, packFirebaseTargetName, parseFirebaseTargetName } from './map.js'
+export {
+  mapLogEntryToSignal,
+  mapLogEntriesToSignals,
+  mapLogEntryToLogEntry,
+  mapLogEntriesToLogEntries,
+  packFirebaseTargetName,
+  parseFirebaseTargetName,
+} from './map.js'
 
 export class FirebaseConnector implements ObservedConnector {
   readonly provider = 'firebase'
+
+  // Optional so the no-arg construction existing tests/callers already use
+  // keeps working; a caller wanting resolved serviceName on this
+  // connector's LogEntry emissions (docs/contracts/logs.md, connectors.md
+  // §7, ADR-132) passes the same FirebaseServiceMap createFirebaseConnector
+  // below already threads to resolve.ts — never a second, independent map.
+  constructor(private readonly serviceMap: FirebaseServiceMap = {}) {}
 
   async poll(ctx: ConnectorContext): Promise<ObservedSignal[]> {
     const creds = readFirebaseCredentials(ctx.credentials)
     const sinceIso = ctx.since ?? new Date(Date.now() - DEFAULT_LOOKBACK_MS).toISOString()
     const entries = await fetchHttpRequestLogEntries(creds, sinceIso)
+
+    // Raw-record retention alongside the graph-facing signal (docs/
+    // contracts/logs.md, connectors.md §7, ADR-132) — additive, never gates
+    // or alters the ObservedSignal[] this method returns.
+    const projectName = ctx.projectName ?? path.basename(ctx.projectDir)
+    for (const logEntry of mapLogEntriesToLogEntries(entries, projectName, this.serviceMap)) {
+      appendLogEntry(logEntry)
+    }
+
     return mapLogEntriesToSignals(entries)
   }
 }
@@ -52,7 +77,7 @@ export function createFirebaseConnector(
   serviceMap: FirebaseServiceMap,
 ): { connector: ObservedConnector; resolveTarget: ResolveConnectorTarget } {
   return {
-    connector: new FirebaseConnector(),
+    connector: new FirebaseConnector(serviceMap),
     resolveTarget: createFirebaseResolveTarget(graph, serviceMap),
   }
 }

--- a/packages/core/src/connectors/firebase/map.ts
+++ b/packages/core/src/connectors/firebase/map.ts
@@ -9,8 +9,12 @@
 // out of scope per firebase.md §Scope. It only reads the httpRequest /
 // resource fields off a Cloud Logging LogEntry.
 
+import type { LogEntry as NeatLogEntry } from '@neat.is/types'
 import type { ObservedSignal } from '../types.js'
 import { isFirebaseResourceType, type FirebaseResourceType, type LogEntry } from './logging-api.js'
+// Type-only — erased at build time, so this never creates a runtime import
+// cycle with resolve.ts (which imports a value from this file).
+import type { FirebaseServiceMap } from './resolve.js'
 
 // The provider-vocabulary identity this connector's signals carry through
 // the shared pipeline (targetKind/targetName, per types.ts's ObservedSignal
@@ -135,6 +139,96 @@ export function mapLogEntriesToSignals(entries: LogEntry[]): ObservedSignal[] {
   for (const entry of entries) {
     const signal = mapLogEntryToSignal(entry)
     if (signal) out.push(signal)
+  }
+  return out
+}
+
+// ── LogEntry -> NEAT LogEntry (docs/contracts/logs.md, connectors.md §7,
+// ADR-132) ───────────────────────────────────────────────────────────────
+//
+// Additive alongside mapLogEntryToSignal above, from the same raw Cloud
+// Logging record — one NEAT LogEntry per raw entry, never gated on whether a
+// signal was produced from it. serviceName resolves through the identical
+// FirebaseServiceMap resolve.ts's own resourceName lookup consults (a pure
+// config-time map, never a graph query) — never a second, guessed mapping.
+// nodeId is left unset: the RouteNode match resolve.ts computes needs a live
+// graph read this connector's poll() has no access to (unlike Railway/
+// Cloudflare/Supabase, whose poll() already closes over either the graph or
+// a graph-free config lookup) — an honest gap, not a fabricated id.
+function neatServiceNameForLog(
+  resourceType: FirebaseResourceType,
+  resourceName: string,
+  serviceMap: FirebaseServiceMap,
+): string | undefined {
+  switch (resourceType) {
+    case 'cloud_function':
+      return serviceMap.functions?.[resourceName]
+    case 'cloud_run_revision':
+      return serviceMap.cloudRun?.[resourceName]
+    case 'firebase_domain':
+      return serviceMap.hosting?.[resourceName]
+  }
+}
+
+function logSeverityForStatus(status: number | undefined): string {
+  if (typeof status !== 'number') return 'info'
+  if (status >= ERROR_STATUS_THRESHOLD) return 'error'
+  if (status >= 400) return 'warn'
+  return 'info'
+}
+
+export function mapLogEntryToLogEntry(
+  entry: LogEntry,
+  projectName: string,
+  serviceMap: FirebaseServiceMap,
+): NeatLogEntry | null {
+  const resourceType = entry.resource?.type
+  if (!resourceType || !isFirebaseResourceType(resourceType)) return null
+  const resourceName = resourceNameFor(resourceType, entry.resource?.labels)
+  if (!resourceName) return null
+  const timestamp = entry.timestamp
+  if (!timestamp) return null
+
+  const req = entry.httpRequest
+  const method = req?.requestMethod?.toUpperCase()
+  const reqPath = pathFromRequestUrl(req?.requestUrl)
+  const serviceName = neatServiceNameForLog(resourceType, resourceName, serviceMap)
+
+  const message =
+    method && reqPath
+      ? `${method} ${reqPath} → ${req?.status ?? 'unknown'}${req?.latency ? ` (${req.latency})` : ''}`
+      : `${resourceType} ${resourceName} event`
+
+  return {
+    id: entry.insertId ? `firebase-${entry.insertId}` : `firebase-${resourceName}-${timestamp}`,
+    projectName,
+    source: 'firebase',
+    ...(serviceName ? { serviceName } : {}),
+    timestamp,
+    severity: logSeverityForStatus(req?.status),
+    message,
+    attributes: {
+      resourceType,
+      resourceName,
+      ...(method ? { method } : {}),
+      ...(reqPath ? { path: reqPath } : {}),
+      ...(typeof req?.status === 'number' ? { status: req.status } : {}),
+      ...(req?.latency ? { latency: req.latency } : {}),
+      ...(req?.userAgent ? { userAgent: req.userAgent } : {}),
+      ...(req?.remoteIp ? { remoteIp: req.remoteIp } : {}),
+    },
+  }
+}
+
+export function mapLogEntriesToLogEntries(
+  entries: LogEntry[],
+  projectName: string,
+  serviceMap: FirebaseServiceMap,
+): NeatLogEntry[] {
+  const out: NeatLogEntry[] = []
+  for (const entry of entries) {
+    const logEntry = mapLogEntryToLogEntry(entry, projectName, serviceMap)
+    if (logEntry) out.push(logEntry)
   }
   return out
 }

--- a/packages/core/src/connectors/railway/index.ts
+++ b/packages/core/src/connectors/railway/index.ts
@@ -7,10 +7,12 @@
 // would fuse onto if the app were OTel-instrumented — rather than a
 // client-SDK call site the way the Supabase connector design does.
 
-import type { RouteNode } from '@neat.is/types'
+import path from 'node:path'
+import type { LogEntry, RouteNode } from '@neat.is/types'
 import { EdgeType, NodeType, serviceId } from '@neat.is/types'
 import type { NeatGraph } from '../../graph.js'
 import { normalizePathTemplate } from '../../extract/routes.js'
+import { appendLogEntry } from '../../logs-store.js'
 import type {
   ConnectorCallSite,
   ConnectorContext,
@@ -222,6 +224,84 @@ export function mapRailwayNetworkFlowLogsToSignals(
   }))
 }
 
+// ── httpLogs / networkFlowLogs → LogEntry[] (docs/contracts/logs.md,
+// connectors.md §7, ADR-132) ────────────────────────────────────────────────
+//
+// Additive alongside the bucketed ObservedSignal mapping above: one LogEntry
+// per raw record, never aggregated, so the individual request/flow this
+// connector actually saw stays inspectable via GET /logs even though the
+// graph-facing signal buckets by route/peer. httpLogs's nodeId reuses the
+// exact same `findRailwayRoute` match the signal-side bucketing already
+// computes — never a second resolution pass — so a log entry only ever
+// names a RouteNode the signal path itself would also fuse onto.
+function railwayLogSeverity(status: number): string {
+  if (status >= 500) return 'error'
+  if (status >= 400) return 'warn'
+  return 'info'
+}
+
+export function mapRailwayHttpLogsToLogEntries(
+  entries: RailwayHttpLogEntry[],
+  routeIndex: RailwayRouteIndexEntry[],
+  projectName: string,
+  serviceName: string | undefined,
+): LogEntry[] {
+  return entries.map((entry) => {
+    const method = entry.method.toUpperCase()
+    const normalizedPath = normalizePathTemplate(entry.path)
+    const match = findRailwayRoute(routeIndex, method, normalizedPath)
+    return {
+      id: `railway-http-${entry.requestId}`,
+      projectName,
+      source: 'railway',
+      ...(serviceName ? { serviceName } : {}),
+      ...(match ? { nodeId: match.routeNodeId } : {}),
+      timestamp: entry.timestamp,
+      severity: railwayLogSeverity(entry.httpStatus),
+      message: `${method} ${entry.path} → ${entry.httpStatus} (${entry.totalDuration}ms)`,
+      attributes: {
+        method,
+        path: entry.path,
+        httpStatus: entry.httpStatus,
+        totalDuration: entry.totalDuration,
+        requestId: entry.requestId,
+        deploymentId: entry.deploymentId,
+        edgeRegion: entry.edgeRegion,
+      },
+    }
+  })
+}
+
+export function mapRailwayNetworkFlowLogsToLogEntries(
+  entries: RailwayNetworkFlowLogEntry[],
+  projectName: string,
+  serviceName: string | undefined,
+): LogEntry[] {
+  return entries.map((entry, i) => {
+    const peer = entry.peerServiceId ?? 'external'
+    const direction = entry.direction ?? 'flow'
+    const bytes = entry.byteCount ?? 0
+    const packets = entry.packetCount ?? 0
+    return {
+      id: `railway-flow-${entry.timestamp}-${i}`,
+      projectName,
+      source: 'railway',
+      ...(serviceName ? { serviceName } : {}),
+      timestamp: entry.timestamp,
+      severity: entry.dropCause ? 'warn' : 'info',
+      message: `${direction} ${peer}: ${bytes}B / ${packets} pkts${entry.dropCause ? ` (dropped: ${entry.dropCause})` : ''}`,
+      attributes: {
+        peerServiceId: entry.peerServiceId,
+        peerKind: entry.peerKind,
+        direction: entry.direction,
+        byteCount: entry.byteCount,
+        packetCount: entry.packetCount,
+        dropCause: entry.dropCause,
+      },
+    }
+  })
+}
+
 // ── target resolution (README.md pipeline step 2 — provider-specific) ──────
 //
 // A pure function of (signal, ctx, config) — no graph access, unlike
@@ -305,6 +385,17 @@ export function createRailwayConnector(graph: NeatGraph, config: RailwayConnecto
 
       const serviceName = config.serviceNameById[config.serviceId]
       const routeIndex = serviceName ? buildRailwayRouteIndex(graph, serviceName) : []
+
+      // Raw-record retention alongside the graph-facing signal (docs/
+      // contracts/logs.md, connectors.md §7, ADR-132) — additive, never
+      // gates or alters the ObservedSignal[] this method returns.
+      const projectName = ctx.projectName ?? path.basename(ctx.projectDir)
+      for (const entry of mapRailwayHttpLogsToLogEntries(httpLogs, routeIndex, projectName, serviceName)) {
+        appendLogEntry(entry)
+      }
+      for (const entry of mapRailwayNetworkFlowLogsToLogEntries(flowLogs, projectName, serviceName)) {
+        appendLogEntry(entry)
+      }
 
       return [
         ...mapRailwayHttpLogsToSignals(httpLogs, routeIndex),

--- a/packages/core/src/connectors/supabase/index.ts
+++ b/packages/core/src/connectors/supabase/index.ts
@@ -13,11 +13,19 @@
 // resolution (minting the OBSERVED edge) is the shared connectors/index.ts
 // pipeline; this module never touches the graph directly (ADR-030).
 
+import path from 'node:path'
 import type { NeatGraph } from '../../graph.js'
+import { appendLogEntry } from '../../logs-store.js'
 import type { ResolveConnectorTarget } from '../index.js'
 import type { ConnectorContext, ObservedConnector, ObservedSignal } from '../types.js'
 import { boundedSupabaseLogWindow, fetchSupabaseEdgeLogs } from './client.js'
-import { diffPgStatStatementsToSignals, mapEdgeLogRowsToSignals, type StatementBaseline } from './map.js'
+import {
+  diffPgStatStatementsToSignals,
+  mapEdgeLogRowsToLogEntries,
+  mapEdgeLogRowsToSignals,
+  mapPgStatStatementsToLogEntries,
+  type StatementBaseline,
+} from './map.js'
 import { fetchPgStatStatements, DEFAULT_STATEMENT_LIMIT } from './postgres-client.js'
 import { createSupabaseResolveTarget } from './resolve.js'
 import { readSupabaseCredentials, type SupabaseConnectorConfig } from './types.js'
@@ -40,7 +48,9 @@ export {
 export { DEFAULT_STATEMENT_LIMIT, fetchPgStatStatements } from './postgres-client.js'
 export {
   diffPgStatStatementsToSignals,
+  mapEdgeLogRowsToLogEntries,
   mapEdgeLogRowsToSignals,
+  mapPgStatStatementsToLogEntries,
   tableNameFromQueryText,
   targetFromRestPath,
   type StatementBaseline,
@@ -85,6 +95,14 @@ export class SupabaseConnector implements ObservedConnector {
     const logRows = await fetchSupabaseEdgeLogs(this.config, creds.managementToken, startIso, endIso)
     const signals: ObservedSignal[] = mapEdgeLogRowsToSignals(logRows)
 
+    // Raw-record retention alongside the graph-facing signal (docs/
+    // contracts/logs.md, connectors.md §7, ADR-132) — additive, never gates
+    // or alters the ObservedSignal[] this method returns.
+    const projectName = ctx.projectName ?? path.basename(ctx.projectDir)
+    for (const logEntry of mapEdgeLogRowsToLogEntries(logRows, projectName, this.config.serviceName)) {
+      appendLogEntry(logEntry)
+    }
+
     // Surface 2 only runs when a Postgres connection string is present —
     // supabase.md §Scope's local-profile-only-for-now split, expressed
     // entirely through what `ctx.credentials` carries rather than a
@@ -97,6 +115,14 @@ export class SupabaseConnector implements ObservedConnector {
         this.config.apiProjectRef,
       )
       signals.push(...diffPgStatStatementsToSignals(statementRows, this.statementBaselines, now.toISOString()))
+      for (const logEntry of mapPgStatStatementsToLogEntries(
+        statementRows,
+        projectName,
+        this.config.serviceName,
+        now.toISOString(),
+      )) {
+        appendLogEntry(logEntry)
+      }
     }
 
     return signals

--- a/packages/core/src/connectors/supabase/map.ts
+++ b/packages/core/src/connectors/supabase/map.ts
@@ -14,6 +14,7 @@
 //      PostgREST-shaped query and diffs against the previous poll's counts to
 //      turn a cumulative total into this window's delta.
 
+import type { LogEntry } from '@neat.is/types'
 import type { ObservedSignal } from '../types.js'
 import { SUPABASE_RPC_TARGET_KIND, SUPABASE_TABLE_TARGET_KIND, type PgStatStatementsRow, type SupabaseEdgeLogRow } from './types.js'
 
@@ -197,4 +198,73 @@ export function diffPgStatStatementsToSignals(
   }
 
   return signals
+}
+
+// ── edge_logs / pg_stat_statements → LogEntry[] (docs/contracts/logs.md,
+// connectors.md §7, ADR-132) ────────────────────────────────────────────────
+//
+// Additive alongside the two ObservedSignal mappers above, one LogEntry per
+// raw row rather than aggregated/diffed. edge_logs rows outside the
+// `/rest/v1/...` PostgREST shape (Auth/Storage/Realtime/Functions traffic)
+// are still logged here even though mapEdgeLogRowsToSignals drops them as
+// out of scope for fusion — a real request this project's Supabase project
+// served either way. pg_stat_statements rows are logged every poll tick,
+// independent of diffPgStatStatementsToSignals's baseline/delta state — the
+// "first sighting, no signal yet" case that diffing drops is still a real
+// counter snapshot worth retaining.
+
+function edgeLogSeverity(status: number): string {
+  if (status >= ERROR_STATUS_THRESHOLD) return 'error'
+  if (status >= 400) return 'warn'
+  return 'info'
+}
+
+export function mapEdgeLogRowsToLogEntries(
+  rows: SupabaseEdgeLogRow[],
+  projectName: string,
+  serviceName: string,
+): LogEntry[] {
+  return rows.map((row, i) => ({
+    id: `supabase-edge-${row.timestamp}-${i}`,
+    projectName,
+    source: 'supabase',
+    serviceName,
+    timestamp: row.timestamp,
+    severity: edgeLogSeverity(row.status_code),
+    message: `${row.method} ${row.path} → ${row.status_code}`,
+    attributes: { method: row.method, path: row.path, statusCode: row.status_code },
+  }))
+}
+
+// Table attribution reuses tableNameFromQueryText — never a second parse.
+// Timestamp is the poll tick's own wall-clock time, matching
+// diffPgStatStatementsToSignals's own lastObservedIso convention for this
+// surface (pg_stat_statements carries no per-row event time of its own).
+export function mapPgStatStatementsToLogEntries(
+  rows: PgStatStatementsRow[],
+  projectName: string,
+  serviceName: string,
+  nowIso: string,
+): LogEntry[] {
+  return rows.map((row) => {
+    const table = tableNameFromQueryText(row.query)
+    const calls = Number(row.calls)
+    const avgMs = calls > 0 ? row.total_exec_time / calls : 0
+    return {
+      id: `supabase-pgstat-${row.queryid}-${nowIso}`,
+      projectName,
+      source: 'supabase',
+      serviceName,
+      timestamp: nowIso,
+      severity: 'info',
+      message: `${table ?? 'unattributed query'}: ${calls} calls, avg ${avgMs.toFixed(2)}ms`,
+      attributes: {
+        queryid: row.queryid,
+        ...(table ? { table } : {}),
+        calls,
+        totalExecTimeMs: row.total_exec_time,
+        rows: row.rows,
+      },
+    }
+  })
 }

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -46,6 +46,16 @@ export interface ConnectorContext {
   // window the provider's own API caps (README.md §Poll cadence and
   // backfill) — never an unbounded full-history query.
   since?: string
+  // The NEAT project name this poll's `LogEntry` emissions are scoped to
+  // (docs/contracts/logs.md, connectors.md §7, ADR-132) — the same
+  // `RegistryEntry.name` `daemon.ts` already keys the graph, staleness loop,
+  // and `GET /logs` by. Optional because `poll()`'s signature/shape can't
+  // change and a caller outside `daemon.ts` (a direct test, a one-shot
+  // script) may have no registry entry to hand in; a connector reading this
+  // falls back to `path.basename(projectDir)` — the same "no explicit name
+  // given" convention `cli.ts` already uses — rather than leaving
+  // `LogEntry.projectName` unset.
+  projectName?: string
 }
 
 /**

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -552,7 +552,12 @@ async function bootstrapProject(
     const stopFns = connectors.map((registration) =>
       startConnectorPollLoop(
         registration.connector,
-        { projectDir: entry.path, credentials: registration.credentials },
+        // `projectName: entry.name` (docs/contracts/logs.md, connectors.md
+        // §7, ADR-132) — the same registry name every other per-project
+        // primitive above (graph key, staleness loop, GET /logs) already
+        // scopes by, threaded through so each connector's LogEntry
+        // emissions land in the right project's log bucket.
+        { projectDir: entry.path, credentials: registration.credentials, projectName: entry.name },
         graph,
         registration.resolveTarget,
         { intervalMs: registration.intervalMs },

--- a/packages/core/test/connectors-cloudflare.test.ts
+++ b/packages/core/test/connectors-cloudflare.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { MultiDirectedGraph } from 'graphology'
 import {
   EdgeType,
@@ -24,6 +24,7 @@ import {
   type CloudflareTelemetryEvent,
   type CloudflareTelemetryQueryResponse,
 } from '../src/connectors/cloudflare/index.js'
+import * as logsStore from '../src/logs-store.js'
 
 const SERVICE = 'orders-worker'
 const ENTRY_FILE = 'src/index.ts'
@@ -301,6 +302,55 @@ describe('CloudflareConnector end-to-end via runConnectorPoll', () => {
       // 2 invocations replayed (GET 200 + POST 500) — one error.
       expect(edge.signal?.spanCount).toBe(2)
       expect(edge.signal?.errorCount).toBe(1)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
+describe('CloudflareConnector — LogEntry retention alongside ObservedSignal (docs/contracts/logs.md, connectors.md §7, ADR-129/ADR-132)', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('poll() also appends a LogEntry per raw telemetry event, including the queue message the signal path drops', async () => {
+    // Spying rather than reading back through queryLogEntries: the store's
+    // 24h prune window is relative to real wall-clock time, and this
+    // fixture carries fixed epoch-ms timestamps — spying sidesteps that the
+    // same way connectors-railway.test.ts's LogEntry test does.
+    const appendSpy = vi.spyOn(logsStore, 'appendLogEntry').mockImplementation(() => {})
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify(TELEMETRY_RESPONSE), { status: 200 }))
+    const config = baseConfig()
+    const connector = new CloudflareConnector(config)
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = fetchImpl as unknown as typeof fetch
+    try {
+      await connector.poll(baseCtx())
+
+      const logs = appendSpy.mock.calls.map((call) => call[0])
+      // All 3 raw events retained, including the queue message the signal
+      // path drops (mapEventToSignal returns null for a non-HTTP trigger).
+      expect(logs).toHaveLength(3)
+      expect(logs.every((l) => l.projectName === 'orders-worker' && l.source === 'cloudflare')).toBe(true)
+
+      const okLog = logs.find((l) => l.attributes?.statusCode === 200)
+      expect(okLog).toBeDefined()
+      expect(okLog?.severity).toBe('info')
+      expect(okLog?.serviceName).toBe(SERVICE)
+      expect(okLog?.nodeId).toBe(fileId(SERVICE, ENTRY_FILE))
+      expect(okLog?.timestamp).toBe(new Date(1751566800000).toISOString())
+
+      const failLog = logs.find((l) => l.attributes?.statusCode === 500)
+      expect(failLog?.severity).toBe('error')
+
+      const queueLog = logs.find((l) => l.attributes?.trigger === 'queue message')
+      expect(queueLog).toBeDefined()
+      expect(queueLog?.severity).toBe('info')
+      // No HTTP status on this trigger, so the message falls back to the raw
+      // trigger string rather than fabricating a status line.
+      expect(queueLog?.message).toBe('queue message')
+      // Still the same Worker script, so the same config.workers mapping
+      // resolves serviceName/nodeId even though there's no signal for it.
+      expect(queueLog?.serviceName).toBe(SERVICE)
+      expect(queueLog?.nodeId).toBe(fileId(SERVICE, ENTRY_FILE))
     } finally {
       globalThis.fetch = originalFetch
     }

--- a/packages/core/test/connectors-firebase.test.ts
+++ b/packages/core/test/connectors-firebase.test.ts
@@ -26,6 +26,7 @@ import {
 import type { EntriesListResponse } from '../src/connectors/firebase/logging-api.js'
 import type { FirebaseServiceMap } from '../src/connectors/firebase/resolve.js'
 import type { NeatGraph } from '../src/graph.js'
+import * as logsStore from '../src/logs-store.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -295,6 +296,59 @@ describe('Firebase connector credentials (docs/contracts/connectors.md §6)', ()
     await expect(
       connector.poll({ projectDir: '/repo', credentials: {} }),
     ).rejects.toThrow(/credentials/)
+  })
+})
+
+describe('Firebase connector — LogEntry retention alongside ObservedSignal (docs/contracts/logs.md, connectors.md §7, ADR-132)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('poll() also appends one LogEntry per raw Cloud Logging entry, resolving serviceName through the same FirebaseServiceMap the signal path consults', async () => {
+    // Spying rather than reading back through queryLogEntries: the store's
+    // 24h prune window is relative to real wall-clock time, and this
+    // fixture carries a fixed calendar date — spying sidesteps that the
+    // same way connectors-railway.test.ts's LogEntry test does.
+    const appendSpy = vi.spyOn(logsStore, 'appendLogEntry').mockImplementation(() => {})
+    const { connector } = createFirebaseConnector(newGraph(), SERVICE_MAP)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => FIXTURE,
+      }),
+    )
+
+    await connector.poll(baseCtx())
+
+    const logs = appendSpy.mock.calls.map((call) => call[0])
+    expect(logs).toHaveLength(4)
+    expect(logs.every((l) => l.projectName === 'orders-api' && l.source === 'firebase')).toBe(true)
+
+    const ordersLog = logs.find((l) => l.attributes?.path === '/orders/42')
+    expect(ordersLog).toBeDefined()
+    expect(ordersLog?.severity).toBe('info')
+    expect(ordersLog?.serviceName).toBe(ORDERS_SERVICE)
+    expect(ordersLog?.timestamp).toBe('2026-07-03T10:00:00.100000Z')
+    expect(ordersLog?.message).toBe('GET /orders/42 → 200 (0.081s)')
+
+    const webhookLog = logs.find((l) => l.attributes?.path === '/webhooks/stripe')
+    expect(webhookLog?.severity).toBe('error')
+    expect(webhookLog?.serviceName).toBe(ORDERS_SERVICE)
+
+    // legacyPing (cloud_function) is deliberately absent from
+    // SERVICE_MAP.functions — the same "no configured mapping" honest miss
+    // the signal path's resolve.ts hits — so this log entry carries no
+    // serviceName either, never guessed.
+    const legacyPingLog = logs.find((l) => l.attributes?.path === '/ping')
+    expect(legacyPingLog).toBeDefined()
+    expect(legacyPingLog?.serviceName).toBeUndefined()
+
+    const hostingLog = logs.find((l) => l.attributes?.path === '/status/42')
+    expect(hostingLog?.serviceName).toBe(HOSTING_SERVICE)
   })
 })
 

--- a/packages/core/test/connectors-railway.test.ts
+++ b/packages/core/test/connectors-railway.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { MultiDirectedGraph } from 'graphology'
 import {
   EdgeType,
@@ -26,6 +26,7 @@ import {
   type RailwayHttpLogEntry,
   type RailwayNetworkFlowLogEntry,
 } from '../src/connectors/railway/index.js'
+import * as logsStore from '../src/logs-store.js'
 import httpLogsFixture from './fixtures/railway/http-logs.json' with { type: 'json' }
 import networkFlowLogsFixture from './fixtures/railway/network-flow-logs.json' with { type: 'json' }
 
@@ -398,5 +399,80 @@ describe('Railway connector — end-to-end poll() against fixture GraphQL respon
     const connector = createRailwayConnector(graph, config())
 
     await expect(connector.poll(baseCtx({ credentials: {} }))).rejects.toThrow(/credentials\.token/)
+  })
+})
+
+describe('Railway connector — LogEntry retention alongside ObservedSignal (docs/contracts/logs.md, connectors.md §7, ADR-132)', () => {
+  let realFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    realFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = realFetch
+    vi.restoreAllMocks()
+  })
+
+  function stubRailwayGraphQL(): void {
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { query: string }
+      const isHttpLogs = body.query.includes('httpLogs')
+      const data = isHttpLogs
+        ? { httpLogs: httpLogsFixture }
+        : { networkFlowLogs: networkFlowLogsFixture }
+      return new Response(JSON.stringify({ data }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }) as typeof globalThis.fetch
+  }
+
+  it('poll() also appends a LogEntry per raw httpLogs/networkFlowLogs record — additive, not gated on whether a record resolves to a signal', async () => {
+    stubRailwayGraphQL()
+    // Spying on appendLogEntry rather than reading it back through
+    // queryLogEntries: the store's own 24h prune window (logs-store.ts) is
+    // relative to real wall-clock time, and these fixtures carry a fixed
+    // calendar date the same way the "calendar-flaky test" fix (#681)
+    // documents for this same file's since-bounding tests — spying sidesteps
+    // that entirely rather than re-introducing it here.
+    const appendSpy = vi.spyOn(logsStore, 'appendLogEntry').mockImplementation(() => {})
+    const graph = newGraph()
+    const connector = createRailwayConnector(graph, config())
+
+    const signals = await connector.poll(baseCtx())
+    // Unchanged from the existing ObservedSignal assertions above — this
+    // block only adds a LogEntry assertion, never touches signal behavior.
+    expect(signals.length).toBeGreaterThan(0)
+
+    const logs = appendSpy.mock.calls.map((call) => call[0])
+    // 5 httpLogs rows + 3 networkFlowLogs rows (including the null-peer
+    // "external egress" row the signal path drops) = 8 raw records retained.
+    expect(logs).toHaveLength(8)
+    expect(logs.every((l) => l.projectName === 'orders-api' && l.source === 'railway')).toBe(true)
+
+    const failingRequest = logs.find((l) => l.attributes?.httpStatus === 500)
+    expect(failingRequest).toBeDefined()
+    expect(failingRequest?.severity).toBe('error')
+    expect(failingRequest?.timestamp).toBe('2026-07-03T10:00:05.000Z')
+    expect(failingRequest?.serviceName).toBe(NEAT_SERVICE)
+    expect(failingRequest?.nodeId).toBe(routeId(NEAT_SERVICE, 'GET', '/users/:id'))
+    expect(failingRequest?.message).toBe('GET /users/999 → 500 (812ms)')
+
+    const unmatchedRequest = logs.find((l) => l.attributes?.path === '/internal/healthz')
+    expect(unmatchedRequest).toBeDefined()
+    expect(unmatchedRequest?.severity).toBe('info')
+    // No RouteNode resolved for this path — honest miss, same as the signal
+    // side's unmatched-route case — so no nodeId is fabricated.
+    expect(unmatchedRequest?.nodeId).toBeUndefined()
+
+    const droppedFlow = logs.find((l) => l.attributes?.dropCause === 'policy-deny')
+    expect(droppedFlow).toBeDefined()
+    expect(droppedFlow?.severity).toBe('warn')
+    expect(droppedFlow?.serviceName).toBe(NEAT_SERVICE)
+
+    const externalFlow = logs.find((l) => l.attributes?.peerServiceId === null)
+    expect(externalFlow).toBeDefined()
+    expect(externalFlow?.severity).toBe('info')
   })
 })

--- a/packages/core/test/connectors-supabase.test.ts
+++ b/packages/core/test/connectors-supabase.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { readFileSync, readdirSync, statSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -30,6 +30,7 @@ import {
   type SupabaseEdgeLogRow,
 } from '../src/connectors/supabase/index.js'
 import type { NeatGraph } from '../src/graph.js'
+import * as logsStore from '../src/logs-store.js'
 import logsAllFixture from './fixtures/supabase/logs-all-response.json' with { type: 'json' }
 import pgStatStatementsFixture from './fixtures/supabase/pg-stat-statements.json' with { type: 'json' }
 
@@ -483,6 +484,82 @@ describe('Supabase connector — full pull/map/fuse via runConnectorPoll (docs/c
     const connector = new SupabaseConnector(config())
 
     await expect(connector.poll({ projectDir: '/repo', credentials: {} })).rejects.toThrow(/managementToken/)
+  })
+})
+
+describe('Supabase connector — LogEntry retention alongside ObservedSignal (docs/contracts/logs.md, connectors.md §7, ADR-132)', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  function stubLogsAll(): void {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(logsAllFixture), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as typeof globalThis.fetch
+  }
+
+  it('poll() also appends a LogEntry per edge_logs row, including non-PostgREST traffic the signal path drops', async () => {
+    // Spying rather than reading back through queryLogEntries: the store's
+    // 24h prune window is relative to real wall-clock time, and this
+    // fixture carries a fixed calendar date — spying sidesteps that the
+    // same way connectors-railway.test.ts's LogEntry test does.
+    const appendSpy = vi.spyOn(logsStore, 'appendLogEntry').mockImplementation(() => {})
+    stubLogsAll()
+    const graph = newGraph({ projectNode: true, tableNode: false })
+    const { connector } = createSupabaseConnector(graph, config())
+
+    await connector.poll(baseCtx())
+
+    const logs = appendSpy.mock.calls.map((call) => call[0])
+    // 4 raw edge_logs rows, including the /auth/v1/token row the signal path
+    // drops as out of scope for fusion — still a real request worth logging.
+    expect(logs).toHaveLength(4)
+    expect(logs.every((l) => l.projectName === 'orders-api' && l.source === 'supabase')).toBe(true)
+
+    const errorLog = logs.find((l) => l.attributes?.statusCode === 500)
+    expect(errorLog).toBeDefined()
+    expect(errorLog?.severity).toBe('error')
+    expect(errorLog?.serviceName).toBe(NEAT_SERVICE)
+    expect(errorLog?.message).toBe('GET /rest/v1/orders?select=* → 500')
+
+    const authLog = logs.find((l) => l.attributes?.path === '/auth/v1/token?grant_type=password')
+    expect(authLog).toBeDefined()
+    expect(authLog?.severity).toBe('info')
+    expect(authLog?.serviceName).toBe(NEAT_SERVICE)
+  })
+
+  it('also appends a LogEntry per pg_stat_statements row when the Postgres surface is polled, independent of whether a delta signal fired', async () => {
+    const appendSpy = vi.spyOn(logsStore, 'appendLogEntry').mockImplementation(() => {})
+    stubLogsAll()
+    const graph = newGraph({ projectNode: true, tableNode: true })
+    const fakeFetchStatements = async () => STATEMENT_ROWS
+    const { connector } = createSupabaseConnector(graph, config(), { fetchPgStatStatements: fakeFetchStatements })
+    const ctxWithPg = baseCtx({
+      credentials: {
+        managementToken: 'sbp_test_token',
+        postgresConnectionString: 'postgres://neat_reader@db/postgres',
+      },
+    })
+
+    // First poll: pg_stat_statements only establishes a baseline (no delta
+    // signal — map.ts's diffPgStatStatementsToSignals doc comment), but the
+    // raw-record log still gets appended for all 4 statement rows.
+    await connector.poll(ctxWithPg)
+
+    const logs = appendSpy.mock.calls.map((call) => call[0])
+    const pgLogs = logs.filter((l) => typeof l.attributes?.queryid === 'string')
+    expect(pgLogs).toHaveLength(4)
+
+    const ordersLog = pgLogs.find((l) => l.attributes?.table === 'orders')
+    expect(ordersLog).toBeDefined()
+    expect(ordersLog?.message).toBe('orders: 42 calls, avg 3.06ms')
+    expect(ordersLog?.serviceName).toBe(NEAT_SERVICE)
+
+    const auditLog = pgLogs.find((l) => l.attributes?.queryid === '1111111111111111111')
+    // An INSERT statement — tableNameFromQueryText can't attribute a FROM
+    // clause, so this is logged honestly as unattributed rather than guessed.
+    expect(auditLog?.message).toBe('unattributed query: 5 calls, avg 0.62ms')
+    expect(auditLog?.attributes?.table).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
Refs #708. Builds on #690 (the logs store + REST endpoint) — this PR's diff will shrink once #690 merges and this gets retargeted to main.

## Summary

Each connector's mapping layer already turns a raw provider record (a Railway httpLogs row, a Firebase Cloud Logging entry, a Cloudflare telemetry event, a Supabase edge_logs/pg_stat_statements row) into an `ObservedSignal` for the graph, then drops the record. Per `docs/contracts/connectors.md` §7 (ADR-132), every connector now also emits a `LogEntry` for that same raw record and appends it to the logs store, tagged with the connector's own `source`.

Purely additive: `poll()`'s signature, `ObservedSignal`'s shape, and every existing signal-mapping assertion are unchanged.

- **Railway** — one `LogEntry` per httpLogs/networkFlowLogs row (not aggregated the way the signal bucketing is), reusing the exact route match the signal path already computed for `nodeId`.
- **Firebase** — one `LogEntry` per Cloud Logging entry; `serviceName` resolves through the same `FirebaseServiceMap` `resolve.ts` consults. `nodeId` stays unset — the RouteNode match needs a graph read `poll()` has no access to (unlike Railway/Cloudflare, whose `poll()` already closes over the graph or a graph-free config lookup).
- **Cloudflare** — one `LogEntry` per telemetry event, including non-HTTP triggers (a queue message, a cron tick) that the signal path drops outright, since log retention's job is showing what happened, not just what's fusable.
- **Supabase** — one `LogEntry` per edge_logs row (including Auth/Storage/Realtime/Functions traffic the signal path treats as out of scope) and one per pg_stat_statements row every poll tick, independent of whether that tick's diff produced a delta signal.

`ConnectorContext` gained an optional `projectName` field so a `LogEntry` always knows which project's log bucket it belongs to — `daemon.ts` threads the registry's own project name through the same way it already does for the graph key and staleness loop; a caller that omits it (tests, a one-shot script) falls back to `path.basename(projectDir)`.

## Judgment calls

- **Firebase/Supabase leave `nodeId` unset, Railway/Cloudflare set it.** The difference is architectural, not inconsistency: Railway's connector closes over the graph directly, and Cloudflare's target resolution is a pure config lookup (`config.workers[scriptName]`), so both are available inside `poll()`. Firebase/Supabase's RouteNode/InfraNode matching needs a live graph read that only their separate `resolveTarget` closures hold — reusing it would mean threading the graph into a poll() that today never touches it, which felt like a bigger structural change than this task warranted. Filed as an honest gap rather than adding a second resolution path.
- **Cloudflare logs every event, not just HTTP-triggered ones.** `mapEventToSignal` drops a queue/cron trigger outright (no method to parse), but the raw event is still real activity worth retaining — so `mapEventToLogEntry` doesn't gate on the signal path's own filter.
- **Firebase's `FirebaseConnector` gained an optional constructor param** (`serviceMap: FirebaseServiceMap = {}`) so `poll()` can resolve `serviceName` without duplicating `resolve.ts`'s lookup. Defaults to `{}` so the existing no-arg `new FirebaseConnector()` test keeps working unchanged.
- **Test assertions use `vi.spyOn(logsStore, 'appendLogEntry')` rather than `queryLogEntries`.** The store's 24h prune window is relative to real wall-clock time, and these fixtures carry fixed calendar dates — the same shape of bug #681 already fixed once in this file's own since-bounding tests. Spying sidesteps it rather than reintroducing it.

## Test plan

- [x] `npm install`
- [x] `npm run build --workspace @neat.is/types`
- [x] `npx turbo build --filter=@neat.is/core^...`
- [x] `npx turbo build` (whole monorepo, including `@neat.is/core` itself and `@neat.is/web`)
- [x] `npx eslint` on every changed file — clean
- [x] `npx vitest run --root packages/core` — 1361 passed, 2 skipped, 5 todo, 0 failed (baseline was ~1356; +5 for the new tests). Every pre-existing connector test still passes with its original `ObservedSignal` assertions untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)