### PR TITLE
Add the `neat connector` CLI to turn a connector on (ADR-130)

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -42,6 +42,7 @@ import {
 } from './installers/index.js'
 import { runOrchestrator } from './orchestrator.js'
 import { runSync } from './cli-verbs.js'
+import { runConnectorCommand } from './connectors-cli.js'
 import { DivergenceTypeSchema, type DivergenceType } from '@neat.is/types'
 import {
   createHttpClient,
@@ -166,6 +167,14 @@ export function usage(): void {
   console.log('                   --dry-run          run extraction in-memory; do not write')
   console.log('                   --no-instrument    skip the SDK install apply step')
   console.log('                   --json             emit the delta summary as JSON')
+  console.log('  connector      Turn a built connector on for a project (ADR-130).')
+  console.log('                 Subcommands:')
+  console.log('                   add <provider>   add a connector; prompts, or takes flags')
+  console.log('                   list             list configured connectors (credentials redacted)')
+  console.log('                   remove <id>      remove a connector by id')
+  console.log('                   test <id>        re-run the credential auth round-trip')
+  console.log('                 A credential defaults to an env-var reference ($VAR); add')
+  console.log('                 validates it against the provider unless --skip-validate.')
   console.log('')
   console.log('query commands (mirror the MCP tools, ADR-050):')
   console.log('  root-cause <node-id>             Walk inbound edges to find what broke first.')
@@ -736,6 +745,18 @@ export async function main(): Promise<void> {
   const parsed: ParsedArgs = { ...argvParsed, positional: argvParsed.positional.slice(1) }
   const { positional, apply, dryRun, noInstall } = parsed
   const project = parsed.project ?? DEFAULT_PROJECT
+
+  // `neat connector add/list/remove/test` — the connector on-ramp (ADR-130).
+  // Its provider-specific option and credential flags don't fit the shared
+  // verb parser, so it takes the raw args after `connector` and parses its
+  // own. A new top-level command family, not an eleventh query verb
+  // (connector-config.md §3).
+  if (cmd === 'connector') {
+    const subArgs = argv.slice(argv.indexOf('connector') + 1)
+    const code = await runConnectorCommand(subArgs)
+    if (code !== 0) process.exit(code)
+    return
+  }
 
   if (cmd === 'init') {
     const target = positional[0]

--- a/packages/core/src/connectors-cli.ts
+++ b/packages/core/src/connectors-cli.ts
@@ -1,0 +1,573 @@
+// `neat connector add/list/remove/test` — the write side of the connector
+// on-ramp (docs/contracts/connector-config.md §3, ADR-130).
+//
+// This is the one command a human runs to turn a built connector on for a
+// registered project. It sits on top of the read side that already shipped
+// (#730): connectors-config.ts owns reading and writing
+// `~/.neat/connectors.json` (atomic, `0600`, flock, env-ref resolution), and
+// connectors/registry.ts owns the provider dispatch table (factory, required-
+// field schema) plus the validate round-trip. This module only orchestrates:
+// it gathers a provider's fields from flags and interactive prompts, runs
+// validate-on-add through the connector's own auth path by default, and hands
+// a finished entry to the config writer. It never resolves a secret to disk
+// and never prints a resolved one — the default credential form is a pointer
+// (`$VAR`), and even a listing shows the pointer or `****`, never the value.
+//
+// `neat connector` is a new top-level command family, not an eleventh query
+// verb (contract §3) — same mutation/config category as init / sync / deploy,
+// outside the locked ten-verb query set.
+
+import { createInterface } from 'node:readline/promises'
+import {
+  EnvRefUnsetError,
+  readConnectorsConfig,
+  removeConnectorEntry,
+  upsertConnectorEntry,
+  type ConnectorEntry,
+  type CredentialRef,
+} from './connectors-config.js'
+import {
+  ConnectorConfigError,
+  getProviderDispatch,
+  PROVIDER_DISPATCH,
+  validateConnector,
+  type ProviderDispatch,
+  type ValidateConnectorOptions,
+} from './connectors/registry.js'
+
+// A prompt asks one question and returns the trimmed answer, falling back to
+// `default` on an empty line. Injected in tests so an interactive flow runs
+// without a TTY; the real one (below) reads a line off stdin.
+export type PromptFn = (question: string, opts?: { default?: string }) => Promise<string>
+
+export interface ConnectorCliDeps {
+  // Present → the command may prompt for a missing field. Absent → any missing
+  // required field is a misuse error instead of a hang (the CI / no-TTY case).
+  prompt?: PromptFn
+  // Defaults to the real registry round-trip; injected in tests to drive the
+  // ok / unset-env / rejected outcomes without a live provider account.
+  validate?: (entry: ConnectorEntry, options?: ValidateConnectorOptions) => Promise<void>
+  // Resolved NEAT_HOME; defaults to the env-based resolution in
+  // connectors-config.ts. Threaded so tests point at a temp home directly.
+  home?: string
+}
+
+// ── flag parsing ───────────────────────────────────────────────────────────
+
+interface ParsedConnectorFlags {
+  positionals: string[]
+  // Every `--name value` / `--name=value` pair, keyed by name. Provider option
+  // and credential flags are dynamic (they vary per provider), so the parse is
+  // generic rather than a fixed table.
+  flags: Record<string, string>
+  // `--option key=value`, repeatable.
+  optionPairs: string[]
+  skipValidate: boolean
+  json: boolean
+  yes: boolean
+}
+
+class MisuseError extends Error {}
+
+function parseConnectorFlags(args: string[]): ParsedConnectorFlags {
+  const out: ParsedConnectorFlags = {
+    positionals: [],
+    flags: {},
+    optionPairs: [],
+    skipValidate: false,
+    json: false,
+    yes: false,
+  }
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i] as string
+    if (a === '--skip-validate') { out.skipValidate = true; continue }
+    if (a === '--json') { out.json = true; continue }
+    if (a === '--yes' || a === '-y') { out.yes = true; continue }
+    if (a.startsWith('--')) {
+      const body = a.slice(2)
+      let name: string
+      let value: string
+      const eq = body.indexOf('=')
+      if (eq >= 0) {
+        name = body.slice(0, eq)
+        value = body.slice(eq + 1)
+      } else {
+        name = body
+        const next = args[i + 1]
+        if (next === undefined) throw new MisuseError(`--${name} requires a value`)
+        value = next
+        i++
+      }
+      if (name === 'option') out.optionPairs.push(value)
+      else out.flags[name] = value
+      continue
+    }
+    out.positionals.push(a)
+  }
+  return out
+}
+
+// camelCase option/credential key → the kebab flag that sets it. `accountId`
+// becomes `--account-id`, `serviceNameById` becomes `--service-name-by-id`.
+function toKebabFlag(field: string): string {
+  return field.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+}
+
+// A suggested env-var name for a credential field — the default the credential
+// prompt offers, so pressing Enter stores a pointer rather than a secret.
+// `supabase` + `managementToken` → `$SUPABASE_MANAGEMENT_TOKEN`.
+function suggestEnvRef(provider: string, field: string): string {
+  const snake = field.replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+  return `$${provider}_${snake}`.replace(/[^a-z0-9$]+/gi, '_').toUpperCase()
+}
+
+// A flag/option value can be a plain string, a number (intervalMs), a boolean,
+// or JSON (workers / serviceNameById / functions maps). Parse the shape the
+// value announces; fall back to the raw string.
+function parseScalarOrJson(raw: string): unknown {
+  const t = raw.trim()
+  if (t.length === 0) return raw
+  if (t.startsWith('{') || t.startsWith('[')) {
+    try { return JSON.parse(t) } catch { return raw }
+  }
+  if (/^-?\d+$/.test(t)) return Number(t)
+  if (t === 'true') return true
+  if (t === 'false') return false
+  return raw
+}
+
+// ── credential handling ─────────────────────────────────────────────────────
+
+// A provider is multi-field when its required credential keys are anything
+// other than the single primary key (Firebase: projectId + accessToken).
+function isMultiFieldCredential(dispatch: ProviderDispatch): boolean {
+  const req = dispatch.requiredCredentialFields
+  return !(req.length === 1 && req[0] === dispatch.primaryCredentialKey)
+}
+
+async function resolveOneCredentialRef(
+  provider: string,
+  field: string,
+  flagValue: string | undefined,
+  prompt: PromptFn | undefined,
+): Promise<string> {
+  if (flagValue !== undefined) return flagValue
+  const suggestion = suggestEnvRef(provider, field)
+  if (!prompt) {
+    throw new MisuseError(
+      `missing credential "${field}" — pass --credential-${toKebabFlag(field)} ${suggestion} (or run interactively)`,
+    )
+  }
+  // Env-ref is the default: the prompt offers `$VAR`, so an empty line stores
+  // a pointer. Typing a literal secret is the explicit plaintext opt-in.
+  const answer = await prompt(
+    `Credential for ${provider} "${field}" — an env-var reference like ${suggestion}, or a literal secret to store as plaintext`,
+    { default: suggestion },
+  )
+  return answer.length > 0 ? answer : suggestion
+}
+
+async function gatherCredential(
+  dispatch: ProviderDispatch,
+  flags: Record<string, string>,
+  prompt: PromptFn | undefined,
+): Promise<CredentialRef> {
+  const provider = dispatch.provider
+  if (!isMultiFieldCredential(dispatch)) {
+    const key = dispatch.primaryCredentialKey
+    const flagValue =
+      flags['credential'] ?? flags['token'] ?? flags[`credential-${toKebabFlag(key)}`]
+    return resolveOneCredentialRef(provider, key, flagValue, prompt)
+  }
+  const out: Record<string, string> = {}
+  for (const field of dispatch.requiredCredentialFields) {
+    const flagValue = flags[`credential-${toKebabFlag(field)}`]
+    out[field] = await resolveOneCredentialRef(provider, field, flagValue, prompt)
+  }
+  return out
+}
+
+// ── options handling ─────────────────────────────────────────────────────────
+
+async function gatherOptions(
+  dispatch: ProviderDispatch,
+  parsed: ParsedConnectorFlags,
+  prompt: PromptFn | undefined,
+): Promise<Record<string, unknown>> {
+  const options: Record<string, unknown> = {}
+
+  // A whole-object escape hatch first, then per-key overrides layered on top.
+  if (parsed.flags['options'] !== undefined) {
+    let base: unknown
+    try { base = JSON.parse(parsed.flags['options']) } catch (err) {
+      throw new MisuseError(`--options must be valid JSON: ${(err as Error).message}`)
+    }
+    if (typeof base !== 'object' || base === null || Array.isArray(base)) {
+      throw new MisuseError('--options must be a JSON object')
+    }
+    Object.assign(options, base)
+  }
+  for (const pair of parsed.optionPairs) {
+    const eq = pair.indexOf('=')
+    if (eq < 0) throw new MisuseError(`--option must be key=value, got "${pair}"`)
+    options[pair.slice(0, eq)] = parseScalarOrJson(pair.slice(eq + 1))
+  }
+
+  // Fill each required option field that flags didn't already supply.
+  for (const field of dispatch.requiredOptionFields) {
+    if (field in options) continue
+    const flagValue = parsed.flags[toKebabFlag(field)]
+    if (flagValue !== undefined) {
+      options[field] = parseScalarOrJson(flagValue)
+      continue
+    }
+    if (!prompt) {
+      throw new MisuseError(
+        `missing required option "${field}" for ${dispatch.provider} — pass --${toKebabFlag(field)} <value> (or run interactively)`,
+      )
+    }
+    const answer = await prompt(`${dispatch.provider} option "${field}" (JSON accepted for object values)`, {})
+    options[field] = parseScalarOrJson(answer)
+  }
+  return options
+}
+
+// ── id auto-slug ──────────────────────────────────────────────────────────────
+
+function slugify(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+}
+
+// Auto-slug from the provider, disambiguated by project when the plain slug is
+// taken, then by a numeric suffix (contract §1).
+function autoSlugId(provider: string, project: string | undefined, taken: Set<string>): string {
+  if (!taken.has(provider)) return provider
+  if (project) {
+    const withProject = `${provider}-${slugify(project)}`
+    if (!taken.has(withProject)) return withProject
+  }
+  let n = 2
+  while (taken.has(`${provider}-${n}`)) n++
+  return `${provider}-${n}`
+}
+
+// ── redaction (list / confirmations never print a resolved secret) ───────────
+
+interface RefStatus {
+  // What's safe to show: the `$VAR` pointer, or `****` for a stored literal.
+  display: string
+  // 'env-set' / 'env-unset' for a pointer; 'plaintext' for a stored literal.
+  kind: 'env-set' | 'env-unset' | 'plaintext'
+}
+
+function classifyRef(ref: string, env: NodeJS.ProcessEnv): RefStatus {
+  if (ref.length > 1 && ref.startsWith('$')) {
+    const name = ref.slice(1)
+    const value = env[name]
+    const set = value !== undefined && value.length > 0
+    return { display: ref, kind: set ? 'env-set' : 'env-unset' }
+  }
+  return { display: '****', kind: 'plaintext' }
+}
+
+function redactCredential(
+  credential: CredentialRef,
+  env: NodeJS.ProcessEnv,
+): { display: string; statuses: RefStatus[] } {
+  if (typeof credential === 'string') {
+    const s = classifyRef(credential, env)
+    return { display: s.display, statuses: [s] }
+  }
+  const parts: string[] = []
+  const statuses: RefStatus[] = []
+  for (const [field, ref] of Object.entries(credential)) {
+    const s = classifyRef(ref, env)
+    parts.push(`${field}=${s.display}`)
+    statuses.push(s)
+  }
+  return { display: `{ ${parts.join(', ')} }`, statuses }
+}
+
+function statusLabel(statuses: RefStatus[]): string {
+  if (statuses.some((s) => s.kind === 'env-unset')) return 'env unset'
+  if (statuses.every((s) => s.kind === 'plaintext')) return 'plaintext'
+  if (statuses.some((s) => s.kind === 'plaintext')) return 'mixed'
+  return 'env set'
+}
+
+// ── outcome messaging for validate (shared by add + test) ────────────────────
+
+type ValidateOutcome =
+  | { status: 'ok' }
+  | { status: 'unset-env'; message: string }
+  | { status: 'config'; message: string }
+  | { status: 'rejected'; message: string }
+
+async function runValidate(
+  entry: ConnectorEntry,
+  deps: ConnectorCliDeps,
+): Promise<ValidateOutcome> {
+  const validate = deps.validate ?? validateConnector
+  try {
+    await validate(entry, {})
+    return { status: 'ok' }
+  } catch (err) {
+    if (err instanceof EnvRefUnsetError) return { status: 'unset-env', message: err.message }
+    if (err instanceof ConnectorConfigError) return { status: 'config', message: err.message }
+    return { status: 'rejected', message: (err as Error).message }
+  }
+}
+
+// ── subcommands ──────────────────────────────────────────────────────────────
+
+const KNOWN_PROVIDERS = Object.keys(PROVIDER_DISPATCH).sort()
+
+async function resolveProvider(
+  positional: string | undefined,
+  prompt: PromptFn | undefined,
+): Promise<ProviderDispatch> {
+  let name = positional
+  if (!name) {
+    if (!prompt) {
+      throw new MisuseError(`missing <provider> — one of: ${KNOWN_PROVIDERS.join(', ')}`)
+    }
+    name = (await prompt(`Provider (one of: ${KNOWN_PROVIDERS.join(', ')})`, {})).trim()
+  }
+  const dispatch = getProviderDispatch(name)
+  if (!dispatch) {
+    throw new MisuseError(`unknown provider "${name}" — known providers: ${KNOWN_PROVIDERS.join(', ')}`)
+  }
+  return dispatch
+}
+
+async function connectorAdd(parsed: ParsedConnectorFlags, deps: ConnectorCliDeps): Promise<number> {
+  const dispatch = await resolveProvider(parsed.positionals[0], deps.prompt)
+  const provider = dispatch.provider
+
+  // Project is optional — an omitted project binds the connector to whichever
+  // project the daemon bootstraps (contract §1). Only prompt when interactive.
+  let project = parsed.flags['project']
+  if (project === undefined && deps.prompt) {
+    const answer = (await deps.prompt('Project name (blank binds to whatever project the daemon runs)', {})).trim()
+    if (answer.length > 0) project = answer
+  }
+
+  const credential = await gatherCredential(dispatch, parsed.flags, deps.prompt)
+  const options = await gatherOptions(dispatch, parsed, deps.prompt)
+
+  const config = await readConnectorsConfig(deps.home)
+  const taken = new Set(config.connectors.map((c) => c.id))
+  const id = parsed.flags['id'] ?? autoSlugId(provider, project, taken)
+
+  const entry: ConnectorEntry = {
+    id,
+    provider,
+    ...(project ? { project } : {}),
+    credential,
+    ...(Object.keys(options).length > 0 ? { options } : {}),
+  }
+
+  // Validate-on-add by default — a wrong credential fails here, before the
+  // entry is written, so it never surfaces quietly at the first poll (§4).
+  if (!parsed.skipValidate) {
+    const outcome = await runValidate(entry, deps)
+    if (outcome.status === 'unset-env') {
+      // Distinct from a validation failure: the token isn't wrong, the env var
+      // just isn't exported yet (§4). Nothing is written.
+      console.error(`neat connector add: ${outcome.message}`)
+      console.error(
+        `The credential points at an environment variable that isn't set. ` +
+          `Export it and re-run, or pass --skip-validate to add now and populate it before the daemon runs.`,
+      )
+      return 1
+    }
+    if (outcome.status === 'config') {
+      console.error(`neat connector add: ${outcome.message}`)
+      return 2
+    }
+    if (outcome.status === 'rejected') {
+      console.error(`neat connector add: ${provider} rejected the credential — ${outcome.message}`)
+      console.error('Fix the credential (or pass --skip-validate to add without checking).')
+      return 1
+    }
+  }
+
+  const { replaced } = await upsertConnectorEntry(entry, deps.home)
+
+  const { display } = redactCredential(credential, process.env)
+  const verb = replaced ? 'updated' : 'added'
+  console.log(`${verb} connector "${id}" (${provider}${project ? `, project ${project}` : ''})`)
+  console.log(`  credential: ${display}`)
+  if (parsed.skipValidate) {
+    console.log('  validation skipped (--skip-validate) — the daemon checks the credential at its next poll.')
+  } else {
+    console.log(`  validated: ${provider} accepted the credential.`)
+  }
+  console.log('Restart the project daemon to start polling this connector.')
+  return 0
+}
+
+async function connectorList(parsed: ParsedConnectorFlags, deps: ConnectorCliDeps): Promise<number> {
+  const config = await readConnectorsConfig(deps.home)
+  const filter = parsed.flags['project']
+  const entries = filter
+    ? config.connectors.filter((c) => c.project === filter)
+    : config.connectors
+
+  if (parsed.json) {
+    // Machine-readable, and still redacted — a resolved secret never leaves
+    // this process, JSON or not.
+    const rows = entries.map((c) => {
+      const { display, statuses } = redactCredential(c.credential, process.env)
+      return {
+        id: c.id,
+        provider: c.provider,
+        ...(c.project ? { project: c.project } : {}),
+        credential: display,
+        credentialStatus: statusLabel(statuses),
+      }
+    })
+    console.log(JSON.stringify(rows, null, 2))
+    return 0
+  }
+
+  if (entries.length === 0) {
+    console.log(
+      filter
+        ? `no connectors configured for project "${filter}".`
+        : 'no connectors configured. run `neat connector add <provider>` to add one.',
+    )
+    return 0
+  }
+  for (const c of entries) {
+    const { display, statuses } = redactCredential(c.credential, process.env)
+    const project = c.project ?? '(any project)'
+    console.log(`${c.id}\t${c.provider}\t${project}\t${display}\t[${statusLabel(statuses)}]`)
+  }
+  return 0
+}
+
+async function connectorRemove(parsed: ParsedConnectorFlags, deps: ConnectorCliDeps): Promise<number> {
+  const id = parsed.positionals[0]
+  if (!id) throw new MisuseError('missing <id> — run `neat connector list` to see configured ids')
+  const removed = await removeConnectorEntry(id, deps.home)
+  if (!removed) {
+    console.error(`neat connector remove: no connector with id "${id}".`)
+    return 1
+  }
+  console.log(`removed connector "${id}" (${removed.provider}).`)
+  return 0
+}
+
+async function connectorTest(parsed: ParsedConnectorFlags, deps: ConnectorCliDeps): Promise<number> {
+  const id = parsed.positionals[0]
+  if (!id) throw new MisuseError('missing <id> — run `neat connector list` to see configured ids')
+  const config = await readConnectorsConfig(deps.home)
+  const entry = config.connectors.find((c) => c.id === id)
+  if (!entry) {
+    console.error(`neat connector test: no connector with id "${id}".`)
+    return 1
+  }
+
+  const outcome = await runValidate(entry, deps)
+  if (outcome.status === 'ok') {
+    console.log(`ok: "${id}" (${entry.provider}) — the provider accepted the credential.`)
+    return 0
+  }
+  if (outcome.status === 'unset-env') {
+    console.error(`neat connector test: ${outcome.message}`)
+    console.error('The credential points at an environment variable that is not set — export it and re-run.')
+    return 1
+  }
+  if (outcome.status === 'config') {
+    console.error(`neat connector test: ${outcome.message}`)
+    return 2
+  }
+  console.error(`neat connector test: ${entry.provider} rejected the credential — ${outcome.message}`)
+  return 1
+}
+
+// ── entry point ──────────────────────────────────────────────────────────────
+
+function printConnectorUsage(): void {
+  console.log('usage: neat connector <add|list|remove|test> [args]')
+  console.log('')
+  console.log('  add <provider>     Add a connector. Prompts for missing fields, or takes them as flags.')
+  console.log(`                     providers: ${KNOWN_PROVIDERS.join(', ')}`)
+  console.log('                     Flags: --project <name>  --id <id>')
+  console.log('                            --credential <$VAR|secret>  (alias --token; --credential-<field> for multi-field)')
+  console.log('                            --<option> <value>  --option key=value  --options <json>')
+  console.log('                            --skip-validate   add without the auth round-trip')
+  console.log('                     A credential defaults to an env-var reference ($VAR); a literal value is stored plaintext.')
+  console.log('  list               List configured connectors (credentials shown redacted). Flags: --project <name>  --json')
+  console.log('  remove <id>        Remove a connector by id.')
+  console.log('  test <id>          Re-run the auth round-trip against a configured connector.')
+}
+
+/**
+ * `neat connector ...` — args are the tokens after `connector`. Returns a
+ * process exit code (0 ok, 1 failure, 2 misuse) so the CLI dispatcher can
+ * `process.exit` on it, matching the query verbs.
+ */
+export async function runConnectorCommand(
+  args: string[],
+  deps: ConnectorCliDeps = {},
+): Promise<number> {
+  const sub = args[0]
+  if (!sub || sub === '-h' || sub === '--help') {
+    printConnectorUsage()
+    return sub ? 0 : 2
+  }
+
+  // Prompting is available only on a real TTY unless a prompt was injected
+  // (tests). Off a TTY with no flags, a missing field is a clear misuse error
+  // rather than a hung read.
+  const resolvedDeps: ConnectorCliDeps = {
+    ...deps,
+    prompt: deps.prompt ?? (process.stdin.isTTY ? defaultPrompt : undefined),
+  }
+
+  let parsed: ParsedConnectorFlags
+  try {
+    parsed = parseConnectorFlags(args.slice(1))
+  } catch (err) {
+    if (err instanceof MisuseError) {
+      console.error(`neat connector ${sub}: ${err.message}`)
+      return 2
+    }
+    throw err
+  }
+
+  try {
+    switch (sub) {
+      case 'add': return await connectorAdd(parsed, resolvedDeps)
+      case 'list': return await connectorList(parsed, resolvedDeps)
+      case 'remove': return await connectorRemove(parsed, resolvedDeps)
+      case 'test': return await connectorTest(parsed, resolvedDeps)
+      default:
+        console.error(`neat connector: unknown subcommand "${sub}"`)
+        printConnectorUsage()
+        return 2
+    }
+  } catch (err) {
+    if (err instanceof MisuseError) {
+      console.error(`neat connector ${sub}: ${err.message}`)
+      return 2
+    }
+    console.error(`neat connector ${sub}: ${(err as Error).message}`)
+    return 1
+  }
+}
+
+// Real interactive prompt — one line off stdin, with a bracketed default an
+// empty answer falls back to. Only wired when stdin is a TTY.
+const defaultPrompt: PromptFn = async (question, opts) => {
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    const suffix = opts?.default ? ` [${opts.default}]` : ''
+    const answer = (await rl.question(`${question}${suffix}: `)).trim()
+    return answer.length === 0 && opts?.default ? opts.default : answer
+  } finally {
+    rl.close()
+  }
+}

--- a/packages/core/src/connectors-config.ts
+++ b/packages/core/src/connectors-config.ts
@@ -287,3 +287,134 @@ function resolveRef(value: string, env: NodeJS.ProcessEnv): string {
 export function connectorMatchesProject(entry: ConnectorEntry, project: string): boolean {
   return entry.project === undefined || entry.project === project
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// Writing `~/.neat/connectors.json` — atomic, 0600, flock (contract §1).
+//
+// This is the write half of the seam the reader above owns: `neat connector
+// add/remove` (cli, connectors-cli.ts) call these to mutate the file, never
+// touching disk themselves. Every write matches the project registry's
+// discipline — tmp + fsync + rename so a reader never sees a half-written
+// file, an exclusive lock so two concurrent writers can't clobber each other
+// — plus the one guarantee this file's secrets demand and the project
+// registry doesn't: mode `0600`, set explicitly on the bytes we create rather
+// than left to the umask.
+// ─────────────────────────────────────────────────────────────────────────
+
+const LOCK_TIMEOUT_MS = 5_000
+const LOCK_RETRY_MS = 50
+const CONNECTORS_FILE_MODE = 0o600
+
+export function connectorsConfigLockPath(home: string = neatHome()): string {
+  return `${connectorsConfigPath(home)}.lock`
+}
+
+// tmp + fchmod(0600) + fsync + rename. The mode is stamped on the temp file's
+// own fd before the rename swaps it into place, so the secret-bearing file is
+// never even briefly readable by group/other — rename is atomic on POSIX and
+// carries the temp inode's 0600 across. Mirrors registry.ts's writeAtomically,
+// with the explicit mode this file's contents require.
+async function writeConnectorsFileAtomically(target: string, contents: string): Promise<void> {
+  await fs.mkdir(path.dirname(target), { recursive: true })
+  const tmp = `${target}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`
+  const fd = await fs.open(tmp, 'w', CONNECTORS_FILE_MODE)
+  try {
+    await fd.chmod(CONNECTORS_FILE_MODE)
+    await fd.writeFile(contents, 'utf8')
+    await fd.sync()
+  } finally {
+    await fd.close()
+  }
+  await fs.rename(tmp, target)
+}
+
+// Exclusive-create lock, the cross-platform flock(LOCK_EX) equivalent the
+// project registry uses (registry.ts) — deliberately not the registry's own
+// daemon-aware classifier, because the daemon only ever *reads* this file, so
+// a live daemon is never the lock holder here. A plain timeout is the whole
+// story.
+async function acquireConnectorsLock(lockPath: string, timeoutMs = LOCK_TIMEOUT_MS): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  await fs.mkdir(path.dirname(lockPath), { recursive: true })
+  for (;;) {
+    try {
+      const fd = await fs.open(lockPath, 'wx')
+      await fd.close()
+      return
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `neat connectors: timed out after ${timeoutMs}ms waiting for ${lockPath}. ` +
+            'Another neat command is writing the connector config; if none is, remove the file by hand.',
+        )
+      }
+      await new Promise((r) => setTimeout(r, LOCK_RETRY_MS))
+    }
+  }
+}
+
+async function withConnectorsLock<T>(home: string, fn: () => Promise<T>): Promise<T> {
+  const lock = connectorsConfigLockPath(home)
+  await acquireConnectorsLock(lock)
+  try {
+    return await fn()
+  } finally {
+    await fs.unlink(lock).catch(() => {})
+  }
+}
+
+/**
+ * Overwrite `~/.neat/connectors.json` with `config`, atomically and at `0600`.
+ * Re-validates the shape on the way out so a caller mutating the in-memory
+ * object can't write a file the reader would then reject. Not lock-wrapped
+ * itself — the read-modify-write helpers below hold the lock across their
+ * whole cycle.
+ */
+export async function writeConnectorsConfig(
+  config: ConnectorsConfig,
+  home: string = neatHome(),
+): Promise<void> {
+  const validated = validateConfig(config, connectorsConfigPath(home))
+  const body = JSON.stringify({ version: validated.version, connectors: validated.connectors }, null, 2) + '\n'
+  await writeConnectorsFileAtomically(connectorsConfigPath(home), body)
+}
+
+/**
+ * Add `entry`, or replace the existing entry with the same `id` in place. The
+ * whole read-modify-write runs under the file lock so a concurrent `add` /
+ * `remove` can't lose an entry. Returns whether an existing entry was replaced
+ * (`false` means it was appended) so the CLI can word its confirmation.
+ */
+export async function upsertConnectorEntry(
+  entry: ConnectorEntry,
+  home: string = neatHome(),
+): Promise<{ replaced: boolean }> {
+  return withConnectorsLock(home, async () => {
+    const config = await readConnectorsConfig(home)
+    const idx = config.connectors.findIndex((c) => c.id === entry.id)
+    const replaced = idx >= 0
+    if (replaced) config.connectors[idx] = entry
+    else config.connectors.push(entry)
+    await writeConnectorsConfig(config, home)
+    return { replaced }
+  })
+}
+
+/**
+ * Remove the entry with `id`. Returns the removed entry, or `undefined` when
+ * no entry carried that id (the CLI turns that into a clear "no such id").
+ */
+export async function removeConnectorEntry(
+  id: string,
+  home: string = neatHome(),
+): Promise<ConnectorEntry | undefined> {
+  return withConnectorsLock(home, async () => {
+    const config = await readConnectorsConfig(home)
+    const idx = config.connectors.findIndex((c) => c.id === id)
+    if (idx < 0) return undefined
+    const [removed] = config.connectors.splice(idx, 1)
+    await writeConnectorsConfig(config, home)
+    return removed
+  })
+}

