### PR TITLE
Read connectors.json at daemon bootstrap and start its poll loops (ADR-130)

### DIFF
--- a/packages/core/src/connectors-config.ts
+++ b/packages/core/src/connectors-config.ts
@@ -1,0 +1,289 @@
+// Connector configuration — `~/.neat/connectors.json` read + env-ref
+// resolution (docs/contracts/connector-config.md, ADR-130).
+//
+// This is the file family sibling to the machine-level project registry
+// (registry.ts): per-user, machine-local, never version-controlled. Where the
+// project registry says which projects exist, `connectors.json` says which
+// built connectors are turned on for them and where each one's credential
+// comes from. It is
+// the one file in the family that references real secrets, so it is mode
+// `0600` and — by default — holds a *pointer* to a secret (an env-var
+// reference resolved only at daemon-read time), never the secret itself
+// (contract §1, §2).
+//
+// This module owns two of the contract's three seams: reading/validating the
+// file (`readConnectorsConfig`) and resolving a `credential` env-ref to a
+// value in memory (`resolveCredential`). The provider dispatch table
+// (connectors/registry.ts) turns a resolved entry into a `ConnectorRegistration`;
+// the daemon (daemon.ts) triggers the read at slot bootstrap and hands the
+// registrations to `startConnectorPollLoop`. This file never writes the
+// snapshot and never lets a resolved secret reach disk (contract §6,
+// connectors.md §6, contracts.md Rule 13).
+
+import os from 'node:os'
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+
+// Only bump 1 → 2 when the on-disk shape changes in a way an old reader
+// couldn't ignore. A file with no `version` reads as 1 (the shape below).
+export const CONNECTORS_CONFIG_VERSION = 1
+
+/**
+ * A credential, before resolution. Either a single env-ref/plaintext string
+ * (single-field providers — `"$RAILWAY_TOKEN"`), or a per-field map of them
+ * (multi-field providers — `{ managementToken: "$SUPABASE_MGMT_TOKEN",
+ * postgresConnectionString: "$SUPABASE_DB_URL" }`). A leading `$` marks the
+ * string as the name of an environment variable; anything else is a literal
+ * (contract §2).
+ */
+export type CredentialRef = string | Record<string, string>
+
+/**
+ * One entry in `~/.neat/connectors.json`. Mirrors the contract §1 schema
+ * exactly — `credentials`/`config`/`enabled`/`addedAt` are deliberately
+ * absent; the shape converged on a single `credential` ref plus opaque
+ * `options`, and every listed entry is active (there is no `enabled` gate).
+ */
+export interface ConnectorEntry {
+  // Addressable handle, auto-slugged from provider (disambiguated by project
+  // when a provider repeats). The CLI's `remove <id>` / `test <id>` use it.
+  id: string
+  // 'supabase' | 'railway' | 'firebase' | 'cloudflare' | ... — validated
+  // against the dispatch table (registry.ts), not hardcoded here.
+  provider: string
+  // Matches a registered project's `name`; omitted binds to whichever project
+  // the daemon is bootstrapping (one daemon per project, ADR-096).
+  project?: string
+  // Env-ref by default (see resolveCredential).
+  credential: CredentialRef
+  // Provider-shaped, non-secret config (project ref, service-id mappings,
+  // poll cadence). Opaque here; the dispatch table maps it onto each
+  // provider's own config type.
+  options?: Record<string, unknown>
+}
+
+export interface ConnectorsConfig {
+  version: number
+  connectors: ConnectorEntry[]
+}
+
+/**
+ * A credential after env-ref resolution — values in memory only. `single`
+ * for a one-string credential (the dispatch table knows which record key it
+ * lands under); `fields` for a multi-field credential (the keys are already
+ * the provider's own).
+ */
+export type ResolvedCredential =
+  | { kind: 'single'; value: string }
+  | { kind: 'fields'; fields: Record<string, string> }
+
+/**
+ * Thrown when a `$VAR` credential reference names an environment variable
+ * that isn't set. Kept distinct from every other failure so a caller can
+ * tell "you forgot to `export`" apart from "your token is wrong" (contract
+ * §4). The message names the variable *with* its `$` — `"$SUPABASE_KEY is
+ * unset"` — so a log line points straight at what to set.
+ */
+export class EnvRefUnsetError extends Error {
+  readonly ref: string
+  readonly varName: string
+  constructor(ref: string, varName: string) {
+    super(`${ref} is unset`)
+    this.name = 'EnvRefUnsetError'
+    this.ref = ref
+    this.varName = varName
+  }
+}
+
+// Resolve `~/.neat/` the same way registry.ts does, per call, so a test
+// overriding NEAT_HOME (or HOME) before a run lands here too — module-load
+// order never matters.
+function neatHome(): string {
+  const override = process.env.NEAT_HOME
+  if (override && override.length > 0) return path.resolve(override)
+  return path.join(os.homedir(), '.neat')
+}
+
+export function connectorsConfigPath(home: string = neatHome()): string {
+  return path.join(home, 'connectors.json')
+}
+
+// Owner-read/write only. Anything with group or other bits set is looser than
+// the contract's `0600` guarantee and gets a warning (not a refusal — a
+// mis-permissioned file is a hygiene problem, not a reason to leave a
+// connector dark).
+const MODE_MASK_LOOSER_THAN_0600 = 0o077
+
+async function warnIfModeLooserThan0600(file: string): Promise<void> {
+  // The POSIX bits are meaningless on Windows; skip the check there rather
+  // than warn on every read.
+  if (process.platform === 'win32') return
+  try {
+    const stat = await fs.stat(file)
+    if ((stat.mode & MODE_MASK_LOOSER_THAN_0600) !== 0) {
+      const mode = (stat.mode & 0o777).toString(8).padStart(3, '0')
+      console.warn(
+        `[neat] ${file} is mode 0${mode}, looser than the 0600 this file's secrets call for — run \`chmod 600 ${file}\``,
+      )
+    }
+  } catch {
+    // Racing a delete between read and stat is harmless — the read already
+    // succeeded; skip the permission warning rather than crash on it.
+  }
+}
+
+/**
+ * Read and validate `~/.neat/connectors.json`.
+ *
+ * - A missing file is the common, un-configured case → an empty connector
+ *   list, never an error (the daemon just starts no poll loops).
+ * - A malformed file throws a clear error naming what's wrong. The daemon's
+ *   read path catches it and leaves the slot's connectors empty rather than
+ *   crashing the whole daemon (contract §6, `project-registry.md`'s
+ *   graceful-skip discipline).
+ * - A file looser than `0600` is read but warns.
+ */
+export async function readConnectorsConfig(
+  home: string = neatHome(),
+): Promise<ConnectorsConfig> {
+  const file = connectorsConfigPath(home)
+  let raw: string
+  try {
+    raw = await fs.readFile(file, 'utf8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { version: CONNECTORS_CONFIG_VERSION, connectors: [] }
+    }
+    throw err
+  }
+  await warnIfModeLooserThan0600(file)
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new Error(`${file} is not valid JSON: ${(err as Error).message}`)
+  }
+  return validateConfig(parsed, file)
+}
+
+function validateConfig(parsed: unknown, file: string): ConnectorsConfig {
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`${file} must be a JSON object with a "connectors" array`)
+  }
+  const obj = parsed as Record<string, unknown>
+  const version = obj.version === undefined ? CONNECTORS_CONFIG_VERSION : obj.version
+  if (typeof version !== 'number' || !Number.isInteger(version)) {
+    throw new Error(`${file}: "version" must be an integer`)
+  }
+  const rawConnectors = obj.connectors
+  if (!Array.isArray(rawConnectors)) {
+    throw new Error(`${file}: "connectors" must be an array`)
+  }
+  const connectors = rawConnectors.map((entry, i) => validateEntry(entry, i, file))
+  return { version, connectors }
+}
+
+function validateEntry(entry: unknown, index: number, file: string): ConnectorEntry {
+  const where = `${file}: connectors[${index}]`
+  if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+    throw new Error(`${where} must be an object`)
+  }
+  const e = entry as Record<string, unknown>
+  const id = e.id
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new Error(`${where}.id must be a non-empty string`)
+  }
+  const provider = e.provider
+  if (typeof provider !== 'string' || provider.length === 0) {
+    throw new Error(`${where}.provider must be a non-empty string`)
+  }
+  if (e.project !== undefined && typeof e.project !== 'string') {
+    throw new Error(`${where}.project must be a string when present`)
+  }
+  const credential = validateCredentialRef(e.credential, `${where}.credential`)
+  let options: Record<string, unknown> | undefined
+  if (e.options !== undefined) {
+    if (typeof e.options !== 'object' || e.options === null || Array.isArray(e.options)) {
+      throw new Error(`${where}.options must be an object when present`)
+    }
+    options = e.options as Record<string, unknown>
+  }
+  return {
+    id,
+    provider,
+    ...(typeof e.project === 'string' ? { project: e.project } : {}),
+    credential,
+    ...(options ? { options } : {}),
+  }
+}
+
+function validateCredentialRef(raw: unknown, where: string): CredentialRef {
+  if (typeof raw === 'string') {
+    if (raw.length === 0) throw new Error(`${where} must be a non-empty string`)
+    return raw
+  }
+  if (typeof raw === 'object' && raw !== null && !Array.isArray(raw)) {
+    const fields = raw as Record<string, unknown>
+    const keys = Object.keys(fields)
+    if (keys.length === 0) throw new Error(`${where} object must have at least one field`)
+    for (const key of keys) {
+      const v = fields[key]
+      if (typeof v !== 'string' || v.length === 0) {
+        throw new Error(`${where}.${key} must be a non-empty string`)
+      }
+    }
+    return fields as Record<string, string>
+  }
+  throw new Error(`${where} must be a string or an object of strings`)
+}
+
+/**
+ * Resolve one credential ref to values held only in memory.
+ *
+ * A `$`-prefixed string is an environment-variable reference — resolved
+ * against `env` (default `process.env`) at the moment the daemon builds a
+ * registration; an unset variable throws `EnvRefUnsetError`. Any other string
+ * is an explicit plaintext literal (the opt-in at-rest fallback, contract
+ * §2), passed through unchanged. A field map resolves each value the same
+ * way.
+ */
+export function resolveCredential(
+  ref: CredentialRef,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedCredential {
+  if (typeof ref === 'string') {
+    return { kind: 'single', value: resolveRef(ref, env) }
+  }
+  const fields: Record<string, string> = {}
+  for (const [key, value] of Object.entries(ref)) {
+    fields[key] = resolveRef(value, env)
+  }
+  return { kind: 'fields', fields }
+}
+
+// A leading `$` (with at least one char after it) marks an env-ref; the value
+// must be set and non-empty. Everything else — including a bare `"$"` — is a
+// plaintext literal.
+function resolveRef(value: string, env: NodeJS.ProcessEnv): string {
+  if (value.length > 1 && value.startsWith('$')) {
+    const varName = value.slice(1)
+    const resolved = env[varName]
+    if (resolved === undefined || resolved.length === 0) {
+      throw new EnvRefUnsetError(value, varName)
+    }
+    return resolved
+  }
+  return value
+}
+
+/**
+ * Whether a connector entry belongs to the project a daemon slot is
+ * bootstrapping. An entry with no `project` binds to whatever project is
+ * being bootstrapped (the single-daemon-per-project common case); an entry
+ * naming a project matches only that one. A non-match is skipped, never
+ * errored (contract §6).
+ */
+export function connectorMatchesProject(entry: ConnectorEntry, project: string): boolean {
+  return entry.project === undefined || entry.project === project
+}

--- a/packages/core/src/connectors/registry.ts
+++ b/packages/core/src/connectors/registry.ts
@@ -1,0 +1,248 @@
+// Provider dispatch table — the one place a connector provider registers
+// (docs/contracts/connector-config.md §5, ADR-130).
+//
+// The shipped provider factories deliberately differ in shape: Supabase and
+// Firebase hand back `{ connector, resolveTarget }` from one call, Railway
+// pairs `createRailwayConnector(graph, config)` with a separate
+// `createRailwayResolveTarget(config)`, and Cloudflare constructs its
+// connector class directly alongside `createCloudflareResolveTarget(config)`.
+// This table is the normalization seam that adapts all of them into the one
+// uniform `ConnectorRegistration` the daemon's poll loop consumes — the same
+// data-driven discipline `compat.json` holds for driver logic (CLAUDE.md
+// § Don't do). A new provider adds one entry here; daemon.ts and cli.ts never
+// grow a per-provider branch.
+//
+// `buildRegistration` turns one resolved config entry into a registration;
+// `loadConnectorRegistrations` reads the whole file (via connectors-config.ts)
+// and builds every entry that matches a project. The daemon calls the latter
+// at slot bootstrap.
+
+import type { NeatGraph } from '../graph.js'
+import type { ConnectorRegistration, ObservedConnector, ResolveConnectorTarget } from './index.js'
+import { createSupabaseConnector, type SupabaseConnectorConfig } from './supabase/index.js'
+import {
+  createRailwayConnector,
+  createRailwayResolveTarget,
+  type RailwayConnectorConfig,
+} from './railway/index.js'
+import { createFirebaseConnector, type FirebaseServiceMap } from './firebase/index.js'
+import {
+  CloudflareConnector,
+  createCloudflareResolveTarget,
+  type CloudflareConnectorConfig,
+} from './cloudflare/index.js'
+import {
+  connectorMatchesProject,
+  EnvRefUnsetError,
+  readConnectorsConfig,
+  resolveCredential,
+  type ConnectorEntry,
+} from '../connectors-config.js'
+
+/** What a provider's factory pairing produces once normalized. */
+interface BuiltConnector {
+  connector: ObservedConnector
+  resolveTarget: ResolveConnectorTarget
+}
+
+/**
+ * One provider's dispatch-table entry. Beyond the factory this carries the
+ * schema the CLI (`neat connector add`) reads to know what to prompt for
+ * (contract §5) — declared here so provider specifics live in data the table
+ * reads, never scattered across the CLI and daemon.
+ */
+export interface ProviderDispatch {
+  provider: string
+  // The credential-record key a single-string credential resolves into (this
+  // provider's primary secret field). A multi-field credential carries its
+  // own keys and ignores this.
+  primaryCredentialKey: string
+  // Credential-record keys this provider's `poll()` requires. Checked at
+  // build time so a missing field fails honestly at daemon-read rather than
+  // silently at the first poll.
+  requiredCredentialFields: readonly string[]
+  // `options` keys this provider's factory requires.
+  requiredOptionFields: readonly string[]
+  // Adapt (graph, non-secret options) into the uniform connector pairing.
+  build(graph: NeatGraph, options: Record<string, unknown>): BuiltConnector
+}
+
+// ── The table. Five providers are designed; four are built and register
+// here. Vercel's Drains connector (#724) is a push connector still awaiting a
+// `receive()` amendment to connectors.md — it adds its entry when it lands.
+export const PROVIDER_DISPATCH: Record<string, ProviderDispatch> = {
+  supabase: {
+    provider: 'supabase',
+    primaryCredentialKey: 'managementToken',
+    requiredCredentialFields: ['managementToken'],
+    requiredOptionFields: ['apiProjectRef', 'nodeRef', 'serviceName'],
+    build(graph, options) {
+      // createSupabaseConnector already returns the pairing.
+      return createSupabaseConnector(graph, options as unknown as SupabaseConnectorConfig)
+    },
+  },
+  railway: {
+    provider: 'railway',
+    primaryCredentialKey: 'token',
+    requiredCredentialFields: ['token'],
+    requiredOptionFields: ['environmentId', 'serviceId', 'serviceNameById'],
+    build(graph, options) {
+      const config = options as unknown as RailwayConnectorConfig
+      // Split factories — connector and resolveTarget are built separately.
+      return {
+        connector: createRailwayConnector(graph, config),
+        resolveTarget: createRailwayResolveTarget(config),
+      }
+    },
+  },
+  firebase: {
+    provider: 'firebase',
+    // Firebase reads both projectId and accessToken from the credential; the
+    // single-string form maps to the secret, and the required-fields check
+    // below catches a projectId that was never supplied.
+    primaryCredentialKey: 'accessToken',
+    requiredCredentialFields: ['projectId', 'accessToken'],
+    requiredOptionFields: [],
+    build(graph, options) {
+      // options is the FirebaseServiceMap; createFirebaseConnector returns the
+      // pairing.
+      return createFirebaseConnector(graph, options as unknown as FirebaseServiceMap)
+    },
+  },
+  cloudflare: {
+    provider: 'cloudflare',
+    primaryCredentialKey: 'apiToken',
+    requiredCredentialFields: ['apiToken'],
+    requiredOptionFields: ['accountId', 'workers'],
+    build(_graph, options) {
+      const config = options as unknown as CloudflareConnectorConfig
+      // Class + separate resolveTarget factory; resolveTarget needs no graph.
+      return {
+        connector: new CloudflareConnector(config),
+        resolveTarget: createCloudflareResolveTarget(config),
+      }
+    },
+  },
+}
+
+export function getProviderDispatch(provider: string): ProviderDispatch | undefined {
+  return PROVIDER_DISPATCH[provider]
+}
+
+export type BuildResult =
+  | { ok: true; registration: ConnectorRegistration }
+  | { ok: false; reason: string }
+
+/**
+ * Turn one resolved config entry into a `ConnectorRegistration`, or a skip
+ * reason. Never throws — a bad entry (unknown provider, unset env-ref,
+ * missing required field, provider factory rejecting its config) resolves to
+ * `{ ok: false, reason }` so one broken connector never takes the daemon slot
+ * down with it (contract §6).
+ */
+export function buildRegistration(
+  entry: ConnectorEntry,
+  graph: NeatGraph,
+  env: NodeJS.ProcessEnv = process.env,
+): BuildResult {
+  const dispatch = PROVIDER_DISPATCH[entry.provider]
+  if (!dispatch) {
+    return { ok: false, reason: `unknown provider "${entry.provider}"` }
+  }
+
+  // Resolve env-ref credential to in-memory values (contract §2, §6). An
+  // unset variable is a distinct, named failure — never a silent empty-poll.
+  let credentials: Record<string, unknown>
+  try {
+    const resolved = resolveCredential(entry.credential, env)
+    credentials =
+      resolved.kind === 'single'
+        ? { [dispatch.primaryCredentialKey]: resolved.value }
+        : { ...resolved.fields }
+  } catch (err) {
+    if (err instanceof EnvRefUnsetError) return { ok: false, reason: err.message }
+    return { ok: false, reason: (err as Error).message }
+  }
+
+  const missingCreds = dispatch.requiredCredentialFields.filter((k) => !credentials[k])
+  if (missingCreds.length > 0) {
+    return {
+      ok: false,
+      reason: `credential missing required field(s): ${missingCreds.join(', ')}`,
+    }
+  }
+
+  const options = entry.options ?? {}
+  const missingOpts = dispatch.requiredOptionFields.filter((k) => !(k in options))
+  if (missingOpts.length > 0) {
+    return {
+      ok: false,
+      reason: `options missing required field(s): ${missingOpts.join(', ')}`,
+    }
+  }
+
+  let built: BuiltConnector
+  try {
+    built = dispatch.build(graph, options)
+  } catch (err) {
+    return { ok: false, reason: (err as Error).message }
+  }
+
+  const intervalMs = typeof options.intervalMs === 'number' ? options.intervalMs : undefined
+  return {
+    ok: true,
+    registration: {
+      connector: built.connector,
+      credentials,
+      resolveTarget: built.resolveTarget,
+      ...(intervalMs !== undefined ? { intervalMs } : {}),
+    },
+  }
+}
+
+export interface LoadConnectorsInput {
+  // The project this daemon slot is bootstrapping — only entries that match
+  // it (or omit `project`) load.
+  project: string
+  // The slot's live graph; resolveTarget closes over it.
+  graph: NeatGraph
+  // Resolved NEAT_HOME; defaults to the env-based resolution in
+  // connectors-config.ts.
+  home?: string
+  env?: NodeJS.ProcessEnv
+  // Called once per skipped entry (unknown provider, unset env-ref, missing
+  // field, ...) so the daemon can log it. A skip is never fatal.
+  onSkip?: (entry: ConnectorEntry, reason: string) => void
+}
+
+/**
+ * Read `~/.neat/connectors.json` and build a registration for every entry
+ * that matches `project`. The daemon calls this at slot bootstrap and hands
+ * the result to `startConnectorPollLoop`. A missing file yields an empty
+ * list; a malformed file yields an empty list plus one skip callback, never a
+ * throw — the daemon must survive a hand-edited config.
+ */
+export async function loadConnectorRegistrations(
+  input: LoadConnectorsInput,
+): Promise<ConnectorRegistration[]> {
+  const { project, graph, home, env = process.env, onSkip } = input
+  let connectors: ConnectorEntry[]
+  try {
+    connectors = (await readConnectorsConfig(home)).connectors
+  } catch (err) {
+    onSkip?.(
+      { id: '(file)', provider: '(all)', credential: '' },
+      `connectors.json unreadable — ${(err as Error).message}`,
+    )
+    return []
+  }
+
+  const registrations: ConnectorRegistration[] = []
+  for (const entry of connectors) {
+    if (!connectorMatchesProject(entry, project)) continue
+    const result = buildRegistration(entry, graph, env)
+    if (result.ok) registrations.push(result.registration)
+    else onSkip?.(entry, result.reason)
+  }
+  return registrations
+}

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -46,6 +46,7 @@ import { buildOtelReceiver, listenSteppingOtlp } from './otel.js'
 import { attachGraphToEventBus } from './events.js'
 import { handleSpan, makeErrorSpanWriter, startStalenessLoop } from './ingest.js'
 import { startConnectorPollLoop, type ConnectorRegistration } from './connectors/index.js'
+import { loadConnectorRegistrations } from './connectors/registry.js'
 import {
   listProjects,
   pruneRegistry,
@@ -251,10 +252,12 @@ export interface DaemonOptions {
   // Connectors plane (docs/contracts/connectors.md, ADR-124) — pull-based
   // OBSERVED connectors polled on an interval alongside every project this
   // daemon bootstraps, the same way every project gets the staleness loop.
-  // Applied identically to every project slot; there is no per-project
-  // config-loading here yet (that's provider-specific, later work) — a
-  // caller wanting project-scoped connectors runs a separate `startDaemon`
-  // per project (the single-project ADR-096 mode is the common case).
+  // These are applied to every project slot programmatically; on top of them,
+  // each slot also loads its own project-matched connectors from
+  // `~/.neat/connectors.json` at bootstrap (ADR-130, connector-config.md §6 —
+  // resolved through the dispatch table in connectors/registry.ts). The two
+  // sources merge: file-configured connectors join whatever a caller passes
+  // here.
   connectors?: ConnectorRegistration[]
 }
 
@@ -488,6 +491,7 @@ function spanBelongsToSingleProject(
 async function bootstrapProject(
   entry: RegistryEntry,
   connectors: ConnectorRegistration[] = [],
+  neatHome?: string,
 ): Promise<ProjectSlot> {
   const paths = pathsForProject(entry.name, path.join(entry.path, 'neat-out'))
 
@@ -546,10 +550,29 @@ async function bootstrapProject(
       staleEventsPath: paths.staleEventsPath,
       project: entry.name,
     })
-    // Connectors plane (docs/contracts/connectors.md, ADR-124) — one poll
-    // loop per registered connector, same interval-loop shape as the
+    // Connectors plane (docs/contracts/connectors.md, ADR-124; on-ramp
+    // ADR-130) — every project-matched entry in `~/.neat/connectors.json`
+    // becomes a registration here, resolved through
+    // the dispatch table so no provider specifics leak into this file. The
+    // env-ref credential resolves now, into memory only, and never reaches
+    // the snapshot (connector-config.md §6). A bad entry is skipped with a
+    // log, never fatal to the slot; these merge with any registrations a
+    // programmatic caller passed in `opts.connectors`.
+    const fileConnectors = neatHome
+      ? await loadConnectorRegistrations({
+          project: entry.name,
+          graph,
+          home: neatHome,
+          onSkip: (skipped, reason) =>
+            console.warn(
+              `neatd: connector "${skipped.id}" (${skipped.provider}) skipped for project "${entry.name}" — ${reason}`,
+            ),
+        })
+      : []
+    const allConnectors = [...connectors, ...fileConnectors]
+    // One poll loop per registered connector, same interval-loop shape as the
     // staleness loop above and torn down alongside it (teardownSlot).
-    const stopFns = connectors.map((registration) =>
+    const stopFns = allConnectors.map((registration) =>
       startConnectorPollLoop(
         registration.connector,
         { projectDir: entry.path, credentials: registration.credentials },
@@ -763,7 +786,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
   // the new slot status so callers can decide whether to deliver the span.
   async function tryRecoverSlot(entry: RegistryEntry): Promise<ProjectSlot> {
     try {
-      const fresh = await bootstrapProject(entry, opts.connectors ?? [])
+      const fresh = await bootstrapProject(entry, opts.connectors ?? [], home)
       // The slot being replaced must release its graph's bus listeners
       // (#475) — a stale attach on the prior graph would double-emit.
       const prior = slots.get(entry.name)
@@ -790,7 +813,7 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
     bootstrapStatus.set(entry.name, 'bootstrapping')
     bootstrapStartedAt.set(entry.name, Date.now())
     try {
-      const slot = await bootstrapProject(entry, opts.connectors ?? [])
+      const slot = await bootstrapProject(entry, opts.connectors ?? [], home)
       // Same replacement rule as tryRecoverSlot (#475).
       const prior = slots.get(entry.name)
       if (prior) teardownSlot(prior)

--- a/packages/core/test/connectors-config.test.ts
+++ b/packages/core/test/connectors-config.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import os from 'node:os'
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import {
+  CONNECTORS_CONFIG_VERSION,
+  EnvRefUnsetError,
+  connectorMatchesProject,
+  connectorsConfigPath,
+  readConnectorsConfig,
+  resolveCredential,
+  type ConnectorEntry,
+} from '../src/connectors-config.js'
+
+// docs/contracts/connector-config.md §1 (read/0600), §2 (env-ref resolution),
+// §6 (project match). The reader owns `~/.neat/connectors.json`; a secret
+// resolves only in memory and the file itself holds a pointer by default.
+
+const tmpDirs: string[] = []
+
+async function makeHome(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-connectors-cfg-'))
+  const real = await fs.realpath(dir)
+  tmpDirs.push(real)
+  return real
+}
+
+async function writeConfig(home: string, contents: string, mode = 0o600): Promise<string> {
+  const file = connectorsConfigPath(home)
+  await fs.writeFile(file, contents)
+  await fs.chmod(file, mode)
+  return file
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  while (tmpDirs.length > 0) {
+    await fs.rm(tmpDirs.pop()!, { recursive: true, force: true }).catch(() => {})
+  }
+})
+
+describe('readConnectorsConfig', () => {
+  it('a missing file is the un-configured case — empty list, never an error', async () => {
+    const home = await makeHome()
+    const config = await readConnectorsConfig(home)
+    expect(config).toEqual({ version: CONNECTORS_CONFIG_VERSION, connectors: [] })
+  })
+
+  it('reads and validates a well-formed file', async () => {
+    const home = await makeHome()
+    await writeConfig(
+      home,
+      JSON.stringify({
+        version: 1,
+        connectors: [
+          {
+            id: 'supabase-prod',
+            provider: 'supabase',
+            project: 'brief',
+            credential: '$SUPABASE_KEY',
+            options: { apiProjectRef: 'abcdefghijklmnopqrst', nodeRef: 'x.supabase.co', serviceName: 'api' },
+          },
+        ],
+      }),
+    )
+    const config = await readConnectorsConfig(home)
+    expect(config.connectors).toHaveLength(1)
+    const entry = config.connectors[0]
+    expect(entry.id).toBe('supabase-prod')
+    expect(entry.provider).toBe('supabase')
+    expect(entry.project).toBe('brief')
+    expect(entry.credential).toBe('$SUPABASE_KEY')
+    expect(entry.options).toMatchObject({ serviceName: 'api' })
+  })
+
+  it('accepts a multi-field credential object', async () => {
+    const home = await makeHome()
+    await writeConfig(
+      home,
+      JSON.stringify({
+        connectors: [
+          {
+            id: 'fb',
+            provider: 'firebase',
+            credential: { projectId: '$FB_PROJECT', accessToken: '$FB_TOKEN' },
+          },
+        ],
+      }),
+    )
+    const config = await readConnectorsConfig(home)
+    expect(config.connectors[0].credential).toEqual({
+      projectId: '$FB_PROJECT',
+      accessToken: '$FB_TOKEN',
+    })
+  })
+
+  it('a file with no version reads as the current version', async () => {
+    const home = await makeHome()
+    await writeConfig(home, JSON.stringify({ connectors: [] }))
+    const config = await readConnectorsConfig(home)
+    expect(config.version).toBe(CONNECTORS_CONFIG_VERSION)
+  })
+
+  it('malformed JSON throws a clear error, not a crash', async () => {
+    const home = await makeHome()
+    await writeConfig(home, '{ this is not json ')
+    await expect(readConnectorsConfig(home)).rejects.toThrow(/not valid JSON/)
+  })
+
+  it('a non-object top level is rejected', async () => {
+    const home = await makeHome()
+    await writeConfig(home, JSON.stringify([{ id: 'x' }]))
+    await expect(readConnectorsConfig(home)).rejects.toThrow(/must be a JSON object/)
+  })
+
+  it('an entry missing id is rejected with the offending index', async () => {
+    const home = await makeHome()
+    await writeConfig(
+      home,
+      JSON.stringify({ connectors: [{ provider: 'supabase', credential: '$K' }] }),
+    )
+    await expect(readConnectorsConfig(home)).rejects.toThrow(/connectors\[0\]\.id/)
+  })
+
+  it('an empty credential is rejected', async () => {
+    const home = await makeHome()
+    await writeConfig(
+      home,
+      JSON.stringify({ connectors: [{ id: 'x', provider: 'supabase', credential: '' }] }),
+    )
+    await expect(readConnectorsConfig(home)).rejects.toThrow(/credential must be a non-empty string/)
+  })
+
+  it.runIf(process.platform !== 'win32')(
+    'warns when the file is looser than 0600 but still reads it',
+    async () => {
+      const home = await makeHome()
+      await writeConfig(home, JSON.stringify({ connectors: [] }), 0o644)
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const config = await readConnectorsConfig(home)
+      expect(config.connectors).toEqual([])
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn.mock.calls[0][0]).toMatch(/looser than the 0600/)
+    },
+  )
+
+  it.runIf(process.platform !== 'win32')('does not warn on a correct 0600 file', async () => {
+    const home = await makeHome()
+    await writeConfig(home, JSON.stringify({ connectors: [] }), 0o600)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await readConnectorsConfig(home)
+    expect(warn).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveCredential', () => {
+  it('resolves a single env-ref against the environment', () => {
+    const resolved = resolveCredential('$SUPABASE_KEY', { SUPABASE_KEY: 'sk_live_abc' })
+    expect(resolved).toEqual({ kind: 'single', value: 'sk_live_abc' })
+  })
+
+  it('surfaces an unset env-ref by name — not a silent empty value', () => {
+    expect(() => resolveCredential('$SUPABASE_KEY', {})).toThrow(EnvRefUnsetError)
+    try {
+      resolveCredential('$SUPABASE_KEY', {})
+      throw new Error('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(EnvRefUnsetError)
+      expect((err as Error).message).toBe('$SUPABASE_KEY is unset')
+      expect((err as EnvRefUnsetError).varName).toBe('SUPABASE_KEY')
+    }
+  })
+
+  it('treats an env var set to empty string as unset', () => {
+    expect(() => resolveCredential('$SUPABASE_KEY', { SUPABASE_KEY: '' })).toThrow(
+      /\$SUPABASE_KEY is unset/,
+    )
+  })
+
+  it('passes a plaintext credential through unchanged (explicit opt-in)', () => {
+    const resolved = resolveCredential('sk_live_plaintext', {})
+    expect(resolved).toEqual({ kind: 'single', value: 'sk_live_plaintext' })
+  })
+
+  it('resolves each field of a multi-field credential', () => {
+    const resolved = resolveCredential(
+      { projectId: '$FB_PROJECT', accessToken: '$FB_TOKEN' },
+      { FB_PROJECT: 'my-app', FB_TOKEN: 'ya29.token' },
+    )
+    expect(resolved).toEqual({
+      kind: 'fields',
+      fields: { projectId: 'my-app', accessToken: 'ya29.token' },
+    })
+  })
+
+  it('names the specific unset field in a multi-field credential', () => {
+    expect(() =>
+      resolveCredential(
+        { projectId: '$FB_PROJECT', accessToken: '$FB_TOKEN' },
+        { FB_PROJECT: 'my-app' },
+      ),
+    ).toThrow(/\$FB_TOKEN is unset/)
+  })
+
+  it('mixes a plaintext field with an env-ref field', () => {
+    const resolved = resolveCredential(
+      { projectId: 'my-app', accessToken: '$FB_TOKEN' },
+      { FB_TOKEN: 'ya29.token' },
+    )
+    expect(resolved).toEqual({
+      kind: 'fields',
+      fields: { projectId: 'my-app', accessToken: 'ya29.token' },
+    })
+  })
+})
+
+describe('connectorMatchesProject', () => {
+  const base: ConnectorEntry = { id: 'x', provider: 'supabase', credential: '$K' }
+
+  it('an entry with no project binds to whatever project is bootstrapping', () => {
+    expect(connectorMatchesProject(base, 'brief')).toBe(true)
+    expect(connectorMatchesProject(base, 'newdryve')).toBe(true)
+  })
+
+  it('an entry naming a project matches only that one', () => {
+    const entry = { ...base, project: 'brief' }
+    expect(connectorMatchesProject(entry, 'brief')).toBe(true)
+    expect(connectorMatchesProject(entry, 'newdryve')).toBe(false)
+  })
+})

--- a/packages/core/test/connectors-daemon-read.test.ts
+++ b/packages/core/test/connectors-daemon-read.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import path from 'node:path'
+import os from 'node:os'
+import { promises as fs } from 'node:fs'
+import { getGraph } from '../src/graph.js'
+import { connectorsConfigPath } from '../src/connectors-config.js'
+import { loadConnectorRegistrations } from '../src/connectors/registry.js'
+import { CloudflareConnector } from '../src/connectors/cloudflare/index.js'
+import type { ConnectorContext, ObservedSignal } from '../src/connectors/index.js'
+
+// docs/contracts/connector-config.md §6 — the daemon reads
+// ~/.neat/connectors.json at slot bootstrap, resolves the env-ref credential
+// into memory, and hands one registration per matched entry to the poll loop
+// that already exists. This is the moment the connectors plane turns on: a
+// real connectors.json at a temp NEAT_HOME → running poll loops.
+
+interface Sandbox {
+  home: string
+  projectPaths: Map<string, string>
+  cleanup: () => Promise<void>
+}
+
+// Mirrors daemon-staleness.test.ts's sandbox: a throwaway NEAT_HOME + a
+// registered project, no listeners bound.
+async function setupSandbox(projectNames: string[], extraEnv: string[] = []): Promise<Sandbox> {
+  const home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'neatd-conn-home-')))
+  const projectPaths = new Map<string, string>()
+  const cleanups: Array<() => Promise<void>> = []
+  const savedEnv = new Map<string, string | undefined>()
+  for (const key of ['NEAT_HOME', 'PORT', 'OTEL_PORT', 'HOST', 'NEAT_AUTH_TOKEN', ...extraEnv]) {
+    savedEnv.set(key, process.env[key])
+  }
+  process.env.NEAT_HOME = home
+  process.env.PORT = '0'
+  process.env.OTEL_PORT = '0'
+  process.env.HOST = '127.0.0.1'
+  delete process.env.NEAT_AUTH_TOKEN
+
+  const { addProject } = await import('../src/registry.js')
+  for (const name of projectNames) {
+    const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), `neatd-conn-${name}-`)))
+    await fs.writeFile(path.join(dir, 'package.json'), JSON.stringify({ name, version: '0.0.0' }))
+    await addProject({ name, path: dir, languages: ['javascript'] })
+    projectPaths.set(name, dir)
+    cleanups.push(() => fs.rm(dir, { recursive: true, force: true }))
+  }
+
+  return {
+    home,
+    projectPaths,
+    cleanup: async () => {
+      for (const [key, value] of savedEnv) {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
+      for (const c of cleanups) await c().catch(() => {})
+      await fs.rm(home, { recursive: true, force: true }).catch(() => {})
+    },
+  }
+}
+
+async function writeConnectorsJson(home: string, connectors: unknown[]): Promise<void> {
+  const file = connectorsConfigPath(home)
+  await fs.writeFile(file, JSON.stringify({ version: 1, connectors }))
+  await fs.chmod(file, 0o600)
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline && !predicate()) {
+    await new Promise((r) => setTimeout(r, 15))
+  }
+}
+
+describe('daemon reads connectors.json at slot bootstrap (ADR-130 §6)', () => {
+  const pendingCleanups: Array<() => Promise<void>> = []
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    while (pendingCleanups.length > 0) {
+      await pendingCleanups.pop()!().catch(() => {})
+    }
+  })
+
+  it('a real connectors.json populates the slot with a poll loop that fires with the resolved credential', async () => {
+    const sandbox = await setupSandbox(['conn-alpha'], ['CONN_TEST_CF_TOKEN'])
+    pendingCleanups.push(sandbox.cleanup)
+
+    // The credential is a pointer: connectors.json holds "$CONN_TEST_CF_TOKEN",
+    // the value lives only in the environment and only resolves at read time.
+    process.env.CONN_TEST_CF_TOKEN = 'cf_secret_value'
+    await writeConnectorsJson(sandbox.home, [
+      {
+        id: 'cf-alpha',
+        provider: 'cloudflare',
+        // project omitted → binds to whatever project this daemon bootstraps.
+        credential: '$CONN_TEST_CF_TOKEN',
+        options: {
+          accountId: 'acct-xyz',
+          workers: { 'my-worker': { service: 'api', entryFile: 'src/index.ts' } },
+          // Tighten the loop so the tick fires within the test window instead
+          // of the 60s production default.
+          intervalMs: 20,
+        },
+      },
+    ])
+
+    // Capture the ctx the loop drives poll() with — without hitting the
+    // network. The spy stands in for Cloudflare's telemetry API.
+    const seen: ConnectorContext[] = []
+    vi.spyOn(CloudflareConnector.prototype, 'poll').mockImplementation(
+      async (ctx: ConnectorContext): Promise<ObservedSignal[]> => {
+        seen.push(ctx)
+        return []
+      },
+    )
+
+    const { startDaemon } = await import('../src/daemon.js')
+    const handle = await startDaemon({ bindListeners: false })
+    pendingCleanups.push(handle.stop)
+    await handle.initialBootstrap
+
+    const slot = handle.slots.get('conn-alpha')
+    expect(slot?.status).toBe('active')
+
+    await waitUntil(() => seen.length > 0)
+
+    // The plane is on: the file-configured connector's poll() ran, driven by
+    // the loop the daemon wired from connectors.json.
+    expect(seen.length).toBeGreaterThan(0)
+    const ctx = seen[0]
+    // The env-ref resolved to the real value, in memory, and reached poll()
+    // via ctx.credentials — never written to the file or the snapshot.
+    expect(ctx.credentials.apiToken).toBe('cf_secret_value')
+    expect(ctx.projectDir).toBe(sandbox.projectPaths.get('conn-alpha'))
+  })
+
+  it('the same read path populates registrations deterministically (opts.connectors seam)', async () => {
+    // The daemon composes readConnectorsConfig + the dispatch table via
+    // loadConnectorRegistrations; assert that seam directly against a real
+    // file so the "opts.connectors populates" moment isn't only timing-based.
+    const sandbox = await setupSandbox([], ['CONN_TEST_CF_TOKEN'])
+    pendingCleanups.push(sandbox.cleanup)
+    process.env.CONN_TEST_CF_TOKEN = 'cf_secret_value'
+    await writeConnectorsJson(sandbox.home, [
+      {
+        id: 'cf-alpha',
+        provider: 'cloudflare',
+        project: 'conn-alpha',
+        credential: '$CONN_TEST_CF_TOKEN',
+        options: { accountId: 'acct-xyz', workers: {} },
+      },
+    ])
+
+    const registrations = await loadConnectorRegistrations({
+      project: 'conn-alpha',
+      graph: getGraph('conn-alpha-read-test'),
+      home: sandbox.home,
+    })
+
+    expect(registrations).toHaveLength(1)
+    expect(registrations[0].connector.provider).toBe('cloudflare')
+    expect(registrations[0].credentials.apiToken).toBe('cf_secret_value')
+    expect(typeof registrations[0].resolveTarget).toBe('function')
+  })
+})

--- a/packages/core/test/connectors-registry.test.ts
+++ b/packages/core/test/connectors-registry.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import os from 'node:os'
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import { MultiDirectedGraph } from 'graphology'
+import type { GraphEdge, GraphNode } from '@neat.is/types'
+import type { NeatGraph } from '../src/graph.js'
+import {
+  PROVIDER_DISPATCH,
+  buildRegistration,
+  getProviderDispatch,
+  loadConnectorRegistrations,
+} from '../src/connectors/registry.js'
+import { connectorsConfigPath, type ConnectorEntry } from '../src/connectors-config.js'
+
+// docs/contracts/connector-config.md §5 — the dispatch table is the one place
+// a provider registers and the seam that normalizes the shipped factories'
+// mismatched signatures into one ConnectorRegistration.
+
+function freshGraph(): NeatGraph {
+  return new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+}
+
+const tmpDirs: string[] = []
+async function makeHome(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-connectors-reg-'))
+  const real = await fs.realpath(dir)
+  tmpDirs.push(real)
+  return real
+}
+afterEach(async () => {
+  while (tmpDirs.length > 0) {
+    await fs.rm(tmpDirs.pop()!, { recursive: true, force: true }).catch(() => {})
+  }
+})
+
+// One valid entry + a matching env per built provider. The options match each
+// provider's own config shape (SupabaseConnectorConfig, RailwayConnectorConfig,
+// FirebaseServiceMap, CloudflareConnectorConfig).
+const validCases: Array<{
+  provider: string
+  entry: ConnectorEntry
+  env: NodeJS.ProcessEnv
+  credentialKey: string
+  secret: string
+}> = [
+  {
+    provider: 'supabase',
+    secret: 'sbp_mgmt_token',
+    credentialKey: 'managementToken',
+    env: { SUPABASE_MGMT: 'sbp_mgmt_token' },
+    entry: {
+      id: 'supabase-prod',
+      provider: 'supabase',
+      credential: '$SUPABASE_MGMT',
+      options: { apiProjectRef: 'abcdefghijklmnopqrst', nodeRef: 'x.supabase.co', serviceName: 'api' },
+    },
+  },
+  {
+    provider: 'railway',
+    secret: 'railway_pat',
+    credentialKey: 'token',
+    env: { RAILWAY_TOKEN: 'railway_pat' },
+    entry: {
+      id: 'railway-prod',
+      provider: 'railway',
+      credential: '$RAILWAY_TOKEN',
+      options: { environmentId: 'env-1', serviceId: 'svc-1', serviceNameById: { 'svc-1': 'api' } },
+    },
+  },
+  {
+    provider: 'firebase',
+    secret: 'ya29.access_token',
+    credentialKey: 'accessToken',
+    env: { FB_PROJECT: 'my-app', FB_TOKEN: 'ya29.access_token' },
+    entry: {
+      id: 'firebase-prod',
+      provider: 'firebase',
+      credential: { projectId: '$FB_PROJECT', accessToken: '$FB_TOKEN' },
+      options: { functions: { myFn: 'api' } },
+    },
+  },
+  {
+    provider: 'cloudflare',
+    secret: 'cf_api_token',
+    credentialKey: 'apiToken',
+    env: { CF_TOKEN: 'cf_api_token' },
+    entry: {
+      id: 'cloudflare-prod',
+      provider: 'cloudflare',
+      credential: '$CF_TOKEN',
+      options: {
+        accountId: 'acct-123',
+        workers: { 'my-worker': { service: 'api', entryFile: 'src/index.ts' } },
+      },
+    },
+  },
+]
+
+describe('PROVIDER_DISPATCH table', () => {
+  it('registers every built provider', () => {
+    expect(Object.keys(PROVIDER_DISPATCH).sort()).toEqual([
+      'cloudflare',
+      'firebase',
+      'railway',
+      'supabase',
+    ])
+  })
+
+  it('getProviderDispatch resolves a known provider and misses an unknown one', () => {
+    expect(getProviderDispatch('supabase')?.provider).toBe('supabase')
+    expect(getProviderDispatch('vercel')).toBeUndefined()
+  })
+})
+
+describe('buildRegistration normalizes each provider into one registration shape', () => {
+  it.each(validCases)('$provider → a valid ConnectorRegistration', ({ entry, env, credentialKey, secret, provider }) => {
+    const result = buildRegistration(entry, freshGraph(), env)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const reg = result.registration
+    expect(reg.connector.provider).toBe(provider)
+    expect(typeof reg.resolveTarget).toBe('function')
+    // The resolved secret lives on the registration's credentials record,
+    // under the key that provider's poll() reads it from — and nowhere else.
+    expect(reg.credentials[credentialKey]).toBe(secret)
+  })
+
+  it('firebase carries both resolved credential fields', () => {
+    const fb = validCases.find((c) => c.provider === 'firebase')!
+    const result = buildRegistration(fb.entry, freshGraph(), fb.env)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.registration.credentials).toEqual({
+      projectId: 'my-app',
+      accessToken: 'ya29.access_token',
+    })
+  })
+
+  it('carries intervalMs through from options when set', () => {
+    const entry: ConnectorEntry = {
+      id: 'cf',
+      provider: 'cloudflare',
+      credential: '$CF_TOKEN',
+      options: { accountId: 'a', workers: {}, intervalMs: 15000 },
+    }
+    const result = buildRegistration(entry, freshGraph(), { CF_TOKEN: 't' })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.registration.intervalMs).toBe(15000)
+  })
+})
+
+describe('buildRegistration skips a bad entry rather than throwing', () => {
+  it('unknown provider', () => {
+    const result = buildRegistration(
+      { id: 'x', provider: 'notaprovider', credential: '$K' },
+      freshGraph(),
+      { K: 'v' },
+    )
+    expect(result).toEqual({ ok: false, reason: expect.stringContaining('unknown provider') })
+  })
+
+  it('unset env-ref names the variable', () => {
+    const result = buildRegistration(
+      {
+        id: 'x',
+        provider: 'railway',
+        credential: '$RAILWAY_TOKEN',
+        options: { environmentId: 'e', serviceId: 's', serviceNameById: { s: 'api' } },
+      },
+      freshGraph(),
+      {},
+    )
+    expect(result).toEqual({ ok: false, reason: '$RAILWAY_TOKEN is unset' })
+  })
+
+  it('missing required option field', () => {
+    const result = buildRegistration(
+      {
+        id: 'x',
+        provider: 'supabase',
+        credential: '$SB',
+        options: { apiProjectRef: 'abcdefghijklmnopqrst', serviceName: 'api' }, // nodeRef missing
+      },
+      freshGraph(),
+      { SB: 'tok' },
+    )
+    expect(result).toEqual({
+      ok: false,
+      reason: expect.stringContaining('options missing required field(s): nodeRef'),
+    })
+  })
+
+  it('firebase with a single-string credential misses the projectId field', () => {
+    const result = buildRegistration(
+      { id: 'x', provider: 'firebase', credential: '$FB_TOKEN', options: {} },
+      freshGraph(),
+      { FB_TOKEN: 'ya29.tok' },
+    )
+    expect(result).toEqual({
+      ok: false,
+      reason: expect.stringContaining('credential missing required field(s): projectId'),
+    })
+  })
+})
+
+describe('loadConnectorRegistrations reads the file and builds project-matched entries', () => {
+  async function writeConfig(home: string, entries: ConnectorEntry[]): Promise<void> {
+    await fs.writeFile(connectorsConfigPath(home), JSON.stringify({ version: 1, connectors: entries }))
+    await fs.chmod(connectorsConfigPath(home), 0o600)
+  }
+
+  it('builds only the entries matching the bootstrapping project (plus project-less ones)', async () => {
+    const home = await makeHome()
+    await writeConfig(home, [
+      {
+        id: 'cf-brief',
+        provider: 'cloudflare',
+        project: 'brief',
+        credential: '$CF_TOKEN',
+        options: { accountId: 'a', workers: {} },
+      },
+      {
+        id: 'rw-other',
+        provider: 'railway',
+        project: 'newdryve',
+        credential: '$RW_TOKEN',
+        options: { environmentId: 'e', serviceId: 's', serviceNameById: { s: 'api' } },
+      },
+      {
+        id: 'cf-any',
+        provider: 'cloudflare',
+        credential: '$CF_TOKEN', // no project → binds to whatever bootstraps
+        options: { accountId: 'b', workers: {} },
+      },
+    ])
+
+    const registrations = await loadConnectorRegistrations({
+      project: 'brief',
+      graph: freshGraph(),
+      home,
+      env: { CF_TOKEN: 'cf', RW_TOKEN: 'rw' },
+    })
+    // cf-brief (project match) + cf-any (project-less) — not rw-other.
+    expect(registrations).toHaveLength(2)
+    expect(registrations.every((r) => r.connector.provider === 'cloudflare')).toBe(true)
+    expect(registrations.every((r) => r.credentials.apiToken === 'cf')).toBe(true)
+  })
+
+  it('a missing file yields no registrations and no throw', async () => {
+    const home = await makeHome()
+    const registrations = await loadConnectorRegistrations({
+      project: 'brief',
+      graph: freshGraph(),
+      home,
+    })
+    expect(registrations).toEqual([])
+  })
+
+  it('a malformed file yields no registrations and one skip callback, not a crash', async () => {
+    const home = await makeHome()
+    await fs.writeFile(connectorsConfigPath(home), 'not json at all')
+    await fs.chmod(connectorsConfigPath(home), 0o600)
+    const skips: string[] = []
+    const registrations = await loadConnectorRegistrations({
+      project: 'brief',
+      graph: freshGraph(),
+      home,
+      onSkip: (_e, reason) => skips.push(reason),
+    })
+    expect(registrations).toEqual([])
+    expect(skips).toHaveLength(1)
+    expect(skips[0]).toMatch(/unreadable/)
+  })
+
+  it('an unresolvable entry is skipped, a good sibling still loads', async () => {
+    const home = await makeHome()
+    await writeConfig(home, [
+      {
+        id: 'good',
+        provider: 'cloudflare',
+        credential: '$CF_TOKEN',
+        options: { accountId: 'a', workers: {} },
+      },
+      {
+        id: 'bad',
+        provider: 'railway',
+        credential: '$RW_MISSING', // unset
+        options: { environmentId: 'e', serviceId: 's', serviceNameById: { s: 'api' } },
+      },
+    ])
+    const skips: Array<{ id: string; reason: string }> = []
+    const registrations = await loadConnectorRegistrations({
+      project: 'brief',
+      graph: freshGraph(),
+      home,
+      env: { CF_TOKEN: 'cf' },
+      onSkip: (e, reason) => skips.push({ id: e.id, reason }),
+    })
+    expect(registrations).toHaveLength(1)
+    expect(registrations[0].connector.provider).toBe('cloudflare')
+    expect(skips).toEqual([{ id: 'bad', reason: '$RW_MISSING is unset' }])
+  })
+})


