### PR TITLE
Build the Divergences and Find pages; give Policies its rule list

### DIFF
--- a/packages/web/app/api/divergences/route.ts
+++ b/packages/web/app/api/divergences/route.ts
@@ -1,0 +1,21 @@
+import { proxyProfile } from '../../../lib/proxy'
+import { FIXTURE_DIVERGENCES } from '../../../lib/fixtures'
+
+// ADR-101 — divergences are computed by the selected profile's daemon at the
+// ROOT (`/graph/divergences`, no `/projects/:name` prefix). Read-only, derived
+// (divergence-query.md). The optional `type` / `minConfidence` filters ride
+// through verbatim so the page can narrow the result set server-side.
+export async function GET(request: Request): Promise<Response> {
+  const url = new URL(request.url)
+  const qs = new URLSearchParams()
+  const type = url.searchParams.get('type')
+  const minConfidence = url.searchParams.get('minConfidence')
+  if (type) qs.set('type', type)
+  if (minConfidence) qs.set('minConfidence', minConfidence)
+  const suffix = qs.toString() ? `?${qs.toString()}` : ''
+  return proxyProfile(
+    request,
+    `/graph/divergences${suffix}`,
+    () => Response.json(FIXTURE_DIVERGENCES),
+  )
+}

--- a/packages/web/app/api/policies/route.ts
+++ b/packages/web/app/api/policies/route.ts
@@ -1,0 +1,10 @@
+import { proxyProfile } from '../../../lib/proxy'
+import { FIXTURE_POLICIES } from '../../../lib/fixtures'
+
+// ADR-101 — the policy rule list comes from the selected profile's daemon at
+// the ROOT (`/policies`, no `/projects/:name` prefix). This is the read-only
+// list of rules pinned into an agent's context (policy-schema.md); the
+// violation view lives at `/api/policies/violations`.
+export async function GET(request: Request): Promise<Response> {
+  return proxyProfile(request, '/policies', () => Response.json(FIXTURE_POLICIES))
+}

--- a/packages/web/app/components/AppShell.tsx
+++ b/packages/web/app/components/AppShell.tsx
@@ -12,6 +12,8 @@ import { DebugPanel } from './DebugPanel'
 import { Toaster } from './Toaster'
 import { CommandPalette } from './CommandPalette'
 import { PoliciesPage } from './PoliciesPage'
