### PR TITLE
Amend static-extraction and connectors contracts for the Cloudflare platform tag (ADR-133)

### DIFF
--- a/docs/contracts/connectors.md
+++ b/docs/contracts/connectors.md
@@ -3,7 +3,7 @@ name: connectors
 description: The connectors plane — a second OBSERVED ingestion path (pull) alongside OTLP (push). One provider interface, ambient/passive only, fusion at the same file-grain call site OTLP ingest already targets. Supabase, Railway, Firebase, and Cloudflare Workers/Pages are built providers; every provider's outbound call routes through the shared junction layer (timeout, retry, per-account rate limiting); how a connector gets configured with real credentials lives in the sibling connector-config.md contract.
 governs:
   - "packages/core/src/connectors/**"
-adr: [ADR-124, ADR-127, ADR-128, ADR-129, ADR-130, ADR-131, ADR-132]
+adr: [ADR-124, ADR-127, ADR-128, ADR-129, ADR-130, ADR-131, ADR-132, ADR-133]
 enforcement: [lint, review]
 ---
 
@@ -44,6 +44,10 @@ Profile changes credential source, deployment location, and poll cadence. It nev
 A connector's OBSERVED edge reconciles onto the EXTRACTED call site the same way a span-derived edge does (file-awareness.md §4, `otel-ingest.md`'s in-process-DB / queue / GraphQL / gRPC sections): when the provider's signal names something a static extractor already resolves to a node id, the edge lands file-grained on that node via the identical `upsertObservedEdge` / `reconcileObservedRelPath` path OTLP ingest uses. When no static call site resolves — the extractor doesn't parse the shape yet, or the code isn't in this scan — the edge lands service-level (or provider-node-level), honestly, which is the missing-extracted divergence surfacing exactly what it should: production traffic the codebase's static picture doesn't account for.
 
 This means connector node identity must be chosen so a *future* static extractor for the same provider fuses onto the same id rather than twinning — the same observed-first discipline `otel-ingest.md` documents for GraphQL operations (ADR-122) and gRPC methods (ADR-123).
+
+### 4a. A `resolveTarget` can declare an honest fallback node, never create one itself (ADR-133)
+
+A provider module has no mutation authority (ADR-030) — `createSupabaseResolveTarget` and Cloudflare's own `createCloudflareResolveTarget` both hit this: the provider's signal can name a resource no static extractor has (yet) declared, and `resolveTarget` cannot mint the node itself. The generic pipeline (`connectors/index.ts`) is the one place with ingest.ts mutation authority, so the fallback is expressed *declaratively*: `ResolvedConnectorTarget` carries an optional `ensureInfraNode?: { kind: string; name: string; provider: string }`. When set, `runConnectorPoll` calls `ensureInfraNode(graph, kind, name, provider)` (`ingest.ts`, mirroring the existing `ensureServiceNode`/`ensureDatabaseNode` shape) before minting the edge, so the observed-but-undeclared case lands a real edge — surfacing as a `missing-extracted` divergence — instead of a silent drop. This is additive to the pipeline; it changes no existing provider's behavior unless that provider's `resolveTarget` opts in. Cloudflare's `createCloudflareResolveTarget` is the first user: an invocation naming a Worker script absent from both the tagged graph (ADR-133's `platform`/`platformName` fields, `static-extraction.md`) and the connector config's explicit override falls back to `infraId('cloudflare-worker', scriptName)`, sourced from an auto-created `service:<scriptName>` the same way every other connector's call-site-less case already auto-creates its source.
 
 ## 5. No mocks on the poll path
 

