### PR TITLE
Drop the unused GraphEdge import that reddened main

### DIFF
--- a/packages/web/test/inspector-a11y-and-escaping.test.tsx
+++ b/packages/web/test/inspector-a11y-and-escaping.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { GraphNode, GraphEdge } from '@neat.is/types'
+import type { GraphNode } from '@neat.is/types'
 import type { GraphData } from '../app/components/AppShell'
 import { Inspector } from '../app/components/Inspector'
 


### PR DESCRIPTION
One-line lint fix: `inspector-a11y-and-escaping.test.tsx` (from #719) imported `GraphEdge` without using it, which passed the PR under turbo cache but failed `turbo lint` on the combined main. Imports `GraphNode` only now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)