--- a/packages/core/src/connectors/registry.ts
+++ b/packages/core/src/connectors/registry.ts
@@ -17,8 +17,9 @@
 // and builds every entry that matches a project. The daemon calls the latter
 // at slot bootstrap.
 
-import type { NeatGraph } from '../graph.js'
+import { createEmptyGraph, type NeatGraph } from '../graph.js'
 import type { ConnectorRegistration, ObservedConnector, ResolveConnectorTarget } from './index.js'
+import type { ConnectorContext } from './types.js'
 import { createSupabaseConnector, type SupabaseConnectorConfig } from './supabase/index.js'
 import {
   createRailwayConnector,
@@ -245,4 +246,75 @@ export async function loadConnectorRegistrations(
     else onSkip?.(entry, result.reason)
   }
   return registrations
+}
+
+// ── validate-on-add / `neat connector test` (contract §4) ─────────────────
+//
+// `add` and `test` share one round-trip: resolve the entry's credential, build
+// the connector through the dispatch table, and drive one real `poll()` — the
+// connector's own auth path, through the shared junction (ADR-131). Three
+// outcomes stay distinct, because conflating them lies to the user:
+//
+//   • the credential's env-ref is unset  → EnvRefUnsetError, message
+//     "$VAR is unset" — a resolution problem, not a wrong token (§4).
+//   • the entry is misconfigured         → ConnectorConfigError — unknown
+//     provider, or a required credential/option field missing.
+//   • the provider rejects the credential → the poll's own thrown Error — the
+//     real "your token is wrong" validation failure.
+//
+// A clean return means the provider accepted the credential.
+
+/**
+ * The entry names an unknown provider, or is missing a required credential /
+ * option field — a config-shape problem the CLI surfaces differently from a
+ * provider rejecting a well-formed credential.
+ */
+export class ConnectorConfigError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ConnectorConfigError'
+  }
+}
+
+export interface ValidateConnectorOptions {
+  // The project root a poll's `ConnectorContext` reports. The auth round-trip
+  // never reads a file under it, so it's cosmetic here; defaults to cwd.
+  projectDir?: string
+  env?: NodeJS.ProcessEnv
+}
+
+// A one-minute lookback keeps the validate poll's provider-side query as small
+// as the API allows — this is an auth check, not a backfill.
+const VALIDATE_LOOKBACK_MS = 60_000
+
+/**
+ * Run the validate round-trip for one entry (contract §4). Throws
+ * `EnvRefUnsetError` when the credential's env-ref is unset, `ConnectorConfigError`
+ * when the entry is misconfigured, and the provider's own `Error` when the
+ * credential is rejected. Returns cleanly when the provider accepted it.
+ */
+export async function validateConnector(
+  entry: ConnectorEntry,
+  options: ValidateConnectorOptions = {},
+): Promise<void> {
+  const env = options.env ?? process.env
+  // Resolve first so an unset env-ref is its own named failure, never mistaken
+  // for a rejected credential (§4). Throws EnvRefUnsetError; the value is
+  // discarded — buildRegistration resolves it again into the credentials record.
+  resolveCredential(entry.credential, env)
+
+  // Build through the dispatch table — the same normalization the daemon uses
+  // — so a missing field or unknown provider fails here, before any network.
+  const graph = createEmptyGraph()
+  const result = buildRegistration(entry, graph, env)
+  if (!result.ok) throw new ConnectorConfigError(result.reason)
+
+  const ctx: ConnectorContext = {
+    projectDir: options.projectDir ?? process.cwd(),
+    credentials: result.registration.credentials,
+    since: new Date(Date.now() - VALIDATE_LOOKBACK_MS).toISOString(),
+  }
+  // The cheap auth round-trip: the connector's own poll(), through the shared
+  // junction. A rejected credential throws the provider's own error here.
+  await result.registration.connector.poll(ctx)
 }

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -37,6 +37,15 @@ export function getGraph(project: string = DEFAULT_PROJECT): NeatGraph {
   return g
 }
 
