### PR TITLE
Bump to v0.4.27

### DIFF
--- a/packages/claude-skill/package.json
+++ b/packages/claude-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/claude-skill",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "description": "Claude Code skill drop-in for NEAT — wires the @neat.is/mcp server into Claude's MCP config",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/core",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "description": "NEAT graph engine: tree-sitter extraction, OTel ingest, REST API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -51,7 +51,7 @@
     "@fastify/cors": "^10.0.0",
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
-    "@neat.is/types": "^0.4.26",
+    "@neat.is/types": "^0.4.27",
     "chokidar": "^4.0.3",
     "fastify": "^5.0.0",
     "graphology": "^0.25.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/mcp",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "description": "NEAT MCP server: exposes graph queries to AI agents over stdio",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@neat.is/types": "^0.4.26",
+    "@neat.is/types": "^0.4.27",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/neat.is/package.json
+++ b/packages/neat.is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neat.is",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "description": "NEAT — live semantic graph of a software system, queryable from AI agents over MCP. Install once, get the neat / neatd / neat-mcp CLIs.",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -26,9 +26,9 @@
     "README.md"
   ],
   "dependencies": {
-    "@neat.is/core": "^0.4.26",
-    "@neat.is/mcp": "^0.4.26",
-    "@neat.is/claude-skill": "^0.4.26",
-    "@neat.is/web": "^0.4.26"
+    "@neat.is/core": "^0.4.27",
+    "@neat.is/mcp": "^0.4.27",
+    "@neat.is/claude-skill": "^0.4.27",
+    "@neat.is/web": "^0.4.27"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/types",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "description": "Shared Zod schemas, types, and runtime constants for NEAT",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/web",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "description": "NEAT web shell — minimal Next.js app fronting the core API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
-    "@neat.is/types": "^0.4.26",
+    "@neat.is/types": "^0.4.27",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cytoscape": "^3.33.3",


### PR DESCRIPTION
Cuts **v0.4.27** to publish everything merged since 0.4.26.

New since the last release: the Supabase connector implementation, the shared connector junction (ADR-131), and the connector-config (ADR-130) + unified-logs-surface (ADR-132) designs. The six OBSERVED transport boundaries and the Cloudflare/Firebase/Railway connector engines already shipped in 0.4.26.

This is an incremental release; **0.5.0 stays reserved for the validated graduation cut** after the breaker + human-run pass. The connector engines ship dormant — the `neat connector` self-serve CLI (ADR-130) is designed but unbuilt, so no new user-facing surface is exposed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)