### PR TITLE
Offer blast radius and dependencies as node-scoped Inspector actions

### DIFF
--- a/packages/web/app/api/graph/dependencies/[id]/route.ts
+++ b/packages/web/app/api/graph/dependencies/[id]/route.ts
@@ -1,0 +1,18 @@
+import { proxyProfile } from '../../../../../lib/proxy'
+import { fixtureDependencies } from '../../../../../lib/fixtures'
+
+// ADR-101 — transitive dependencies are computed by the selected profile's
+// daemon at the ROOT (`/graph/dependencies/:id`, no `/projects/:name` prefix).
+// The node-scoped "what does this depend on, transitively?" query — the sibling
+// of blast-radius (what depends on it). Surfaced as an Inspector action.
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } },
+): Promise<Response> {
+  const depth = new URL(request.url).searchParams.get('depth') ?? '10'
+  return proxyProfile(
+    request,
+    `/graph/dependencies/${encodeURIComponent(params.id)}?depth=${encodeURIComponent(depth)}`,
+    () => Response.json(fixtureDependencies(params.id)),
+  )
+}

--- a/packages/web/app/components/AppShell.tsx
+++ b/packages/web/app/components/AppShell.tsx
@@ -149,6 +149,28 @@ export function AppShell() {
     setProfile(null)
   }
 
+  // Highlight a BFS set on the canvas — the focus half of the Inspector's
+  // node-scoped blast-radius / dependency actions (web-shell §6: these focus the
+  // canvas, they do not navigate to a page). Dims everything outside the set and
+  // fits to it, using the cy instance GraphCanvas handed up via onCyReady.
+  const focusNodes = useCallback((ids: string[]) => {
+    const cy = cyRef.current
+    if (!cy || ids.length === 0) return
+    setActivePage('graph')
+    cy.elements().removeClass('hl dim')
+    let set = cy.collection()
+    for (const id of ids) {
+      const el = cy.getElementById(id)
+      if (el && el.nonempty()) set = set.union(el)
+    }
+    if (set.empty()) return
+    // include the edges internal to the set so the traced sub-graph reads as one.
+    const withEdges = set.union(set.edgesWith(set))
+    cy.elements().not(withEdges).addClass('dim')
+    withEdges.addClass('hl')
+    cy.animate({ fit: { eles: set, padding: 90 } }, { duration: 320 })
+  }, [])
+
   // pre-select a node from the URL ?node= query (e.g. incidents back-link).
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
@@ -209,6 +231,7 @@ export function AppShell() {
                     selectedNodeId={selectedNodeId}
                     graphData={graphData}
                     onNodeSelect={setSelectedNodeId}
+                    onFocusNodes={focusNodes}
                   />
                 </div>
               ) : activePage === 'policies' ? (

--- a/packages/web/app/components/Inspector.tsx
+++ b/packages/web/app/components/Inspector.tsx
@@ -51,18 +51,40 @@ interface EdgeRow {
   conf?: number
 }
 
+// A node-scoped traversal result (blast-radius / dependencies), normalized to
+// the fields the panel shows. Both daemon shapes carry nodeId + distance; the
+// count comes from totalAffected / total, else the row count (web-shell §6 —
+// these are inspector actions, not pages).
+interface TraversalRow {
+  nodeId: string
+  distance: number
+}
+type TraversalMode = 'deps' | 'blast'
+interface TraversalState {
+  mode: TraversalMode
+  rows: TraversalRow[]
+  total: number
+}
+
 interface InspectorProps {
   // null until AppShell's resolution chain lands on a real project (#461).
   project: string | null
   selectedNodeId: string | null
   graphData: GraphData | null
   onNodeSelect: (id: string) => void
+  // Highlight a BFS set on the canvas (web-shell §6 — the node-scoped query
+  // focuses the canvas rather than navigating to a page). Optional so the
+  // Inspector still renders in isolation (tests, storybook).
+  onFocusNodes?: (ids: string[]) => void
 }
 
-export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: InspectorProps) {
+export function Inspector({ project, selectedNodeId, graphData, onNodeSelect, onFocusNodes }: InspectorProps) {
   const [node, setNode] = useState<GraphNode | null>(null)
   const [rootCause, setRootCause] = useState<RootCauseResult | null>(null)
   const [activeTab, setActiveTab] = useState<'inspect' | 'edges' | 'owners' | 'history'>('inspect')
+  // Node-scoped traversal (blast-radius / dependencies) — run on demand.
+  const [traversal, setTraversal] = useState<TraversalState | null>(null)
+  const [traversalLoading, setTraversalLoading] = useState<TraversalMode | null>(null)
 
   // ADR-057 #3 — re-fetch when project or selection changes. Idle until a
   // project resolves (#461); nothing can be selected without a graph anyway.
@@ -83,6 +105,45 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: 
       .then((d: RootCauseResult) => setRootCause(d.rootCauseNode ? d : null))
       .catch(() => {})
   }, [selectedNodeId, project])
