### PR TITLE
Make the observed=0 overlay dismissable again

### DIFF
--- a/packages/web/app/components/GraphCanvas.tsx
+++ b/packages/web/app/components/GraphCanvas.tsx
@@ -58,6 +58,12 @@ function visualProv(p: string): 'STATIC' | 'OBSERVED' | 'INFERRED' | 'STALE' {
   return 'STATIC'
 }
 
+// Projects whose observed=0 overlay has been dismissed. Lives at module scope so
+// the dismissal survives a GraphCanvas re-mount — the per-daemon reachability
+// poll re-resolves the active profile and remounts us, which would otherwise
+// reset any per-instance ref and let the overlay bounce straight back.
+const observedOverlayDismissed = new Set<string>()
+
 export function GraphCanvas({
   project,
   selectedNodeId,
@@ -82,10 +88,6 @@ export function GraphCanvas({
   const [loading, setLoading] = useState(true)
   const [observedCount, setObservedCount] = useState(0)
   const [overlay, setOverlay] = useState<{ mode: ObservedMode } | null>(null)
-  // Once the operator dismisses the overlay for a project, it stays dismissed —
-  // a re-resolve / reload (effect re-run on [project]) must not resurrect it.
-  // Keyed by project so switching projects re-evaluates honestly.
-  const dismissedForRef = useRef<string | null>(null)
   const [hoverTip, setHoverTip] = useState<{ x: number; y: number; text: string } | null>(null)
 
   // -- cytoscape style ------------------------------------------------------
@@ -466,7 +468,7 @@ export function GraphCanvas({
       renderAll()
       setLoading(false)
 
-      if (obs === 0 && dismissedForRef.current !== proj)
+      if (obs === 0 && !observedOverlayDismissed.has(proj))
         void resolveOverlayMode(proj).then((m) => setOverlay({ mode: m }))
 
       function focusNode(id: string) {
@@ -678,7 +680,7 @@ export function GraphCanvas({
           mode={overlay.mode}
           project={project}
           onDismiss={() => {
-            dismissedForRef.current = project
+            if (project) observedOverlayDismissed.add(project)
             setOverlay(null)
           }}
         />


### PR DESCRIPTION
On a project with zero OBSERVED edges we show the "Your code is mapped"
overlay. With per-daemon profiles the reachability poll re-resolves the
active profile and re-mounts GraphCanvas, and the per-instance ref that
tracked "already dismissed" got wiped on every re-mount. The overlay
re-fired faster than you could click it away, so it behaved like an
inescapable modal.

This moves the dismissal state to a module-level Set keyed by project, so
it survives the re-mount. One click is now enough and the overlay stays
put. The overlay itself and its two modes are untouched — the
canvas-layout contract still requires the two-mode observed overlay and
its escapability, so nothing here removes it; it just makes one dismiss
stick.

The same fix already lives on the (merged) gui-per-daemon-profiles branch;
this brings it to main, where the buggy per-instance version shipped.

Refs #552