### PR TITLE
Harden core API attack surface: SSRF, unvalidated snapshot merge, auth suffix-matching

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -42,7 +42,7 @@ import {
   TRANSITIVE_DEPENDENCIES_MAX_DEPTH,
 } from './traverse.js'
 import { computeGraphDiff, loadSnapshotForDiff } from './diff.js'
-import { mergeSnapshot } from './ingest.js'
+import { mergeSnapshot, SnapshotValidationError } from './ingest.js'
 import { SCHEMA_VERSION, type PersistedGraph } from './persist.js'
 import type { SearchIndex } from './search.js'
 import type { Projects, ProjectContext } from './projects.js'
@@ -532,8 +532,27 @@ function registerRoutes(scope: FastifyInstance, ctx: RouteContext): void {
       if (!against) {
         return reply.code(400).send({ error: 'query parameter `against` is required' })
       }
+      // Security (#693): `against` used to be handed straight to
+      // `loadSnapshotForDiff`, which `fetch()`es any `http(s)` URL and
+      // otherwise reads whatever filesystem path it's given — a live
+      // SSRF/LFI vector once this route is reachable without auth (public-read
+      // mode). `against` now only ever resolves to a snapshot the server
+      // already manages: `self` (this project's own on-disk snapshot, written
+      // by the persist loop / `neat sync`) or the name of another project
+      // this same daemon is tracking. Either way the string is looked up in
+      // the registry map, never concatenated into a path or handed to
+      // `fetch()` — anything that doesn't match a known project is a 400.
+      const targetProjectName = against === 'self' ? proj.name : against
+      const targetProject = registry.get(targetProjectName)
+      if (!targetProject) {
+        return reply.code(400).send({
+          error:
+            'unknown snapshot id — `against` must be `self` or the name of a project this server has a snapshot for',
+          against,
+        })
+      }
       try {
-        const snapshot = await loadSnapshotForDiff(against)
+        const snapshot = await loadSnapshotForDiff(targetProject.paths.snapshotPath)
         return computeGraphDiff(proj.graph, snapshot)
       } catch (err) {
         return reply
@@ -576,6 +595,19 @@ function registerRoutes(scope: FastifyInstance, ctx: RouteContext): void {
         edgeCount: proj.graph.size,
       }
     } catch (err) {
+      // A malformed node/edge (wrong `type` literal, missing required field,
+      // ...) fails GraphNodeSchema/GraphEdgeSchema validation inside
+      // mergeSnapshot and rejects the whole snapshot rather than merging the
+      // valid entries and silently dropping the rest. `issues` carries one
+      // entry per invalid node/edge so the caller can see exactly what was
+      // wrong instead of guessing from a single summary string.
+      if (err instanceof SnapshotValidationError) {
+        return reply.code(400).send({
+          error: 'snapshot merge failed',
+          details: err.message,
+          issues: err.issues,
+        })
+      }
       return reply.code(400).send({
         error: 'snapshot merge failed',
         details: (err as Error).message,

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -65,7 +65,8 @@ export interface AuthOptions {
   // surface stays gated unconditionally (the receiver mounts its own
   // middleware without this flag).
   publicRead?: boolean
-  // Extra paths (or path suffixes) to leave unauthenticated. Used by tests
+  // Extra paths to leave unauthenticated, matched exactly (no suffix
+  // matching — see the note on DEFAULT_UNAUTH_PATHS below). Used by tests
   // and by ad-hoc callers that mount their own probes.
   extraUnauthenticatedSuffixes?: ReadonlyArray<string>
   // Diagnostic hook fired whenever a request is rejected with 401 for a
@@ -81,35 +82,53 @@ export interface AuthOptions {
 // and keeps the bearer requirement.
 const PUBLIC_READ_METHODS: ReadonlySet<string> = new Set(['GET', 'HEAD', 'OPTIONS'])
 
-// Probes that always stay open. Dual-mounted under `/projects/:project/` too,
-// so the check is a suffix match — `/projects/foo/health` is skipped along
-// with the top-level `/health`. ADR-073 §3 names `/healthz` and `/readyz`
-// explicitly; `/health` is the existing endpoint the web shell and CI smoke
-// already lean on, so it keeps the unauthenticated treatment. `/api/config`
-// is the public-read negotiation endpoint — the web shell hits it before any
-// authed call to learn which mode the daemon is running in.
-const DEFAULT_UNAUTH_SUFFIXES: ReadonlyArray<string> = [
+// Probes that always stay open. `/health` is dual-mounted under
+// `/projects/:project/` too (registerRoutes mounts it both unprefixed and
+// inside the `/projects/:project` plugin scope) — that's the one project-
+// scoped variant a real route relies on today. ADR-073 §3 names `/healthz`
+// and `/readyz` explicitly as reserved probe paths (no handler registers them
+// yet); `/health` is the existing endpoint the web shell and CI smoke already
+// lean on. `/api/config` is the public-read negotiation endpoint — the web
+// shell hits it before any authed call to learn which mode the daemon is
+// running in.
+//
+// Matching used to be `path === suffix || path.endsWith(suffix)`, which
+// exempts *any* path that merely ends with one of these strings — a future
+// protected route named e.g. `/admin/health` would slip through
+// unauthenticated by accident. Matching is now exact on the root path, plus
+// one explicit pattern for the `/projects/:project/<name>` shape. Nothing
+// else qualifies.
+const DEFAULT_UNAUTH_PATHS: ReadonlyArray<string> = [
   '/health',
   '/healthz',
   '/readyz',
   '/api/config',
 ]
 
+// `/projects/<one segment>/health` (or /healthz, /readyz, /api/config) —
+// exactly one path segment for the project name, nothing before `/projects`
+// and nothing after the probe name. Built from DEFAULT_UNAUTH_PATHS so the
+// two lists can't drift.
+const PROJECT_SCOPED_UNAUTH_PATTERN = new RegExp(
+  `^/projects/[^/]+/(?:${DEFAULT_UNAUTH_PATHS.map((p) => p.slice(1)).join('|')})$`,
+)
+
 export function mountBearerAuth(app: FastifyInstance, opts: AuthOptions): void {
   if (!opts.token || opts.token.length === 0) return
   if (opts.trustProxy) return
 
   const expected = Buffer.from(opts.token, 'utf8')
-  const suffixes = [...DEFAULT_UNAUTH_SUFFIXES, ...(opts.extraUnauthenticatedSuffixes ?? [])]
+  const exactUnauthPaths = new Set([
+    ...DEFAULT_UNAUTH_PATHS,
+    ...(opts.extraUnauthenticatedSuffixes ?? []),
+  ])
   const publicRead = opts.publicRead === true
 
   app.addHook('preHandler', (req: FastifyRequest, reply: FastifyReply, done: (err?: Error) => void) => {
     const path = (req.url.split('?')[0] ?? '').replace(/\/+$/, '')
-    for (const suffix of suffixes) {
-      if (path === suffix || path.endsWith(suffix)) {
-        done()
-        return
-      }
+    if (exactUnauthPaths.has(path) || PROJECT_SCOPED_UNAUTH_PATTERN.test(path)) {
+      done()
+      return
     }
 
     // Public-read split: GET / HEAD / OPTIONS pass through anonymously, every

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -21,6 +21,8 @@ import type { EvaluationContext as PolicyEvaluationContext } from './policy.js'
 import { canPromoteFrontier } from './policy.js'
 import {
   EdgeType,
+  GraphEdgeSchema,
+  GraphNodeSchema,
   NodeType,
   Provenance,
   confidenceForObservedSignal,
@@ -2299,36 +2301,94 @@ export interface MergeSnapshotResult {
   edgesAdded: number
 }
 
+// A pushed snapshot is untrusted input — it can arrive from `neat sync --to`
+// against a daemon the operator doesn't fully control, or from anything else
+// that can reach the `/snapshot` route. Before #693, every entry's
+// `attributes` went straight from `JSON.parse` to `graph.addNode` /
+// `graph.addEdgeWithKey` with only a schemaVersion check upstream in api.ts —
+// a malformed or hostile payload (wrong `type` literal, missing required
+// field, wrong field type) landed on the live graph as-is. This error
+// collects every entry that fails `GraphNodeSchema` / `GraphEdgeSchema` — the
+// same canonical shapes the rest of the API validates responses against
+// (packages/types) — so the caller gets back exactly what was wrong instead
+// of a generic parse failure or, worse, a silently corrupted graph.
+export class SnapshotValidationError extends Error {
+  constructor(public readonly issues: string[]) {
+    super(`snapshot failed validation (${issues.length} invalid ${issues.length === 1 ? 'entry' : 'entries'})`)
+    this.name = 'SnapshotValidationError'
+  }
+}
+
+function describeZodIssues(error: { issues: Array<{ path: PropertyKey[]; message: string }> }): string {
+  return error.issues
+    .map((issue) => (issue.path.length > 0 ? `${issue.path.join('.')}: ${issue.message}` : issue.message))
+    .join('; ')
+}
+
 export function mergeSnapshot(
   graph: NeatGraph,
   snapshot: PersistedGraph,
 ): MergeSnapshotResult {
   const exported = snapshot.graph as {
-    nodes?: Array<{ key: string; attributes?: GraphNode }>
-    edges?: Array<{ key?: string; source: string; target: string; attributes?: GraphEdge }>
+    nodes?: Array<{ key: string; attributes?: unknown }>
+    edges?: Array<{ key?: string; source: string; target: string; attributes?: unknown }>
+  }
+  const incomingNodes = Array.isArray(exported.nodes) ? exported.nodes : []
+  const incomingEdges = Array.isArray(exported.edges) ? exported.edges : []
+
+  // Validate everything up front and merge nothing until every entry checks
+  // out — a snapshot that's partly hostile or partly corrupt is rejected
+  // whole rather than landing its valid entries and silently dropping the
+  // rest (matching how the schemaVersion check upstream already treats a
+  // bad snapshot as all-or-nothing).
+  const issues: string[] = []
+  const validNodes: Array<{ key: string; attributes: GraphNode }> = []
+  const validEdges: Array<{ key: string; source: string; target: string; attributes: GraphEdge }> = []
+
+  for (const node of incomingNodes) {
+    // No attributes at all is a no-op skip, not a malformed entry — mirrors
+    // the pre-#693 behaviour for this specific (empty) shape.
+    if (node.attributes === undefined) continue
+    const parsed = GraphNodeSchema.safeParse(node.attributes)
+    if (!parsed.success) {
+      issues.push(`node "${node.key}": ${describeZodIssues(parsed.error)}`)
+      continue
+    }
+    validNodes.push({ key: node.key, attributes: parsed.data })
+  }
+
+  for (const edge of incomingEdges) {
+    if (edge.attributes === undefined) continue
+    const parsed = GraphEdgeSchema.safeParse(edge.attributes)
+    if (!parsed.success) {
+      const label = edge.key ?? `${edge.source}->${edge.target}`
+      issues.push(`edge "${label}": ${describeZodIssues(parsed.error)}`)
+      continue
+    }
+    const id = edge.key ?? parsed.data.id
+    validEdges.push({ key: id, source: edge.source, target: edge.target, attributes: parsed.data })
+  }
+
+  if (issues.length > 0) {
+    throw new SnapshotValidationError(issues)
   }
 
   let nodesAdded = 0
   let edgesAdded = 0
 
-  for (const node of exported.nodes ?? []) {
+  for (const node of validNodes) {
     if (graph.hasNode(node.key)) continue
-    if (!node.attributes) continue
     graph.addNode(node.key, node.attributes)
     nodesAdded++
   }
 
-  for (const edge of exported.edges ?? []) {
-    const attrs = edge.attributes
-    if (!attrs) continue
-    const id = edge.key ?? attrs.id
-    if (!id) continue
-    if (graph.hasEdge(id)) continue
+  for (const edge of validEdges) {
+    if (graph.hasEdge(edge.key)) continue
     // Skip when either endpoint is missing — can happen if the snapshot
     // names a node the live graph already evicted and the incoming nodes
     // array didn't include.
     if (!graph.hasNode(edge.source) || !graph.hasNode(edge.target)) continue
-    graph.addEdgeWithKey(id, edge.source, edge.target, attrs)
+    graph.addEdgeWithKey(edge.key, edge.source, edge.target, edge.attributes)
     edgesAdded++
   }
 

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -303,37 +303,60 @@ describe('REST API (fastify.inject)', () => {
     expect(res.statusCode).toBe(400)
   })
 
-  it('GET /graph/diff returns 400 when the snapshot path is unreadable', async () => {
+  // #693 — `against` used to be handed straight to `loadSnapshotForDiff`,
+  // which fetch()es any http(s) URL and otherwise reads whatever filesystem
+  // path it's given. In public-read mode this route needs no auth at all, so
+  // an arbitrary path/URL there was a live SSRF/LFI vector. `against` now
+  // only resolves through the project registry (`self`, or a known project
+  // name) — a filesystem path or a URL never reaches fetch()/fs.readFile()
+  // and is rejected outright.
+  it('GET /graph/diff rejects a filesystem path — never reads it off disk', async () => {
     const res = await app.inject({
       method: 'GET',
-      url: '/graph/diff?against=/no/such/path.json',
+      url: '/graph/diff?against=/etc/passwd',
     })
     expect(res.statusCode).toBe(400)
-    expect(res.json().error).toBe('failed to load snapshot')
+    expect(res.json().error).toMatch(/unknown snapshot id/)
+  })
+
+  it('GET /graph/diff rejects an http(s) URL — never fetches it', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/graph/diff?against=${encodeURIComponent('http://169.254.169.254/latest/meta-data/')}`,
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().error).toMatch(/unknown snapshot id/)
   })
 })
 
 describe('GET /graph/diff', () => {
   let app: FastifyInstance
   let tmpDir: string
-  let basePath: string
+  let snapshotPath: string
 
   beforeEach(async () => {
     const { promises: fs } = await import('node:fs')
     const os = await import('node:os')
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-api-diff-'))
-    basePath = path.join(tmpDir, 'base.json')
 
     resetGraph()
     const graph = getGraph()
     await extractFromDirectory(graph, DEMO_PATH)
 
+    const { Projects, pathsForProject } = await import('../src/projects.js')
+    const { DEFAULT_PROJECT } = await import('../src/graph.js')
+    const paths = pathsForProject(DEFAULT_PROJECT, tmpDir)
+    snapshotPath = paths.snapshotPath
+
     const { saveGraphToDisk } = await import('../src/persist.js')
-    await saveGraphToDisk(graph, basePath)
+    await saveGraphToDisk(graph, snapshotPath)
 
     // Drop one node from the live graph so the diff has something to report.
     graph.dropNode('config:service-b/db-config.yaml')
-    app = await buildApi({ graph })
+
+    const registry = new Projects()
+    registry.set(DEFAULT_PROJECT, { graph, paths })
+    app = await buildApi({ projects: registry })
   })
 
   afterEach(async () => {
@@ -342,10 +365,10 @@ describe('GET /graph/diff', () => {
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 
-  it('reports the dropped node as removed', async () => {
+  it('`against=self` diffs against this project\'s own managed snapshot and reports the dropped node as removed', async () => {
     const res = await app.inject({
       method: 'GET',
-      url: `/graph/diff?against=${encodeURIComponent(basePath)}`,
+      url: '/graph/diff?against=self',
     })
     expect(res.statusCode).toBe(200)
     const body = res.json()
@@ -355,6 +378,89 @@ describe('GET /graph/diff', () => {
       'config:service-b/db-config.yaml',
     )
     expect(body.added.nodes).toEqual([])
+  })
+
+  it('`against=<project name>` resolves the same managed snapshot as `self`', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/graph/diff?against=default',
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().removed.nodes.map((n: { id: string }) => n.id)).toContain(
+      'config:service-b/db-config.yaml',
+    )
+  })
+
+  it('rejects an arbitrary path even when it happens to point at the real snapshot file on disk', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/graph/diff?against=${encodeURIComponent(snapshotPath)}`,
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().error).toMatch(/unknown snapshot id/)
+  })
+})
+
+// #693 — the push/sync route only checked schemaVersion before merging;
+// ingest.ts cast every node/edge straight to GraphNode/GraphEdge with no shape
+// validation ahead of graph.addNode()/addEdgeWithKey(). A malformed or
+// hostile sync payload could land on the live graph as-is.
+describe('POST /snapshot — schema validation (#693)', () => {
+  let app: FastifyInstance
+
+  beforeEach(async () => {
+    resetGraph()
+    app = await buildApi({ graph: getGraph() })
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('rejects a snapshot carrying a node with a bogus `type` and does not merge any of it', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/snapshot',
+      payload: {
+        snapshot: {
+          schemaVersion: 4,
+          exportedAt: new Date().toISOString(),
+          graph: {
+            nodes: [
+              {
+                key: 'service:legit',
+                attributes: {
+                  id: 'service:legit',
+                  type: 'ServiceNode',
+                  name: 'legit',
+                  language: 'javascript',
+                },
+              },
+              {
+                key: 'service:evil',
+                // Not a real NodeType — the shape a hostile or corrupted
+                // sync payload would carry.
+                attributes: { id: 'service:evil', type: 'DropAllTables', name: 'evil' },
+              },
+            ],
+            edges: [],
+          },
+        },
+      },
+    })
+
+    expect(res.statusCode).toBe(400)
+    const body = res.json()
+    expect(body.error).toBe('snapshot merge failed')
+    expect(Array.isArray(body.issues)).toBe(true)
+    expect(body.issues.length).toBeGreaterThan(0)
+
+    // Whole-snapshot rejection: the well-formed sibling node must not have
+    // merged either.
+    const graphRes = await app.inject({ method: 'GET', url: '/graph' })
+    const nodeIds = (graphRes.json().nodes as Array<{ id: string }>).map((n) => n.id)
+    expect(nodeIds).not.toContain('service:legit')
+    expect(nodeIds).not.toContain('service:evil')
   })
 })
 

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -9274,10 +9274,10 @@ describe('REST API canonicalization (ADR-061)', () => {
       const { resetGraph, getGraph } = await import('../../src/graph.js')
       const { saveGraphToDisk } = await import('../../src/persist.js')
       const { writeAtomically } = await import('../../src/registry.js')
+      const { Projects, pathsForProject } = await import('../../src/projects.js')
 
       const DEMO_PATH = path.resolve(__dirname, '../../../../demo')
       tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-adr061-shapes-'))
-      diffPath = path.join(tmpDir, 'base.json')
       const registryHome = path.join(tmpDir, 'neat-home')
 
       process.env.NEAT_HOME = registryHome
@@ -9298,9 +9298,17 @@ describe('REST API canonicalization (ADR-061)', () => {
       resetGraph()
       const graph = getGraph()
       await extractFromDirectory(graph, DEMO_PATH)
+      // #693 — GET /graph/diff no longer accepts an arbitrary filesystem path
+      // in `against`; it resolves through the project registry instead
+      // (`self`, or a known project name). Save the baseline snapshot to this
+      // project's own managed snapshot path so `against=self` finds it.
+      const paths = pathsForProject('default', tmpDir)
+      diffPath = paths.snapshotPath
       await saveGraphToDisk(graph, diffPath)
 
-      app = await buildApi({ graph, scanPath: DEMO_PATH })
+      const projectsRegistry = new Projects()
+      projectsRegistry.set('default', { graph, scanPath: DEMO_PATH, paths })
+      app = await buildApi({ projects: projectsRegistry })
 
       schemas = {
         Incidents: types.IncidentsResponseSchema,
@@ -9387,7 +9395,7 @@ describe('REST API canonicalization (ADR-061)', () => {
       await expectShape('/graph', schemas.SerializedGraph)
     })
     it('GET /graph/diff response parses through GraphDiffResultSchema (ADR-061 #3)', async () => {
-      await expectShape(`/graph/diff?against=${encodeURIComponent(diffPath)}`, schemas.GraphDiff)
+      await expectShape('/graph/diff?against=self', schemas.GraphDiff)
     })
   })
 

--- a/packages/core/test/auth.test.ts
+++ b/packages/core/test/auth.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import Fastify, { type FastifyInstance } from 'fastify'
+import { mountBearerAuth } from '../src/auth.js'
+
+// #693 — mountBearerAuth's preHandler used to exempt a path via
+// `path === suffix || path.endsWith(suffix)` against DEFAULT_UNAUTH_SUFFIXES
+// (`/health`, `/healthz`, `/readyz`, `/api/config`). That means any future
+// protected route that merely *ends* with one of those strings — say
+// `/admin/health`, or a route someone names `.../api/config` for unrelated
+// reasons — becomes accidentally unauthenticated. There was no dedicated test
+// for mountBearerAuth's route matching before this file; cli-client-auth.test.ts
+// covers the CLI client's bearer threading, not the matcher itself.
+
+const TOKEN = 'test-bearer-693'
+
+describe('mountBearerAuth — route matching (#693)', () => {
+  let app: FastifyInstance
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false })
+    mountBearerAuth(app, { token: TOKEN })
+
+    // The real unauthenticated probes.
+    app.get('/health', async () => ({ ok: true }))
+    app.get('/healthz', async () => ({ ok: true }))
+    app.get('/readyz', async () => ({ ok: true }))
+    app.get('/api/config', async () => ({ publicRead: false }))
+    app.get('/projects/:project/health', async () => ({ ok: true }))
+
+    // A hypothetical protected route. Its path happens to *end* with one of
+    // the unauth suffixes above, but it is a different, unrelated resource —
+    // it must stay gated. This is exactly the shape the audit called out.
+    app.get('/admin/health', async () => ({ secret: 'do not leak' }))
+    app.get('/v2/api/config', async () => ({ secret: 'do not leak' }))
+    app.get('/projects/foo/bar/health', async () => ({ secret: 'do not leak' }))
+
+    // An ordinary protected route, for the baseline bearer-check assertions.
+    app.get('/graph', async () => ({ nodes: [], edges: [] }))
+
+    await app.ready()
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('leaves the real unauth probes open with no bearer', async () => {
+    for (const url of ['/health', '/healthz', '/readyz', '/api/config']) {
+      const res = await app.inject({ method: 'GET', url })
+      expect(res.statusCode, `${url} should be reachable without a bearer`).toBe(200)
+    }
+  })
+
+  it('leaves the project-scoped /projects/:project/health open with no bearer', async () => {
+    const res = await app.inject({ method: 'GET', url: '/projects/foo/health' })
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('keeps a route that merely ends with `/health` gated — does not treat it as a suffix match', async () => {
+    const noAuth = await app.inject({ method: 'GET', url: '/admin/health' })
+    expect(noAuth.statusCode).toBe(401)
+
+    const withAuth = await app.inject({
+      method: 'GET',
+      url: '/admin/health',
+      headers: { authorization: `Bearer ${TOKEN}` },
+    })
+    expect(withAuth.statusCode).toBe(200)
+  })
+
+  it('keeps a route that merely ends with `/api/config` gated', async () => {
+    const noAuth = await app.inject({ method: 'GET', url: '/v2/api/config' })
+    expect(noAuth.statusCode).toBe(401)
+
+    const withAuth = await app.inject({
+      method: 'GET',
+      url: '/v2/api/config',
+      headers: { authorization: `Bearer ${TOKEN}` },
+    })
+    expect(withAuth.statusCode).toBe(200)
+  })
+
+  it('keeps a route with an extra segment past the project-scoped probe gated (not just a prefix match)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/projects/foo/bar/health' })
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('requires a valid bearer on an ordinary protected route', async () => {
+    const noAuth = await app.inject({ method: 'GET', url: '/graph' })
+    expect(noAuth.statusCode).toBe(401)
+
+    const badAuth = await app.inject({
+      method: 'GET',
+      url: '/graph',
+      headers: { authorization: 'Bearer wrong-token' },
+    })
+    expect(badAuth.statusCode).toBe(401)
+
+    const goodAuth = await app.inject({
+      method: 'GET',
+      url: '/graph',
+      headers: { authorization: `Bearer ${TOKEN}` },
+    })
+    expect(goodAuth.statusCode).toBe(200)
+  })
+})

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -28,10 +28,12 @@ import {
   buildErrorEventForReceiver,
   handleSpan,
   markStaleEdges,
+  mergeSnapshot,
   promoteFrontierNodes,
   readErrorEvents,
   readStaleEvents,
   resetParentSpanCache,
+  SnapshotValidationError,
   stitchTrace,
   thresholdForEdgeType,
   type IngestContext,
@@ -39,6 +41,7 @@ import {
 import { getRootCause } from '../src/traverse.js'
 import type { ParsedSpan } from '../src/otel.js'
 import type { NeatGraph } from '../src/graph.js'
+import { SCHEMA_VERSION, type PersistedGraph } from '../src/persist.js'
 
 function newGraph(): NeatGraph {
   const g: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
@@ -2714,5 +2717,104 @@ describe('handleSpan WebSocket channel spans (#617)', () => {
     expect(result.count).toBe(1)
     const decayed = ctx.graph.getEdgeAttributes(edgeId) as GraphEdge
     expect(decayed.provenance).toBe(Provenance.STALE)
+  })
+})
+
+// #693 — a snapshot pushed to /snapshot used to have its node/edge entries
+// cast straight to GraphNode/GraphEdge with no shape check ahead of
+// graph.addNode()/addEdgeWithKey(). These tests drive mergeSnapshot directly
+// with a payload shaped like what `JSON.parse` would hand back from a hostile
+// or corrupted POST body — no schemaVersion problem, just an attributes
+// object that doesn't match GraphNodeSchema / GraphEdgeSchema.
+describe('mergeSnapshot (#693 — schema validation)', () => {
+  function snapshotOf(
+    nodes: Array<{ key: string; attributes?: unknown }>,
+    edges: Array<{ key?: string; source: string; target: string; attributes?: unknown }> = [],
+  ): PersistedGraph {
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      exportedAt: new Date().toISOString(),
+      graph: { nodes, edges } as unknown as PersistedGraph['graph'],
+    }
+  }
+
+  it('merges a well-formed snapshot as before', () => {
+    const graph = newGraph()
+    const snapshot = snapshotOf([
+      {
+        key: 'service:service-c',
+        attributes: {
+          id: 'service:service-c',
+          type: NodeType.ServiceNode,
+          name: 'service-c',
+          language: 'javascript',
+        },
+      },
+    ])
+    const result = mergeSnapshot(graph, snapshot)
+    expect(result).toEqual({ nodesAdded: 1, edgesAdded: 0 })
+    expect(graph.hasNode('service:service-c')).toBe(true)
+  })
+
+  it('rejects a snapshot carrying a node with an unrecognised `type` — and merges nothing at all', () => {
+    const graph = newGraph()
+    const snapshot = snapshotOf([
+      {
+        key: 'service:service-c',
+        attributes: {
+          id: 'service:service-c',
+          type: NodeType.ServiceNode,
+          name: 'service-c',
+          language: 'javascript',
+        },
+      },
+      {
+        // Not a real NodeType literal — GraphNodeSchema's discriminated union
+        // rejects it. Before #693 this landed on the graph unchanged.
+        key: 'service:evil',
+        attributes: { id: 'service:evil', type: 'DefinitelyNotARealNodeType', name: 'evil' },
+      },
+    ])
+
+    expect(() => mergeSnapshot(graph, snapshot)).toThrow(SnapshotValidationError)
+    // Whole-snapshot rejection: even the well-formed sibling node in the same
+    // payload must not have been merged.
+    expect(graph.hasNode('service:service-c')).toBe(false)
+    expect(graph.hasNode('service:evil')).toBe(false)
+  })
+
+  it('rejects a snapshot carrying an edge with an invalid provenance, and reports it in `issues`', () => {
+    const graph = newGraph()
+    const snapshot = snapshotOf(
+      [],
+      [
+        {
+          key: 'CALLS:service:service-a->service:service-b',
+          source: 'service:service-a',
+          target: 'service:service-b',
+          attributes: {
+            id: 'CALLS:service:service-a->service:service-b',
+            source: 'service:service-a',
+            target: 'service:service-b',
+            type: EdgeType.CALLS,
+            // Not one of the four Provenance enum values.
+            provenance: 'HALLUCINATED',
+          },
+        },
+      ],
+    )
+
+    let caught: unknown
+    try {
+      mergeSnapshot(graph, snapshot)
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(SnapshotValidationError)
+    expect((caught as SnapshotValidationError).issues.length).toBe(1)
+    expect((caught as SnapshotValidationError).issues[0]).toContain(
+      'CALLS:service:service-a->service:service-b',
+    )
+    expect(graph.hasEdge('CALLS:service:service-a->service:service-b')).toBe(false)
   })
 })


### PR DESCRIPTION
Three security holes from the 2026-07-03 audit, all in packages/core/src, bundled as one PR per the usual small-unrelated-fixes precedent.

## What's here

**SSRF/LFI via `GET /graph/diff?against=`.** `loadSnapshotForDiff` fetch()es any http(s) URL and otherwise reads whatever filesystem path it's handed. The route passed the `against` query param straight through with no allowlist, and in public-read mode this needs no auth at all — a live SSRF/LFI vector. `against` now only resolves through the project registry: `self` (this project's own on-disk snapshot) or the name of another project the same daemon tracks. The string is used purely as a map-lookup key, never concatenated into a path or handed to fetch(); anything else is a flat 400.

**Unvalidated snapshot merge.** The `/snapshot` push/sync route only checked `schemaVersion` before merging, and `mergeSnapshot` cast every node/edge straight to `GraphNode`/`GraphEdge` with no shape check ahead of `graph.addNode()`/`addEdgeWithKey()`. A malformed or hostile sync payload could land on the live graph as-is. `mergeSnapshot` now validates every entry against `GraphNodeSchema`/`GraphEdgeSchema` (the same canonical zod schemas the rest of the API already validates responses against), rejects the whole snapshot on the first bad entry — nothing merges, not even the well-formed siblings in the same payload — and reports every invalid entry back to the caller in a structured `issues` array instead of a generic parse failure.

**Auth suffix-matching.** `mountBearerAuth`'s route matching was `path === suffix || path.endsWith(suffix)` against the unauth probe list (`/health`, `/healthz`, `/readyz`, `/api/config`). That exempts any path merely *ending* with one of those strings — a future protected route named e.g. `/admin/health` would slip through unauthenticated by accident. Matching is now exact on the root path, plus one explicit pattern for the `/projects/:project/<probe>` shape the one real dual-mounted route (`/health`) actually relies on. No suffix matching left.

## Tests

- `packages/core/test/api.test.ts` — diff route rejects a filesystem path and an http(s) URL, `against=self`/`against=<project>` both resolve the managed snapshot correctly, and a malformed node in a pushed snapshot gets a structured 400 with nothing merged.
- `packages/core/test/ingest.test.ts` — `mergeSnapshot` unit tests: well-formed snapshot still merges, a bogus node `type` and an invalid edge `provenance` both reject the whole snapshot and surface in `issues`.
- `packages/core/test/auth.test.ts` — new file, no dedicated coverage of `mountBearerAuth`'s route matching existed before this. Covers the real unauth probes staying open, the project-scoped `/health` variant staying open, and a hypothetical protected route that merely ends with `/health` or `/api/config` staying gated (401 without a bearer, 200 with the right one).
- `packages/core/test/audits/contracts.test.ts` — updated the one ADR-061 shape test that hit `/graph/diff` with an arbitrary temp-file path to use the new `against=self` contract instead.

Refs #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)