+// A standalone graph that lives outside the per-project map — for callers that
+// need a graph object without registering a project slot. `neat connector`'s
+// validate round-trip uses one: building a connector needs a graph to close
+// its `resolveTarget` over, but the credential check never touches it, so a
+// throwaway keeps the CLI from polluting `graphs` with a fake project.
+export function createEmptyGraph(): NeatGraph {
+  return makeGraph()
+}
+
 export function hasProject(project: string): boolean {
   return graphs.has(project)
 }

--- a/packages/core/test/connectors-cli.test.ts
+++ b/packages/core/test/connectors-cli.test.ts
@@ -1,0 +1,403 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import os from 'node:os'
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import { runConnectorCommand, type PromptFn } from '../src/connectors-cli.js'
+import {
+  validateConnector,
+  ConnectorConfigError,
+} from '../src/connectors/registry.js'
+import {
+  EnvRefUnsetError,
+  readConnectorsConfig,
+  connectorsConfigPath,
+  type ConnectorEntry,
+} from '../src/connectors-config.js'
+
+// docs/contracts/connector-config.md §3 (the neat connector command family),
+// §4 (validate-on-add default; "$VAR is unset" ≠ validation failure), §2
+// (env-ref default, plaintext opt-in, redaction). These drive the exported
+// `runConnectorCommand` against an isolated temp NEAT_HOME — no real ~/.neat,
+// no live provider account. The provider auth round-trip is either an injected
+// fake (CLI-level tests) or a stubbed global fetch (validateConnector tests).
+
+let home: string
+let logSpy: ReturnType<typeof vi.spyOn>
+let errSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(async () => {
+  home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'neat-connector-cli-')))
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await fs.rm(home, { recursive: true, force: true }).catch(() => {})
+})
+
+function logged(): string {
+  return logSpy.mock.calls.map((c) => c.map((x) => String(x)).join(' ')).join('\n')
+}
+function errored(): string {
+  return errSpy.mock.calls.map((c) => c.map((x) => String(x)).join(' ')).join('\n')
+}
+async function readEntries(): Promise<ConnectorEntry[]> {
+  return (await readConnectorsConfig(home)).connectors
+}
+// A validate that always accepts — the injected stand-in for a real round-trip.
+const validateOk = async (): Promise<void> => {}
+// A prompt that answers from a queue, in ask order.
+function queuedPrompt(answers: string[]): PromptFn {
+  let i = 0
+  return async () => answers[i++] ?? ''
+}
+
+describe('neat connector add', () => {
+  it('stores an env-ref credential as a pointer, never a resolved secret', async () => {
+    // The env var is set, but the file must still hold the pointer, not the value.
+    process.env.CLI_TEST_CF = 'cf_secret_value'
+    try {
+      const code = await runConnectorCommand(
+        ['add', 'cloudflare', '--account-id', 'a1', '--workers', '{}', '--credential', '$CLI_TEST_CF'],
+        { home, validate: validateOk },
+      )
+      expect(code).toBe(0)
+      const entries = await readEntries()
+      expect(entries).toHaveLength(1)
+      expect(entries[0].credential).toBe('$CLI_TEST_CF')
+      // The resolved secret never appears on disk or in the confirmation.
+      const raw = await fs.readFile(connectorsConfigPath(home), 'utf8')
+      expect(raw).not.toContain('cf_secret_value')
+      expect(logged()).not.toContain('cf_secret_value')
+    } finally {
+      delete process.env.CLI_TEST_CF
+    }
+  })
+
+  it('stores a plaintext credential as a literal (explicit opt-in)', async () => {
+    const code = await runConnectorCommand(
+      ['add', 'railway', '--environment-id', 'e', '--service-id', 's', '--service-name-by-id', '{"s":"api"}', '--token', 'railway_literal'],
+      { home, validate: validateOk },
+    )
+    expect(code).toBe(0)
+    const entries = await readEntries()
+    expect(entries[0].credential).toBe('railway_literal')
+    // But it's never printed back — the confirmation redacts it to ****.
+    expect(logged()).toContain('****')
+    expect(logged()).not.toContain('railway_literal')
+  })
+
+  it('auto-slugs the id from the provider, disambiguating by project on collision', async () => {
+    await runConnectorCommand(
+      ['add', 'cloudflare', '--account-id', 'a1', '--workers', '{}', '--credential', '$X1', '--project', 'brief', '--skip-validate'],
+      { home },
+    )
+    await runConnectorCommand(
+      ['add', 'cloudflare', '--account-id', 'a2', '--workers', '{}', '--credential', '$X2', '--project', 'newdryve', '--skip-validate'],
+      { home },
+    )
+    await runConnectorCommand(
+      ['add', 'cloudflare', '--account-id', 'a3', '--workers', '{}', '--credential', '$X3', '--skip-validate'],
+      { home },
+    )
+    const ids = (await readEntries()).map((e) => e.id)
+    expect(ids).toEqual(['cloudflare', 'cloudflare-newdryve', 'cloudflare-2'])
+  })
+
+  it('honors an explicit --id', async () => {
+    await runConnectorCommand(
+      ['add', 'cloudflare', '--id', 'cf-primary', '--account-id', 'a', '--workers', '{}', '--credential', '$X', '--skip-validate'],
+      { home },
+    )
+    expect((await readEntries())[0].id).toBe('cf-primary')
+  })
+
+  it('an unset env-ref is a distinct failure, not a validation failure, and writes nothing', async () => {
+    // No --skip-validate → validate runs. The var is unset, so the real
+    // validateConnector throws EnvRefUnsetError before any network call.
+    delete process.env.CLI_TEST_UNSET
+    const code = await runConnectorCommand(
+      ['add', 'cloudflare', '--account-id', 'a', '--workers', '{}', '--credential', '$CLI_TEST_UNSET'],
+      { home }, // real validate, no inject
+    )
+    expect(code).toBe(1)
+    expect(errored()).toContain('$CLI_TEST_UNSET is unset')
+    // The message is about an unset variable, not a rejected credential.
+    expect(errored()).not.toMatch(/rejected/i)
+    // Nothing was written.
+    expect(await readEntries()).toEqual([])
+  })
+
+  it('a provider rejecting the credential is a validation failure that writes nothing', async () => {
+    const rejecting = async (): Promise<void> => {
+      throw new Error('telemetry query failed (401 Unauthorized)')
+    }
+    const code = await runConnectorCommand(
+      ['add', 'cloudflare', '--account-id', 'a', '--workers', '{}', '--credential', '$SET_TOKEN'],
+      { home, validate: rejecting },
+    )
+    expect(code).toBe(1)
+    expect(errored()).toMatch(/rejected the credential/)
+    expect(errored()).toContain('401')
+    expect(await readEntries()).toEqual([])
+  })
+
+  it('--skip-validate bypasses the round-trip and writes even with an unset env-ref', async () => {
+    delete process.env.CLI_TEST_UNSET2
+    const validate = vi.fn(validateOk)
+    const code = await runConnectorCommand(
+      ['add', 'cloudflare', '--account-id', 'a', '--workers', '{}', '--credential', '$CLI_TEST_UNSET2', '--skip-validate'],
+      { home, validate },
+    )
+    expect(code).toBe(0)
+    expect(validate).not.toHaveBeenCalled()
+    expect(await readEntries()).toHaveLength(1)
+    expect(logged()).toMatch(/validation skipped/)
+  })
+
+  it('writes the file at mode 0600', async () => {
+    await runConnectorCommand(
+      ['add', 'cloudflare', '--account-id', 'a', '--workers', '{}', '--credential', '$X', '--skip-validate'],
+      { home },
+    )
+    if (process.platform === 'win32') return
+    const stat = await fs.stat(connectorsConfigPath(home))
+    expect((stat.mode & 0o777).toString(8)).toBe('600')
+  })
+
+  it('leaves no temp file behind after an atomic write', async () => {
+    await runConnectorCommand(
+      ['add', 'cloudflare', '--account-id', 'a', '--workers', '{}', '--credential', '$X', '--skip-validate'],
+      { home },
+    )
+    const files = await fs.readdir(home)
+    expect(files.filter((f) => f.includes('.tmp'))).toEqual([])
+  })
+
+  it('gathers missing fields through interactive prompts', async () => {
+    // `add cloudflare` with no flags → prompts for project, credential, then
+    // each required option in order.
+    const prompt = queuedPrompt(['brief', '$CF_TOKEN', 'acct-9', '{}'])
+    const code = await runConnectorCommand(['add', 'cloudflare'], { home, prompt, validate: validateOk })
+    expect(code).toBe(0)
+    const entry = (await readEntries())[0]
+    expect(entry.provider).toBe('cloudflare')
+    expect(entry.project).toBe('brief')
+    expect(entry.credential).toBe('$CF_TOKEN')
+    expect(entry.options).toMatchObject({ accountId: 'acct-9', workers: {} })
+  })
+
+  it('errors (misuse) when a required field is missing and no prompt is available', async () => {
+    const code = await runConnectorCommand(
+      ['add', 'cloudflare', '--credential', '$X', '--skip-validate'], // accountId + workers missing, no prompt
+      { home },
+    )
+    expect(code).toBe(2)
+    expect(errored()).toMatch(/missing required option/)
+    expect(await readEntries()).toEqual([])
+  })
+
+  it('rejects an unknown provider as misuse', async () => {
+    const code = await runConnectorCommand(['add', 'notaprovider', '--credential', '$X'], { home })
+    expect(code).toBe(2)
+    expect(errored()).toMatch(/unknown provider/)
+  })
+
+  it('gathers a multi-field firebase credential as an object of pointers', async () => {
+    const code = await runConnectorCommand(
+      ['add', 'firebase', '--credential-project-id', '$FB_PROJECT', '--credential-access-token', '$FB_TOKEN', '--skip-validate'],
+      { home },
+    )
+    expect(code).toBe(0)
+    expect((await readEntries())[0].credential).toEqual({
+      projectId: '$FB_PROJECT',
+      accessToken: '$FB_TOKEN',
+    })
+  })
+})
+
+describe('neat connector list', () => {
+  beforeEach(async () => {
+    await runConnectorCommand(
+      ['add', 'cloudflare', '--account-id', 'a', '--workers', '{}', '--credential', '$CF_LIST', '--project', 'brief', '--skip-validate'],
+      { home },
+    )
+    await runConnectorCommand(
+      ['add', 'railway', '--environment-id', 'e', '--service-id', 's', '--service-name-by-id', '{"s":"api"}', '--token', 'railway_plain_secret', '--skip-validate'],
+      { home },
+    )
+    logSpy.mockClear()
+  })
+
+  it('shows each entry with its credential redacted — never a resolved secret', async () => {
+    process.env.CF_LIST = 'cf_resolved_value'
+    try {
+      const code = await runConnectorCommand(['list'], { home })
+      expect(code).toBe(0)
+      const out = logged()
+      expect(out).toContain('$CF_LIST') // the pointer is safe to show
+      expect(out).toContain('****') // the plaintext literal is masked
+      expect(out).not.toContain('cf_resolved_value') // never the resolved value
+      expect(out).not.toContain('railway_plain_secret') // never the literal
+    } finally {
+      delete process.env.CF_LIST
+    }
+  })
+
+  it('reports env-ref resolution status per entry', async () => {
+    delete process.env.CF_LIST
+    await runConnectorCommand(['list'], { home })
+    expect(logged()).toMatch(/env unset/)
+  })
+
+  it('--json stays redacted', async () => {
+    process.env.CF_LIST = 'cf_resolved_value'
+    try {
+      await runConnectorCommand(['list', '--json'], { home })
+      const out = logged()
+      const rows = JSON.parse(out)
+      expect(rows).toHaveLength(2)
+      expect(out).not.toContain('cf_resolved_value')
+      expect(out).not.toContain('railway_plain_secret')
+    } finally {
+      delete process.env.CF_LIST
+    }
+  })
+
+  it('filters by --project', async () => {
+    await runConnectorCommand(['list', '--project', 'brief'], { home })
+    const out = logged()
+    expect(out).toContain('cloudflare')
+    expect(out).not.toContain('railway')
+  })
+})
+
+describe('neat connector remove', () => {
+  beforeEach(async () => {
+    await runConnectorCommand(
+      ['add', 'cloudflare', '--id', 'cf-1', '--account-id', 'a', '--workers', '{}', '--credential', '$X', '--skip-validate'],
+      { home },
+    )
+    logSpy.mockClear()
+  })
+
+  it('removes by id', async () => {
+    const code = await runConnectorCommand(['remove', 'cf-1'], { home })
+    expect(code).toBe(0)
+    expect(logged()).toContain('removed connector "cf-1"')
+    expect(await readEntries()).toEqual([])
+  })
+
+  it('reports a clear error for an unknown id and keeps the file intact', async () => {
+    const code = await runConnectorCommand(['remove', 'ghost'], { home })
+    expect(code).toBe(1)
+    expect(errored()).toContain('no connector with id "ghost"')
+    expect(await readEntries()).toHaveLength(1)
+  })
+
+  it('is misuse without an id', async () => {
+    const code = await runConnectorCommand(['remove'], { home })
+    expect(code).toBe(2)
+    expect(errored()).toMatch(/missing <id>/)
+  })
+})
+
+describe('neat connector test', () => {
+  beforeEach(async () => {
+    await runConnectorCommand(
+      ['add', 'cloudflare', '--id', 'cf-1', '--account-id', 'a', '--workers', '{}', '--credential', '$CF_TEST', '--skip-validate'],
+      { home },
+    )
+    logSpy.mockClear()
+    errSpy.mockClear()
+  })
+
+  it('reports ok when the provider accepts the credential', async () => {
+    const code = await runConnectorCommand(['test', 'cf-1'], { home, validate: validateOk })
+    expect(code).toBe(0)
+    expect(logged()).toMatch(/^ok: "cf-1"/)
+  })
+
+  it('reports an unset env-ref distinctly from a rejection', async () => {
+    const unset = async (): Promise<void> => {
+      throw new EnvRefUnsetError('$CF_TEST', 'CF_TEST')
+    }
+    const code = await runConnectorCommand(['test', 'cf-1'], { home, validate: unset })
+    expect(code).toBe(1)
+    expect(errored()).toContain('$CF_TEST is unset')
+    expect(errored()).not.toMatch(/rejected/i)
+  })
+
+  it('reports a rejected credential as a validation failure', async () => {
+    const rejecting = async (): Promise<void> => {
+      throw new Error('telemetry query failed (403 Forbidden)')
+    }
+    const code = await runConnectorCommand(['test', 'cf-1'], { home, validate: rejecting })
+    expect(code).toBe(1)
+    expect(errored()).toMatch(/rejected the credential/)
+    expect(errored()).toContain('403')
+  })
+
+  it('errors when the id is unknown', async () => {
+    const code = await runConnectorCommand(['test', 'nope'], { home })
+    expect(code).toBe(1)
+    expect(errored()).toContain('no connector with id "nope"')
+  })
+})
+
+// The validate round-trip itself (registry.ts), exercised through a stubbed
+// global fetch so the connector's own poll()/auth path runs end to end without
+// a live Cloudflare account. junctionFetch reads globalThis.fetch at call time.
+describe('validateConnector round-trip (contract §4)', () => {
+  const cfEntry: ConnectorEntry = {
+    id: 'cf',
+    provider: 'cloudflare',
+    credential: '$CF_VALIDATE',
+    options: { accountId: 'acct', workers: {} },
+  }
+
+  function fakeResponse(status: number, body: unknown): Response {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? 'OK' : 'Unauthorized',
+      json: async () => body,
+    } as unknown as Response
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('resolves when the provider accepts the credential (200)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => fakeResponse(200, { success: true, result: { events: { events: [] } } })),
+    )
+    await expect(
+      validateConnector(cfEntry, { env: { CF_VALIDATE: 'good_token' } }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('throws the provider error when the credential is rejected (401)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => fakeResponse(401, { success: false, errors: [{ message: 'bad token' }] })))
+    await expect(
+      validateConnector(cfEntry, { env: { CF_VALIDATE: 'wrong_token' } }),
+    ).rejects.toThrow(/telemetry query failed \(401/)
+  })
+
+  it('throws EnvRefUnsetError (distinct) when the env-ref is unset — before any fetch', async () => {
+    const fetchSpy = vi.fn(async () => fakeResponse(200, {}))
+    vi.stubGlobal('fetch', fetchSpy)
+    await expect(validateConnector(cfEntry, { env: {} })).rejects.toBeInstanceOf(EnvRefUnsetError)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('throws ConnectorConfigError for a misconfigured entry (missing option)', async () => {
+    const bad: ConnectorEntry = { id: 'x', provider: 'cloudflare', credential: '$CF_VALIDATE', options: {} }
+    await expect(
+      validateConnector(bad, { env: { CF_VALIDATE: 'tok' } }),
+    ).rejects.toBeInstanceOf(ConnectorConfigError)
+  })
+})


### PR DESCRIPTION
The write side of the ADR-130 connector on-ramp — the `neat connector` verb family a human runs to point a built connector at a project. It builds directly on the read side from #730 (which already reads `~/.neat/connectors.json`, resolves env-refs, and normalizes the four provider factories through the dispatch table), so this only adds the verbs on top.

**What lands**

- `neat connector add <provider>` — gathers the provider's fields from interactive prompts or flags (`--project`, `--credential`/`--token`, per-provider option flags, `--id`, `--skip-validate`). The credential defaults to an env-var pointer (`$VAR`); a literal value is the explicit plaintext opt-in. Validate-on-add runs by default: a cheap round-trip through the connector's own `poll()` auth path (via the shared junction) confirms the credential before the entry is written. `--skip-validate` bypasses it for the offline / env-not-yet-set case. The `id` auto-slugs from the provider, disambiguated by project then a numeric suffix.
- An **unset env-ref is a distinct failure** — `"$SUPABASE_KEY is unset"`, kept apart from a credential the provider rejects, so a user who forgot to `export` isn't told their token is wrong.
- Writes go through the config module atomically at **mode 0600** under a lock, and never into the snapshot.
- `neat connector list` — every entry with its credential **redacted** (the `$VAR` pointer, or `****` for a stored literal — never a resolved secret) plus env-ref set/unset status; `--json` stays redacted too.
- `neat connector remove <id>` — clear "no such id"; atomic rewrite.
- `neat connector test <id>` — re-runs the validate round-trip against an existing entry, reporting ok / unset-env / rejected distinctly.

The validate round-trip lives in `registry.ts` (the dispatch table) and is shared by `add` and `test`; the file writers live in `connectors-config.ts` (the module that already owns reading that file). No per-provider branch in the CLI — provider specifics stay in the dispatch table.

Tests cover add (env-ref stored as a pointer, plaintext opt-in, auto-slug, unset-env distinct from validation-failure, `--skip-validate` bypass, 0600 write, interactive prompts), list (redaction), remove (by id / missing id), test (ok / unset / rejected), and the `validateConnector` round-trip end to end through a stubbed global fetch — no live provider accounts.

Refs #728, #730