### PR TITLE
Fix Incidents demo fixtures shape and make stacktrace rows keyboard-expandable

### DIFF
--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -1187,7 +1187,20 @@ html, body {
   word-break: break-all;
   border-bottom: 1px solid var(--rule);
 }
-.stack-toggle { color: var(--fg-muted); font-size: 0.55rem; }
+.stack-toggle {
+  color: var(--fg-muted);
+  font-size: 0.55rem;
+  font-family: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+.stack-toggle:focus-visible {
+  outline: 1px solid var(--fg-muted);
+  outline-offset: 2px;
+}
 
 /* status chips (env / public-read / sign-out) inherit mono via .status */
 .env-chip, .public-read-chip { font-family: var(--font-mono); }

--- a/packages/web/app/incidents/IncidentsClient.tsx
+++ b/packages/web/app/incidents/IncidentsClient.tsx
@@ -44,6 +44,8 @@ export function IncidentsClient() {
   const [error, setError] = useState<string | null>(null)
   const [openRow, setOpenRow] = useState<string | null>(null)
 
+  const toggleRow = (rowKey: string) => setOpenRow((prev) => (prev === rowKey ? null : rowKey))
+
   // ADR-101 — resolve the active profile the same way AppShell does so a cold
   // deep-link to /incidents lands on the same daemon: URL → localStorage →
   // daemon discovery (reachability-confirmed) → null (#419, #461). The project
@@ -143,8 +145,7 @@ export function IncidentsClient() {
                   <Fragment key={rowKey}>
                     <tr
                       style={{ cursor: evt.exceptionStacktrace ? 'pointer' : undefined }}
-                      onClick={() => evt.exceptionStacktrace && setOpenRow(isOpen ? null : rowKey)}
-                      title={evt.exceptionStacktrace ? (isOpen ? 'Collapse stacktrace' : 'Expand stacktrace') : undefined}
+                      onClick={() => evt.exceptionStacktrace && toggleRow(rowKey)}
                     >
                       <td className="td-node">
                         <Link href={`/?node=${encodeURIComponent(evt.affectedNode)}`} className="incidents-node-link">
@@ -156,7 +157,18 @@ export function IncidentsClient() {
                       <td className="td-msg">
                         {evt.errorMessage}
                         {evt.exceptionStacktrace && (
-                          <span className="stack-toggle">{isOpen ? ' ▲' : ' ▼'}</span>
+                          <button
+                            type="button"
+                            className="stack-toggle"
+                            aria-expanded={isOpen}
+                            aria-label={isOpen ? 'Collapse stacktrace' : 'Expand stacktrace'}
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              toggleRow(rowKey)
+                            }}
+                          >
+                            {isOpen ? ' ▲' : ' ▼'}
+                          </button>
                         )}
                       </td>
                     </tr>

--- a/packages/web/lib/fixtures.ts
+++ b/packages/web/lib/fixtures.ts
@@ -1,3 +1,5 @@
+import type { ErrorEvent } from '@neat.is/types'
+
 // Fixture data returned when NEAT_DEMO=1 and core is unreachable.
 // File-first graph (file-awareness.md §1-§3): FileNodes are the primary
 // nodes, CALLS edges originate from files, and `service ──CONTAINS──▶ file`
@@ -48,28 +50,46 @@ export const FIXTURE_GRAPH = {
   ],
 }
 
-export const FIXTURE_INCIDENTS = {
+// Shaped to the canonical ErrorEvent envelope (@neat.is/types, ADR-061's
+// /api/incidents contract) — affectedNode/errorType/errorMessage/
+// exceptionStacktrace, not the nodeId/type/message/stacktrace trio this
+// fixture used to carry (#699). id/service/traceId/spanId are required by
+// the schema even though the table itself only renders a subset of fields.
+export const FIXTURE_INCIDENTS: { count: number; total: number; events: ErrorEvent[] } = {
   count: 3,
   total: 3,
   events: [
     {
-      nodeId: 'service:payments',
+      id: 'evt-payments-a1b2c3',
       timestamp: new Date(Date.now() - 1000 * 60 * 14).toISOString(),
-      type: 'ERR_VERSION_MISMATCH',
-      message: 'pg driver 7.4.0 incompatible with PostgreSQL 15 — connection failed',
-      stacktrace: 'Error: connect ECONNREFUSED\n    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1187:16)\n    at pg.Client.connect (/app/node_modules/pg/lib/client.js:54:9)',
+      service: 'payments',
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+      spanId: '00f067aa0ba902b7',
+      errorType: 'ERR_VERSION_MISMATCH',
+      errorMessage: 'pg driver 7.4.0 incompatible with PostgreSQL 15 — connection failed',
+      exceptionType: 'Error',
+      exceptionStacktrace: 'Error: connect ECONNREFUSED\n    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1187:16)\n    at pg.Client.connect (/app/node_modules/pg/lib/client.js:54:9)',
+      affectedNode: 'file:payments:src/db.ts',
     },
     {
-      nodeId: 'service:checkout',
+      id: 'evt-checkout-d4e5f6',
       timestamp: new Date(Date.now() - 1000 * 60 * 38).toISOString(),
-      type: 'ERR_TIMEOUT',
-      message: 'upstream payments service exceeded 5s timeout on /charge',
+      service: 'checkout',
+      traceId: 'a3ce929d0e0e47364bf92f3577b34da6',
+      spanId: '0ba902b700f067aa',
+      errorType: 'ERR_TIMEOUT',
+      errorMessage: 'upstream payments service exceeded 5s timeout on /charge',
+      affectedNode: 'file:checkout:src/routes/charge.ts',
     },
     {
-      nodeId: 'service:auth',
+      id: 'evt-auth-g7h8i9',
       timestamp: new Date(Date.now() - 1000 * 60 * 91).toISOString(),
-      type: 'ERR_RATE_LIMIT',
-      message: 'Redis rate-limit key expired — 429 burst on /token',
+      service: 'auth',
+      traceId: '77b34da6a3ce929d0e0e47364bf92f35',
+      spanId: '902b700f067aa0ba',
+      errorType: 'ERR_RATE_LIMIT',
+      errorMessage: 'Redis rate-limit key expired — 429 burst on /token',
+      affectedNode: 'file:auth:src/token.ts',
     },
   ],
 }

--- a/packages/web/test/incidents-client.test.tsx
+++ b/packages/web/test/incidents-client.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// #699 — two regressions on the Incidents page:
+//  1. FIXTURE_INCIDENTS (demo mode) drifted to a stale nodeId/type/message/
+//     stacktrace shape while IncidentsClient reads the canonical ErrorEvent
+//     envelope (affectedNode/errorType/errorMessage/exceptionStacktrace),
+//     so demo mode rendered undefined cells and a `/?node=undefined` link.
+//  2. The stacktrace row only expanded on a `<tr onClick>` with no keyboard
+//     path — not reachable via Tab, no Enter/Space affordance.
+// These tests exercise the real fixture object against the real component so
+// a future shape drift, or a regression back to a click-only row, fails here.
+
+import { IncidentsClient } from '../app/incidents/IncidentsClient'
+import { FIXTURE_INCIDENTS } from '../lib/fixtures'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('#699 — Incidents table renders the canonical fixture shape and is keyboard-expandable', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        if (url.includes('/api/profiles')) {
+          return jsonResponse([
+            { project: 'demo', endpoint: 'http://127.0.0.1:8080', status: 'running' },
+          ])
+        }
+        if (url.includes('/api/health')) {
+          return jsonResponse({ ok: true })
+        }
+        if (url.includes('/api/incidents')) {
+          // The real demo-mode fixture, not a hand-rolled stand-in — this is
+          // what ties the test to fixtures.ts actually matching the envelope
+          // IncidentsClient expects.
+          return jsonResponse(FIXTURE_INCIDENTS)
+        }
+        return jsonResponse({})
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('renders every fixture row with real values — no undefined cells, no broken node links', async () => {
+    render(<IncidentsClient />)
+
+    const rows = await screen.findAllByRole('row')
+    // header row + one row per fixture event.
+    expect(rows.length).toBe(FIXTURE_INCIDENTS.events.length + 1)
+
+    for (const evt of FIXTURE_INCIDENTS.events) {
+      const link = screen.getByRole('link', { name: evt.affectedNode })
+      expect(link).toHaveAttribute('href', `/?node=${encodeURIComponent(evt.affectedNode)}`)
+      expect(screen.getByText(evt.errorType as string)).toBeInTheDocument()
+      expect(screen.getByText(evt.errorMessage, { exact: false })).toBeInTheDocument()
+    }
+  })
+
+  it('a stacktrace row expands via keyboard (Enter and Space) and exposes aria-expanded', async () => {
+    const user = userEvent.setup()
+    render(<IncidentsClient />)
+
+    const withStack = FIXTURE_INCIDENTS.events.find((e) => e.exceptionStacktrace)
+    expect(withStack).toBeDefined()
+
+    const toggle = await screen.findByRole('button', { name: 'Expand stacktrace' })
+    expect(toggle.tagName).toBe('BUTTON')
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    // The stacktrace text spans multiple lines; match a single-line marker
+    // from it rather than the whole (newline-containing) string, since
+    // getByText normalizes whitespace against the query as given.
+    const stackMarker = withStack!.exceptionStacktrace!.split('\n')[0]
+    expect(screen.queryByText(stackMarker, { exact: false })).not.toBeInTheDocument()
+
+    toggle.focus()
+    expect(toggle).toHaveFocus()
+
+    await user.keyboard('{Enter}')
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(await screen.findByText(stackMarker, { exact: false })).toBeInTheDocument()
+
+    await user.keyboard(' ')
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText(stackMarker, { exact: false })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Two small fixes on the Incidents page from #699.

**Fixtures.** `FIXTURE_INCIDENTS` was still shaped as `nodeId`/`type`/`message`/`stacktrace`, but `IncidentsClient` reads the canonical `ErrorEvent` envelope (`@neat.is/types`) — `affectedNode`/`errorType`/`errorMessage`/`exceptionStacktrace`, plus required `id`/`service`/`traceId`/`spanId`. Demo mode was rendering undefined cells and a `/?node=undefined` link. The fixture now types directly against `ErrorEvent` so this can't silently drift again.

**Keyboard access.** The stacktrace row only expanded on a `<tr onClick>` — no keyboard path. Replaced it with a real `<button>` carrying `aria-expanded`, so it's reachable via Tab and works with Enter/Space, same toggle logic underneath. Added a small CSS reset on `.stack-toggle` so the button doesn't pick up default browser chrome.

Added `packages/web/test/incidents-client.test.tsx` covering both: the real fixture renders correctly with no undefined cells or broken links, and a stacktrace row expands/collapses via keyboard while exposing `aria-expanded`. Confirmed both cases fail against the pre-fix code and pass after.

Scoped to data correctness and accessibility of the Incidents page itself — doesn't touch nav.ts/PageSidebar.tsx, which is #697's separate, still-open question about nav placement.

## Test plan
- [x] `npx turbo build test lint --filter=@neat.is/web` green
- [x] New tests fail on pre-fix code, pass after (verified via git stash)

Refs #699