### PR TITLE
Docs accuracy sweep: stale tool counts, routes, and status claims

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -29,16 +29,22 @@ Auth is a delegated bearer token (ADR-073). Set `NEAT_AUTH_TOKEN` and the daemon
 
 OTel exporters send the same bearer; rotate the OTLP token independently with `NEAT_OTEL_TOKEN`. When TLS and auth already terminate in an upstream proxy, set `NEAT_AUTH_PROXY=true` so the daemon skips the request-side bearer check while the bind-authority gate still requires `NEAT_AUTH_TOKEN`. See the README's "Run NEAT on a server" section for the full deployment recipe.
 
-## Multi-project routing
+## Client resolution: profiles (ADR-101 / ADR-102)
 
-Every read endpoint dual-mounts (per ADR-026):
+Every NEAT client — the GUI, the `neat` CLI, the `neat-mcp` server — reaches a daemon through a **profile**: `{ endpoint, authToken? }`. A daemon serves its one project at the REST root (`GET /graph`, not `/projects/:name/graph`) per ADR-096; a profile's `endpoint` is that root, and the project name is only the profile's label.
+
+The web GUI discovers profiles through its own `/api/profiles` route (`packages/web/app/api/profiles/route.ts`), which enumerates `~/.neat/daemons/*.json` — one profile per running per-project daemon — and confirms reachability before auto-selecting (`resolveProfile` in `packages/web/lib/resolve-project.ts`). It does not call this package's `/projects` endpoint below. Full resolution chain, precedence, and the CLI/MCP equivalents live in [`docs/contracts/client-profiles.md`](./contracts/client-profiles.md).
+
+### Legacy dual-mount (ADR-026)
+
+`@neat.is/core` still exposes the pre-ADR-101 dual-mount for every read endpoint:
 
 ```
 GET /<endpoint>                          ← default project
 GET /projects/:project/<endpoint>        ← scoped to <project>
 ```
 
