### PR TITLE
Give the four operation node types their own canvas shapes

### DIFF
--- a/packages/web/app/components/GraphCanvas.tsx
+++ b/packages/web/app/components/GraphCanvas.tsx
@@ -8,6 +8,7 @@ import {
   buildModel,
   compoundElements,
   degreeByNode,
+  isObservedNode,
   type FileFirstModel,
 } from './graph-model'
 import { ObservedOverlay, type ObservedMode } from './ObservedOverlay'
@@ -141,6 +142,23 @@ export function GraphCanvas({
         selector: 'node.k-frontier',
         style: { shape: 'diamond', 'border-style': 'dashed', 'border-color': muted },
       },
+      // -- operation nodes: the interesting OBSERVED surface (the routes,
+      //    operations, methods, and channels a service actually serves).
+      //    Distinct stroked shapes; tinted the OBSERVED green once runtime has
+      //    spoken for them (.obs), left muted while only declared.
+      // route — rhomboid (an HTTP endpoint / entry point)
+      { selector: 'node.k-route', style: { shape: 'rhomboid', 'border-color': muted } },
+      // graphql operation — pentagon (nods to the GraphQL mark)
+      { selector: 'node.k-graphql', style: { shape: 'pentagon', 'border-color': muted } },
+      // grpc method — round-triangle (a dispatched call)
+      { selector: 'node.k-grpc', style: { shape: 'round-triangle', 'border-color': muted } },
+      // websocket channel — cut-rectangle (a socket / channel port)
+      { selector: 'node.k-ws', style: { shape: 'cut-rectangle', 'border-color': muted } },
+      // observed operation node — the runtime layer, so the one accent applies
+      {
+        selector: 'node.k-route.obs, node.k-graphql.obs, node.k-grpc.obs, node.k-ws.obs',
+        style: { 'border-color': observed, color: observed },
+      },
       // service — compound container (round-rectangle). Files nest inside.
       {
         selector: 'node.k-service',
@@ -236,8 +254,8 @@ export function GraphCanvas({
     ]
   }, [])
 
-  const nodeClasses = (kind: string, isHub: boolean) =>
-    `k-${kind}${isHub ? ' is-hub' : ''}`
+  const nodeClasses = (kind: string, isHub: boolean, observed = false) =>
+    `k-${kind}${isHub ? ' is-hub' : ''}${observed ? ' obs' : ''}`
   const edgeClasses = (prov: string, coarse: boolean) =>
     `p-${visualProv(prov)}${coarse ? ' coarse' : ''}`
 
@@ -308,7 +326,7 @@ export function GraphCanvas({
         add.push({
           group: 'nodes',
           data: { ...el.data, _size: sizeFor(kind, d) },
-          classes: nodeClasses(kind, d >= hubCut),
+          classes: nodeClasses(kind, d >= hubCut, Boolean(el.data._observed)),
         })
       } else {
         add.push({
@@ -347,6 +365,7 @@ export function GraphCanvas({
       const parent =
         n.type === 'FileNode' ? model.serviceByFile.get(n.id) : undefined
       const near = neighborPosition(cy, full, n.id)
+      const observed = isObservedNode(n)
       fresh.push({
         group: 'nodes',
         data: {
@@ -354,11 +373,12 @@ export function GraphCanvas({
           label: labelOf(n),
           _nodeType: n.type,
           _kind: kind,
+          _observed: observed,
           _size: sizeFor(kind, 1),
           ...(parent && cy.getElementById(parent).nonempty() ? { parent } : {}),
           _raw: n,
         },
-        classes: nodeClasses(kind, false) + ' pulse',
+        classes: nodeClasses(kind, false, observed) + ' pulse',
         ...(near ? { position: near } : {}),
       })
     }
@@ -667,7 +687,10 @@ export function GraphCanvas({
         <div className="legend-row"><span className="swatch" /><span className="name">Extracted</span></div>
         <div className="legend-row"><span className="swatch dashed" /><span className="name">Observed</span></div>
         <div className="legend-row"><span className="swatch dotted" /><span className="name">Inferred</span></div>
-        <div className="legend-row"><span className="swatch stale" /><span className="name">Stale</span></div>
+        <div className="legend-row" title="Last seen too long ago — an OBSERVED edge that stopped speaking, decayed live on the daemon.">
+          <span className="swatch stale" /><span className="name">Stale</span>
+        </div>
+        <div className="legend-caption">Stale — last seen too long ago; runtime went quiet and the edge decayed.</div>
         <div className="legend-rule" />
         <h4 style={{ marginTop: 0 }}>Node kind</h4>
         <div className="nodes-grid">
@@ -677,7 +700,12 @@ export function GraphCanvas({
           <div className="nrow"><span className="kdot" />config</div>
           <div className="nrow"><span className="kdot" />infra</div>
           <div className="nrow"><span className="kdot" />frontier</div>
+          <div className="nrow"><span className="kdot obs" />route</div>
+          <div className="nrow"><span className="kdot obs" />graphql</div>
+          <div className="nrow"><span className="kdot obs" />grpc</div>
+          <div className="nrow"><span className="kdot obs" />websocket</div>
         </div>
+        <div className="legend-caption">Green — the operations a service serves, seen at runtime.</div>
       </aside>
 
       {overlay && (
@@ -710,6 +738,14 @@ function visualKindOf(type: string): string {
       return 'frontier'
     case 'InfraNode':
       return 'infra'
+    case 'RouteNode':
+      return 'route'
+    case 'GraphQLOperationNode':
+      return 'graphql'
+    case 'GrpcMethodNode':
+      return 'grpc'
+    case 'WebSocketChannelNode':
+      return 'ws'
     default:
       return 'service'
   }

--- a/packages/web/app/components/graph-model.ts
+++ b/packages/web/app/components/graph-model.ts
@@ -164,7 +164,25 @@ const RENDERED_NODE_TYPES = new Set([
   'ConfigNode',
   'InfraNode',
   'FrontierNode',
+  // The operation nodes (ADR-119/122/123/125) — the routes, GraphQL operations,
+  // gRPC methods, and WebSocket channels a service actually serves. Minted
+  // observed-first from OTel (a RouteNode also fuses a static twin), so they are
+  // the interesting OBSERVED surface, not a service rollup. They render as
+  // first-class leaf nodes with their own shapes, like db / infra / frontier.
+  'RouteNode',
+  'GraphQLOperationNode',
+  'GrpcMethodNode',
+  'WebSocketChannelNode',
 ])
+
+// A node has an OBSERVED footprint when the runtime has spoken for it — carried
+// on `lastObserved` / `firstObserved`. Used to tint the operation nodes green
+// (the runtime layer) when they've actually been seen, and leave a declared-only
+// route muted. This is a node-level read of the same OBSERVED signal edges carry.
+export function isObservedNode(n: GraphNode): boolean {
+  const a = n as { lastObserved?: unknown; firstObserved?: unknown }
+  return Boolean(a.lastObserved || a.firstObserved)
+}
 
 export function compoundElements(
   nodes: GraphNode[],
@@ -208,6 +226,7 @@ export function compoundElements(
         label: nodeDisplayLabel(n),
         _nodeType: n.type,
         _kind: visualKind(n),
+        _observed: isObservedNode(n),
         ...(parentExists ? { parent } : {}),
         _raw: n,
       },
@@ -275,6 +294,14 @@ function visualKind(n: GraphNode): string {
       return 'frontier'
     case 'InfraNode':
       return 'infra'
+    case 'RouteNode':
+      return 'route'
+    case 'GraphQLOperationNode':
+      return 'graphql'
+    case 'GrpcMethodNode':
+      return 'grpc'
+    case 'WebSocketChannelNode':
+      return 'ws'
     default:
       return 'service'
   }

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -1416,6 +1416,17 @@ a:focus-visible, button:focus-visible {
   border: 1.2px solid var(--fg-muted); background: transparent;
 }
 .legend .nodes-grid .nrow .kdot.file { background: var(--fg); border-color: var(--fg); border-radius: 50%; }
+/* operation nodes — the OBSERVED runtime surface, keyed to the one green */
+.legend .nodes-grid .nrow .kdot.obs { border-color: var(--prov-observed); background: color-mix(in srgb, var(--prov-observed) 22%, transparent); }
+/* small explanatory captions under a legend group (Stale, operation nodes) */
+.legend .legend-caption {
+  font-family: var(--font-body);
+  font-size: 0.68rem;
+  line-height: 1.35;
+  color: var(--fg-muted);
+  margin: 6px 0 2px;
+  max-width: 210px;
+}
 
 /* ---- THE TWO-MODE OBSERVED OVERLAY (hero honesty screen) --------- */
 .observed-overlay {

--- a/packages/web/lib/fixtures.ts
+++ b/packages/web/lib/fixtures.ts
@@ -27,6 +27,14 @@ export const FIXTURE_GRAPH = {
     { id: 'database:payments-db.internal', type: 'DatabaseNode', name: 'payments-db', host: 'payments-db.internal', port: 5432, engine: 'postgresql', engineVersion: '15.2', compatibleDrivers: [] },
     { id: 'database:auth-db.internal', type: 'DatabaseNode', name: 'auth-db', host: 'auth-db.internal', port: 5432, engine: 'postgresql', engineVersion: '14.8', compatibleDrivers: [] },
     { id: 'infra:redis:cache.internal', type: 'InfraNode', name: 'cache', kind: 'cache', provider: 'redis' },
+    // operation nodes — the routes / operations / methods / channels a service
+    // actually serves (ADR-119/122/123/125). Minted observed-first from OTel, so
+    // they carry lastObserved and render tinted green. The WS channel went quiet,
+    // so its edge decayed OBSERVED → STALE while the node stays known.
+    { id: 'route:api-gateway:GET /charge', type: 'RouteNode', name: 'GET /charge', method: 'GET', path: '/charge', lastObserved: new Date(Date.now() - 1000 * 60 * 2).toISOString() },
+    { id: 'graphql:api-gateway:query orders', type: 'GraphQLOperationNode', name: 'query orders', operationType: 'query', operationName: 'orders', lastObserved: new Date(Date.now() - 1000 * 60 * 4).toISOString() },
+    { id: 'grpc:payments.PaymentService/Charge', type: 'GrpcMethodNode', name: 'PaymentService/Charge', rpcService: 'payments.PaymentService', rpcMethod: 'Charge', lastObserved: new Date(Date.now() - 1000 * 60 * 3).toISOString() },
+    { id: 'ws:notifications:/live', type: 'WebSocketChannelNode', name: '/live', channel: '/live', lastObserved: new Date(Date.now() - 1000 * 60 * 90).toISOString() },
   ],
   edges: [
     // service ──CONTAINS──▶ file (structural ownership, not traffic)
@@ -47,6 +55,14 @@ export const FIXTURE_GRAPH = {
     { id: 'CONNECTS_TO:EXTRACTED:auth-db->pg', source: 'file:auth:src/db.ts', target: 'database:auth-db.internal', type: 'CONNECTS_TO', provenance: 'EXTRACTED', confidence: 0.95, evidence: { file: 'src/db.ts', line: 11 } },
     { id: 'CONNECTS_TO:INFERRED:checkout-cache->redis', source: 'file:checkout:src/lib/cache.ts', target: 'infra:redis:cache.internal', type: 'CONNECTS_TO', provenance: 'INFERRED', confidence: 0.6 },
     { id: 'CONNECTS_TO:INFERRED:auth-token->redis', source: 'file:auth:src/token.ts', target: 'infra:redis:cache.internal', type: 'CONNECTS_TO', provenance: 'INFERRED', confidence: 0.6 },
+    // OBSERVED edges landing on the operation nodes — the gateway serving each
+    // route / operation / method it was seen handling.
+    { id: 'CALLS:OBSERVED:gw-proxy->route-charge', source: 'file:api-gateway:src/proxy.ts', target: 'route:api-gateway:GET /charge', type: 'CALLS', provenance: 'OBSERVED', confidence: 0.99, evidence: { file: 'src/proxy.ts', line: 52 }, signal: { spanCount: 42891, errorCount: 12 } },
+    { id: 'CALLS:OBSERVED:gw-proxy->gql-orders', source: 'file:api-gateway:src/proxy.ts', target: 'graphql:api-gateway:query orders', type: 'CALLS', provenance: 'OBSERVED', confidence: 0.96, evidence: { file: 'src/proxy.ts', line: 73 }, signal: { spanCount: 6120, errorCount: 0 } },
+    { id: 'CALLS:OBSERVED:charge->grpc-charge', source: 'file:checkout:src/routes/charge.ts', target: 'grpc:payments.PaymentService/Charge', type: 'CALLS', provenance: 'OBSERVED', confidence: 0.97, evidence: { file: 'src/routes/charge.ts', line: 140 }, signal: { spanCount: 9210, errorCount: 4 } },
+    // a WebSocket channel that went quiet — the CONNECTS_TO liveness edge decayed
+    // OBSERVED → STALE (ADR-125). Renders faded/dashed; the legend explains it.
+    { id: 'CONNECTS_TO:STALE:gw-proxy->ws-live', source: 'file:api-gateway:src/proxy.ts', target: 'ws:notifications:/live', type: 'CONNECTS_TO', provenance: 'STALE', confidence: 0.7 },
   ],
 }
 

--- a/packages/web/test/canvas-node-shapes.test.ts
+++ b/packages/web/test/canvas-node-shapes.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import type { GraphNode, GraphEdge } from '@neat.is/types'
+import { buildModel, compoundElements, isObservedNode } from '../app/components/graph-model'
+
+// Gate 2 (truthful frontend): the four operation node types (ADR-119/122/123/125)
+// — RouteNode, GraphQLOperationNode, GrpcMethodNode, WebSocketChannelNode — gained
+// distinct canvas shapes. They must actually render (be in the compound element
+// set) and carry their own `_kind`, and observed ones must flag `_observed` so the
+// canvas tints them the OBSERVED green.
+
+const nodes: GraphNode[] = [
+  { id: 'service:gw', type: 'ServiceNode', name: 'gw' } as GraphNode,
+  { id: 'file:gw:proxy.ts', type: 'FileNode', service: 'gw', path: 'src/proxy.ts' } as GraphNode,
+  { id: 'route:gw:GET /x', type: 'RouteNode', name: 'GET /x', lastObserved: '2026-07-08T00:00:00.000Z' } as unknown as GraphNode,
+  { id: 'graphql:gw:query q', type: 'GraphQLOperationNode', name: 'query q', lastObserved: '2026-07-08T00:00:00.000Z' } as unknown as GraphNode,
+  { id: 'grpc:svc/M', type: 'GrpcMethodNode', name: 'svc/M', lastObserved: '2026-07-08T00:00:00.000Z' } as unknown as GraphNode,
+  // a declared-only route with no runtime footprint — stays muted, not green.
+  { id: 'route:gw:GET /unhit', type: 'RouteNode', name: 'GET /unhit' } as unknown as GraphNode,
+  { id: 'ws:gw:/live', type: 'WebSocketChannelNode', name: '/live', lastObserved: '2026-07-08T00:00:00.000Z' } as unknown as GraphNode,
+]
+const edges: GraphEdge[] = [
+  { id: 'c1', source: 'service:gw', target: 'file:gw:proxy.ts', type: 'CONTAINS', provenance: 'EXTRACTED' } as GraphEdge,
+]
+
+describe('canvas node shapes — the four operation node types', () => {
+  const model = buildModel(nodes, edges)
+  const els = compoundElements(nodes, edges, model)
+  const nodeEls = els.filter((e) => e.group === 'nodes')
+  const byId = new Map(nodeEls.map((e) => [String(e.data.id), e.data]))
+
+  it('renders each operation node with its own visual kind', () => {
+    expect(byId.get('route:gw:GET /x')?._kind).toBe('route')
+    expect(byId.get('graphql:gw:query q')?._kind).toBe('graphql')
+    expect(byId.get('grpc:svc/M')?._kind).toBe('grpc')
+    expect(byId.get('ws:gw:/live')?._kind).toBe('ws')
+  })
+
+  it('flags observed operation nodes as _observed and leaves declared-only ones muted', () => {
+    expect(byId.get('route:gw:GET /x')?._observed).toBe(true)
+    expect(byId.get('ws:gw:/live')?._observed).toBe(true)
+    expect(byId.get('route:gw:GET /unhit')?._observed).toBe(false)
+  })
+
+  it('isObservedNode reads the runtime footprint off lastObserved / firstObserved', () => {
+    expect(isObservedNode({ id: 'a', type: 'RouteNode', lastObserved: 'x' } as unknown as GraphNode)).toBe(true)
+    expect(isObservedNode({ id: 'b', type: 'RouteNode', firstObserved: 'x' } as unknown as GraphNode)).toBe(true)
+    expect(isObservedNode({ id: 'c', type: 'RouteNode' } as unknown as GraphNode)).toBe(false)
+  })
+})


### PR DESCRIPTION
The graph gained RouteNode, GraphQLOperationNode, GrpcMethodNode, and WebSocketChannelNode (ADR-119/122/123/125) — the routes, operations, methods, and channels a service actually serves, recovered from the traces. On the canvas they were falling back to the default circle, and in fact weren't rendering at all: the compound builder's rendered-type set never listed them. They're the interesting edge of the OBSERVED layer, so they should read as distinct things.

Each now gets its own stroked shape — route a rhomboid, GraphQL a pentagon, gRPC a round-triangle, a WebSocket channel a cut-rectangle — alongside the existing vocabulary (file circle, db barrel, config tag, infra hexagon, frontier diamond). Because these nodes are minted from runtime, they carry the one OBSERVED green once the graph has actually seen them (read off `lastObserved`/`firstObserved`); a declared-only route stays muted. The legend gains all four with that note.

The Stale legend row also gets a line of copy. STALE decay runs live on the daemon now — an OBSERVED edge whose runtime goes quiet transitions to STALE — so the legend explains it as "last seen too long ago" instead of a bare swatch. The demo fixture carries a channel that went quiet, so the faded-dashed Stale edge and all four shapes render offline.

Verified in the worktree: `typecheck` clean, `lint` clean, `test` green (17 files / 76 tests, incl. a new `canvas-node-shapes` spec), and a full `next build`. Also driven in a browser against the demo fixture — the four green shapes and the Stale edge render on the canvas, and the cytoscape instance reports each operation node with its own kind and the observed tint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)