+import { DivergencesPage } from './DivergencesPage'
+import { FindPage } from './FindPage'
 import { StubPage } from './StubPage'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -211,6 +213,18 @@ export function AppShell() {
                 </div>
               ) : activePage === 'policies' ? (
                 <PoliciesPage
+                  project={project}
+                  onNodeSelect={setSelectedNodeId}
+                  onNavigateGraph={() => setActivePage('graph')}
+                />
+              ) : activePage === 'divergences' ? (
+                <DivergencesPage
+                  project={project}
+                  onNodeSelect={setSelectedNodeId}
+                  onNavigateGraph={() => setActivePage('graph')}
+                />
+              ) : activePage === 'find' ? (
+                <FindPage
                   project={project}
                   onNodeSelect={setSelectedNodeId}
                   onNavigateGraph={() => setActivePage('graph')}

--- a/packages/web/app/components/DivergencesPage.tsx
+++ b/packages/web/app/components/DivergencesPage.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type { Divergence, DivergenceResult, DivergenceType } from '@neat.is/types'
+import { authedFetch } from '../../lib/authed-fetch'
+import { Badge } from '@/components/ui/badge'
+
+// ---------------------------------------------------------------------------
+// Divergences page — the peer query view over the fused graph (web-shell §6,
+// divergence-query.md). Read-only, derived: `get_divergences` surfacing where a
+// declared relationship and its observed twin diverge, at whichever grain both
+// sides share (file-awareness §7). A row focuses that pair on the graph.
+//
+// This is a peer query, not the marquee — the fused graph is the spine. The
+// copy never frames NEAT as a "divergence detector" (web-shell §1).
+// ---------------------------------------------------------------------------
+
+interface DivergencesPageProps {
+  project: string | null
+  onNodeSelect: (id: string) => void
+  onNavigateGraph: () => void
+}
+
+// Human labels for the five locked divergence types (divergence.ts).
+const TYPE_LABEL: Record<DivergenceType, string> = {
+  'missing-observed': 'missing observed',
+  'missing-extracted': 'missing extracted',
+  'version-mismatch': 'version mismatch',
+  'host-mismatch': 'host mismatch',
+  'compat-violation': 'compat violation',
+}
+
+// One honest line per type describing what the mismatch means, shown as the
+// column-empty hover / context. Kept terse; the reason field carries specifics.
+const TYPE_HINT: Record<DivergenceType, string> = {
+  'missing-observed': 'declared in code, never seen at runtime',
+  'missing-extracted': 'seen at runtime, never declared in code',
+  'version-mismatch': 'declared version differs from the observed one',
+  'host-mismatch': 'declared host differs from the observed one',
+  'compat-violation': 'a compat rule fires against the live edge',
+}
+
+// The evidence file:line rides on the embedded EXTRACTED / OBSERVED edge for the
+// edge-shaped divergences (missing-observed / missing-extracted / compat). The
+// value-shaped ones (host / version mismatch) carry no call site.
+function evidenceOf(d: Divergence): string | null {
+  const edge =
+    'extracted' in d ? d.extracted : 'observed' in d ? d.observed : undefined
+  if (edge && edge.evidence?.file) {
+    return `${edge.evidence.file}${typeof edge.evidence.line === 'number' ? `:${edge.evidence.line}` : ''}`
+  }
+  return null
+}
+
+// The concrete declared-vs-observed values for the value-shaped divergences, so
+// the mismatch is legible without opening the node.
+function deltaOf(d: Divergence): string | null {
+  if (d.type === 'host-mismatch') return `${d.extractedHost} → ${d.observedHost}`
+  if (d.type === 'version-mismatch') return `${d.extractedVersion} → ${d.observedVersion}`
+  return null
+}
+
+export function DivergencesPage({ project, onNodeSelect, onNavigateGraph }: DivergencesPageProps) {
+  const [result, setResult] = useState<DivergenceResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [activeType, setActiveType] = useState<DivergenceType | 'all'>('all')
+
+  // The peer query. Idle until a project resolves (#461, web-multi-project §2).
+  useEffect(() => {
+    if (!project) {
+      setResult(null)
+      return
+    }
+    setError(null)
+    authedFetch(`/api/divergences?project=${encodeURIComponent(project)}`)
+      .then((r) => r.json())
+      .then((d: DivergenceResult) => {
+        setResult(Array.isArray(d.divergences) ? d : { divergences: [], totalAffected: 0, computedAt: '' })
+      })
+      .catch(() => setError('could not load divergences'))
+  }, [project])
+
+  const divergences = result?.divergences ?? []
+
+  // Type chips reflect only the types actually present, so the filter never
+  // offers an empty bucket.
+  const presentTypes = useMemo(() => {
+    const s = new Set<DivergenceType>()
+    for (const d of divergences) s.add(d.type)
+    return [...s]
+  }, [divergences])
+
+  const shown = activeType === 'all' ? divergences : divergences.filter((d) => d.type === activeType)
+
+  const focus = (id: string) => {
+    onNodeSelect(id)
+    onNavigateGraph()
+  }
+
+  return (
+    <div className="page-scroll">
+      <header className="page-head">
+        <h1 className="page-title">Divergences</h1>
+        <p className="page-sub">
+          Where a declared relationship and its observed twin diverge — read off
+          the fused graph, at whichever grain both sides share. A row focuses that
+          pair on the graph.
+        </p>
+      </header>
+
+      <section className="page-section">
+        <div className="page-section-head">
+          <h2>Flagged pairs</h2>
+          <Badge variant="secondary" className="ml-2">live · read-only</Badge>
+          {result && divergences.length > 0 && (
+            <span className="page-count">{result.totalAffected} affected</span>
+          )}
+        </div>
+
+        {presentTypes.length > 1 && (
+          <div className="filter-chips" role="group" aria-label="Filter by divergence type">
+            <button
+              type="button"
+              className={`chip${activeType === 'all' ? ' on' : ''}`}
+              onClick={() => setActiveType('all')}
+            >
+              all <span className="chip-ct">{divergences.length}</span>
+            </button>
+            {presentTypes.map((t) => (
+              <button
+                key={t}
+                type="button"
+                className={`chip${activeType === t ? ' on' : ''}`}
+                title={TYPE_HINT[t]}
+                onClick={() => setActiveType(t)}
+              >
+                {TYPE_LABEL[t]}{' '}
+                <span className="chip-ct">{divergences.filter((d) => d.type === t).length}</span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {error && <div className="page-empty">{error}</div>}
+
+        {!error && result === null && <div className="page-empty">loading divergences…</div>}
+
+        {!error && result !== null && divergences.length === 0 && (
+          <div className="page-empty">
+            Nothing diverged — every declared relationship has its observed twin,
+            and every observed one a declared match. The picture is fused.
+          </div>
+        )}
+
+        {!error && shown.length > 0 && (
+          <table className="page-table">
+            <thead>
+              <tr>
+                <th>Type</th>
+                <th>Relationship</th>
+                <th>What diverged</th>
+                <th>Evidence</th>
+                <th>Conf.</th>
+              </tr>
+            </thead>
+            <tbody>
+              {shown.map((d, i) => {
+                const evidence = evidenceOf(d)
+                const delta = deltaOf(d)
+                return (
+                  <tr key={`${d.type}-${d.source}-${d.target}-${i}`}>
+                    <td>
+                      <Badge variant="outline" title={TYPE_HINT[d.type]}>
+                        {TYPE_LABEL[d.type]}
+                      </Badge>
+                    </td>
+                    <td>
+                      <span className="rel">
+                        <button className="td-link" onClick={() => focus(d.source)} title="Focus this node on the graph">
+                          {d.source}
+                        </button>
+                        <span className="rel-arrow" aria-hidden="true"> → </span>
+                        <button className="td-link" onClick={() => focus(d.target)} title="Focus this node on the graph">
+                          {d.target}
+                        </button>
+                      </span>
+                    </td>
+                    <td className="td-msg">
+                      {d.reason}
+                      {delta && <div className="td-delta">{delta}</div>}
+                      {d.recommendation && <div className="td-fix">{d.recommendation}</div>}
+                    </td>
+                    <td className="td-mono">{evidence ?? '—'}</td>
+                    <td className="td-mono">{d.confidence.toFixed(2)}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/packages/web/app/components/FindPage.tsx
+++ b/packages/web/app/components/FindPage.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { authedFetch } from '../../lib/authed-fetch'
+
+// ---------------------------------------------------------------------------
+// Find page — semantic_search over the fused graph as a full-page surface
+// (web-shell §4/§5). The ⌘K palette runs the same search inline; this is the
+// room-to-breathe version for exploring the result set. Selecting a result
+// focuses that node on the graph.
+// ---------------------------------------------------------------------------
+
+interface FindPageProps {
+  project: string | null
+  onNodeSelect: (id: string) => void
+  onNavigateGraph: () => void
+}
+
+interface SearchResult {
+  node: { id: string; type: string; name?: string }
+  score: number
+}
+
+export function FindPage({ project, onNodeSelect, onNavigateGraph }: FindPageProps) {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<SearchResult[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Debounced semantic search, idle until a project resolves (#461) and until
+  // the user has typed something. Mirrors CommandPalette's debounce shape.
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    if (!query.trim() || !project) {
+      setResults(null)
+      setError(null)
+      return
+    }
+    debounceRef.current = setTimeout(() => {
+      authedFetch(`/api/search?q=${encodeURIComponent(query)}&project=${encodeURIComponent(project)}`)
+        .then((r) => r.json())
+        .then((d: { results?: SearchResult[] }) => {
+          setResults(Array.isArray(d.results) ? d.results : [])
+          setError(null)
+        })
+        .catch(() => setError('search failed'))
+    }, 220)
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [query, project])
+
+  const select = (id: string) => {
+    onNodeSelect(id)
+    onNavigateGraph()
+  }
+
+  return (
+    <div className="page-scroll">
+      <header className="page-head">
+        <h1 className="page-title">Find</h1>
+        <p className="page-sub">
+          Semantic search over the fused graph. Jump straight to a node, a file, or
+          a service — or press ⌘K anywhere for the same search inline.
+        </p>
+      </header>
+
+      <section className="page-section">
+        <input
+          type="search"
+          className="find-input"
+          placeholder="Search the graph — a file, a service, a database…"
+          aria-label="Search the graph"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          autoFocus
+        />
+
+        {error && <div className="page-empty">{error}</div>}
+
+        {!error && results === null && (
+          <div className="page-empty">
+            Type to search. Results are ranked by semantic relevance over the
+            node set — names, paths, and node kinds.
+          </div>
+        )}
+
+        {!error && results !== null && results.length === 0 && (
+          <div className="page-empty">Nothing matches “{query}”. Try a node name, a file path, or a service.</div>
+        )}
+
+        {!error && results !== null && results.length > 0 && (
+          <table className="page-table">
+            <thead>
+              <tr>
+                <th>Node</th>
+                <th>Kind</th>
+                <th>Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {results.map((r) => (
+                <tr key={r.node.id}>
+                  <td>
+                    <button className="td-link" onClick={() => select(r.node.id)} title="Focus this node on the graph">
+                      {r.node.name ?? r.node.id}
+                    </button>
+                  </td>
+                  <td className="td-mono">{r.node.type.replace('Node', '').toLowerCase()}</td>
+                  <td className="td-mono">{typeof r.score === 'number' ? r.score.toFixed(2) : '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/packages/web/app/components/PoliciesPage.tsx
+++ b/packages/web/app/components/PoliciesPage.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import type { PolicyViolation } from '@neat.is/types'
+import type { Policy, PolicyViolation } from '@neat.is/types'
 import { authedFetch } from '../../lib/authed-fetch'
 import { Badge } from '@/components/ui/badge'
 
@@ -30,22 +30,40 @@ interface PoliciesPageProps {
 }
 
 const SEVERITY_VARIANT: Record<string, 'destructive' | 'outline' | 'secondary'> = {
+  critical: 'destructive',
   error: 'destructive',
   warn: 'outline',
   warning: 'outline',
   info: 'secondary',
 }
 
+// The five locked rule types (policy-schema.md), spelled out for the list.
+const RULE_TYPE_LABEL: Record<string, string> = {
+  structural: 'structural',
+  compatibility: 'compatibility',
+  provenance: 'provenance',
+  ownership: 'ownership',
+  'blast-radius': 'blast radius',
+}
+
 export function PoliciesPage({ project, onNodeSelect, onNavigateGraph }: PoliciesPageProps) {
+  const [policies, setPolicies] = useState<Policy[] | null>(null)
   const [violations, setViolations] = useState<PolicyViolation[] | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  // LIVE — the violation view. Idle until a project resolves (#461).
+  // LIVE — the rule list (what's injected into the agent's context) + the
+  // violation view. Both idle until a project resolves (#461).
   useEffect(() => {
     if (!project) {
+      setPolicies(null)
       setViolations(null)
       return
     }
+    authedFetch(`/api/policies?project=${encodeURIComponent(project)}`)
+      .then((r) => r.json())
+      .then((d: { policies?: Policy[] }) => setPolicies(Array.isArray(d.policies) ? d.policies : []))
+      .catch(() => setPolicies([]))
+
     authedFetch(`/api/policies/violations?project=${encodeURIComponent(project)}`)
       .then((r) => r.json())
       .then((d: { violations?: PolicyViolation[] }) => {
@@ -60,10 +78,56 @@ export function PoliciesPage({ project, onNodeSelect, onNavigateGraph }: Policie
       <header className="page-head">
         <h1 className="page-title">Policies</h1>
         <p className="page-sub">
-          Rules pinned into your agent&apos;s context. The violation view is live;
-          enforcement is in preview until the governance kernel ships.
+          The rules from <code>policy.json</code>, pinned into your agent&apos;s
+          context so it works inside the lines. The rule list and the violation
+          view are live; enforcement is in preview until the governance kernel ships.
         </p>
       </header>
+
+      {/* ---- LIVE: the rule list injected into the agent's context ---- */}
+      <section className="page-section">
+        <div className="page-section-head">
+          <h2>Injected into your agent&apos;s context</h2>
+          <Badge variant="secondary" className="ml-2">live · read-only</Badge>
+          {policies && policies.length > 0 && (
+            <span className="page-count">{policies.length} rules</span>
+          )}
+        </div>
+
+        {policies === null && <div className="page-empty">loading rules…</div>}
+
+        {policies !== null && policies.length === 0 && (
+          <div className="page-empty">
+            No rules yet — add a <code>policy.json</code> at your project root and
+            the rules land here, delivered to your agent as context (never a gate).
+          </div>
+        )}
+
+        {policies && policies.length > 0 && (
+          <table className="page-table">
+            <thead>
+              <tr>
+                <th>Severity</th>
+                <th>Rule</th>
+                <th>Type</th>
+                <th>What it asserts</th>
+              </tr>
+            </thead>
+            <tbody>
+              {policies.map((p) => (
+                <tr key={p.id}>
+                  <td>
+                    <Badge variant={SEVERITY_VARIANT[p.severity] ?? 'outline'}>{p.severity}</Badge>
+                  </td>
+                  <td className="td-mono">{p.name}</td>
+                  <td className="td-mono">{RULE_TYPE_LABEL[p.rule.type] ?? p.rule.type}</td>
+                  <td className="td-msg">{p.description ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
 
       {/* ---- LIVE: the violation view ---- */}
       <section className="page-section">

--- a/packages/web/app/components/StubPage.tsx
+++ b/packages/web/app/components/StubPage.tsx
@@ -4,29 +4,20 @@ import { Badge } from '@/components/ui/badge'
 import { ALL_NAV, type NavId } from '../../lib/nav'
 
 // A clearly-marked TODO page for sibling capabilities not built in the GUI-redo
-// CORE (Divergences / Find / Settings). web-completeness #26: this is not a
-// stub pretending to work — it states plainly that the surface isn't built yet
-// and points at what it will be. No live-looking controls that do nothing.
+// CORE (Settings). web-completeness #26: this is not a stub pretending to work —
+// it states plainly that the surface isn't built yet and points at what it will
+// be. No live-looking controls that do nothing.
 //
-// These are progressive per the locked sequence (eng-02 #4): shell + graph +
-// the two-mode overlay are the core that has to be great on day one; the
-// sibling list pages land thinner and iterate.
+// Divergences and Find graduated to real in-shell pages (Gate 2); Settings is
+// the remaining progressive sibling per the locked sequence (eng-02 #4): shell +
+// graph + the two-mode overlay are the core that has to be great on day one; the
+// sibling pages land thinner and iterate.
 
 interface StubPageProps {
   id: NavId
 }
 
 const COPY: Partial<Record<NavId, { lede: string; detail: string }>> = {
-  divergences: {
-    lede: 'A peer query over the fused graph, not the headline.',
-    detail:
-      'Where a declared relationship and its observed twin diverge, at whichever grain both sides share. This will land as a list view; a row focuses the pair on the graph. Today, divergences are reachable through the API and the Inspector’s root-cause block.',
-  },
-  find: {
-    lede: 'Press ⌘K anywhere — the command palette is the Find surface.',
-    detail:
-      'Jump to a node, a file, or a page, and run a semantic search over the graph. A dedicated full-page Find view is progressive; the palette covers it for now.',
-  },
   settings: {
     lede: 'Project, daemon connection, and token.',
     detail:

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -312,6 +312,55 @@ html, body {
 .stub-note p { font-family: var(--font-body); font-size: 1rem; color: var(--fg); line-height: 1.65; margin: 0 0 16px; }
 .stub-note .stub-foot { color: var(--fg-muted); font-size: 0.9rem; margin: 0; }
 
+/* running count on a section head (e.g. "12 affected", "3 rules") */
+.page-section-head .page-count {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+/* type-filter chips (Divergences) — monochrome, hard corners, green when on */
+.filter-chips { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 22px; }
+.filter-chips .chip {
+  font-family: var(--font-mono);
+  font-size: 0.6rem; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--fg-muted); background: transparent;
+  border: 1px solid var(--rule); padding: 6px 11px; cursor: pointer;
+  transition: color 0.16s ease, border-color 0.16s ease;
+}
+.filter-chips .chip:hover { color: var(--fg); border-color: var(--fg-muted); }
+.filter-chips .chip.on { color: var(--prov-observed); border-color: var(--prov-observed); }
+.filter-chips .chip .chip-ct { color: var(--fg-muted); margin-left: 3px; }
+.filter-chips .chip.on .chip-ct { color: var(--prov-observed); }
+
+/* the source → target relationship cell */
+.page-table .rel { display: inline-flex; align-items: center; flex-wrap: wrap; gap: 4px; }
+.page-table .rel-arrow { color: var(--fg-muted); font-family: var(--font-mono); }
+.page-table .td-delta {
+  font-family: var(--font-mono); font-size: 0.72rem; color: var(--fg-muted);
+  margin-top: 6px;
+}
+.page-table .td-fix {
+  font-family: var(--font-body); font-size: 0.82rem; font-style: italic;
+  color: var(--fg-muted); margin-top: 6px;
+}
+
+/* Find page search input */
+.find-input {
+  width: 100%; max-width: 620px; display: block;
+  font-family: var(--font-mono); font-size: 0.92rem;
+  color: var(--fg); background: transparent;
+  border: 1px solid var(--rule); border-radius: 0;
+  padding: 12px 14px; margin-bottom: 28px;
+  outline: none;
+  transition: border-color 0.16s ease;
+}
+.find-input:focus { border-color: var(--prov-observed); }
+.find-input::placeholder { color: var(--fg-muted); }
+
 /* ---- TOP BAR ------------------------------------------------------ */
 .topbar {
   display: flex;

--- a/packages/web/audit/09-gaps-and-stubs.md
+++ b/packages/web/audit/09-gaps-and-stubs.md
@@ -43,11 +43,11 @@ When code state changes, this file changes in lockstep.
 | Button | Status | Notes |
 |--------|--------|-------|
 | Graph | wired | The fused-graph spatial view — primary page. |
-| Policies | wired | Violation view (live) + enforcement preview. |
-| Divergences | disabled | Sibling page, progressive; rendered disabled with "soon" affordance. |
-| Incidents | disabled | Sibling page, progressive; rendered disabled with "soon" affordance. |
-| Find | disabled | ⌘K palette is the Find surface today; a full page is progressive. |
-| Settings | disabled | Sibling page, progressive; rendered disabled with "soon" affordance. |
+| Policies | wired | Rule list (live) + violation view (live) + enforcement preview. |
+| Divergences | wired | In-shell peer-query page over `/api/divergences`; a row focuses the pair on the graph. |
+| Incidents | wired | Routes to `/incidents`; the OTel error-events table. |
+| Find | wired | In-shell semantic-search page over `/api/search`; the ⌘K palette runs the same search inline. |
+| Settings | disabled | Sibling page, progressive; routes through to StubPage's "not built yet" copy. |
 
 ### Policies page (enforcement preview)
 

--- a/packages/web/lib/fixtures.ts
+++ b/packages/web/lib/fixtures.ts
@@ -109,6 +109,75 @@ export const FIXTURE_PROFILES = [
 
 export const FIXTURE_VIOLATIONS = { violations: [] }
 
+// The rule list a project pins into `policy.json` — surfaced read-only on the
+// Policies page as "the rules injected into your agent's context." Demo mode
+// shows a couple of representative rules so the surface isn't blank offline.
+export const FIXTURE_POLICIES = {
+  version: 1 as const,
+  policies: [
+    {
+      id: 'db-connection-required',
+      name: 'Every service reaches a database',
+      description: 'Each ServiceNode must declare a CONNECTS_TO edge to a DatabaseNode.',
+      severity: 'warning' as const,
+      rule: { type: 'structural' as const, fromNodeType: 'ServiceNode', edgeType: 'CONNECTS_TO', toNodeType: 'DatabaseNode' },
+    },
+    {
+      id: 'drivers-stay-compatible',
+      name: 'Drivers stay compatible with their engines',
+      description: 'Re-runs the compat check against the live graph on every evaluation.',
+      severity: 'error' as const,
+      rule: { type: 'compatibility' as const },
+    },
+    {
+      id: 'services-declare-owner',
+      name: 'Services declare an owner',
+      description: 'Every ServiceNode carries a non-empty owner field (from package.json / pyproject.toml).',
+      severity: 'info' as const,
+      rule: { type: 'ownership' as const, nodeType: 'ServiceNode', field: 'owner' },
+    },
+  ],
+}
+
+// A DivergenceResult (divergence.ts) over the fixture graph: two declared/
+// observed mismatches the demo can show offline. One missing-observed (a
+// declared edge production never exercised) and one host-mismatch (declared
+// host vs. the host runtime actually connected to).
+export const FIXTURE_DIVERGENCES = {
+  divergences: [
+    {
+      type: 'missing-observed' as const,
+      source: 'file:checkout:src/notify.ts',
+      target: 'service:notifications',
+      confidence: 0.9,
+      reason: 'Declared CALLS to notifications has no observed twin — production never exercised this path.',
+      recommendation: 'Drive traffic through the notify path, or remove the dead call if it is no longer reachable.',
+      edgeType: 'CALLS' as const,
+      extracted: {
+        id: 'CALLS:EXTRACTED:notify->notifications',
+        source: 'file:checkout:src/notify.ts',
+        target: 'service:notifications',
+        type: 'CALLS' as const,
+        provenance: 'EXTRACTED' as const,
+        confidence: 0.9,
+        evidence: { file: 'src/notify.ts', line: 22 },
+      },
+    },
+    {
+      type: 'host-mismatch' as const,
+      source: 'file:auth:src/db.ts',
+      target: 'database:auth-db.internal',
+      confidence: 0.82,
+      reason: 'Declared host auth-db.internal, but runtime connected to auth-db.prod.internal.',
+      recommendation: 'Reconcile the connection string with the host production actually reaches.',
+      extractedHost: 'auth-db.internal',
+      observedHost: 'auth-db.prod.internal',
+    },
+  ],
+  totalAffected: 2,
+  computedAt: new Date().toISOString(),
+}
+
 // A node's searchable / display name. FileNodes carry `path` rather than
 // `name`, so fall back to it (then to the id) — keeps search file-aware.
 function fixtureNodeLabel(n: { name?: string; path?: string; id: string }): string {

--- a/packages/web/lib/nav.ts
+++ b/packages/web/lib/nav.ts
@@ -52,7 +52,7 @@ export const NAV_GROUPS: { label: string; items: NavItem[] }[] = [
         id: 'divergences',
         label: 'Divergences',
         hint: 'Where a declared relationship and its observed twin diverge',
-        kind: 'todo',
+        kind: 'page',
       },
       {
         id: 'policies',
@@ -75,7 +75,7 @@ export const NAV_GROUPS: { label: string; items: NavItem[] }[] = [
         id: 'find',
         label: 'Find',
         hint: 'Jump to a node, file, or page · ⌘K',
-        kind: 'todo',
+        kind: 'page',
       },
       {
         id: 'settings',

--- a/packages/web/test/divergences-page.test.tsx
+++ b/packages/web/test/divergences-page.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// Gate 2 (truthful frontend): the Divergences page is a real in-shell surface
+// over `get_divergences`. These tests drive the real component against the real
+// FIXTURE_DIVERGENCES so a wire-shape drift or a broken focus-on-row fails here.
+
+import { DivergencesPage } from '../app/components/DivergencesPage'
+import { FIXTURE_DIVERGENCES } from '../lib/fixtures'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function mockFetch(divergencesBody: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/api/divergences')) return jsonResponse(divergencesBody)
+      return jsonResponse({})
+    }),
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('Divergences page — renders the fixture result and focuses a pair on click', () => {
+  beforeEach(() => mockFetch(FIXTURE_DIVERGENCES))
+
+  it('renders a row per divergence with its type, relationship, and confidence', async () => {
+    render(<DivergencesPage project="demo" onNodeSelect={vi.fn()} onNavigateGraph={vi.fn()} />)
+
+    // one row per fixture divergence — the missing-observed and host-mismatch.
+    for (const d of FIXTURE_DIVERGENCES.divergences) {
+      expect(await screen.findByText(d.reason)).toBeInTheDocument()
+      // both endpoints render as focus buttons.
+      expect(screen.getAllByRole('button', { name: d.source }).length).toBeGreaterThan(0)
+    }
+    // the type label is spelled out (missing-observed → "missing observed").
+    expect(screen.getAllByText('missing observed').length).toBeGreaterThan(0)
+  })
+
+  it('clicking an endpoint focuses that node on the graph', async () => {
+    const onNodeSelect = vi.fn()
+    const onNavigateGraph = vi.fn()
+    const user = userEvent.setup()
+    render(<DivergencesPage project="demo" onNodeSelect={onNodeSelect} onNavigateGraph={onNavigateGraph} />)
+
+    const first = FIXTURE_DIVERGENCES.divergences[0]
+    const btn = await screen.findByRole('button', { name: first.source })
+    await user.click(btn)
+    expect(onNodeSelect).toHaveBeenCalledWith(first.source)
+    expect(onNavigateGraph).toHaveBeenCalled()
+  })
+})
+
+describe('Divergences page — designed empty state', () => {
+  beforeEach(() => mockFetch({ divergences: [], totalAffected: 0, computedAt: new Date().toISOString() }))
+
+  it('shows the fused-picture empty state when nothing diverged', async () => {
+    render(<DivergencesPage project="demo" onNodeSelect={vi.fn()} onNavigateGraph={vi.fn()} />)
+    expect(await screen.findByText(/Nothing diverged/i)).toBeInTheDocument()
+  })
+})

--- a/packages/web/test/nav-reachability.test.tsx
+++ b/packages/web/test/nav-reachability.test.tsx
@@ -43,6 +43,13 @@ describe('#697 — nav.ts: incidents is promoted off the todo list', () => {
     expect(incidents?.kind).toBe('page')
   })
 
+  // Gate 2 (truthful frontend): Divergences and Find graduated from StubPage
+  // todos to real in-shell pages, so they're kind "page" now too.
+  it('Divergences and Find are kind "page" (real surfaces, not todos)', () => {
+    expect(ALL_NAV.find((n) => n.id === 'divergences')?.kind).toBe('page')
+    expect(ALL_NAV.find((n) => n.id === 'find')?.kind).toBe('page')
+  })
+
   it('at least one sibling nav item is still marked todo, so the reachable-todo behavior below has something real to prove', () => {
     const todoItems = ALL_NAV.filter((n) => n.kind === 'todo')
     expect(todoItems.length).toBeGreaterThan(0)
@@ -50,16 +57,16 @@ describe('#697 — nav.ts: incidents is promoted off the todo list', () => {
 })
 
 describe('#697 — PageSidebar: todo items are clickable, not disabled', () => {
-  it('a todo-marked nav item (Divergences) renders enabled and routes through onNavigate instead of being disabled', async () => {
+  it('a todo-marked nav item (Settings) renders enabled and routes through onNavigate instead of being disabled', async () => {
     const { onNavigate } = renderSidebar()
     const user = userEvent.setup()
-    const button = screen.getByRole('button', { name: /Divergences/i })
+    const button = screen.getByRole('button', { name: /Settings/i })
 
     expect(button).not.toHaveAttribute('disabled')
     expect(button.getAttribute('aria-disabled')).not.toBe('true')
 
     await user.click(button)
-    expect(onNavigate).toHaveBeenCalledWith('divergences')
+    expect(onNavigate).toHaveBeenCalledWith('settings')
   })
 
   it('Incidents renders as a plain enabled entry (no "soon" affordance) and navigates to the real /incidents route', async () => {
@@ -79,11 +86,11 @@ describe('#697 — PageSidebar: todo items are clickable, not disabled', () => {
 
 describe('#697 — StubPage: what a reachable todo item actually renders', () => {
   it('renders real, honest placeholder copy for a todo page rather than inert/internal-only text', () => {
-    render(<StubPage id="divergences" />)
-    expect(screen.getByRole('heading', { name: 'Divergences' })).toBeInTheDocument()
+    render(<StubPage id="settings" />)
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument()
     expect(screen.getByText('not built yet')).toBeInTheDocument()
     expect(
-      screen.getByText(/A peer query over the fused graph, not the headline\./),
+      screen.getByText(/Project, daemon connection, and token\./),
     ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Three sibling pages in the shell were still landing on the "not built yet" placeholder. This wires the two that read cleanly off endpoints the daemon already serves, and fills the gap in the one page that was half-built — the list/table views that ask the fused graph the same questions the canvas answers spatially.

**Divergences** becomes a real in-shell page over `/graph/divergences`: the flagged declared-vs-observed pairs, each carrying its confidence and `file:line` evidence, filterable by type, every endpoint clickable to focus that pair on the graph. It reads as a peer query off the fused graph, not the marquee (web-shell §1/§6).

**Find** is the full-page face of the ⌘K search — `semantic_search` over the graph with room to explore the result set; the palette runs the same search inline.

**Policies** gains the rule list the contract always named (web-shell §7): the rules from `policy.json`, shown read-only as "injected into your agent's context," above the live violation view and the enforcement preview. The list informs; it never gates.

Both new pages follow the established `PoliciesPage` in-shell pattern, so the sidebar and topbar stay put, and both carry a designed empty state. Divergences and Find graduate from `todo` to `page` in the nav; Settings stays the lone progressive sibling on `StubPage`. The gaps-and-stubs audit and the nav-reachability test move with them.

Verified in the worktree: `typecheck` clean, `lint` clean, `test` green (16 files / 73 tests, incl. a new `divergences-page` spec and the updated nav-reachability spec), and a full `next build` compiles both new API routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)