### PR TITLE
Add the `neat connector` CLI to turn connectors on (ADR-130)

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -41,6 +41,7 @@ import {
   type PatchSection,
 } from './installers/index.js'
 import { runOrchestrator } from './orchestrator.js'
+import { runConnectorCommand } from './connector-cli.js'
 import { runSync } from './cli-verbs.js'
 import { DivergenceTypeSchema, type DivergenceType } from '@neat.is/types'
 import {
@@ -166,6 +167,17 @@ export function usage(): void {
   console.log('                   --dry-run          run extraction in-memory; do not write')
   console.log('                   --no-instrument    skip the SDK install apply step')
   console.log('                   --json             emit the delta summary as JSON')
+  console.log('  connector      Configure pull-based OBSERVED connectors (supabase, railway,')
+  console.log('                 firebase, cloudflare). Subcommands:')
+  console.log('                   add <provider>   add a connector; validates the credential')
+  console.log('                                    against the provider first (--skip-validate to skip)')
+  console.log('                                    flags: --project <name>, --credential/--token <$VAR|value>,')
+  console.log('                                    --id <id>, --<option> <value>, --plaintext, --skip-validate')
+  console.log('                   list             list configured connectors (credentials redacted)')
+  console.log('                   remove <id>      remove a connector by id')
+  console.log('                   test <id>        re-check an existing connector\'s credential')
+  console.log('                 Credentials default to an env-var reference ($VAR) resolved at')
+  console.log('                 run time; the config file is written owner-only (0600).')
   console.log('')
   console.log('query commands (mirror the MCP tools, ADR-050):')
   console.log('  root-cause <node-id>             Walk inbound edges to find what broke first.')
@@ -710,6 +722,16 @@ export async function main(): Promise<void> {
   if (cmd0 === '--version' || cmd0 === '-v' || cmd0 === 'version') {
     printVersion()
     process.exit(0)
+  }
+
+  // `neat connector <add|list|remove|test>` — the ADR-130 connector on-ramp
+  // (docs/contracts/connector-config.md §3). A top-level config command family,
+  // not an eleventh query verb; it takes provider-specific flags, so it parses
+  // its own argv rather than routing through the shared query-flag table.
+  if (cmd0 === 'connector') {
+    const code = await runConnectorCommand(argv.slice(1))
+    if (code !== 0) process.exit(code)
+    return
   }
 
   // No positional command — `npx neat.is` (optionally with flags like

--- a/packages/core/src/connector-cli.ts
+++ b/packages/core/src/connector-cli.ts
@@ -1,0 +1,498 @@
+// `neat connector add/list/remove/test` — the write side of the ADR-130
+// on-ramp (docs/contracts/connector-config.md §3). The daemon-read chain
+// (#730) already turns a `~/.neat/connectors.json` entry into a running poll
+// loop; this is the command a human actually touches to put an entry there.
+//
+// Everything provider-specific is dispatched through the registry table
+// (connectors/registry.ts §5) — the required-field schema this prompts for and
+// the auth round-trip `add`/`test` run both come from the entry, so no per-
+// provider branch lives here. The two security non-negotiables the contract
+// names ride through this module: validate-on-add by default (the credential
+// is proven against the provider before it's written), and env-ref-by-default /
+// `0600` / never-a-resolved-secret-on-screen (the write helpers in
+// connectors-config.ts own the file mode; this module only ever prints the
+// redacted pointer, never a resolved value).
+//
+// Handlers take their filesystem home, environment, `fetch`, prompt, and output
+// streams as injected deps so the whole surface is testable against a temp home
+// and a stubbed provider — no live account, no real `~/.neat`.
+
+import readline from 'node:readline'
+import {
+  autoSlugConnectorId,
+  describeCredential,
+  isEnvRef,
+  readConnectorsConfig,
+  removeConnectorEntry,
+  upsertConnectorEntry,
+  type ConnectorEntry,
+  type CredentialRef,
+} from './connectors-config.js'
+import {
+  getProviderDispatch,
+  PROVIDER_DISPATCH,
+  validateConnectorEntry,
+  type ProviderDispatch,
+  type ValidateOutcome,
+} from './connectors/registry.js'
+
+// ── deps / injection ──────────────────────────────────────────────────────
+
+export interface ConnectorCliDeps {
+  // NEAT_HOME override. Undefined uses connectors-config.ts's own env-based
+  // resolution (the real CLI); tests pass a temp home.
+  home?: string
+  env?: NodeJS.ProcessEnv
+  // Test seam for the provider auth round-trip (contract §4). Undefined → the
+  // junction's real `fetch`.
+  fetchImpl?: typeof fetch
+  // Interactive prompt. Undefined → a readline prompt that returns '' when
+  // stdin isn't a TTY, so CI never hangs waiting on input.
+  prompt?: (question: string) => Promise<string>
+  // Whether to prompt at all for missing fields. Undefined → `process.stdin`
+  // is a TTY. Non-interactive runs require every field as a flag.
+  interactive?: boolean
+  out?: (line: string) => void
+  err?: (line: string) => void
+}
+
+interface ResolvedDeps {
+  home: string | undefined
+  env: NodeJS.ProcessEnv
+  fetchImpl?: typeof fetch
+  prompt: (question: string) => Promise<string>
+  interactive: boolean
+  out: (line: string) => void
+  err: (line: string) => void
+}
+
+async function defaultPrompt(question: string): Promise<string> {
+  if (!process.stdin.isTTY) return ''
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    return await new Promise<string>((resolve) => rl.question(`${question} `, resolve))
+  } finally {
+    rl.close()
+  }
+}
+
+function resolveDeps(deps: ConnectorCliDeps): ResolvedDeps {
+  return {
+    home: deps.home,
+    env: deps.env ?? process.env,
+    ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
+    prompt: deps.prompt ?? defaultPrompt,
+    interactive: deps.interactive ?? Boolean(process.stdin.isTTY),
+    out: deps.out ?? ((l) => console.log(l)),
+    err: deps.err ?? ((l) => console.error(l)),
+  }
+}
+
+// ── argument parsing ──────────────────────────────────────────────────────
+
+export interface ConnectorArgs {
+  subcommand: string
+  positional: string[]
+  project?: string
+  // Single-field credential from --credential / --token (an env-ref or a
+  // literal). Multi-field providers read their fields from `fields` instead.
+  credential?: string
+  id?: string
+  skipValidate: boolean
+  plaintext: boolean
+  // Provider-specific option/credential fields, camelCased from their kebab
+  // flag (`--account-id` → accountId). Object-valued flags (`--workers '{…}'`)
+  // are JSON-parsed; `*Ms` flags are numbered; everything else stays a string.
+  fields: Record<string, unknown>
+}
+
+function kebabToCamel(name: string): string {
+  return name.replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase())
+}
+
+function coerceFieldValue(name: string, raw: string): unknown {
+  const t = raw.trim()
+  if (t.startsWith('{') || t.startsWith('[')) {
+    try {
+      return JSON.parse(t)
+    } catch {
+      return raw
+    }
+  }
+  // Only numeric-shaped option names become numbers, so string ids that happen
+  // to be all-digits (rare, but possible) are never silently retyped.
+  if (/Ms$/.test(name) && /^\d+$/.test(t)) return Number(t)
+  return raw
+}
+
+export function parseConnectorArgs(
+  args: string[],
+): { ok: true; value: ConnectorArgs } | { ok: false; error: string } {
+  const out: ConnectorArgs = {
+    subcommand: '',
+    positional: [],
+    skipValidate: false,
+    plaintext: false,
+    fields: {},
+  }
+  const positional: string[] = []
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i] as string
+    if (arg === '--skip-validate') {
+      out.skipValidate = true
+      continue
+    }
+    if (arg === '--plaintext') {
+      out.plaintext = true
+      continue
+    }
+    if (arg.startsWith('--')) {
+      let flag = arg
+      let value: string | undefined
+      const eq = arg.indexOf('=')
+      if (eq >= 0) {
+        flag = arg.slice(0, eq)
+        value = arg.slice(eq + 1)
+      } else {
+        const next = args[i + 1]
+        if (next === undefined || next.startsWith('--')) {
+          return { ok: false, error: `${flag} requires a value` }
+        }
+        value = next
+        i++
+      }
+      const name = flag.slice(2)
+      if (name === 'project') {
+        out.project = value
+        continue
+      }
+      if (name === 'credential' || name === 'token') {
+        out.credential = value
+        continue
+      }
+      if (name === 'id') {
+        out.id = value
+        continue
+      }
+      const field = kebabToCamel(name)
+      out.fields[field] = coerceFieldValue(field, value)
+      continue
+    }
+    positional.push(arg)
+  }
+  out.subcommand = positional[0] ?? ''
+  out.positional = positional.slice(1)
+  return { ok: true, value: out }
+}
+
+// ── credential assembly ───────────────────────────────────────────────────
+
+// Build the credential ref from flags + prompts. A single-field provider takes
+// one ref (--credential/--token or its primary key flag); a multi-field
+// provider (Firebase carries projectId + accessToken) takes one ref per
+// required field. Values are stored verbatim: a leading `$` is an env-ref
+// pointer, anything else is a literal — the exact rule the daemon resolves by,
+// so no transformation happens here.
+async function buildCredentialRef(
+  dispatch: ProviderDispatch,
+  args: ConnectorArgs,
+  deps: ResolvedDeps,
+): Promise<CredentialRef> {
+  const hint = 'an env-var reference like $PROVIDER_TOKEN is recommended (stored as a pointer, not the secret); a literal value is stored as-is'
+  if (dispatch.requiredCredentialFields.length <= 1) {
+    const key = dispatch.primaryCredentialKey
+    let value = args.credential
+    if (value === undefined && typeof args.fields[key] === 'string') {
+      value = args.fields[key] as string
+    }
+    if (value === undefined && deps.interactive) {
+      value = await deps.prompt(`Credential for ${dispatch.provider} (${hint}):`)
+    }
+    return (value ?? '').trim()
+  }
+  const out: Record<string, string> = {}
+  for (const f of dispatch.requiredCredentialFields) {
+    let value: string | undefined
+    if (typeof args.fields[f] === 'string') value = args.fields[f] as string
+    else if (f === dispatch.primaryCredentialKey && args.credential !== undefined) value = args.credential
+    if (value === undefined && deps.interactive) {
+      value = await deps.prompt(`Credential field "${f}" for ${dispatch.provider} (${hint}):`)
+    }
+    out[f] = (value ?? '').trim()
+  }
+  return out
+}
+
+// Whether every required credential field carries a non-empty value.
+function credentialComplete(dispatch: ProviderDispatch, ref: CredentialRef): string[] {
+  if (typeof ref === 'string') {
+    return ref.length > 0 ? [] : [dispatch.primaryCredentialKey]
+  }
+  return dispatch.requiredCredentialFields.filter((f) => !ref[f] || ref[f].length === 0)
+}
+
+// The plaintext (non-env-ref) fields in a credential — the ones that put a
+// secret at rest and so warrant the opt-in warning.
+function plaintextFields(ref: CredentialRef): string[] {
+  if (typeof ref === 'string') return isEnvRef(ref) ? [] : ['credential']
+  return Object.entries(ref)
+    .filter(([, v]) => !isEnvRef(v))
+    .map(([k]) => k)
+}
+
+// ── `add` ─────────────────────────────────────────────────────────────────
+
+async function connectorAdd(args: ConnectorArgs, deps: ResolvedDeps): Promise<number> {
+  // Provider — positional or prompt. Must be a known, built provider.
+  let provider = args.positional[0]
+  if (!provider && deps.interactive) {
+    provider = (await deps.prompt(`Provider (${Object.keys(PROVIDER_DISPATCH).sort().join(', ')}):`)).trim()
+  }
+  if (!provider) {
+    deps.err('neat connector add: a provider is required (e.g. `neat connector add supabase`)')
+    return 2
+  }
+  const dispatch = getProviderDispatch(provider)
+  if (!dispatch) {
+    deps.err(
+      `neat connector add: unknown provider "${provider}". known providers: ${Object.keys(PROVIDER_DISPATCH).sort().join(', ')}`,
+    )
+    return 2
+  }
+
+  // Project — optional; blank binds to whatever project the daemon bootstraps.
+  let project = args.project
+  if (project === undefined && deps.interactive) {
+    const answer = (await deps.prompt('Project (blank = the project the daemon is bootstrapping):')).trim()
+    if (answer.length > 0) project = answer
+  }
+
+  // Credential + non-secret options.
+  const credential = await buildCredentialRef(dispatch, args, deps)
+  const options: Record<string, unknown> = { ...args.fields }
+  // The credential fields aren't options — strip any that arrived via a
+  // generic flag so they don't double-write into `options`.
+  for (const k of dispatch.requiredCredentialFields) delete options[k]
+
+  // Prompt for any still-missing required option field (interactive only).
+  for (const field of dispatch.requiredOptionFields) {
+    if (field in options) continue
+    if (!deps.interactive) continue
+    const answer = (await deps.prompt(`Option "${field}" for ${provider}:`)).trim()
+    if (answer.length > 0) options[field] = coerceFieldValue(field, answer)
+  }
+
+  // Structural completeness — caught before any write, even under
+  // --skip-validate, so an entry that can never run isn't silently stored.
+  const missingCred = credentialComplete(dispatch, credential)
+  if (missingCred.length > 0) {
+    deps.err(
+      `neat connector add: credential is incomplete — missing ${missingCred.join(', ')}. ` +
+        'Pass it as a flag (e.g. `--token $PROVIDER_TOKEN`) or run interactively.',
+    )
+    return 2
+  }
+  const missingOpts = dispatch.requiredOptionFields.filter((f) => !(f in options))
+  if (missingOpts.length > 0) {
+    deps.err(
+      `neat connector add: missing required option(s) for ${provider}: ${missingOpts.join(', ')}. ` +
+        `Pass e.g. \`--${missingOpts[0].replace(/([A-Z])/g, '-$1').toLowerCase()} <value>\`.`,
+    )
+    return 2
+  }
+
+  // Assemble the entry — auto-slug the id unless one was given.
+  const existing = await readConnectorsConfig(deps.home)
+  const existingIds = new Set(existing.connectors.map((c) => c.id))
+  const id = args.id ?? autoSlugConnectorId(provider, project, existingIds)
+  const entry: ConnectorEntry = {
+    id,
+    provider,
+    ...(project ? { project } : {}),
+    credential,
+    ...(Object.keys(options).length > 0 ? { options } : {}),
+  }
+
+  // Validate-on-add by default (contract §4) — a wrong credential fails fast
+  // here rather than quietly at the first poll. An unset env-ref is its own
+  // distinct outcome, never conflated with a rejected token.
+  if (!args.skipValidate) {
+    const outcome = await validateConnectorEntry(entry, deps.env, deps.fetchImpl)
+    const code = reportPreWriteValidation(outcome, deps)
+    if (code !== 0) return code
+  }
+
+  // Plaintext is the explicit opt-in; surface it so a secret never lands at
+  // rest by accident (contract §2).
+  const plaintext = plaintextFields(credential)
+  if (plaintext.length > 0 && !args.plaintext) {
+    deps.err(
+      `neat connector add: storing a literal secret at rest for ${plaintext.join(', ')} — ` +
+        'prefer an env-var reference like `$PROVIDER_TOKEN` (pass --plaintext to silence this).',
+    )
+  }
+
+  const { replaced } = await upsertConnectorEntry(entry, deps.home)
+  const verb = replaced ? 'updated' : 'added'
+  const where = project ? `project "${project}"` : 'the bootstrapping project'
+  deps.out(`${verb} connector "${id}" (${provider}) for ${where}.`)
+  if (args.skipValidate) {
+    deps.out('skipped validation (--skip-validate) — the credential is checked at the next daemon poll.')
+  }
+  deps.out('Restart the project\'s daemon (or start it) to begin polling this connector.')
+  return 0
+}
+
+// Turn a pre-write validation outcome into an exit code, printing the distinct
+// message each case warrants. 0 means proceed to write.
+function reportPreWriteValidation(outcome: ValidateOutcome, deps: ResolvedDeps): number {
+  switch (outcome.status) {
+    case 'ok':
+      deps.out('credential validated against the provider.')
+      return 0
+    case 'unset-env':
+      deps.err(
+        `neat connector add: ${outcome.reason}. Export the variable before adding, ` +
+          'or pass --skip-validate to add now and set it before the daemon runs.',
+      )
+      return 1
+    case 'rejected':
+      deps.err(
+        `neat connector add: the provider rejected the credential — ${outcome.reason}. ` +
+          'Nothing was written. Fix the credential, or pass --skip-validate to store it anyway.',
+      )
+      return 1
+    case 'missing-field':
+      deps.err(`neat connector add: ${outcome.reason}.`)
+      return 2
+    case 'unknown-provider':
+      deps.err(`neat connector add: ${outcome.reason}.`)
+      return 2
+  }
+}
+
+// ── `list` ────────────────────────────────────────────────────────────────
+
+async function connectorList(deps: ResolvedDeps, filterProject?: string): Promise<number> {
+  const config = await readConnectorsConfig(deps.home)
+  let entries = config.connectors
+  if (filterProject) entries = entries.filter((e) => e.project === filterProject)
+  if (entries.length === 0) {
+    deps.out(
+      filterProject
+        ? `no connectors configured for project "${filterProject}".`
+        : 'no connectors configured. run `neat connector add <provider>` to add one.',
+    )
+    return 0
+  }
+  deps.out('id\tprovider\tproject\tcredential')
+  for (const e of entries) {
+    const project = e.project ?? '(bootstrapping project)'
+    const credential = describeCredential(e.credential, deps.env)
+      .map((c) => {
+        const status = c.status ? ` (${c.status})` : c.kind === 'plaintext' ? ' (plaintext)' : ''
+        return c.field ? `${c.field}=${c.display}${status}` : `${c.display}${status}`
+      })
+      .join(', ')
+    deps.out(`${e.id}\t${e.provider}\t${project}\t${credential}`)
+  }
+  return 0
+}
+
+// ── `remove` ──────────────────────────────────────────────────────────────
+
+async function connectorRemove(deps: ResolvedDeps, id: string | undefined): Promise<number> {
+  if (!id) {
+    deps.err('neat connector remove: missing <id>. run `neat connector list` to see configured ids.')
+    return 2
+  }
+  const removed = await removeConnectorEntry(id, deps.home)
+  if (!removed) {
+    deps.err(`neat connector remove: no connector with id "${id}". run \`neat connector list\` to see configured ids.`)
+    return 1
+  }
+  deps.out(`removed connector "${id}" (${removed.provider}).`)
+  return 0
+}
+
+// ── `test` ────────────────────────────────────────────────────────────────
+
+async function connectorTest(deps: ResolvedDeps, id: string | undefined): Promise<number> {
+  if (!id) {
+    deps.err('neat connector test: missing <id>. run `neat connector list` to see configured ids.')
+    return 2
+  }
+  const config = await readConnectorsConfig(deps.home)
+  const entry = config.connectors.find((c) => c.id === id)
+  if (!entry) {
+    deps.err(`neat connector test: no connector with id "${id}". run \`neat connector list\` to see configured ids.`)
+    return 1
+  }
+  const outcome = await validateConnectorEntry(entry, deps.env, deps.fetchImpl)
+  switch (outcome.status) {
+    case 'ok':
+      deps.out(`ok: "${id}" (${entry.provider}) authenticated against the provider.`)
+      return 0
+    case 'unset-env':
+      deps.err(`unset: "${id}" (${entry.provider}) — ${outcome.reason}. Export the variable so the daemon can resolve it.`)
+      return 1
+    case 'rejected':
+      deps.err(`rejected: "${id}" (${entry.provider}) — ${outcome.reason}.`)
+      return 1
+    case 'missing-field':
+      deps.err(`incomplete: "${id}" (${entry.provider}) — ${outcome.reason}.`)
+      return 2
+    case 'unknown-provider':
+      deps.err(`unknown provider: "${id}" — ${outcome.reason}.`)
+      return 2
+  }
+}
+
+// ── dispatch ──────────────────────────────────────────────────────────────
+
+export function printConnectorUsage(write: (line: string) => void): void {
+  write('usage: neat connector <add|list|remove|test> [args]')
+  write('  add <provider>    add a connector; validates the credential first (--skip-validate to skip)')
+  write('                    flags: --project <name>  --credential/--token <$VAR|value>  --id <id>')
+  write('                           --<option> <value> (provider-specific)  --plaintext  --skip-validate')
+  write('  list              list configured connectors (credentials shown redacted)')
+  write('                    flags: --project <name>')
+  write('  remove <id>       remove a connector by id')
+  write('  test <id>         re-run the credential validation for an existing connector')
+}
+
+/**
+ * Entry point the CLI wires `neat connector …` to. `rawArgs` is argv past the
+ * `connector` token. Returns a process exit code; never calls `process.exit`
+ * itself so the caller (and tests) own control flow.
+ */
+export async function runConnectorCommand(
+  rawArgs: string[],
+  deps: ConnectorCliDeps = {},
+): Promise<number> {
+  const resolved = resolveDeps(deps)
+  const parsed = parseConnectorArgs(rawArgs)
+  if (!parsed.ok) {
+    resolved.err(`neat connector: ${parsed.error}`)
+    return 2
+  }
+  const a = parsed.value
+  switch (a.subcommand) {
+    case 'add':
+      return connectorAdd(a, resolved)
+    case 'list':
+      return connectorList(resolved, a.project)
+    case 'remove':
+      return connectorRemove(resolved, a.positional[0])
+    case 'test':
+      return connectorTest(resolved, a.positional[0])
+    case '':
+      resolved.err('neat connector: missing subcommand.')
+      printConnectorUsage(resolved.err)
+      return 2
+    default:
+      resolved.err(`neat connector: unknown subcommand "${a.subcommand}".`)
+      printConnectorUsage(resolved.err)
+      return 2
+  }
+}

