### PR TITLE
Stop the Inspector panel crashing on nodes with missing fields

### DIFF
--- a/packages/web/app/components/Inspector.tsx
+++ b/packages/web/app/components/Inspector.tsx
@@ -15,8 +15,10 @@ interface RootCauseResult {
   traversalPath: string[]
 }
 
-function escapeHtml(s: string): string {
-  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] ?? c))
+function escapeHtml(s: string | null | undefined): string {
+  // never crash the panel on a missing field — a node/edge can lack a name,
+  // target, etc.; render empty rather than throwing on undefined.replace.
+  return (s == null ? '' : String(s)).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] ?? c))
 }
 
 function visualProv(provenance: string): 'STATIC' | 'OBSERVED' | 'INFERRED' {


### PR DESCRIPTION
Selecting a node in the dashboard could take down the whole Inspector panel. `escapeHtml` in `packages/web/app/components/Inspector.tsx` took a plain `string` and called `.replace` on it directly, but several callers pass optional fields that are legitimately undefined for some nodes and edges — a call's `targetName`, a node title's `rest`, a tag. When one of those was missing, the panel threw `undefined is not an object (evaluating 's.replace')` on selection. This reproduced live on a freshly-extracted graph.

The fix makes `escapeHtml` null-safe: a `null` or `undefined` value renders as empty rather than throwing, so a node or edge missing a name or target no longer crashes the panel. That's the only change.

Build: `npx turbo build --filter=@neat.is/web` passes.