+
+  // Clear any run traversal when the selection (or project) changes — the
+  // blast-radius / dependency set belongs to the previously-selected node.
+  useEffect(() => {
+    setTraversal(null)
+    setTraversalLoading(null)
+  }, [selectedNodeId, project])
+
+  // Run the node-scoped query on demand (web-shell §6 — an inspector action, not
+  // a page). `blast` = what depends on this, transitively; `deps` = what this
+  // depends on. Both daemon shapes carry nodeId + distance; normalize and count.
+  const runTraversal = (mode: TraversalMode) => {
+    if (!selectedNodeId || !project) return
+    setTraversalLoading(mode)
+    const proj = `?project=${encodeURIComponent(project)}`
+    const path =
+      mode === 'blast'
+        ? `/api/graph/blast-radius/${encodeURIComponent(selectedNodeId)}${proj}`
+        : `/api/graph/dependencies/${encodeURIComponent(selectedNodeId)}${proj}`
+    authedFetch(path)
+      .then((r) => r.json())
+      .then((d: Record<string, unknown>) => {
+        const list = (mode === 'blast' ? d.affectedNodes : d.dependencies) as
+          | { nodeId: string; distance?: number }[]
+          | undefined
+        const rows: TraversalRow[] = Array.isArray(list)
+          ? list.map((x) => ({ nodeId: x.nodeId, distance: x.distance ?? 1 }))
+          : []
+        const total =
+          typeof d.totalAffected === 'number'
+            ? d.totalAffected
+            : typeof d.total === 'number'
+              ? d.total
+              : rows.length
+        setTraversal({ mode, rows, total })
+        setTraversalLoading(null)
+      })
+      .catch(() => setTraversalLoading(null))
+  }
 
   // file-first model off the full graph, for file→target detail and the
   // service→files view. Memoized so it's not rebuilt on every render.
@@ -332,6 +393,77 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect }: 
                 )}
               </section>
             )}