--- a/docs/contracts/static-extraction.md
+++ b/docs/contracts/static-extraction.md
@@ -4,7 +4,7 @@ description: Producers under packages/core/src/extract/* read source code and co
 governs:
   - "packages/core/src/extract/**"
   - "packages/core/src/watch.ts"
-adr: [ADR-032, ADR-065, ADR-115, ADR-119, ADR-123, ADR-030, ADR-031, ADR-024, ADR-055]
+adr: [ADR-032, ADR-065, ADR-115, ADR-119, ADR-123, ADR-030, ADR-031, ADR-024, ADR-055, ADR-133]
 enforcement: [lint, review]
 ---
 
@@ -100,6 +100,7 @@ Other extensions are skipped silently by `walkSourceFiles` per `IGNORED_DIRS` an
 | `calls/route-match.ts` | client `file ──CALLS──▶ route` cross-service match (ADR-119) | ✅ |
 | `proto.ts`           | GrpcMethodNode + `service ──CONTAINS──▶ method` from `.proto` (ADR-123) | ✅ |
 | `infra/{docker-compose,dockerfile,k8s,terraform}.ts` | InfraNode + DEPENDS_ON / RUNS_ON / CONNECTS_TO | ✅ (evidence populated) |
+| `infra/cloudflare.ts` | `platform` tag on ServiceNode/FileNode + InfraNode + DEPENDS_ON / RUNS_ON / CONNECTS_TO (ADR-133) | ✅ |
 
 New producers under `calls/` for source-level DB connections (`new pg.Pool(...)`) and inter-service imports land under issue #141. They follow the same interface, same evidence shape, same idempotency.
 
@@ -120,6 +121,15 @@ Issue #142 adds `framework?: string` to `ServiceNodeSchema`. This is **schema gr
 | `django` (Python)      | `django`         |
 
 The table lives in `compat.json` or a sibling data file. Population happens at extract time. The snapshot guard catches schema drift.
+
+## `platform` on ServiceNode/FileNode — Cloudflare Workers/Pages extraction (ADR-133)
+
+`infra/cloudflare.ts` reads `wrangler.toml`/`wrangler.jsonc` (TOML via `smol-toml`; JSONC via the existing comment-mask helper + `JSON.parse` — no new grammar) and stamps two additive fields:
+
+- `platform?: string` on `ServiceNodeSchema` — `'cloudflare'` when the service has a wrangler config. The frontend's icon key at the service-rollup level; a free string, not an enum, the same discipline `framework` already established.
+- `platform?: string` + `platformName?: string` on `FileNodeSchema` — stamped on the Worker's entry file (resolved from wrangler's own `main` field, verbatim; not the SDK installer's eight-step entry-detection precedence). `platformName` is the Worker's own script name (wrangler's `name` field) — the only identifier Cloudflare's telemetry carries, and what the Cloudflare connector's `resolveTarget` looks up against (`connectors.md` §4).
+
+Declared Cloudflare resources — KV/D1/R2/Durable Object/Queue bindings, cron triggers, service bindings, routes/custom domains, declared env-var names (never values) — become `InfraNode`s at `infraId(kind, name)` (kinds: `cloudflare-kv`, `cloudflare-d1`, `cloudflare-r2`, `cloudflare-durable-object`, `cloudflare-queue`, `cloudflare-cron`, `cloudflare-route`, `cloudflare-env-var`, `cloudflare-service-binding`), wired from the entry FileNode: `CONNECTS_TO` for routes (network-reachability, matching `dockerfile.ts`'s EXPOSE→port pattern), `DEPENDS_ON` for everything else declarative, `RUNS_ON` to a single shared `infra:workerd:cloudflare` node carrying `compatibility_date` as `evidence.snippet` (matching `dockerfile.ts`'s image-node + entrypoint-snippet pattern). A service binding resolves directly onto the target Worker's own entry FileNode (`CALLS`) when that Worker is tagged in the same scan; otherwise it falls back to a `cloudflare-service-binding` InfraNode, honestly. No new `NodeType`. Per-environment `[env.X]` wrangler sections are out of scope for v1 — only top-level config is read.
 
 ## Route extraction + HTTP client↔route matching (ADR-119)
 


### PR DESCRIPTION
## Summary

Prose-first, per CLAUDE.md: this lands ADR-133's contract amendments ahead of any code. ADR-133 is the design spine for #737 — a `platform: cloudflare` identifier the extractor stamps onto a service and its entry file, so the connector fuses onto that tag instead of a hand-maintained `connectors.json` mapping, and the same tag drives the GUI icon.

- `static-extraction.md` — adds the `infra/cloudflare.ts` producer to the producer table, documents the new `platform`/`platformName` fields on ServiceNode/FileNode, and the InfraNode shape for declared Cloudflare resources (KV/D1/R2/DO/Queue/cron/routes/env-vars/service-bindings).
- `connectors.md` — documents the graph-aware `resolveTarget` pattern and a new generic-pipeline capability (`ResolvedConnectorTarget.ensureInfraNode`) that lets a provider's honest "observed but undeclared" fallback land a real edge — surfacing as a `missing-extracted` divergence — instead of a silent drop, without any provider module gaining mutation authority it doesn't have today.

Full ADR-133 text is in the PR body of the follow-up extractor PR (and handed to the maintainer directly, since `docs/decisions.md` is gitignored).

No code changes in this PR — extractor, connector rewire, and Hono recognizer land as separate PRs against this same design.

## Test plan

- [x] `npx turbo build` — full workspace build green
- [x] `npx vitest run --root packages/core test/audits/contracts.test.ts` — 739 passed, 2 skipped, 5 todo (unchanged pass count; docs-only diff)

Refs #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)