### PR TITLE
Inspector.tsx: drop manual HTML escaping, make tab controls keyboard accessible

### DIFF
--- a/packages/web/app/components/Inspector.tsx
+++ b/packages/web/app/components/Inspector.tsx
@@ -15,12 +15,6 @@ interface RootCauseResult {
   traversalPath: string[]
 }
 
-function escapeHtml(s: string | null | undefined): string {
-  // never crash the panel on a missing field — a node/edge can lack a name,
-  // target, etc.; render empty rather than throwing on undefined.replace.
-  return (s == null ? '' : String(s)).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] ?? c))
-}
-
 function visualProv(provenance: string): 'STATIC' | 'OBSERVED' | 'INFERRED' {
   if (provenance === 'OBSERVED') return 'OBSERVED'
   if (provenance === 'INFERRED') return 'INFERRED'
@@ -101,12 +95,12 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: 
     return (
       <aside className="inspect" id="inspect">
         <div className="inspect-tabs" role="tablist">
-          <div className="inspect-tab on" role="tab" aria-selected={true}>Inspect</div>
-          <div className="inspect-tab" role="tab" aria-selected={false}>Edges</div>
+          <button type="button" className="inspect-tab on" role="tab" aria-selected={true}>Inspect</button>
+          <button type="button" className="inspect-tab" role="tab" aria-selected={false}>Edges</button>
           {/* ADR-056 — Owners deferred: explicit disabled affordance. */}
-          <div className="inspect-tab disabled" role="tab" aria-selected={false} aria-disabled={true} title="Owners — coming in v0.3.x" style={{ opacity: 0.4, cursor: 'not-allowed' }}>Owners</div>
+          <button type="button" className="inspect-tab disabled" role="tab" aria-selected={false} disabled title="Owners — coming in v0.3.x" style={{ opacity: 0.4, cursor: 'not-allowed' }}>Owners</button>
           {/* ADR-056 — History deferred: explicit disabled affordance. */}
-          <div className="inspect-tab disabled" role="tab" aria-selected={false} aria-disabled={true} title="History — coming in v0.3.x" style={{ opacity: 0.4, cursor: 'not-allowed' }}>History</div>
+          <button type="button" className="inspect-tab disabled" role="tab" aria-selected={false} disabled title="History — coming in v0.3.x" style={{ opacity: 0.4, cursor: 'not-allowed' }}>History</button>
         </div>
         <div className="insp-section" style={{ paddingTop: 40 }}>
           <div style={{ fontFamily: 'var(--font-body)', fontStyle: 'italic', color: 'var(--fg-muted)', textAlign: 'center', fontSize: '1rem' }}>
@@ -189,29 +183,29 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: 
   return (
     <aside className="inspect" id="inspect">
       <div className="inspect-tabs" role="tablist">
-        <div className={`inspect-tab${activeTab === 'inspect' ? ' on' : ''}`} role="tab" aria-selected={activeTab === 'inspect'} onClick={() => setActiveTab('inspect')}>Inspect</div>
-        <div className={`inspect-tab${activeTab === 'edges' ? ' on' : ''}`} role="tab" aria-selected={activeTab === 'edges'} onClick={() => setActiveTab('edges')}>Edges<span className="ct">{edgeCount}</span></div>
+        <button type="button" className={`inspect-tab${activeTab === 'inspect' ? ' on' : ''}`} role="tab" aria-selected={activeTab === 'inspect'} aria-controls="inspect-body" onClick={() => setActiveTab('inspect')}>Inspect</button>
+        <button type="button" className={`inspect-tab${activeTab === 'edges' ? ' on' : ''}`} role="tab" aria-selected={activeTab === 'edges'} aria-controls="inspect-body" onClick={() => setActiveTab('edges')}>Edges<span className="ct">{edgeCount}</span></button>
         {/* ADR-056 — Owners wired: shows ServiceNode.owner when available (ADR-054). */}
-        <div className={`inspect-tab${activeTab === 'owners' ? ' on' : ''}`} role="tab" aria-selected={activeTab === 'owners'} onClick={() => setActiveTab('owners')}>Owners</div>
+        <button type="button" className={`inspect-tab${activeTab === 'owners' ? ' on' : ''}`} role="tab" aria-selected={activeTab === 'owners'} aria-controls="inspect-body" onClick={() => setActiveTab('owners')}>Owners</button>
         {/* ADR-056 — History deferred: explicit disabled affordance. */}
-        <div className="inspect-tab disabled" role="tab" aria-selected={false} aria-disabled={true} title="History — coming in v0.3.x" style={{ opacity: 0.4, cursor: 'not-allowed' }}>History</div>
+        <button type="button" className="inspect-tab disabled" role="tab" aria-selected={false} disabled title="History — coming in v0.3.x" style={{ opacity: 0.4, cursor: 'not-allowed' }}>History</button>
       </div>
 
       <div id="inspect-body">
         {activeTab === 'inspect' && (
           <>
             <section className="insp-section">
-              <div className="insp-eyebrow">{escapeHtml(typeLabel)}</div>
+              <div className="insp-eyebrow">{typeLabel}</div>
               <div className="insp-title">
-                {stem && <span className="stem">{escapeHtml(stem)}</span>}
-                {escapeHtml(rest)}
+                {stem && <span className="stem">{stem}</span>}
+                {rest}
               </div>
-              <div className="insp-sub">{escapeHtml(node.id)}</div>
+              <div className="insp-sub">{node.id}</div>
               <div className="insp-tags">
-                {(node as { language?: string }).language && <span className="tag">{escapeHtml((node as { language: string }).language)}</span>}
-                {(node as { engine?: string }).engine && <span className="tag">{escapeHtml((node as { engine: string }).engine)}</span>}
-                {(node as { kind?: string }).kind && <span className="tag">{escapeHtml((node as { kind: string }).kind)}</span>}
-                {!isFile && props.length === 0 && <span className="tag">{escapeHtml(typeLabel.toLowerCase())}</span>}
+                {(node as { language?: string }).language && <span className="tag">{(node as { language: string }).language}</span>}
+                {(node as { engine?: string }).engine && <span className="tag">{(node as { engine: string }).engine}</span>}
+                {(node as { kind?: string }).kind && <span className="tag">{(node as { kind: string }).kind}</span>}
+                {!isFile && props.length === 0 && <span className="tag">{typeLabel.toLowerCase()}</span>}
               </div>
             </section>
 
@@ -228,7 +222,7 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: 
                   <svg className="glyph" viewBox="0 0 12 12" aria-hidden="true">
                     <polygon points="6,0.5 11,3.25 11,8.75 6,11.5 1,8.75 1,3.25" strokeLinejoin="round" />
                   </svg>
-                  <span className="svc-name">{escapeHtml((owningService as { name?: string }).name ?? owningService.id)}</span>
+                  <span className="svc-name">{(owningService as { name?: string }).name ?? owningService.id}</span>
                 </button>
               </section>
             )}
@@ -244,16 +238,17 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: 
                       <span style={{ display: 'flex', alignItems: 'center', gap: 10, width: '100%' }}>
                         <span className={`pdot ${visualProv(c.provenance)}`} />
                         <span className="verb">{visualProv(c.provenance).toLowerCase()}</span>
-                        <span
+                        <button
+                          type="button"
                           className="target clickable"
                           onClick={() => onNodeSelect(c.targetId)}
                           title={`Select ${c.targetName}`}
-                        >{escapeHtml(c.targetName)}</span>
+                        >{c.targetName}</button>
                         <span className="conf">{typeof c.confidence === 'number' ? c.confidence.toFixed(2) : '—'}</span>
                       </span>
                       {c.evidenceFile && (
                         <span className="edge-evidence" style={{ width: '100%' }}>
-                          {escapeHtml(c.evidenceFile)}{typeof c.evidenceLine === 'number' ? `:${c.evidenceLine}` : ''}
+                          {c.evidenceFile}{typeof c.evidenceLine === 'number' ? `:${c.evidenceLine}` : ''}
                         </span>
                       )}
                     </li>
@@ -277,16 +272,17 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: 
                       <span style={{ display: 'flex', alignItems: 'center', gap: 10, width: '100%' }}>
                         <span className={`pdot ${visualProv(c.provenance)}`} />
                         <span className="verb">{visualProv(c.provenance).toLowerCase()}</span>
-                        <span
+                        <button
+                          type="button"
                           className="target clickable"
                           onClick={() => onNodeSelect(c.targetId)}
                           title={`Select ${c.targetName}`}
-                        >{escapeHtml(c.targetName)}</span>
+                        >{c.targetName}</button>
                         <span className="conf">{typeof c.confidence === 'number' ? c.confidence.toFixed(2) : '—'}</span>
                       </span>
                       {c.evidenceFile && (
                         <span className="edge-evidence" style={{ width: '100%' }}>
-                          {escapeHtml(c.evidenceFile)}{typeof c.evidenceLine === 'number' ? `:${c.evidenceLine}` : ''}
+                          {c.evidenceFile}{typeof c.evidenceLine === 'number' ? `:${c.evidenceLine}` : ''}
                         </span>
                       )}
                     </li>
@@ -304,13 +300,16 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: 
                 <div className="insp-h">Files <span className="ct">{serviceFiles.length}</span></div>
                 <ul className="file-list">
                   {serviceFiles.length ? serviceFiles.map((f) => (
-                    <li
-                      key={f.id}
-                      onClick={() => { onNodeSelect(f.id) }}
-                      title={(f as { path?: string }).path}
-                    >
-                      <svg className="fglyph" viewBox="0 0 12 12" aria-hidden="true"><rect x="1.5" y="1.5" width="9" height="9" /></svg>
-                      <span className="fpath">{escapeHtml((f as { path?: string }).path ?? f.id)}</span>
+                    <li key={f.id}>
+                      <button
+                        type="button"
+                        className="file-row"
+                        onClick={() => { onNodeSelect(f.id) }}
+                        title={(f as { path?: string }).path}
+                      >
+                        <svg className="fglyph" viewBox="0 0 12 12" aria-hidden="true"><rect x="1.5" y="1.5" width="9" height="9" /></svg>
+                        <span className="fpath">{(f as { path?: string }).path ?? f.id}</span>
+                      </button>
                     </li>
                   )) : (
                     <li style={{ cursor: 'default' }}><span className="fpath" style={{ color: 'var(--fg-muted)', fontStyle: 'italic', fontFamily: 'var(--font-body)' }}>no files attributed to this service</span></li>
@@ -339,9 +338,9 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: 
                 <div className="insp-h">Root cause</div>
                 <div className="root-cause-block">
                   <div className="rc-label">divergence detected</div>
-                  <div className="rc-node">{escapeHtml(rootCause.rootCauseNode ?? '')}</div>
-                  <div className="rc-reason">{escapeHtml(rootCause.reason)}</div>
-                  {rootCause.fixRecommendation && <div className="rc-fix">{escapeHtml(rootCause.fixRecommendation)}</div>}
+                  <div className="rc-node">{rootCause.rootCauseNode ?? ''}</div>
+                  <div className="rc-reason">{rootCause.reason}</div>
+                  {rootCause.fixRecommendation && <div className="rc-fix">{rootCause.fixRecommendation}</div>}
                 </div>
               </section>
             )}
@@ -352,8 +351,8 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: 
                 <dl className="kv">
                   {props.map(([k, v]) => (
                     <div key={k} style={{ display: 'contents' }}>
-                      <dt>{escapeHtml(k)}</dt>
-                      <dd>{escapeHtml(v)}</dd>
+                      <dt>{k}</dt>
+                      <dd>{v}</dd>
                     </div>
                   ))}
                 </dl>
@@ -369,8 +368,8 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: 
                   {inEdges.length ? inEdges.map((e, i) => (
                     <li key={i}>
                       <span className={`pdot ${e.prov}`} />
-                      <span className="verb">{escapeHtml(e.verb)}</span>
-                      <span className="target">{escapeHtml(e.target)}</span>
+                      <span className="verb">{e.verb}</span>
+                      <span className="target">{e.target}</span>
                       <span className="conf">{typeof e.conf === 'number' ? e.conf.toFixed(2) : '—'}</span>
                     </li>
                   )) : (
@@ -406,8 +405,8 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: 
               {allEdges.length ? allEdges.map((e, i) => (
                 <li key={i}>
                   <span className={`pdot ${e.prov}`} />
-                  <span className="verb">{escapeHtml(e.verb)}</span>
-                  <span className="target">{escapeHtml(e.target)}</span>
+                  <span className="verb">{e.verb}</span>
+                  <span className="target">{e.target}</span>
                   <span className="conf">{typeof e.conf === 'number' ? e.conf.toFixed(2) : '—'}</span>
                 </li>
               )) : (
@@ -421,7 +420,7 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: 
           <section className="insp-section">
             <div className="insp-h">Owners</div>
             {owner ? (
-              <dl className="kv"><dt>owner</dt><dd>{escapeHtml(owner)}</dd></dl>
+              <dl className="kv"><dt>owner</dt><dd>{owner}</dd></dl>
             ) : (
               <div style={{ color: 'var(--fg-muted)', fontStyle: 'italic', fontFamily: 'var(--font-body)', fontSize: '0.92rem' }}>
                 no owner declared in package.json or pyproject.toml (ADR-054)

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -776,6 +776,9 @@ html, body {
   gap: 20px;
 }
 .inspect-tab {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid transparent;
   padding: 16px 0 14px;
   font-family: var(--font-mono);
   font-size: var(--label-size);
@@ -783,8 +786,7 @@ html, body {
   text-transform: uppercase;
   color: var(--fg-muted);
   cursor: pointer;
-  border-bottom: 1px solid transparent;
-  margin-bottom: -1px;
+  margin: 0 0 -1px;
   transition: color 0.16s ease;
 }
 .inspect-tab:hover { color: var(--fg); }
@@ -910,7 +912,15 @@ html, body {
   flex: 1;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.edge-list .target.clickable { cursor: pointer; transition: color 0.14s ease; }
+.edge-list .target.clickable {
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  cursor: pointer;
+  transition: color 0.14s ease;
+}
 .edge-list .target.clickable:hover { color: var(--fg-muted); }
 .edge-list .pdot {
   width: 7px; height: 7px; border-radius: 50%;
@@ -942,11 +952,8 @@ html, body {
 /* file list when a service is selected */
 .file-list { list-style: none; margin: 0; padding: 0; }
 .file-list li {
-  display: flex; align-items: center; gap: 10px;
   padding: 9px 0;
   border-top: 1px solid var(--rule);
-  cursor: pointer;
-  transition: color 0.14s ease;
 }
 .file-list li:first-child { border-top: none; }
 .file-list li:hover .fpath { color: var(--fg-muted); }
@@ -959,6 +966,18 @@ html, body {
   flex: 1;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   transition: color 0.14s ease;
+}
+.file-list .file-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  cursor: pointer;
 }
 
 /* owning service link */

--- a/packages/web/test/inspector-a11y-and-escaping.test.tsx
+++ b/packages/web/test/inspector-a11y-and-escaping.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { GraphNode, GraphEdge } from '@neat.is/types'
+import type { GraphData } from '../app/components/AppShell'
+import { Inspector } from '../app/components/Inspector'
+
+// #698 — Inspector.tsx double-escaped JSX text (a name with `&`/`<` rendered
+// as visible HTML entities) and its call/import/service drilldown tabs were
+// unreachable by keyboard (clickable divs, no tabIndex/key handling).
+const nodes: GraphNode[] = [
+  { id: 'service:esc', type: 'ServiceNode', name: 'A & B <script>', language: 'ts' } as GraphNode,
+]
+const graphData: GraphData = { nodes, edges: [] }
+
+function stubNodeFetch(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const m = url.match(/\/api\/graph\/node\/([^?]+)/)
+      if (m) {
+        const id = decodeURIComponent(m[1])
+        const node = nodes.find((n) => n.id === id)
+        return new Response(JSON.stringify({ node }), { status: 200, headers: { 'content-type': 'application/json' } })
+      }
+      return new Response(JSON.stringify({ rootCauseNode: null }), { status: 200, headers: { 'content-type': 'application/json' } })
+    }),
+  )
+}
+
+beforeEach(() => stubNodeFetch())
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks() })
+
+describe('Inspector text rendering (#698 — no manual HTML escaping)', () => {
+  it('renders a name containing & and < as literal characters, not double-escaped entities', async () => {
+    render(
+      <Inspector
+        project="default"
+        selectedNodeId="service:esc"
+        graphData={graphData}
+        onNodeSelect={vi.fn()}
+      />,
+    )
+
+    // React already escapes JSX text children; a hand-rolled escapeHtml()
+    // upstream of that would turn "A & B <script>" into visible
+    // "A &amp; B &lt;script&gt;" text.
+    await waitFor(() => expect(screen.getByText('A & B <script>')).toBeInTheDocument())
+    expect(screen.queryByText(/&amp;/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/&lt;/)).not.toBeInTheDocument()
+  })
+})
+
+describe('Inspector drilldown tabs keyboard accessibility (#698)', () => {
+  it('tabs are real buttons: focusable via Tab and activatable via Enter/Space', async () => {
+    const user = userEvent.setup()
+    render(
+      <Inspector
+        project="default"
+        selectedNodeId="service:esc"
+        graphData={graphData}
+        onNodeSelect={vi.fn()}
+      />,
+    )
+    await waitFor(() => expect(screen.getByRole('tablist')).toBeInTheDocument())
+
+    const edgesTab = screen.getByRole('tab', { name: /Edges/ })
+    const ownersTab = screen.getByRole('tab', { name: 'Owners' })
+
+    // real <button> elements — not inert divs with no keyboard path
+    expect(edgesTab.tagName).toBe('BUTTON')
+    expect(ownersTab.tagName).toBe('BUTTON')
+
+    // reachable by keyboard focus (a plain div with role="tab" and no
+    // tabIndex cannot receive focus at all)
+    edgesTab.focus()
+    expect(edgesTab).toHaveFocus()
+
+    // Enter activates the focused tab
+    await user.keyboard('{Enter}')
+    expect(edgesTab).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByText(/All edges/i)).toBeInTheDocument()
+
+    // Space activates the Owners tab
+    ownersTab.focus()
+    expect(ownersTab).toHaveFocus()
+    await user.keyboard(' ')
+    expect(ownersTab).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByText(/no owner declared/i)).toBeInTheDocument()
+  })
+
+  it('the disabled History tab correctly opts out of the tab order', async () => {
+    render(
+      <Inspector
+        project="default"
+        selectedNodeId="service:esc"
+        graphData={graphData}
+        onNodeSelect={vi.fn()}
+      />,
+    )
+    await waitFor(() => expect(screen.getByRole('tablist')).toBeInTheDocument())
+    const historyTab = screen.getByRole('tab', { name: /History/ })
+    expect(historyTab.tagName).toBe('BUTTON')
+    expect(historyTab).toBeDisabled()
+  })
+})


### PR DESCRIPTION
Two findings from the 2026-07-03 AI slop audit (#698), bundled since they touch the same render tree in Inspector.tsx.

## 1. Manual HTML escaping was redundant and wrong

`escapeHtml()` was applied to every string rendered as JSX text. React already escapes text content passed as JSX children, so this double-escaped everything — a name containing `&` or `<` rendered as visible `&amp;` / `&lt;` entities instead of the actual character.

Removed the helper and all 24 call sites, passing the raw strings straight into JSX. Checked every site: none of them build an HTML string or use `dangerouslySetInnerHTML`, so there's no legitimate escaping being dropped here — it's a straight bug fix, no exceptions.

## 2. Tab/drilldown controls weren't keyboard accessible

The four Inspect/Edges/Owners/History tabs, the target rows under "Calls from this file" and "Imports", and the file rows under a service's file list were all clickable `div`/`span`/`li` elements with no keyboard path — not focusable, no Enter/Space handling.

Swapped all of them to real `<button>` elements, which get focusability, Enter/Space activation, and correct semantics for free (no manual `tabIndex`/`onKeyDown` needed). Added matching CSS resets (`background`, `border`, `padding`, `text-align`) so the buttons keep the exact same visual appearance as before. The disabled "coming soon" tabs (Owners in the empty state, History) now use the native `disabled` attribute instead of `aria-disabled` + a cursor hack.

## Testing

Added `packages/web/test/inspector-a11y-and-escaping.test.tsx`:
- a node name containing `&` and `<` renders as the literal characters, not entities
- the tabs are real buttons, reachable via `.focus()`, and activate on both Enter and Space (using `@testing-library/user-event`, which only fires the click for real `<button>` elements — so this test is meaningful evidence the fix works, not just a superficial re-render check)
- the disabled History tab is a real `<button disabled>`, correctly opted out of the tab order

Confirmed both new test cases fail against the pre-fix markup (stashed the fix, ran the tests, saw them fail with the expected double-escaped text / `DIV` tagName) and pass after restoring it.

`npx turbo build test lint --filter=@neat.is/web` is green.

Refs #698