### PR DESCRIPTION
The connectors plane has everything downstream of a credential already built and tested — `startConnectorPollLoop`, the shared junction, each provider's `poll()` — but nothing feeds it a credential, so no connector runs. This is the daemon-read chain that populates `opts.connectors` from `~/.neat/connectors.json` and turns the plane on.

What lands here (per `docs/contracts/connector-config.md`, ADR-130):

- **`connectors-config.ts`** owns `~/.neat/connectors.json`: reads and validates it (a missing file is the un-configured case, not an error; malformed fails clearly without crashing the daemon; a file looser than `0600` warns), and resolves a credential to a value. A credential is an env-var reference by default (`"$SUPABASE_KEY"`), resolved only in memory at read time so no secret sits at rest in the file. An unset variable is surfaced by name (`"$SUPABASE_KEY is unset"`) and skips that one connector rather than polling with an empty credential. Plaintext is the explicit opt-in fallback.
- **`connectors/registry.ts`** is the provider dispatch table — the one place a provider registers, and the normalization seam that adapts the shipped factories' mismatched signatures (Supabase and Firebase return a pair, Railway and Cloudflare split the connector from its `resolveTarget`) into one uniform `ConnectorRegistration`. A new provider adds one entry; `daemon.ts` and `cli.ts` never grow a per-provider branch.
- **`daemon.ts`** reads the file at slot bootstrap, builds a registration for every project-matched entry through the table, and hands it to the poll loop that already exists. A bad entry is skipped with a log, never fatal to the slot; file-configured connectors merge with any a caller passes in `opts.connectors`.

Tests cover the reader (missing / malformed / `0600` / env-ref resolved / unset-var-skips), the dispatch table (each of the four built providers normalizes to a valid registration; unknown-provider and unset-env skip paths), and an integration test that a real `connectors.json` at a temp `NEAT_HOME` with the env var set drives the daemon's poll loop with the resolved credential in memory — the plane turning on.

The `neat connector` CLI that writes the file is the follow-up PR; this is the load-bearing middle it will be testable against.

Refs #678