-The default project is named `'default'`. Named projects scope to `~/.neat/projects/<name>/`. Use the `/projects` list endpoint (below) to enumerate registered projects.
+The default project is named `'default'`. Named projects scope to `~/.neat/projects/<name>/`. This is the surface the `neat` CLI still addresses today (`cli-client.ts`'s `projectPath`); it reconciles to profile-root addressing as the daemon refactor (ADR-096) lands. New client code targets a profile's endpoint root instead of this prefix.
 
 ## Error envelope
 
@@ -313,9 +319,9 @@ PolicyViolation = {
 }
 ```
 
-### `GET /projects` ✅
+### `GET /projects` ✅ (legacy)
 
-List of registered projects on this machine. Single-mount, not dual-mounted (it's the switcher itself).
+List of projects registered on this daemon under the pre-ADR-101 registry model. Single-mount, not dual-mounted.
 
 **Response (per ADR-051 #4 — shape locked):**
 ```ts
@@ -329,7 +335,7 @@ Array<{
 }>
 ```
 
-Use this to populate a project picker UI.
+The GUI's project picker resolves per-daemon profiles instead of calling this (`/api/profiles`, ADR-101 — see "Client resolution: profiles" above). This endpoint stays useful for a caller working directly against a single multi-project core daemon.
 
 ---
 
@@ -379,12 +385,14 @@ Dry-run policy evaluation. Returns what *would* fire if a hypothetical action we
 
 ### `GET /events` ✅
 
-Server-Sent Events stream of live graph mutations, live since v0.2.8 (ADR-051). Dual-mounted per ADR-026:
+Server-Sent Events stream of live graph mutations, live since v0.2.8 (ADR-051). Dual-mounted per the legacy ADR-026 surface described above:
 
 ```
 GET /events                         ← default project
 GET /projects/:project/events       ← scoped
 ```
+
+The GUI's `/api/events` proxy targets the selected profile's endpoint root directly (no `/projects/:name` prefix), per the client-profile model in "Client resolution: profiles" above.
 
 **Headers:** standard EventSource.
 
@@ -500,4 +508,6 @@ Sources of truth (in case this doc drifts):
 - `packages/core/src/api.ts` — actual route registrations
 - `docs/contracts/rest-api.md` — REST contract (ADR-040)
 - `docs/contracts/frontend-api.md` — SSE + multi-project contract (ADR-051)
+- `docs/contracts/client-profiles.md` — profile resolution for every client (ADR-101 / ADR-102)
+- `packages/web/lib/resolve-project.ts` — the GUI's profile resolution
 - `packages/types/src/` — every response shape, exported as both TypeScript types and Zod schemas

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,8 +9,10 @@ neat/
   packages/
     types/   shared Zod schemas + runtime constants. Zero @neat.is/* deps.
     core/    graph engine, tree-sitter extraction, OTel ingest, REST API.
-    mcp/     stdio MCP server. Six tools mapped to core's traversal endpoints.
-    web/     Next.js shell. Wordmark + /api/health. Dashboard is post-MVP.
+    mcp/     stdio MCP server. Sixteen tools (MCP_TOOL_NAMES in @neat.is/types)
+             mapped to core's traversal endpoints plus the /neat extend surface.
+    web/     Next.js shell. Multi-page dashboard — graph canvas, incidents,
+             policies, search — over the per-daemon profile model (ADR-101).
   demo/
     service-a/   express + axios. Calls service-b. OTel-instrumented.
     service-b/   express + pg 7.4.0 + OTel. Talks to payments-db (PG 15).

--- a/docs/contracts/mcp-tools.md
+++ b/docs/contracts/mcp-tools.md
@@ -33,7 +33,7 @@ A helper `formatToolResponse({ summary, block, confidence?, provenance? })` live
 
 ## Transitive `get_dependencies` (issue #144)
 
-Default depth 3, max 10. Calls a new core endpoint `GET /graph/node/:id/dependencies?depth=N` (see ADR-040). Returns flat list with distance, edge type, provenance. Direct-only consumers pass `depth=1`.
+Default depth 3, max 10. Calls the core endpoint `GET /graph/dependencies/:nodeId?depth=N` (see ADR-040). Returns flat list with distance, edge type, provenance. Direct-only consumers pass `depth=1`.
 
 ## REST-only data path
 

--- a/docs/runbook-publish.md
+++ b/docs/runbook-publish.md
@@ -1,6 +1,6 @@
 # Runbook — publishing to npm
 
-Five packages ship to the npm registry on every release: `@neat.is/types`, `@neat.is/core`, `@neat.is/mcp`, `@neat.is/claude-skill`, and the `neat.is` umbrella. They publish in dependency order — npm rejects the umbrella if its deps aren't already on the registry.
+Six packages ship to the npm registry in version lockstep on every release: `@neat.is/types`, `@neat.is/core`, `@neat.is/mcp`, `@neat.is/claude-skill`, `@neat.is/web`, and the `neat.is` umbrella. A seventh, `@neat.is/instrumentation-registry`, ships alongside them on its own independent version line. They publish in dependency order — npm rejects the umbrella if its deps aren't already on the registry.
 
 The preferred path is **CI on tag push**. Local publish is a fallback for when CI isn't an option.
 
@@ -38,7 +38,7 @@ The publish workflow at `.github/workflows/publish.yml` references this secret a
 
 A successful `vX.Y.Z` push lights up three publish surfaces in one workflow run:
 
-1. **npm** — six lockstep packages (`@neat.is/{types,core,mcp,claude-skill,web}` plus the `neat.is` umbrella).
+1. **npm** — six lockstep packages (`@neat.is/{types,core,mcp,claude-skill,web}` plus the `neat.is` umbrella), plus the independently-versioned `@neat.is/instrumentation-registry`.
 2. **ghcr.io** — the generic `neat` container image, tagged `vX.Y.Z` and `latest`.
 3. **GitHub Release** — auto-created via `gh release create --generate-notes --latest`. The default body lists merged PRs since the previous tag; the maintainer edits it afterwards with curated forward-looking prose (comms-voice rules apply).
 
@@ -81,11 +81,13 @@ downstream and promotes a green one to `@next`; releases to `@latest` are cut fr
 Five steps from a clean working tree on `main`:
 
 ```bash
-# 1. Bump versions in lockstep across all five publishable packages.
+# 1. Bump versions in lockstep across all six version-locked packages.
 #    Edit by hand or use a small script — we don't have changesets.
-#    Files: packages/{types,core,mcp,claude-skill,neat.is}/package.json
-#    Don't forget the cross-package deps (`@neat.is/types: ^X.Y.Z` in core/mcp,
+#    Files: packages/{types,core,mcp,claude-skill,web,neat.is}/package.json
+#    Don't forget the cross-package deps (`@neat.is/types: ^X.Y.Z` in core/mcp/web,
 #    `@neat.is/core: ^X.Y.Z` in neat.is).
+#    @neat.is/instrumentation-registry rides its own version line — leave it
+#    out of this bump (see "Nightly channel" above).
 
 # 2. Commit + push.
 git commit -am "Bump to X.Y.Z"
@@ -105,10 +107,10 @@ The workflow:
 
 1. Checks out the tagged commit.
 2. Runs `npm ci` + `npx turbo build test lint` (gates the publish on green).
-3. Verifies all five package versions match (catches a half-bumped state).
-4. Publishes in dependency order. Skips any package whose target version is already on the registry — re-runs after partial failure are safe.
+3. Verifies all six lockstep package versions match (catches a half-bumped state).
+4. Publishes in dependency order — the six lockstep packages plus `@neat.is/instrumentation-registry` on its own version line. Skips any package whose target version is already on the registry — re-runs after partial failure are safe.
 
-A successful run produces five new package versions visible at https://www.npmjs.com/package/neat.is and the four scoped packages.
+A successful run produces six new lockstep package versions visible at https://www.npmjs.com/package/neat.is and the five scoped packages (`@neat.is/types`, `@neat.is/core`, `@neat.is/mcp`, `@neat.is/claude-skill`, `@neat.is/web`), plus a new `@neat.is/instrumentation-registry` version whenever its independent line is bumped.
 
 ## Dry run via CI
 
@@ -139,7 +141,7 @@ The script preflights aggressively:
 - Verifies `npm whoami`. Fails fast on 401.
 - Refuses to run if you're not on `main` (overridable with a confirm prompt).
 - Refuses to run if the working tree has uncommitted changes.
-- Verifies all five package versions are in lockstep before publishing anything.
+- Verifies all six lockstep package versions match before publishing anything.
 - Skips packages already at the target version (idempotent re-runs).
 
 ## Troubleshooting
@@ -149,17 +151,15 @@ The script preflights aggressively:
 | `E401 Unauthorized` from `npm whoami` or publish | Local auth token expired or revoked. | `npm login` to refresh. Verify with `npm whoami`. |
 | `E404 Not Found - PUT https://registry.npmjs.org/...` | Misleading error — usually means **auth failure** for an existing scoped package. npm hides 401/403 as 404 for some publish operations. | Same fix as 401. Run `npm whoami` first; re-login if needed. Verify scope membership: `npm access list packages` should include `@neat.is/*`. |
 | `E403 Forbidden` | Token doesn't have publish scope on `@neat.is/*`, or 2FA `--otp` was required and not provided. | Recreate the granular token with the right scope, or pass `--otp=<code>` on a publish that requires it. |
-| `E409 Conflict — version already published` | Trying to republish an existing immutable version. | Bump the version in all five package.jsons; tag a new vX.Y.Z. The local script auto-skips this case; you'd only see it in the CI workflow if version-sync check passed but a previous run already shipped this version. |
+| `E409 Conflict — version already published` | Trying to republish an existing immutable version. | Bump the version in all six lockstep package.jsons; tag a new vX.Y.Z. The local script auto-skips this case; you'd only see it in the CI workflow if version-sync check passed but a previous run already shipped this version. |
 | Workflow runs but no packages publish | The version-sync check found mismatched versions, OR every package was already at the target version (no-op publish). | Look at the workflow log for the "Verify versions are in lockstep" step output. |
 | `gyp ERR! find Python` or similar build errors during `prepublishOnly` | C toolchain missing on the runner. | CI runners come with build tools; locally install Xcode CLT (macOS), `build-essential` (Ubuntu), or MSVS Build Tools (Windows). |
 
 ## What ships and what doesn't
 
-**Published:** `@neat.is/types`, `@neat.is/core`, `@neat.is/mcp`, `@neat.is/claude-skill`, `neat.is`.
+**Published:** `@neat.is/types`, `@neat.is/core`, `@neat.is/mcp`, `@neat.is/claude-skill`, `@neat.is/web`, `neat.is` — the six version-locked packages — plus `@neat.is/instrumentation-registry`, which ships on its own independent version line (see "Nightly channel" above).
 
-**Not published:** `@neat.is/web` (private; lives in the monorepo for the v0.3.0 frontend track but isn't a runtime dep of anything else).
-
-**Not in the umbrella:** anything outside the four core/mcp/claude-skill/types packages. The `neat.is` umbrella's job is to put `neat`, `neatd`, and `neat-mcp` on PATH — nothing else.
+**Not in the umbrella:** anything outside the `core`/`mcp`/`claude-skill`/`web` runtime deps. The `neat.is` umbrella's job is to put `neat`, `neatd`, and `neat-mcp` on PATH — nothing else.
 
 ## When this runbook is wrong
 

--- a/packages/claude-skill/README.md
+++ b/packages/claude-skill/README.md
@@ -1,6 +1,6 @@
 # @neat.is/claude-skill
 
-Drop-in MCP config that hooks NEAT's nine MCP tools into Claude Code.
+Drop-in MCP config that hooks NEAT's sixteen MCP tools into Claude Code.
 
 See [SKILL.md](./SKILL.md) for the tool list, install steps, and prerequisites.
 
@@ -14,4 +14,4 @@ The shipped artifact is `claude_code_config.json` — a single object you merge 
 
 ## When this drifts
 
-If the nine MCP tools change shape or the `@neat.is/mcp` package ships a different stdio entrypoint, this snippet needs to keep up. The contract test in `packages/core/test/audits/contracts.test.ts` enforces the snippet shape — `command: 'npx'`, args wired to `@neat.is/mcp`, type `stdio`, plus `NEAT_API_URL` env wired through.
+If the sixteen MCP tools change shape or the `@neat.is/mcp` package ships a different stdio entrypoint, this snippet needs to keep up. The contract test in `packages/core/test/audits/contracts.test.ts` enforces the snippet shape — `command: 'npx'`, args wired to `@neat.is/mcp`, type `stdio`, plus `NEAT_API_URL` env wired through.

--- a/packages/web/audit/09-gaps-and-stubs.md
+++ b/packages/web/audit/09-gaps-and-stubs.md
@@ -130,11 +130,15 @@ user-visible toasts — keeps the surface quiet on healthy days. This is by desi
 Resolved in ADR-057 (this batch): GraphCanvas, Inspector, StatusBar, Rail, and
 the Incidents page all re-fetch on `project` change.
 
-### Metrics — fully synthetic
+### Metrics — derived from OBSERVED signal, p99 still honest-dash
 
-The three Inspector metrics (req/s, p99, err%) still come from `Math.random()`,
-re-randomised per node. No real metrics API yet. Deferred — surfaces as numbers
-that don't change while you stare at one node.
+Inspector's `spans` and `err %` aggregate the OBSERVED-provenance edges on the
+selected node (`spanCount` / `errorCount` off the edge signal, #357) and render
+`—` when no OBSERVED edge exists yet — real numbers, not placeholders. `p99 ms`
+has no signal to derive from yet and renders `—` rather than a synthetic
+stand-in. The `claude-design/` prototype — a separate, unmounted surface, not
+part of the Next.js app router — still generates all three metrics via
+`Math.random()`; the mounted Inspector is the one that ships to users.
 
 ---
 
@@ -156,7 +160,7 @@ remain because they document the future surface.
 | Canvas | `#cy` has `aria-label="Service dependency graph"` and `role="img"`. |
 | Search input | `aria-label`, `aria-expanded` set. |
 | Search dropdown | `role="listbox"` / `role="option"` set. |
-| Metrics | Random values re-announced on every render — known issue, deferred until real metrics. |
+| Metrics | Mounted Inspector renders stable, OBSERVED-derived values (or `—`) — no re-randomising. `claude-design/`'s prototype still re-randomises per render if it's ever mounted. |
 
 ---
 


### PR DESCRIPTION
Five doc-vs-code mismatches from the audit, all mechanical — bundled as one PR, no source changes.

- `docs/architecture.md` — the mcp package line and the web package line now describe the current surface: sixteen tools (`MCP_TOOL_NAMES` in `@neat.is/types`) and a multi-page dashboard over the ADR-101 profile model.
- `docs/contracts/mcp-tools.md` — the transitive-dependencies section now names the real route, `/graph/dependencies/:nodeId`, matching what `packages/mcp/src/tools.ts` and `packages/core/src/api.ts` already call.
- `docs/api-reference.md` — leads with the ADR-101/ADR-102 profile model every client (GUI, CLI, MCP) resolves through, and keeps the ADR-026 dual-mount + `GET /projects` documented but labeled legacy, since the CLI still addresses a daemon that way today.
- `packages/claude-skill/README.md` — tool count corrected to sixteen, matching `SKILL.md` (already accurate) and `MCP_TOOL_NAMES`. `docs/runbook-publish.md` settles on one consistent count throughout: six version-locked packages (including `@neat.is/web`, which does publish) plus the independently-versioned `@neat.is/instrumentation-registry`.
- `packages/web/audit/09-gaps-and-stubs.md` — the Inspector metrics note now reflects that `spans` / `err %` derive from OBSERVED edge signal (with an honest `—` fallback, same for `p99 ms`); `claude-design/` is called out as the still-unmounted prototype that generates fake numbers via `Math.random()`.

Verified numbers for a sanity check: MCP tool count is **16** (10 read tools + 6 `/neat extend` tools, counted directly off `MCP_TOOL_NAMES` in `packages/types/src/mcp-tools.ts`). Publishable package count is **6** version-locked (`types`, `core`, `mcp`, `claude-skill`, `web`, `neat.is` umbrella) **+ 1** independently-versioned (`instrumentation-registry`) — confirmed against `.github/workflows/publish.yml` and `scripts/publish.sh`, both of which publish all seven.

## Test plan

- [x] `npx turbo build test lint` from repo root — 17/17 tasks green, no source files touched.

Refs #700