--- a/packages/core/src/connectors-config.ts
+++ b/packages/core/src/connectors-config.ts
@@ -287,3 +287,230 @@ function resolveRef(value: string, env: NodeJS.ProcessEnv): string {
 export function connectorMatchesProject(entry: ConnectorEntry, project: string): boolean {
   return entry.project === undefined || entry.project === project
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// Write side — `neat connector add/remove` mutate this file (contract §1, §3).
+//
+// The read side above never touches disk beyond a read; this is the half the
+// CLI drives. Two invariants the contract calls non-negotiable ride here: the
+// file lands mode `0600` on every write (owner-only — it points at real
+// secrets), and every write is atomic (tmp + fsync + rename) under an
+// exclusive lock, so a concurrent write can't leave a half-file behind. The
+// same discipline the sibling machine-level registry file already holds
+// (registry.ts), plus the explicit `0600` this file's secrets add.
+// ─────────────────────────────────────────────────────────────────────────
+
+const CONNECTORS_LOCK_TIMEOUT_MS = 5_000
+const CONNECTORS_LOCK_RETRY_MS = 50
+
+export function connectorsConfigLockPath(home: string = neatHome()): string {
+  return path.join(home, 'connectors.json.lock')
+}
+
+// A leading `$` (with at least one char after it) marks a value as an env-ref,
+// the exact rule `resolveRef` above resolves by. Kept as one predicate so the
+// writer, the reader, and the `list` display can never disagree on what counts
+// as a pointer vs a literal.
+export function isEnvRef(value: string): boolean {
+  return value.length > 1 && value.startsWith('$')
+}
+
+/**
+ * tmp + fsync + rename, with the tmp file created mode `0600` so the bytes are
+ * never briefly readable by group/other before the rename swaps them in. An
+ * explicit `chmod(0o600)` on the handle backs the open-mode up in case a umask
+ * ever widened it (it can't for `0600`, but the belt-and-suspenders keeps the
+ * guarantee legible to the contract's future permission audit). rename is
+ * atomic on POSIX and carries the tmp inode's mode with it.
+ */
+async function writeConfigAtomically0600(file: string, contents: string): Promise<void> {
+  await fs.mkdir(path.dirname(file), { recursive: true })
+  const tmp = `${file}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`
+  const fd = await fs.open(tmp, 'w', 0o600)
+  try {
+    await fd.writeFile(contents, 'utf8')
+    await fd.chmod(0o600)
+    await fd.sync()
+  } finally {
+    await fd.close()
+  }
+  await fs.rename(tmp, file)
+}
+
+// Exclusive-create lock, the same cross-platform flock stand-in the sibling
+// registry uses: `wx` fails if the file exists, so whoever creates it holds the
+// lock; a contender retries until the 5s timeout. Best-effort PID stamp so a
+// stuck lock names who to look for.
+async function acquireConnectorsLock(
+  lockPath: string,
+  timeoutMs: number = CONNECTORS_LOCK_TIMEOUT_MS,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  await fs.mkdir(path.dirname(lockPath), { recursive: true })
+  for (;;) {
+    try {
+      const fd = await fs.open(lockPath, 'wx')
+      try {
+        await fd.writeFile(`${process.pid}\n`, 'utf8')
+      } finally {
+        await fd.close()
+      }
+      return
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `neat connector: timed out after ${timeoutMs}ms waiting for ${lockPath}. ` +
+            'Another neat process may be writing the connector config; if none is, remove that file by hand.',
+        )
+      }
+      await new Promise((r) => setTimeout(r, CONNECTORS_LOCK_RETRY_MS))
+    }
+  }
+}
+
+async function releaseConnectorsLock(lockPath: string): Promise<void> {
+  await fs.unlink(lockPath).catch(() => {})
+}
+
+async function withConnectorsLock<T>(home: string, fn: () => Promise<T>): Promise<T> {
+  const lock = connectorsConfigLockPath(home)
+  await acquireConnectorsLock(lock)
+  try {
+    return await fn()
+  } finally {
+    await releaseConnectorsLock(lock)
+  }
+}
+
+function serializeConfig(config: ConnectorsConfig): string {
+  return (
+    JSON.stringify(
+      { version: config.version ?? CONNECTORS_CONFIG_VERSION, connectors: config.connectors },
+      null,
+      2,
+    ) + '\n'
+  )
+}
+
+/**
+ * Insert `entry`, or replace the existing entry with the same `id`. The whole
+ * read-modify-write runs under one lock so two concurrent adds can't clobber
+ * each other, and the entry is validated before it lands so a malformed write
+ * fails loudly rather than corrupting the file. Returns whether an existing
+ * entry was replaced (vs a fresh insert) so the CLI can report which happened.
+ */
+export async function upsertConnectorEntry(
+  entry: ConnectorEntry,
+  home: string = neatHome(),
+): Promise<{ replaced: boolean }> {
+  const file = connectorsConfigPath(home)
+  return withConnectorsLock(home, async () => {
+    const config = await readConnectorsConfig(home)
+    // Re-validate through the same reader-side check so a hand-built entry
+    // can't slip a bad shape past the writer.
+    validateEntry(entry, config.connectors.length, file)
+    const idx = config.connectors.findIndex((c) => c.id === entry.id)
+    const replaced = idx >= 0
+    if (replaced) config.connectors[idx] = entry
+    else config.connectors.push(entry)
+    await writeConfigAtomically0600(file, serializeConfig(config))
+    return { replaced }
+  })
+}
+
+/**
+ * Remove the entry with `id`. Returns the removed entry, or `undefined` when no
+ * entry carried that id (the CLI turns that into a clear "no such id"). Atomic
+ * `0600` rewrite under the same lock as `upsertConnectorEntry`.
+ */
+export async function removeConnectorEntry(
+  id: string,
+  home: string = neatHome(),
+): Promise<ConnectorEntry | undefined> {
+  const file = connectorsConfigPath(home)
+  return withConnectorsLock(home, async () => {
+    const config = await readConnectorsConfig(home)
+    const idx = config.connectors.findIndex((c) => c.id === id)
+    if (idx < 0) return undefined
+    const [removed] = config.connectors.splice(idx, 1)
+    await writeConfigAtomically0600(file, serializeConfig(config))
+    return removed
+  })
+}
+
+// Lower-case, collapse any run of non-alphanumerics to a single hyphen, trim
+// stray hyphens. Turns a project name or provider into a stable id fragment.
+function slugFragment(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+/**
+ * Auto-slug an `id` from the provider, disambiguated by project when a provider
+ * repeats (contract §1). Bare provider first (`supabase`); on collision, the
+ * provider plus its project (`supabase-brief`); then a numeric suffix
+ * (`supabase-2`) as a last resort so `add` never fails just to name an entry.
+ */
+export function autoSlugConnectorId(
+  provider: string,
+  project: string | undefined,
+  existingIds: ReadonlySet<string>,
+): string {
+  const base = slugFragment(provider) || 'connector'
+  if (!existingIds.has(base)) return base
+  const projectFrag = project ? slugFragment(project) : ''
+  if (projectFrag) {
+    const withProject = `${base}-${projectFrag}`
+    if (!existingIds.has(withProject)) return withProject
+  }
+  const stem = projectFrag ? `${base}-${projectFrag}` : base
+  for (let n = 2; ; n++) {
+    const candidate = `${stem}-${n}`
+    if (!existingIds.has(candidate)) return candidate
+  }
+}
+
+/** One credential field rendered for `list`, never carrying a resolved secret. */
+export interface CredentialFieldDisplay {
+  // Present only for a multi-field credential; the single-string form has none.
+  field?: string
+  kind: 'env-ref' | 'plaintext'
+  // The env-var name (with its `$`) for a ref — safe to print, it's a pointer,
+  // not the secret — or a fixed `****` mask for a plaintext literal.
+  display: string
+  // env-ref only: whether the referenced variable is set in `env`.
+  status?: 'set' | 'unset'
+}
+
+/**
+ * Render a credential for `neat connector list` — the redacted view, never the
+ * resolved secret (contract §2, and the never-log-a-secret rule connectors.md
+ * §6 / contracts.md Rule 13 already hold). An env-ref shows its `$VAR` pointer
+ * plus whether that variable is currently set; a plaintext literal shows only
+ * `****`. Reuses `isEnvRef` so the display can't drift from what the daemon
+ * actually resolves.
+ */
+export function describeCredential(
+  ref: CredentialRef,
+  env: NodeJS.ProcessEnv = process.env,
+): CredentialFieldDisplay[] {
+  const one = (value: string, field?: string): CredentialFieldDisplay => {
+    if (isEnvRef(value)) {
+      const varName = value.slice(1)
+      const resolved = env[varName]
+      const set = typeof resolved === 'string' && resolved.length > 0
+      return {
+        ...(field ? { field } : {}),
+        kind: 'env-ref',
+        display: value,
+        status: set ? 'set' : 'unset',
+      }
+    }
+    return { ...(field ? { field } : {}), kind: 'plaintext', display: '****' }
+  }
+  if (typeof ref === 'string') return [one(ref)]
+  return Object.entries(ref).map(([k, v]) => one(v, k))
+}

--- a/packages/core/src/connectors/registry.ts
+++ b/packages/core/src/connectors/registry.ts
@@ -19,10 +19,12 @@
 
 import type { NeatGraph } from '../graph.js'
 import type { ConnectorRegistration, ObservedConnector, ResolveConnectorTarget } from './index.js'
-import { createSupabaseConnector, type SupabaseConnectorConfig } from './supabase/index.js'
+import { bearerAuthHeader, junctionFetch } from './junction.js'
+import { createSupabaseConnector, DEFAULT_SUPABASE_MANAGEMENT_API_URL, type SupabaseConnectorConfig } from './supabase/index.js'
 import {
   createRailwayConnector,
   createRailwayResolveTarget,
+  DEFAULT_RAILWAY_API_URL,
   type RailwayConnectorConfig,
 } from './railway/index.js'
 import { createFirebaseConnector, type FirebaseServiceMap } from './firebase/index.js'
@@ -46,6 +48,76 @@ interface BuiltConnector {
 }
 
 /**
+ * The verdict of a provider's cheap auth round-trip (contract §4). `ok` means
+ * the resolved credential authenticated against the provider; a failure names
+ * why in plain terms the CLI can print verbatim — never echoing the credential
+ * itself.
+ */
+export type ConnectorValidation = { ok: true } | { ok: false; reason: string }
+
+/** What a dispatch-table validator receives — already-resolved credentials. */
+export interface ValidateInput {
+  // env-refs already resolved to their in-memory values (contract §2). Keyed
+  // the way this provider's `poll()` reads them.
+  credentials: Record<string, unknown>
+  // Non-secret provider config from the entry's `options`.
+  options: Record<string, unknown>
+  // Dependency-injection seam for tests — a fake `fetch` stands in for the live
+  // provider so validate-on-add never needs a real account (contract §4's
+  // round-trip is exercised against a stub, mirroring each connector's own
+  // `fetchImpl` test seam).
+  fetchImpl?: typeof fetch
+}
+
+// The Cloudflare API host, defaulted here rather than importing a private const
+// out of the connector's client — the same value cloudflare/client.ts uses.
+const CLOUDFLARE_API_BASE_URL = 'https://api.cloudflare.com/client/v4'
+
+/**
+ * One authenticated GET/POST through the shared junction (ADR-131), interpreted
+ * as a validation verdict. A 2xx means the credential authenticated; a 401/403
+ * means the provider rejected it (the "creds present but wrong" case the
+ * contract keeps distinct from an unset env-ref); any other status or a
+ * transport failure is reported as an inability to confirm, never a false
+ * "valid". The bearer token flows into the Authorization header and nowhere
+ * else — the reason strings below carry only the provider name and HTTP status,
+ * never the secret (contract §2, connectors.md §6).
+ */
+async function authProbe(input: {
+  provider: string
+  accountKey: string
+  url: string | URL
+  token: string
+  init?: RequestInit
+  fetchImpl?: typeof fetch
+}): Promise<ConnectorValidation> {
+  const { provider, accountKey, url, token, init, fetchImpl } = input
+  try {
+    const res = await junctionFetch(
+      url,
+      {
+        ...(init ?? {}),
+        headers: { ...bearerAuthHeader(token), ...((init?.headers as Record<string, string>) ?? {}) },
+      },
+      { provider, accountKey, ...(fetchImpl ? { fetchImpl } : {}) },
+    )
+    if (res.ok) return { ok: true }
+    if (res.status === 401 || res.status === 403) {
+      return { ok: false, reason: `${provider} rejected the credential (HTTP ${res.status})` }
+    }
+    return {
+      ok: false,
+      reason: `${provider} auth check returned HTTP ${res.status} ${res.statusText} — could not confirm the credential`,
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `${provider} auth check could not reach the provider: ${(err as Error).message}`,
+    }
+  }
+}
+
+/**
  * One provider's dispatch-table entry. Beyond the factory this carries the
  * schema the CLI (`neat connector add`) reads to know what to prompt for
  * (contract §5) — declared here so provider specifics live in data the table
@@ -65,6 +137,10 @@ export interface ProviderDispatch {
   requiredOptionFields: readonly string[]
   // Adapt (graph, non-secret options) into the uniform connector pairing.
   build(graph: NeatGraph, options: Record<string, unknown>): BuiltConnector
+  // The cheap auth round-trip `neat connector add`/`test` run before writing
+  // (contract §4, §5). Data-driven like everything else on this entry: the CLI
+  // never hand-rolls a per-provider auth check, it dispatches here.
+  validate(input: ValidateInput): Promise<ConnectorValidation>
 }
 
 // ── The table. Five providers are designed; four are built and register
@@ -80,6 +156,20 @@ export const PROVIDER_DISPATCH: Record<string, ProviderDispatch> = {
       // createSupabaseConnector already returns the pairing.
       return createSupabaseConnector(graph, options as unknown as SupabaseConnectorConfig)
     },
+    // GET /v1/projects — the Management API's own auth-gated list endpoint, the
+    // cheapest confirmation the management token is live (the same surface
+    // client.ts polls, minus the heavy log query).
+    validate({ credentials, options, fetchImpl }) {
+      const cfg = options as Partial<SupabaseConnectorConfig>
+      const baseUrl = cfg.managementApiUrl ?? DEFAULT_SUPABASE_MANAGEMENT_API_URL
+      return authProbe({
+        provider: 'supabase',
+        accountKey: cfg.apiProjectRef ?? 'validate',
+        url: `${baseUrl}/v1/projects`,
+        token: String(credentials.managementToken ?? ''),
+        ...(fetchImpl ? { fetchImpl } : {}),
+      })
+    },
   },
   railway: {
     provider: 'railway',
@@ -93,6 +183,25 @@ export const PROVIDER_DISPATCH: Record<string, ProviderDispatch> = {
         connector: createRailwayConnector(graph, config),
         resolveTarget: createRailwayResolveTarget(config),
       }
+    },
+    // A minimal GraphQL POST — Railway's gateway 401s an unauthenticated call
+    // at the HTTP layer, so a 2xx confirms the token was accepted regardless of
+    // the query's own shape (the connector's real queries are still
+    // needs-endpoint-testing per railway/types.ts — auth is what we check).
+    validate({ credentials, options, fetchImpl }) {
+      const cfg = options as Partial<RailwayConnectorConfig>
+      return authProbe({
+        provider: 'railway',
+        accountKey: cfg.environmentId ?? 'validate',
+        url: cfg.apiUrl ?? DEFAULT_RAILWAY_API_URL,
+        token: String(credentials.token ?? ''),
+        init: {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ query: '{ __typename }' }),
+        },
+        ...(fetchImpl ? { fetchImpl } : {}),
+      })
     },
   },
   firebase: {
@@ -108,6 +217,19 @@ export const PROVIDER_DISPATCH: Record<string, ProviderDispatch> = {
       // pairing.
       return createFirebaseConnector(graph, options as unknown as FirebaseServiceMap)
     },
+    // GET the project's Cloud Logging log-name list (pageSize 1) — within the
+    // same `roles/logging.viewer` grant the connector polls under, and the
+    // lightest call that still fails 401/403 on a bad or wrong-scoped token.
+    validate({ credentials, fetchImpl }) {
+      const projectId = String(credentials.projectId ?? '')
+      return authProbe({
+        provider: 'firebase',
+        accountKey: projectId || 'validate',
+        url: `https://logging.googleapis.com/v2/projects/${projectId}/logs?pageSize=1`,
+        token: String(credentials.accessToken ?? ''),
+        ...(fetchImpl ? { fetchImpl } : {}),
+      })
+    },
   },
   cloudflare: {
     provider: 'cloudflare',
@@ -122,6 +244,19 @@ export const PROVIDER_DISPATCH: Record<string, ProviderDispatch> = {
         resolveTarget: createCloudflareResolveTarget(config),
       }
     },
+    // GET /user/tokens/verify — Cloudflare's own purpose-built "is this API
+    // token live" endpoint. 200 on a valid token, 401 on an invalid one.
+    validate({ credentials, options, fetchImpl }) {
+      const cfg = options as Partial<CloudflareConnectorConfig>
+      const baseUrl = cfg.baseUrl ?? CLOUDFLARE_API_BASE_URL
+      return authProbe({
+        provider: 'cloudflare',
+        accountKey: cfg.accountId ?? 'validate',
+        url: `${baseUrl}/user/tokens/verify`,
+        token: String(credentials.apiToken ?? ''),
+        ...(fetchImpl ? { fetchImpl } : {}),
+      })
+    },
   },
 }
 
@@ -132,6 +267,45 @@ export function getProviderDispatch(provider: string): ProviderDispatch | undefi
 export type BuildResult =
   | { ok: true; registration: ConnectorRegistration }
   | { ok: false; reason: string }
+
+/**
+ * Resolve an entry's env-ref credential to in-memory values keyed the way this
+ * provider reads them (contract §2, §6), and confirm every required credential
+ * field is present. The `unset-env` failure is kept distinct from every other
+ * kind so a caller can tell "you forgot to `export`" apart from "your token is
+ * malformed" (contract §4). Shared by `buildRegistration` (daemon read) and
+ * `validateConnectorEntry` (the CLI) so both resolve credentials identically.
+ */
+type CredentialResolution =
+  | { ok: true; credentials: Record<string, unknown> }
+  | { ok: false; kind: 'unset-env' | 'error' | 'missing-field'; reason: string }
+
+function resolveEntryCredentials(
+  dispatch: ProviderDispatch,
+  entry: ConnectorEntry,
+  env: NodeJS.ProcessEnv,
+): CredentialResolution {
+  let credentials: Record<string, unknown>
+  try {
+    const resolved = resolveCredential(entry.credential, env)
+    credentials =
+      resolved.kind === 'single'
+        ? { [dispatch.primaryCredentialKey]: resolved.value }
+        : { ...resolved.fields }
+  } catch (err) {
+    if (err instanceof EnvRefUnsetError) return { ok: false, kind: 'unset-env', reason: err.message }
+    return { ok: false, kind: 'error', reason: (err as Error).message }
+  }
+  const missingCreds = dispatch.requiredCredentialFields.filter((k) => !credentials[k])
+  if (missingCreds.length > 0) {
+    return {
+      ok: false,
+      kind: 'missing-field',
+      reason: `credential missing required field(s): ${missingCreds.join(', ')}`,
+    }
+  }
+  return { ok: true, credentials }
+}
 
 /**
  * Turn one resolved config entry into a `ConnectorRegistration`, or a skip
@@ -150,27 +324,9 @@ export function buildRegistration(
     return { ok: false, reason: `unknown provider "${entry.provider}"` }
   }
 
-  // Resolve env-ref credential to in-memory values (contract §2, §6). An
-  // unset variable is a distinct, named failure — never a silent empty-poll.
-  let credentials: Record<string, unknown>
-  try {
-    const resolved = resolveCredential(entry.credential, env)
-    credentials =
-      resolved.kind === 'single'
-        ? { [dispatch.primaryCredentialKey]: resolved.value }
-        : { ...resolved.fields }
-  } catch (err) {
-    if (err instanceof EnvRefUnsetError) return { ok: false, reason: err.message }
-    return { ok: false, reason: (err as Error).message }
-  }
-
-  const missingCreds = dispatch.requiredCredentialFields.filter((k) => !credentials[k])
-  if (missingCreds.length > 0) {
-    return {
-      ok: false,
-      reason: `credential missing required field(s): ${missingCreds.join(', ')}`,
-    }
-  }
+  const creds = resolveEntryCredentials(dispatch, entry, env)
+  if (!creds.ok) return { ok: false, reason: creds.reason }
+  const credentials = creds.credentials
 
   const options = entry.options ?? {}
   const missingOpts = dispatch.requiredOptionFields.filter((k) => !(k in options))
@@ -198,6 +354,60 @@ export function buildRegistration(
       ...(intervalMs !== undefined ? { intervalMs } : {}),
     },
   }
+}
+
+/**
+ * The verdict `neat connector add` (validate-on-add) and `neat connector test`
+ * both report (contract §4). Five distinct outcomes so the CLI can speak
+ * plainly: `ok` (authenticated), `unset-env` (a `$VAR` credential's variable
+ * isn't set — resolution failure, *not* the provider rejecting a token),
+ * `rejected` (creds resolved but the provider's auth path turned them down),
+ * `unknown-provider`, and `missing-field` (a required credential/option is
+ * absent — caught before any network call).
+ */
+export type ValidateOutcome =
+  | { status: 'ok' }
+  | { status: 'unset-env'; reason: string }
+  | { status: 'rejected'; reason: string }
+  | { status: 'unknown-provider'; reason: string }
+  | { status: 'missing-field'; reason: string }
+
+/**
+ * Run the provider's cheap auth round-trip against an entry — resolving its
+ * env-ref credential first, so an unset variable short-circuits as `unset-env`
+ * before any request goes out (contract §4). Dispatches the actual round-trip
+ * through the table's `validate` (§5), so no per-provider auth logic lives in
+ * the CLI. `fetchImpl` is the test seam that stands a fake provider in for the
+ * live one.
+ */
+export async function validateConnectorEntry(
+  entry: ConnectorEntry,
+  env: NodeJS.ProcessEnv = process.env,
+  fetchImpl?: typeof fetch,
+): Promise<ValidateOutcome> {
+  const dispatch = PROVIDER_DISPATCH[entry.provider]
+  if (!dispatch) {
+    return { status: 'unknown-provider', reason: `unknown provider "${entry.provider}"` }
+  }
+  const creds = resolveEntryCredentials(dispatch, entry, env)
+  if (!creds.ok) {
+    if (creds.kind === 'unset-env') return { status: 'unset-env', reason: creds.reason }
+    return { status: 'missing-field', reason: creds.reason }
+  }
+  const options = entry.options ?? {}
+  const missingOpts = dispatch.requiredOptionFields.filter((k) => !(k in options))
+  if (missingOpts.length > 0) {
+    return {
+      status: 'missing-field',
+      reason: `options missing required field(s): ${missingOpts.join(', ')}`,
+    }
+  }
+  const result = await dispatch.validate({
+    credentials: creds.credentials,
+    options,
+    ...(fetchImpl ? { fetchImpl } : {}),
+  })
+  return result.ok ? { status: 'ok' } : { status: 'rejected', reason: result.reason }
 }
 
 export interface LoadConnectorsInput {

--- a/packages/core/test/connector-cli.test.ts
+++ b/packages/core/test/connector-cli.test.ts
@@ -1,0 +1,407 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import os from 'node:os'
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import {
+  parseConnectorArgs,
+  runConnectorCommand,
+  type ConnectorCliDeps,
+} from '../src/connector-cli.js'
+import { connectorsConfigPath, readConnectorsConfig } from '../src/connectors-config.js'
+
+// docs/contracts/connector-config.md §2 (env-ref default / plaintext opt-in),
+// §3 (the verb family), §4 (validate-on-add; unset-env ≠ rejection). The write
+// side: env-ref stored as a pointer, atomic 0600 writes, a redacted `list`, and
+// the three distinct validation outcomes — all exercised against a temp home
+// and a stubbed provider, never a live account.
+
+const tmpDirs: string[] = []
+
+async function makeHome(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-connector-cli-'))
+  const real = await fs.realpath(dir)
+  tmpDirs.push(real)
+  return path.join(real, 'neat')
+}
+
+afterEach(async () => {
+  while (tmpDirs.length > 0) {
+    await fs.rm(tmpDirs.pop()!, { recursive: true, force: true }).catch(() => {})
+  }
+})
+
+// A fake `fetch` standing in for a provider's auth path (contract §4 round-trip
+// against a stub). `calls` records every URL so a test can assert validation
+// was or wasn't attempted.
+function stubFetch(status: number): { fetch: typeof fetch; calls: string[] } {
+  const calls: string[] = []
+  const fetchImpl = (async (url: string | URL) => {
+    calls.push(String(url))
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? 'OK' : status === 401 ? 'Unauthorized' : 'Error',
+      json: async () => ({}),
+    } as Response
+  }) as unknown as typeof fetch
+  return { fetch: fetchImpl, calls }
+}
+
+interface Captured {
+  out: string[]
+  err: string[]
+  code: number
+}
+
+async function run(args: string[], deps: Partial<ConnectorCliDeps>): Promise<Captured> {
+  const out: string[] = []
+  const err: string[] = []
+  const code = await runConnectorCommand(args, {
+    interactive: false,
+    out: (l) => out.push(l),
+    err: (l) => err.push(l),
+    ...deps,
+  })
+  return { out, err, code }
+}
+
+const SUPABASE_OPTS = [
+  '--api-project-ref',
+  'abcdefghijklmnopqrst',
+  '--node-ref',
+  'x.supabase.co',
+  '--service-name',
+  'api',
+]
+
+describe('parseConnectorArgs', () => {
+  it('splits subcommand, positionals, known flags, and generic provider fields', () => {
+    const r = parseConnectorArgs([
+      'add',
+      'supabase',
+      '--project',
+      'brief',
+      '--token',
+      '$SUPABASE_KEY',
+      '--account-id',
+      'acct-123',
+      '--skip-validate',
+    ])
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.value.subcommand).toBe('add')
+    expect(r.value.positional).toEqual(['supabase'])
+    expect(r.value.project).toBe('brief')
+    expect(r.value.credential).toBe('$SUPABASE_KEY')
+    expect(r.value.fields.accountId).toBe('acct-123')
+    expect(r.value.skipValidate).toBe(true)
+  })
+
+  it('kebab flags become camelCase fields and JSON values parse', () => {
+    const r = parseConnectorArgs(['add', 'cloudflare', '--workers', '{"w":{"service":"api"}}'])
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.value.fields.workers).toEqual({ w: { service: 'api' } })
+  })
+
+  it('supports --flag=value form', () => {
+    const r = parseConnectorArgs(['add', 'supabase', '--project=brief'])
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.value.project).toBe('brief')
+  })
+
+  it('a value-flag with no value is an error', () => {
+    const r = parseConnectorArgs(['add', 'supabase', '--project'])
+    expect(r.ok).toBe(false)
+  })
+})
+
+describe('connector add', () => {
+  it('stores an env-ref credential as a pointer, never resolved (contract §2)', async () => {
+    const home = await makeHome()
+    const { code } = await run(
+      ['add', 'supabase', '--credential', '$SUPABASE_KEY', ...SUPABASE_OPTS, '--skip-validate'],
+      { home, env: { SUPABASE_KEY: 'sk_live_secret' } },
+    )
+    expect(code).toBe(0)
+    const config = await readConnectorsConfig(home)
+    expect(config.connectors).toHaveLength(1)
+    expect(config.connectors[0].credential).toBe('$SUPABASE_KEY')
+    // The resolved secret never lands on disk.
+    const raw = await fs.readFile(connectorsConfigPath(home), 'utf8')
+    expect(raw).not.toContain('sk_live_secret')
+  })
+
+  it('auto-slugs the id from provider, disambiguating a repeat by project', async () => {
+    const home = await makeHome()
+    const env = { SUPABASE_KEY: 'x' }
+    await run(['add', 'supabase', '--project', 'brief', '--credential', '$SUPABASE_KEY', ...SUPABASE_OPTS, '--skip-validate'], { home, env })
+    await run(['add', 'supabase', '--project', 'newdryve', '--credential', '$SUPABASE_KEY', ...SUPABASE_OPTS, '--skip-validate'], { home, env })
+    await run(['add', 'supabase', '--project', 'brief', '--credential', '$SUPABASE_KEY', ...SUPABASE_OPTS, '--skip-validate'], { home, env })
+    const config = await readConnectorsConfig(home)
+    expect(config.connectors.map((c) => c.id)).toEqual(['supabase', 'supabase-newdryve', 'supabase-brief'])
+  })
+
+  it('honors an explicit --id', async () => {
+    const home = await makeHome()
+    const { code } = await run(
+      ['add', 'supabase', '--id', 'my-sb', '--credential', '$K', ...SUPABASE_OPTS, '--skip-validate'],
+      { home, env: { K: 'x' } },
+    )
+    expect(code).toBe(0)
+    const config = await readConnectorsConfig(home)
+    expect(config.connectors[0].id).toBe('my-sb')
+  })
+
+  it('writes the file mode 0600 (contract §1)', async () => {
+    const home = await makeHome()
+    await run(['add', 'supabase', '--credential', '$K', ...SUPABASE_OPTS, '--skip-validate'], { home, env: { K: 'x' } })
+    const stat = await fs.stat(connectorsConfigPath(home))
+    expect(stat.mode & 0o777).toBe(0o600)
+  })
+
+  it('validate-on-add: an unset env-ref is distinct from a rejection and writes nothing (contract §4)', async () => {
+    const home = await makeHome()
+    const stub = stubFetch(200)
+    const { code, err } = await run(
+      ['add', 'supabase', '--credential', '$SUPABASE_KEY', ...SUPABASE_OPTS],
+      { home, env: {}, fetchImpl: stub.fetch },
+    )
+    expect(code).toBe(1)
+    expect(err.join('\n')).toContain('$SUPABASE_KEY is unset')
+    // A resolution failure never reaches the provider…
+    expect(stub.calls).toHaveLength(0)
+    // …and nothing was written.
+    const config = await readConnectorsConfig(home)
+    expect(config.connectors).toHaveLength(0)
+  })
+
+  it('validate-on-add: the provider rejecting the credential writes nothing', async () => {
+    const home = await makeHome()
+    const stub = stubFetch(401)
+    const { code, err } = await run(
+      ['add', 'supabase', '--credential', '$SUPABASE_KEY', ...SUPABASE_OPTS],
+      { home, env: { SUPABASE_KEY: 'wrong' }, fetchImpl: stub.fetch },
+    )
+    expect(code).toBe(1)
+    expect(err.join('\n')).toMatch(/rejected the credential/)
+    expect(stub.calls.length).toBeGreaterThan(0)
+    const config = await readConnectorsConfig(home)
+    expect(config.connectors).toHaveLength(0)
+  })
+
+  it('validate-on-add: a good credential authenticates and the entry is written', async () => {
+    const home = await makeHome()
+    const stub = stubFetch(200)
+    const { code, out } = await run(
+      ['add', 'supabase', '--credential', '$SUPABASE_KEY', ...SUPABASE_OPTS],
+      { home, env: { SUPABASE_KEY: 'right' }, fetchImpl: stub.fetch },
+    )
+    expect(code).toBe(0)
+    expect(out.join('\n')).toMatch(/validated against the provider/)
+    expect(stub.calls.length).toBeGreaterThan(0)
+    const config = await readConnectorsConfig(home)
+    expect(config.connectors).toHaveLength(1)
+  })
+
+  it('--skip-validate bypasses the round-trip entirely', async () => {
+    const home = await makeHome()
+    const stub = stubFetch(401)
+    const { code } = await run(
+      ['add', 'supabase', '--credential', '$SUPABASE_KEY', ...SUPABASE_OPTS, '--skip-validate'],
+      { home, env: {}, fetchImpl: stub.fetch },
+    )
+    expect(code).toBe(0)
+    expect(stub.calls).toHaveLength(0)
+    const config = await readConnectorsConfig(home)
+    expect(config.connectors).toHaveLength(1)
+  })
+
+  it('a plaintext credential is the explicit opt-in — stored, but warned about', async () => {
+    const home = await makeHome()
+    const { code, err } = await run(
+      ['add', 'supabase', '--credential', 'sk_literal_secret', ...SUPABASE_OPTS, '--skip-validate'],
+      { home, env: {} },
+    )
+    expect(code).toBe(0)
+    expect(err.join('\n')).toMatch(/storing a literal secret at rest/)
+    const config = await readConnectorsConfig(home)
+    expect(config.connectors[0].credential).toBe('sk_literal_secret')
+  })
+
+  it('--plaintext silences the at-rest warning', async () => {
+    const home = await makeHome()
+    const { err } = await run(
+      ['add', 'supabase', '--credential', 'sk_literal', ...SUPABASE_OPTS, '--skip-validate', '--plaintext'],
+      { home, env: {} },
+    )
+    expect(err.join('\n')).not.toMatch(/storing a literal secret/)
+  })
+
+  it('builds a multi-field credential (firebase) from per-field flags', async () => {
+    const home = await makeHome()
+    const { code } = await run(
+      [
+        'add',
+        'firebase',
+        '--project-id',
+        '$FB_PROJECT',
+        '--access-token',
+        '$FB_TOKEN',
+        '--functions',
+        '{"myFn":"api"}',
+        '--skip-validate',
+      ],
+      { home, env: { FB_PROJECT: 'app', FB_TOKEN: 'tok' } },
+    )
+    expect(code).toBe(0)
+    const config = await readConnectorsConfig(home)
+    expect(config.connectors[0].credential).toEqual({ projectId: '$FB_PROJECT', accessToken: '$FB_TOKEN' })
+    expect(config.connectors[0].options).toEqual({ functions: { myFn: 'api' } })
+  })
+
+  it('rejects an unknown provider before writing', async () => {
+    const home = await makeHome()
+    const { code, err } = await run(['add', 'notaprovider', '--skip-validate'], { home, env: {} })
+    expect(code).toBe(2)
+    expect(err.join('\n')).toMatch(/unknown provider/)
+    await expect(readConnectorsConfig(home)).resolves.toEqual(
+      expect.objectContaining({ connectors: [] }),
+    )
+  })
+
+  it('errors on a missing required option rather than storing a dead entry', async () => {
+    const home = await makeHome()
+    // nodeRef omitted.
+    const { code, err } = await run(
+      ['add', 'supabase', '--credential', '$K', '--api-project-ref', 'abcdefghijklmnopqrst', '--service-name', 'api', '--skip-validate'],
+      { home, env: { K: 'x' } },
+    )
+    expect(code).toBe(2)
+    expect(err.join('\n')).toMatch(/missing required option/)
+  })
+
+  it('prompts for missing fields when interactive', async () => {
+    const home = await makeHome()
+    const answers = ['brief', '$SUPABASE_KEY', 'abcdefghijklmnopqrst', 'x.supabase.co', 'api']
+    let i = 0
+    const { code } = await run(['add', 'supabase', '--skip-validate'], {
+      home,
+      env: { SUPABASE_KEY: 'x' },
+      interactive: true,
+      prompt: async () => answers[i++] ?? '',
+    })
+    expect(code).toBe(0)
+    const config = await readConnectorsConfig(home)
+    expect(config.connectors[0].project).toBe('brief')
+    expect(config.connectors[0].credential).toBe('$SUPABASE_KEY')
+  })
+})
+
+describe('connector list', () => {
+  it('redacts credentials — the resolved secret is never printed', async () => {
+    const home = await makeHome()
+    const env = { SUPABASE_KEY: 'sk_live_TOPSECRET' }
+    await run(['add', 'supabase', '--credential', '$SUPABASE_KEY', ...SUPABASE_OPTS, '--skip-validate'], { home, env })
+    const { code, out } = await run(['list'], { home, env })
+    expect(code).toBe(0)
+    const text = out.join('\n')
+    expect(text).toContain('$SUPABASE_KEY (set)')
+    expect(text).not.toContain('sk_live_TOPSECRET')
+  })
+
+  it('shows env-ref set/unset status and masks plaintext', async () => {
+    const home = await makeHome()
+    await run(['add', 'supabase', '--id', 'ref', '--credential', '$MISSING', ...SUPABASE_OPTS, '--skip-validate'], { home, env: {} })
+    await run(['add', 'supabase', '--id', 'lit', '--credential', 'literal_secret', ...SUPABASE_OPTS, '--skip-validate', '--plaintext'], { home, env: {} })
+    const { out } = await run(['list'], { home, env: {} })
+    const text = out.join('\n')
+    expect(text).toContain('$MISSING (unset)')
+    expect(text).toContain('**** (plaintext)')
+    expect(text).not.toContain('literal_secret')
+  })
+
+  it('filters by --project', async () => {
+    const home = await makeHome()
+    const env = { K: 'x' }
+    await run(['add', 'supabase', '--project', 'brief', '--credential', '$K', ...SUPABASE_OPTS, '--skip-validate'], { home, env })
+    await run(['add', 'railway', '--project', 'newdryve', '--credential', '$K', '--environment-id', 'e', '--service-id', 's', '--service-name-by-id', '{"s":"api"}', '--skip-validate'], { home, env })
+    const { out } = await run(['list', '--project', 'brief'], { home, env })
+    const text = out.join('\n')
+    expect(text).toContain('supabase')
+    expect(text).not.toContain('railway')
+  })
+
+  it('reports an empty config plainly', async () => {
+    const home = await makeHome()
+    const { code, out } = await run(['list'], { home, env: {} })
+    expect(code).toBe(0)
+    expect(out.join('\n')).toMatch(/no connectors configured/)
+  })
+})
+
+describe('connector remove', () => {
+  it('removes by id', async () => {
+    const home = await makeHome()
+    await run(['add', 'supabase', '--id', 'gone', '--credential', '$K', ...SUPABASE_OPTS, '--skip-validate'], { home, env: { K: 'x' } })
+    const { code, out } = await run(['remove', 'gone'], { home, env: {} })
+    expect(code).toBe(0)
+    expect(out.join('\n')).toMatch(/removed connector "gone"/)
+    const config = await readConnectorsConfig(home)
+    expect(config.connectors).toHaveLength(0)
+  })
+
+  it('a missing id is a clear error, exit 1', async () => {
+    const home = await makeHome()
+    const { code, err } = await run(['remove', 'nope'], { home, env: {} })
+    expect(code).toBe(1)
+    expect(err.join('\n')).toMatch(/no connector with id "nope"/)
+  })
+
+  it('missing <id> argument is misuse, exit 2', async () => {
+    const home = await makeHome()
+    const { code } = await run(['remove'], { home, env: {} })
+    expect(code).toBe(2)
+  })
+})
+
+describe('connector test', () => {
+  it('ok when the provider authenticates', async () => {
+    const home = await makeHome()
+    const env = { SUPABASE_KEY: 'right' }
+    await run(['add', 'supabase', '--id', 'sb', '--credential', '$SUPABASE_KEY', ...SUPABASE_OPTS, '--skip-validate'], { home, env })
+    const stub = stubFetch(200)
+    const { code, out } = await run(['test', 'sb'], { home, env, fetchImpl: stub.fetch })
+    expect(code).toBe(0)
+    expect(out.join('\n')).toMatch(/^ok:/m)
+  })
+
+  it('unset when the env-ref variable is not set — distinct from rejection', async () => {
+    const home = await makeHome()
+    await run(['add', 'supabase', '--id', 'sb', '--credential', '$SUPABASE_KEY', ...SUPABASE_OPTS, '--skip-validate'], { home, env: { SUPABASE_KEY: 'x' } })
+    const stub = stubFetch(200)
+    const { code, err } = await run(['test', 'sb'], { home, env: {}, fetchImpl: stub.fetch })
+    expect(code).toBe(1)
+    expect(err.join('\n')).toMatch(/^unset:/m)
+    expect(err.join('\n')).toContain('$SUPABASE_KEY is unset')
+    expect(stub.calls).toHaveLength(0)
+  })
+
+  it('rejected when the provider turns the credential down', async () => {
+    const home = await makeHome()
+    const env = { SUPABASE_KEY: 'wrong' }
+    await run(['add', 'supabase', '--id', 'sb', '--credential', '$SUPABASE_KEY', ...SUPABASE_OPTS, '--skip-validate'], { home, env })
+    const stub = stubFetch(403)
+    const { code, err } = await run(['test', 'sb'], { home, env, fetchImpl: stub.fetch })
+    expect(code).toBe(1)
+    expect(err.join('\n')).toMatch(/^rejected:/m)
+  })
+
+  it('no such id is a clear error', async () => {
+    const home = await makeHome()
+    const { code, err } = await run(['test', 'ghost'], { home, env: {} })
+    expect(code).toBe(1)
+    expect(err.join('\n')).toMatch(/no connector with id "ghost"/)
+  })
+})


