### PR TITLE
Fix web test suite warnings: jsdom navigation, act(), non-boolean jsx attribute

### DIFF
--- a/packages/web/test/cold-load-gating.test.tsx
+++ b/packages/web/test/cold-load-gating.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, waitFor } from '@testing-library/react'
+import { render, waitFor, act } from '@testing-library/react'
 
 // #461 — consumers handed an unresolved (null) project must stay silent.
 // AppShell passes null until the URL → localStorage → daemon-discovery chain
@@ -21,9 +21,16 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 describe('#461 — data-fetching consumers gate on an unresolved profile', () => {
   const fetchCalls: string[] = []
+  let location: { pathname: string; search: string; href: string }
 
   beforeEach(() => {
     fetchCalls.length = 0
+    // IncidentsClient's auth gate assigns `window.location.href` on an
+    // unauthenticated redirect; jsdom's real Location doesn't implement
+    // navigation, so — same as test/auth-gate-bare-root.test.tsx — swap in a
+    // writable stub. Rail and TopBar don't read it, so this is a no-op there.
+    location = { pathname: '/', search: '', href: 'http://localhost/' }
+    Object.defineProperty(window, 'location', { configurable: true, value: location })
     vi.stubGlobal(
       'fetch',
       vi.fn(async (input: RequestInfo | URL) => {
@@ -52,7 +59,13 @@ describe('#461 — data-fetching consumers gate on an unresolved profile', () =>
 
   it('Rail fires nothing while project is null, then fetches once it resolves', async () => {
     const { rerender } = render(<Rail project={null} />)
-    await new Promise((r) => setTimeout(r, 30))
+    // Rail renders next/link's <Link>; under jsdom (no IntersectionObserver)
+    // it falls back to a requestIdleCallback-scheduled visibility update, which
+    // lands during this wait. act() keeps that update from leaking outside a
+    // React-tracked scope and tripping the "not wrapped in act(...)" warning.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30))
+    })
     expect(fetchCalls).toEqual([])
 
     // Resolution lands — same prop transition AppShell performs.
@@ -83,7 +96,7 @@ describe('#461 — data-fetching consumers gate on an unresolved profile', () =>
 
   it('IncidentsClient deep-linked in a fresh session resolves via discovery, never project=default', async () => {
     // No ?project= in the URL, nothing in localStorage — the cold deep-link.
-    window.history.replaceState({}, '', '/incidents')
+    location.pathname = '/incidents'
     try {
       window.localStorage.removeItem('neat:lastProject')
     } catch { /* jsdom storage can be flaky; the fetch assertions carry the test */ }

--- a/packages/web/test/project-resolution.test.tsx
+++ b/packages/web/test/project-resolution.test.tsx
@@ -93,7 +93,13 @@ describe('#419 — AppShell resolves to a reachable daemon end to end', () => {
   beforeEach(() => {
     fetchCalls.length = 0
     // No URL or localStorage project, so resolution falls to daemon discovery.
-    window.history.replaceState({}, '', '/')
+    // AppShell's auth gate assigns `window.location.href` on an unauthenticated
+    // redirect; jsdom's real Location doesn't implement navigation, so — same
+    // as test/auth-gate-bare-root.test.tsx — swap in a writable stub.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/', search: '', href: 'http://localhost/' },
+    })
     Object.defineProperty(window, 'localStorage', {
       configurable: true,
       value: makeStorage(),

--- a/packages/web/test/single-project-resolution.test.tsx
+++ b/packages/web/test/single-project-resolution.test.tsx
@@ -50,7 +50,13 @@ describe('ADR-101 — the dashboard resolves the active per-daemon profile', () 
 
   beforeEach(() => {
     fetchCalls.length = 0
-    window.history.replaceState({}, '', '/')
+    // AppShell's auth gate assigns `window.location.href` on an unauthenticated
+    // redirect; jsdom's real Location doesn't implement navigation, so — same
+    // as test/auth-gate-bare-root.test.tsx — swap in a writable stub.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/', search: '', href: 'http://localhost/' },
+    })
 
     vi.stubGlobal(
       'fetch',

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -3,7 +3,13 @@ import react from '@vitejs/plugin-react'
 import path from 'node:path'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    // styled-jsx's `<style jsx>` tags are normally compiled away by Next's
+    // own SWC pipeline. Vitest never runs that pipeline, so without this
+    // Babel plugin the literal `jsx` prop reaches the DOM `<style>` element
+    // and React warns about a non-boolean attribute (components/logo-animation.tsx).
+    react({ babel: { plugins: ['styled-jsx/babel'] } }),
+  ],
   resolve: {
     // Mirrors the `@/*` alias in tsconfig so client components that use
     // shadcn's import shape resolve under vitest.


### PR DESCRIPTION
The web test suite passed green while quietly logging three kinds of noise. Root-caused and fixed each rather than blanket-suppressing.

**jsdom navigation errors (use-auth-gate)** — `project-resolution.test.tsx`, `single-project-resolution.test.tsx`, and `cold-load-gating.test.tsx` render `AppShell`/`IncidentsClient`, both of which call `useAuthGate()`. With no stored token and no public-read config in these fixtures, the gate assigns `window.location.href` to redirect to `/login`, and jsdom doesn't implement navigation, so it logs "Not implemented: navigation" on every one of those tests. `auth-gate-bare-root.test.tsx` already had the right pattern — a writable `window.location` stub swapped in via `Object.defineProperty` — so this applies that same stub to the other three files instead of inventing something new.

**React act() warning** — the `Rail` component renders next/link's `<Link>`. jsdom has no `IntersectionObserver`, so Link's `useIntersection` hook falls back to a `requestIdleCallback`-scheduled visibility flip a tick after mount. The Rail test in `cold-load-gating.test.tsx` waited on a raw `setTimeout` after `render()`, so that state update landed outside any act-tracked scope. Wrapped the wait in `act(async () => { ... })`, matching how the rest of the suite already leans on RTL's act-wrapping (`waitFor`) for async updates.

**Non-boolean `jsx` attribute warning** — `LogoAnimation` uses `<style jsx>{...}</style>`. Next's own SWC pipeline compiles that away at build time; Vitest never runs that pipeline, so the literal `jsx` prop was reaching the DOM `<style>` element. Wired `styled-jsx/babel` into the Vitest React plugin config so tests compile `<style jsx>` the same way Next's production build does.

All three were genuine test-setup gaps, not test-environment dead ends — no console-error suppression was needed anywhere.

## Test plan
- [x] `npx vitest run` in `packages/web` — 11 files / 55 tests pass, zero warnings (ran 3x to confirm no flake)
- [x] `npx turbo build test lint --filter=@neat.is/web` — all green

Refs #703