+
+            {/* Node-scoped queries: blast radius (what depends on this,
+                transitively) + dependencies (what this depends on). These are
+                inspector actions that focus the canvas — never a page
+                (web-shell §6). Run on demand. */}
+            <section className="insp-section">
+              <div className="insp-h">Impact</div>
+              <div className="traversal-actions">
+                <button
+                  type="button"
+                  className={`traversal-btn${traversal?.mode === 'blast' ? ' on' : ''}`}
+                  onClick={() => runTraversal('blast')}
+                  disabled={traversalLoading !== null}
+                >
+                  {traversalLoading === 'blast' ? 'computing…' : 'Blast radius'}
+                </button>
+                <button
+                  type="button"
+                  className={`traversal-btn${traversal?.mode === 'deps' ? ' on' : ''}`}
+                  onClick={() => runTraversal('deps')}
+                  disabled={traversalLoading !== null}
+                >
+                  {traversalLoading === 'deps' ? 'computing…' : 'Dependencies'}
+                </button>
+              </div>
+              <div className="traversal-hint">
+                {traversal
+                  ? traversal.mode === 'blast'
+                    ? 'what breaks if this changes — transitively'
+                    : 'what this depends on — transitively'
+                  : 'trace this node’s reach across the graph'}
+              </div>
+              {traversal &&
+                (traversal.rows.length === 0 ? (
+                  <div className="insp-sub" style={{ fontStyle: 'italic', fontFamily: 'var(--font-body)', marginTop: 8 }}>
+                    {traversal.mode === 'blast' ? 'nothing depends on this node' : 'this node depends on nothing'}
+                  </div>
+                ) : (
+                  <>
+                    <div className="traversal-summary">
+                      <span>
+                        {traversal.total} {traversal.mode === 'blast' ? 'affected' : 'dependencies'}
+                      </span>
+                      {onFocusNodes && (
+                        <button
+                          type="button"
+                          className="traversal-highlight"
+                          onClick={() => onFocusNodes(traversal.rows.map((r) => r.nodeId))}
+                        >
+                          highlight on graph
+                        </button>
+                      )}
+                    </div>
+                    <ul className="edge-list">
+                      {traversal.rows.slice(0, 40).map((r) => (
+                        <li key={r.nodeId}>
+                          <span className="verb">{r.distance} hop{r.distance === 1 ? '' : 's'}</span>
+                          <button
+                            type="button"
+                            className="target clickable"
+                            onClick={() => onNodeSelect(r.nodeId)}
+                            title={`Select ${r.nodeId}`}
+                          >
+                            {r.nodeId}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  </>
+                ))}
+            </section>
 
             {rootCause && (
               <section className="insp-section">

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -975,6 +975,35 @@ html, body {
   width: 7px; height: 7px; border-radius: 50%;
   flex-shrink: 0;
 }
+
+/* Inspector node-scoped query actions (blast radius / dependencies) */
+.traversal-actions { display: flex; gap: 8px; margin-bottom: 8px; }
+.traversal-btn {
+  font-family: var(--font-mono);
+  font-size: 0.58rem; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--fg-muted); background: transparent;
+  border: 1px solid var(--rule); padding: 6px 10px; cursor: pointer;
+  transition: color 0.14s ease, border-color 0.14s ease;
+}
+.traversal-btn:hover:not(:disabled) { color: var(--fg); border-color: var(--fg-muted); }
+.traversal-btn.on { color: var(--prov-observed); border-color: var(--prov-observed); }
+.traversal-btn:disabled { opacity: 0.5; cursor: default; }
+.traversal-hint {
+  font-family: var(--font-body); font-style: italic;
+  font-size: 0.82rem; color: var(--fg-muted); margin-bottom: 8px;
+}
+.traversal-summary {
+  display: flex; align-items: center; justify-content: space-between;
+  font-family: var(--font-mono); font-size: 0.6rem; letter-spacing: 0.06em;
+  text-transform: uppercase; color: var(--fg-muted);
+  padding: 6px 0 4px; border-bottom: 1px solid var(--rule); margin-bottom: 4px;
+}
+.traversal-highlight {
+  font-family: var(--font-mono); font-size: 0.58rem; letter-spacing: 0.05em;
+  color: var(--prov-observed); background: transparent; border: none;
+  padding: 0; cursor: pointer; text-transform: uppercase;
+}
+.traversal-highlight:hover { text-decoration: underline; }
 .edge-list .pdot.STATIC   { background: var(--prov-static); }
 .edge-list .pdot.OBSERVED { background: var(--prov-observed); }
 .edge-list .pdot.INFERRED { background: var(--prov-inferred); }

--- a/packages/web/audit/09-gaps-and-stubs.md
+++ b/packages/web/audit/09-gaps-and-stubs.md
@@ -82,6 +82,17 @@ When code state changes, this file changes in lockstep.
 | Owners | wired | Renders `ServiceNode.owner` per ADR-054, or "no owner declared" hint. |
 | History | disabled | Tooltip: "History — coming in v0.3.x". |
 
+### Inspector node-scoped queries (web-shell §6 — actions, not pages)
+
+Blast-radius and dependencies are node-scoped inspector actions that focus the
+canvas, per web-shell §6 — never nav pages.
+
+| Button | Status | Notes |
+|--------|--------|-------|
+| Blast radius | wired | Inspector Impact section — fetches `/api/graph/blast-radius/:id`, lists what depends on the node transitively; each row selects that node. |
+| Dependencies | wired | Inspector Impact section — fetches `/api/graph/dependencies/:id`, lists what the node depends on transitively; each row selects that node. |
+| highlight on graph | wired | Dims all but the traced set and fits the canvas to it (the BFS-highlight, web-shell §6). |
+
 ### GraphCanvas drill-down (file-awareness §2/§3)
 
 File-first canvas: services are grouping namespaces only, not visual entities.

--- a/packages/web/lib/fixtures.ts
+++ b/packages/web/lib/fixtures.ts
@@ -234,3 +234,12 @@ export function fixtureBlastRadius(id: string) {
     .map((e) => ({ nodeId: e.target, distance: 1, confidence: e.confidence, path: [id, e.target] }))
   return { origin: id, affectedNodes: downstream, violationCount: 0 }
 }
+
+// The transitive-dependencies DEMO fallback (TransitiveDependenciesResult) — the
+// outbound edges from a node, shaped like the daemon's `/graph/dependencies`.
+export function fixtureDependencies(id: string) {
+  const deps = FIXTURE_GRAPH.edges
+    .filter((e) => e.source === id && e.type !== 'CONTAINS')
+    .map((e) => ({ nodeId: e.target, distance: 1, edgeType: e.type, provenance: e.provenance }))
+  return { origin: id, depth: 10, dependencies: deps, total: deps.length }
+}

--- a/packages/web/test/inspector-impact.test.tsx
+++ b/packages/web/test/inspector-impact.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import type { GraphNode, GraphEdge } from '@neat.is/types'
+import type { GraphData } from '../app/components/AppShell'
+import { Inspector } from '../app/components/Inspector'
+
+// web-shell §6 — blast-radius and dependencies are node-scoped Inspector actions
+// (never nav pages). They run on demand against the daemon and list the traced
+// set; each row selects that node, and "highlight on graph" focuses the set.
+const nodes: GraphNode[] = [
+  { id: 'service:a', type: 'ServiceNode', name: 'a', language: 'ts' } as GraphNode,
+  { id: 'file:a:x.ts', type: 'FileNode', service: 'a', path: 'src/x.ts', language: 'ts' } as GraphNode,
+  { id: 'database:d', type: 'DatabaseNode', name: 'orders-db', engine: 'pg', engineVersion: '15', compatibleDrivers: [] } as GraphNode,
+]
+const edges: GraphEdge[] = [
+  { id: 'c1', source: 'service:a', target: 'file:a:x.ts', type: 'CONTAINS', provenance: 'EXTRACTED' } as GraphEdge,
+  { id: 'call1', source: 'file:a:x.ts', target: 'database:d', type: 'CALLS', provenance: 'OBSERVED', confidence: 0.91, evidence: { file: 'src/x.ts', line: 128 } } as GraphEdge,
+]
+const graphData: GraphData = { nodes, edges }
+
+function stubFetch(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const json = (body: unknown) =>
+        new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+      if (url.includes('/api/graph/blast-radius/')) {
+        return json({ origin: 'file:a:x.ts', affectedNodes: [{ nodeId: 'database:d', distance: 2, edgeProvenance: 'OBSERVED', path: ['file:a:x.ts', 'x', 'database:d'], confidence: 0.8 }], totalAffected: 1 })
+      }
+      const m = url.match(/\/api\/graph\/node\/([^?]+)/)
+      if (m) {
+        const node = nodes.find((n) => n.id === decodeURIComponent(m[1]))
+        return json({ node })
+      }
+      return json({ rootCauseNode: null })
+    }),
+  )
+}
+
+beforeEach(() => stubFetch())
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks() })
+
+describe('Inspector Impact — node-scoped blast radius (web-shell §6)', () => {
+  it('runs blast radius on demand and lists the affected set with a graph-highlight action', async () => {
+    const onNodeSelect = vi.fn()
+    const onFocusNodes = vi.fn()
+    render(
+      <Inspector
+        project="default"
+        selectedNodeId="file:a:x.ts"
+        graphData={graphData}
+        onNodeSelect={onNodeSelect}
+        onFocusNodes={onFocusNodes}
+      />,
+    )
+
+    // the actions are offered but nothing runs until asked (they're actions).
+    const blastBtn = await screen.findByRole('button', { name: /Blast radius/i })
+    fireEvent.click(blastBtn)
+
+    // the affected node appears and is selectable.
+    const affected = await screen.findByRole('button', { name: 'database:d' })
+    fireEvent.click(affected)
+    expect(onNodeSelect).toHaveBeenCalledWith('database:d')
+
+    // highlight-on-graph focuses the traced set on the canvas.
+    const highlight = screen.getByRole('button', { name: /highlight on graph/i })
+    fireEvent.click(highlight)
+    expect(onFocusNodes).toHaveBeenCalledWith(['database:d'])
+  })
+
+  it('offers both node-scoped actions without navigating to a page', () => {
+    render(
+      <Inspector
+        project="default"
+        selectedNodeId="file:a:x.ts"
+        graphData={graphData}
+        onNodeSelect={vi.fn()}
+      />,
+    )
+    return waitFor(() => {
+      expect(screen.getByRole('button', { name: /Blast radius/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Dependencies/i })).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
Selecting a node in the Inspector tells you what it is and what it calls, but not how far its reach runs. The graph already answers that — blast radius (what breaks if this changes, transitively) and dependencies (what it leans on) — and the daemon serves both queries. They just weren't reachable from the GUI.

Per web-shell §6 these are node-scoped actions, not nav pages: you pick a node, ask the question, and the answer focuses the canvas. So the Inspector gains an **Impact** section with the two actions, run on demand. Each result row selects that node; **highlight on graph** dims everything outside the traced set and fits the canvas to it, so the reach reads at a glance.

Adds the `/api/graph/dependencies/:id` proxy (blast-radius already had one) plus its demo fallback, and threads a canvas-highlight callback down from AppShell, which owns the cytoscape instance.

Verified in the worktree on top of the two sibling Gate-2 PRs: `typecheck` clean, `lint` clean, `test` green (18 files / 78 tests, incl. a new `inspector-impact` spec), and a full `next build` compiles the new route. Also driven in a browser against the demo fixture — Blast radius returns the affected set, each row selects its node, and highlight-on-graph dims the rest of the canvas and fits to the traced sub-graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)