### PR DESCRIPTION
The daemon-read half of ADR-130 landed in #730 — it reads `~/.neat/connectors.json` at slot bootstrap and starts a poll loop per matching entry. This is the write side, the `neat connector` command family a person actually runs to put an entry in that file.

## What's here

- **`neat connector add <provider>`** — interactive prompts when run bare, flags for scripting/CI (`--project`, `--credential`/`--token`, `--id`, provider option flags like `--account-id`, `--skip-validate`). Auto-slugs the `id` from the provider (disambiguated by project on a repeat) unless `--id` is given.
- **validate-on-add, by default** — before writing, `add` runs a cheap auth round-trip through the provider's own auth path (via the dispatch-table validator, through the shared junction). A wrong credential fails fast and honestly at add-time instead of quietly at the first poll. `--skip-validate` bypasses it for the offline / env-not-yet-set case.
- **env-ref by default** — a credential like `$SUPABASE_KEY` is stored as a pointer, resolved only at run time; a literal value is the explicit opt-in and gets a warning. An **unset env-ref** is kept a distinct outcome from a **rejected** credential — "you forgot to `export`" reads differently from "your token is wrong".
- **`neat connector list`** — shows each connector with its credential redacted to the `$VAR` pointer (plus set/unset) or `****` for a literal; a resolved secret is never printed.
- **`neat connector remove <id>`** / **`neat connector test <id>`** — remove by id; re-run the same validation round-trip against an existing entry, reporting ok / unset-env / rejected distinctly.

## Security

The two non-negotiables from the design: validate-on-add is the default, and the file is written atomically, owner-only (`0600`), under a lock, with the credential defaulting to an env-ref so no secret sits at rest — and a resolved secret never reaches disk, a log, or the screen. The per-provider auth check lives in the dispatch table next to the factory and schema, so the CLI never hand-rolls a provider branch; `add --validate` and `test` share it.

## Tests

`connector-cli.test.ts` covers add (env-ref stored as pointer, plaintext opt-in + warning, auto-slug, unset-env ≠ rejection, `--skip-validate` bypass, atomic 0600 write, multi-field firebase credential, interactive prompts), list (redaction), remove (by id / missing), and test (ok / unset / rejected). The provider auth round-trip is exercised against a stubbed `fetch` — no live account.

Builds on the #730 read side; the schema, env-ref resolution, and dispatch table are reused, not duplicated.

Refs #678, #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)