### PR TITLE
Fix TopBar: non-interactive status renders as a focusable button

### DIFF
--- a/packages/web/app/components/TopBar.tsx
+++ b/packages/web/app/components/TopBar.tsx
@@ -102,10 +102,21 @@ export function TopBar({ project, profiles, onSelectProfile, onOpenPalette, page
 
       <div className="top-actions">
         <span className="daemon-url" title="NEAT daemon URL">{CORE_URL_PUBLIC}</span>
-        <button className="top-btn" aria-label={isLive ? 'Core connected' : 'Core offline'}>
+        {/* status only — there's no reconnect action to wire up (health is
+            polled automatically above), so this stays a live region rather
+            than a button that does nothing on click (#695). Matches the
+            role="status" / aria-live="polite" convention Toaster.tsx uses
+            for other ambient state. */}
+        <span
+          className="top-btn"
+          role="status"
+          aria-live="polite"
+          aria-label={isLive ? 'Core connected' : 'Core offline'}
+          style={{ cursor: 'default' }}
+        >
           <span className={`dot${isLive ? ' live' : ''}`} />
           {isLive ? 'live' : 'offline'}
-        </button>
+        </span>
         {/* account — disabled-with-affordance: hosted auth is not in this redo
             (web-completeness #26). */}
         <button

--- a/packages/web/test/topbar-connection-status.test.tsx
+++ b/packages/web/test/topbar-connection-status.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+// #695 — the live/offline chip in the top-right of TopBar used to be a
+// focusable <button> with no onClick, which looked actionable but did
+// nothing when clicked or activated with a keyboard. There's no reconnect
+// capability anywhere in the codebase to wire it to (the health poll below
+// is already automatic), so it's a status region instead — same
+// role="status" / aria-live="polite" convention Toaster.tsx uses for other
+// ambient state that updates on its own.
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('#695 — TopBar connection indicator', () => {
+  it('renders the core connection state as a status region, not a focusable button', async () => {
+    const { TopBar } = await import('../app/components/TopBar')
+    render(
+      <TopBar
+        project="demo"
+        profiles={[]}
+        onSelectProfile={vi.fn()}
+        onOpenPalette={vi.fn()}
+        pageLabel="graph view"
+      />,
+    )
+
+    const indicator = await screen.findByRole('status', { name: 'Core connected' })
+    expect(indicator.tagName).toBe('SPAN')
+    expect(indicator.getAttribute('aria-live')).toBe('polite')
+    // Not in the tab order and not exposed as a button — activating it
+    // (click or Enter/Space while focused) has nothing to do.
+    expect(indicator.getAttribute('tabindex')).toBeNull()
+    expect(screen.queryByRole('button', { name: /Core (connected|offline)/ })).toBeNull()
+  })
+
+  it('flips label and live-region content from offline to connected once the health check resolves', async () => {
+    const { TopBar } = await import('../app/components/TopBar')
+    render(
+      <TopBar
+        project="demo"
+        profiles={[]}
+        onSelectProfile={vi.fn()}
+        onOpenPalette={vi.fn()}
+        pageLabel="graph view"
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('status', { name: 'Core connected' })).toBeTruthy()
+    })
+  })
+
+  it('stays a status region (offline) when there is no resolved project to poll', async () => {
+    const { TopBar } = await import('../app/components/TopBar')
+    render(
+      <TopBar
+        project={null}
+        profiles={[]}
+        onSelectProfile={vi.fn()}
+        onOpenPalette={vi.fn()}
+        pageLabel="graph view"
+      />,
+    )
+
+    const indicator = screen.getByRole('status', { name: 'Core offline' })
+    expect(indicator.tagName).toBe('SPAN')
+    expect(screen.queryByRole('button', { name: /Core (connected|offline)/ })).toBeNull()
+  })
+})


### PR DESCRIPTION
The live/offline chip in the top-right of TopBar was a `<button>` with no `onClick` — keyboard-focusable, visually looks like a button, does nothing when clicked or activated. From the 2026-07-03 AI slop audit (#695).

I checked for a real action to wire it to first: no reconnect/retry capability exists anywhere in the codebase, the health check already polls automatically every 15s in `useEffect`, and `connectionBus` is a one-way pub/sub for other components to subscribe to, not something a click can trigger. So there's nothing sensible to hook the button up to.

Swapped it to a `span` with `role="status"` and `aria-live="polite"`, matching the convention `Toaster.tsx` already uses for other ambient state, instead of inventing a new pattern. It's no longer in the tab order and no longer implies an action.

Added `packages/web/test/topbar-connection-status.test.tsx` covering: the indicator renders as a status region rather than a button, it isn't in the tab order, and the label/live-region content correctly reflects offline (no project) vs connected (health check resolves ok) states.

## Test plan
- [x] `npx turbo build test lint --filter=@neat.is/web` green
- [x] New test fails against the old `<button>` markup, passes against the fix

Refs #695