### PR TITLE
Promote Incidents in nav; make todo/placeholder pages reachable

### DIFF
--- a/packages/web/app/components/PageSidebar.tsx
+++ b/packages/web/app/components/PageSidebar.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import {
   GitBranchIcon,
   ShieldIcon,
@@ -38,6 +39,15 @@ const ICONS: Record<NavId, React.ComponentType<{ className?: string }>> = {
   settings: SettingsIcon,
 }
 
+// Most nav ids are views AppShell switches between in place (graph, policies,
+// and the StubPage-rendered siblings). Incidents is the one nav id that's
+// actually a standalone route (app/incidents/page.tsx) rather than an
+// AppShell-internal view, so it needs a real navigation instead of the
+// in-shell onNavigate callback.
+const ROUTES: Partial<Record<NavId, string>> = {
+  incidents: '/incidents',
+}
+
 interface PageSidebarProps {
   active: NavId
   onNavigate: (id: NavId) => void
@@ -45,6 +55,7 @@ interface PageSidebarProps {
 }
 
 export function PageSidebar({ active, onNavigate, badges = {} }: PageSidebarProps) {
+  const router = useRouter()
   return (
     <Sidebar collapsible="icon">
       <SidebarHeader>
@@ -66,18 +77,20 @@ export function PageSidebar({ active, onNavigate, badges = {} }: PageSidebarProp
                   const Icon = ICONS[item.id]
                   const isTodo = item.kind === 'todo'
                   const badge = badges[item.id]
+                  const route = ROUTES[item.id]
                   return (
                     <SidebarMenuItem key={item.id}>
                       <SidebarMenuButton
                         isActive={active === item.id}
                         tooltip={isTodo ? `${item.label} — coming soon` : item.label}
-                        // web-completeness #26: sibling pages not built this
-                        // redo are explicitly disabled with affordance, never a
-                        // live-looking button that does nothing.
-                        disabled={isTodo}
-                        aria-disabled={isTodo}
+                        // #697: every nav entry is a normal, clickable button —
+                        // todo-marked siblings route through to StubPage's
+                        // honest "here's what's coming" copy (web-completeness
+                        // #26 is satisfied by that placeholder being real and
+                        // wired, not by disabling the entry).
                         onClick={() => {
-                          if (!isTodo) onNavigate(item.id)
+                          if (route) router.push(route)
+                          else onNavigate(item.id)
                         }}
                         render={<button type="button" />}
                       >

--- a/packages/web/app/components/StubPage.tsx
+++ b/packages/web/app/components/StubPage.tsx
@@ -50,10 +50,8 @@ export function StubPage({ id }: StubPageProps) {
         <div className="stub-note">
           <p>{copy?.detail}</p>
           <p className="stub-foot">
-            This page is part of the progressive sibling set — the GUI-redo core
-            shipped the shell, the canvas, and the two-mode observed overlay
-            first. It is shown as an explicit placeholder, not a stub that looks
-            active and does nothing.
+            The graph canvas and its live overlay shipped first; pages like
+            this one are landing next.
           </p>
         </div>
       </section>

--- a/packages/web/lib/nav.ts
+++ b/packages/web/lib/nav.ts
@@ -8,8 +8,11 @@
 // query family alongside the node-scoped root-cause / blast / deps actions.
 //
 // `kind: 'page'` is a real, shipped capability. `kind: 'todo'` is a sibling
-// page explicitly marked as not-yet-built — rendered disabled per
-// web-completeness #26 (no permanent stub that looks active and does nothing).
+// page explicitly marked as not-yet-built — it's still a normal, clickable
+// nav entry (#697): it routes through like any other page, landing on
+// StubPage's honest "here's what's coming" copy instead of the real surface.
+// web-completeness #26 is satisfied by that placeholder being real and wired,
+// not by disabling the entry.
 
 export type NavId =
   | 'graph'
@@ -24,7 +27,7 @@ export interface NavItem {
   label: string
   /** one-line description shown in the command palette */
   hint: string
-  /** 'page' = wired this redo; 'todo' = sibling, disabled-with-affordance */
+  /** 'page' = wired this redo; 'todo' = sibling, reachable via StubPage */
   kind: 'page' | 'todo'
 }
 
@@ -61,7 +64,7 @@ export const NAV_GROUPS: { label: string; items: NavItem[] }[] = [
         id: 'incidents',
         label: 'Incidents',
         hint: 'OTel error events',
-        kind: 'todo',
+        kind: 'page',
       },
     ],
   },

--- a/packages/web/test/nav-reachability.test.tsx
+++ b/packages/web/test/nav-reachability.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// #697 — the maintainer's nav-reachability decision: Incidents is a real,
+// shipped page (no longer flagged `todo`), and todo-marked sibling pages are
+// normal clickable nav entries that route through to StubPage's honest
+// "coming soon" copy, instead of being disabled outright.
+//
+// next/navigation needs a real Next router context to resolve `useRouter()`;
+// stub it the same way test/login-surface.test.tsx does so PageSidebar can
+// call router.push() in jsdom without one.
+const pushMock = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, replace: vi.fn(), prefetch: vi.fn() }),
+}))
+
+import { SidebarProvider } from '@/components/ui/sidebar'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { PageSidebar } from '../app/components/PageSidebar'
+import { StubPage } from '../app/components/StubPage'
+import { ALL_NAV } from '../lib/nav'
+
+function renderSidebar() {
+  const onNavigate = vi.fn()
+  render(
+    <TooltipProvider delay={0}>
+      <SidebarProvider defaultOpen>
+        <PageSidebar active="graph" onNavigate={onNavigate} />
+      </SidebarProvider>
+    </TooltipProvider>,
+  )
+  return { onNavigate }
+}
+
+afterEach(() => {
+  pushMock.mockClear()
+})
+
+describe('#697 — nav.ts: incidents is promoted off the todo list', () => {
+  it('the incidents entry is kind "page", not "todo"', () => {
+    const incidents = ALL_NAV.find((n) => n.id === 'incidents')
+    expect(incidents?.kind).toBe('page')
+  })
+
+  it('at least one sibling nav item is still marked todo, so the reachable-todo behavior below has something real to prove', () => {
+    const todoItems = ALL_NAV.filter((n) => n.kind === 'todo')
+    expect(todoItems.length).toBeGreaterThan(0)
+  })
+})
+
+describe('#697 — PageSidebar: todo items are clickable, not disabled', () => {
+  it('a todo-marked nav item (Divergences) renders enabled and routes through onNavigate instead of being disabled', async () => {
+    const { onNavigate } = renderSidebar()
+    const user = userEvent.setup()
+    const button = screen.getByRole('button', { name: /Divergences/i })
+
+    expect(button).not.toHaveAttribute('disabled')
+    expect(button.getAttribute('aria-disabled')).not.toBe('true')
+
+    await user.click(button)
+    expect(onNavigate).toHaveBeenCalledWith('divergences')
+  })
+
+  it('Incidents renders as a plain enabled entry (no "soon" affordance) and navigates to the real /incidents route', async () => {
+    const { onNavigate } = renderSidebar()
+    const user = userEvent.setup()
+    const button = screen.getByRole('button', { name: /^Incidents$/ })
+
+    expect(button).not.toHaveAttribute('disabled')
+    expect(button.getAttribute('aria-disabled')).not.toBe('true')
+    expect(button.textContent).not.toMatch(/soon/i)
+
+    await user.click(button)
+    expect(pushMock).toHaveBeenCalledWith('/incidents')
+    expect(onNavigate).not.toHaveBeenCalled()
+  })
+})
+
+describe('#697 — StubPage: what a reachable todo item actually renders', () => {
+  it('renders real, honest placeholder copy for a todo page rather than inert/internal-only text', () => {
+    render(<StubPage id="divergences" />)
+    expect(screen.getByRole('heading', { name: 'Divergences' })).toBeInTheDocument()
+    expect(screen.getByText('not built yet')).toBeInTheDocument()
+    expect(
+      screen.getByText(/A peer query over the fused graph, not the headline\./),
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/web/test/project-resolution.test.tsx
+++ b/packages/web/test/project-resolution.test.tsx
@@ -45,6 +45,13 @@ describe('#419 — resolveProfile (the resolution selector, tested directly)', (
   })
 })
 
+// next/navigation is server-aware; stub it so AppShell's sidebar (which
+// routes the Incidents nav item via useRouter().push, #697) can render in
+// jsdom without a real Next router context.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+}))
+
 // Stub the heavy data-fetching children so AppShell renders under jsdom; the
 // canvas echoes the project it was handed onto a /api fetch so we can read
 // resolution. The stub mirrors the real #461 gate: a null project fires nothing.

--- a/packages/web/test/single-project-resolution.test.tsx
+++ b/packages/web/test/single-project-resolution.test.tsx
@@ -7,6 +7,13 @@ import { render, waitFor, screen } from '@testing-library/react'
 // then lands every data-fetching consumer on that profile's label. This test
 // pins down that resolution and that the profile switcher renders.
 
+// next/navigation is server-aware; stub it so AppShell's sidebar (which
+// routes the Incidents nav item via useRouter().push, #697) can render in
+// jsdom without a real Next router context.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+}))
+
 // GraphCanvas, Inspector, and StatusBar each dynamic-import or render libraries
 // (cytoscape, eventsource polyfills) that don't run cleanly under jsdom. Stub
 // them with profile-aware fetchers so the test observes each consumer's "did I


### PR DESCRIPTION
This follows the maintainer's decision on #697: open it up, don't hide. `todo` in nav no longer means "disabled" — it means "clickable, honestly labeled as coming soon."

## What changed

**`lib/nav.ts`** — dropped the `todo` flag on the `incidents` entry. The route at `app/incidents/page.tsx` is a real, working page (its data/a11y issues are tracked separately in #699), so the nav item is now a normal `kind: 'page'` entry. Updated the file's comments to describe the new todo semantics (reachable via StubPage, not disabled).

**`app/components/PageSidebar.tsx`** — removed the blanket `disabled`/`aria-disabled` on todo-marked items. Every nav entry is now a normal, clickable button. Incidents is the one nav id that's an actual standalone Next.js route rather than an AppShell-internal view, so it routes via `useRouter().push('/incidents')`; everything else still goes through the existing `onNavigate` callback, which for todo-marked siblings (Divergences, Find, Settings) lands on StubPage.

**`app/components/StubPage.tsx`** — tightened one paragraph of the placeholder copy that read like an internal audit note ("not a stub that looks active and does nothing", "GUI-redo core") rather than something meant for a user. Didn't touch the rest of the copy — it already explains what's coming plainly.

**Tests** — added `test/nav-reachability.test.tsx` covering: incidents is no longer `todo`; a still-todo item (Divergences) is enabled and clickable; Incidents navigates to the real route; StubPage renders real explanatory copy. Also updated `test/project-resolution.test.tsx` and `test/single-project-resolution.test.tsx`, which render the full `AppShell` (and therefore `PageSidebar`) — they needed a `next/navigation` stub now that the sidebar calls `useRouter()`, same pattern already used in `test/login-surface.test.tsx`.

## Test plan

- [x] `npx turbo build test lint --filter=@neat.is/web` green (60 tests passing)
- [ ] Manual: click Incidents in the sidebar, confirm it lands on the real incidents table
- [ ] Manual: click a todo item (e.g. Divergences), confirm it lands on StubPage instead of doing nothing

Refs #697