### PR TITLE
Tag Cloudflare Workers/Pages with a platform identifier at extract time (ADR-133)

### DIFF
--- a/packages/core/src/extract/infra/cloudflare.ts
+++ b/packages/core/src/extract/infra/cloudflare.ts
@@ -1,0 +1,361 @@
+// Cloudflare Workers/Pages extraction (ADR-133, docs/contracts/static-extraction.md).
+//
+// Reads a service's `wrangler.toml`/`wrangler.jsonc`/`wrangler.json` and stamps
+// the `platform: cloudflare` identifier every downstream consumer keys on: the
+// ServiceNode (the frontend's icon key at the service-rollup level) and the
+// Worker's entry FileNode, which also carries `platformName` — the Worker's own
+// script name, the only identifier Cloudflare's own telemetry carries and what
+// the Cloudflare connector's resolveTarget looks up against
+// (docs/contracts/connectors.md §4a).
+//
+// Declared resources (bindings, routes, cron triggers, env-var names) become
+// InfraNodes wired from the entry file, the same shape dockerfile.ts/k8s.ts/
+// docker-compose.ts already use — no new NodeType. Per-environment `[env.X]`
+// wrangler sections are out of scope for v1; only top-level config is read.
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { parse as parseToml } from 'smol-toml'
+import type { FileNode, GraphEdge, ServiceNode } from '@neat.is/types'
+import { EdgeType, EdgeTypeValue, Provenance, confidenceForExtracted } from '@neat.is/types'
+import type { NeatGraph } from '../../graph.js'
+import { exists, maskCommentsInSource, makeEdgeId, type DiscoveredService } from '../shared.js'
+import { recordExtractionError } from '../errors.js'
+import { ensureFileNode, toPosix } from '../calls/shared.js'
+import { makeInfraNode } from './shared.js'
+
+interface WranglerBindingLike {
+  binding?: string
+  name?: string
+  queue?: string
+}
+
+interface WranglerRouteLike {
+  pattern?: string
+}
+
+interface WranglerServiceBinding {
+  binding?: string
+  service?: string
+}
+
+interface WranglerConfig {
+  name?: string
+  main?: string
+  compatibility_date?: string
+  routes?: (string | WranglerRouteLike)[]
+  route?: string | WranglerRouteLike
+  kv_namespaces?: WranglerBindingLike[]
+  d1_databases?: WranglerBindingLike[]
+  r2_buckets?: WranglerBindingLike[]
+  durable_objects?: { bindings?: WranglerBindingLike[] }
+  queues?: { producers?: WranglerBindingLike[]; consumers?: WranglerBindingLike[] }
+  triggers?: { crons?: string[] }
+  services?: WranglerServiceBinding[]
+  vars?: Record<string, unknown>
+}
+
+interface WranglerRead {
+  config: WranglerConfig
+  relFile: string
+  raw: string
+}
+
+const WRANGLER_FILENAMES = ['wrangler.toml', 'wrangler.jsonc', 'wrangler.json']
+
+async function readWranglerConfig(dir: string): Promise<WranglerRead | null> {
+  for (const filename of WRANGLER_FILENAMES) {
+    const abs = path.join(dir, filename)
+    if (!(await exists(abs))) continue
+    const raw = await fs.readFile(abs, 'utf8')
+    const config =
+      filename === 'wrangler.toml'
+        ? (parseToml(raw) as unknown as WranglerConfig)
+        : (JSON.parse(maskCommentsInSource(raw)) as WranglerConfig)
+    return { config, relFile: filename, raw }
+  }
+  return null
+}
+
+// Best-effort 1-indexed line for a declared value — a simple text search, the
+// same "read config as data" discipline `proto.ts`'s brace-balanced scan and
+// `terraform.ts`'s `lineAt` already use rather than a real TOML/JSONC AST.
+function lineContaining(raw: string, needle: string | undefined): number | undefined {
+  if (!needle) return undefined
+  const idx = raw.indexOf(needle)
+  if (idx === -1) return undefined
+  let line = 1
+  for (let i = 0; i < idx; i++) if (raw[i] === '\n') line++
+  return line
+}
+
+function normalizeRoutes(config: WranglerConfig): string[] {
+  const out: string[] = []
+  const pushOne = (r: unknown): void => {
+    if (typeof r === 'string') out.push(r)
+    else if (r && typeof r === 'object' && typeof (r as WranglerRouteLike).pattern === 'string') {
+      out.push((r as WranglerRouteLike).pattern!)
+    }
+  }
+  if (Array.isArray(config.routes)) config.routes.forEach(pushOne)
+  else if (config.route) pushOne(config.route)
+  return out
+}
+
+// One declared-resource InfraNode + edge from the entry anchor (FileNode, or
+// the ServiceNode itself when no entry file resolved — the honest
+// service-level fallback file-awareness.md already names for this case).
+function addResourceEdge(
+  graph: NeatGraph,
+  anchorId: string,
+  edgeType: EdgeTypeValue,
+  kind: string,
+  name: string,
+  evidenceFile: string,
+  line: number | undefined,
+): { nodesAdded: number; edgesAdded: number } {
+  let nodesAdded = 0
+  let edgesAdded = 0
+  const node = makeInfraNode(kind, name, 'cloudflare')
+  if (!graph.hasNode(node.id)) {
+    graph.addNode(node.id, node)
+    nodesAdded++
+  }
+  if (node.id === anchorId) return { nodesAdded, edgesAdded } // no self-loops
+  const edgeId = makeEdgeId(anchorId, node.id, edgeType)
+  if (!graph.hasEdge(edgeId)) {
+    const edge: GraphEdge = {
+      id: edgeId,
+      source: anchorId,
+      target: node.id,
+      type: edgeType,
+      provenance: Provenance.EXTRACTED,
+      confidence: confidenceForExtracted('structural'),
+      evidence: { file: evidenceFile, ...(line !== undefined ? { line } : {}) },
+    }
+    graph.addEdgeWithKey(edgeId, edge.source, edge.target, edge)
+    edgesAdded++
+  }
+  return { nodesAdded, edgesAdded }
+}
+
+interface DiscoveredWorker {
+  service: DiscoveredService
+  config: WranglerConfig
+  relFile: string
+  raw: string
+  evidenceFile: string
+}
+
+export async function addCloudflareWorkers(
+  graph: NeatGraph,
+  services: DiscoveredService[],
+  scanPath: string,
+): Promise<{ nodesAdded: number; edgesAdded: number }> {
+  let nodesAdded = 0
+  let edgesAdded = 0
+
+  // Pass 1 — read every service's wrangler config (if any) before writing a
+  // single node, so pass 2's service-binding resolution sees the full
+  // worker-name → entry-file map for this scan, same discipline `route-match.ts`
+  // uses running routes before calls.
+  const discovered: DiscoveredWorker[] = []
+  const workerIndex = new Map<string, { anchorId: string }>()
+
+  for (const service of services) {
+    let read: WranglerRead | null
+    try {
+      read = await readWranglerConfig(service.dir)
+    } catch (err) {
+      recordExtractionError('infra cloudflare', path.relative(scanPath, service.dir), err)
+      continue
+    }
+    if (!read || !read.config.name) continue
+
+    const evidenceFile = toPosix(path.relative(scanPath, path.join(service.dir, read.relFile)))
+    discovered.push({ service, config: read.config, relFile: read.relFile, raw: read.raw, evidenceFile })
+  }
+
+  // Tag every ServiceNode + entry FileNode first, populating workerIndex, so
+  // pass 2's service-binding resolution can target a real FileNode even when
+  // the referenced Worker is later in `services` than the one declaring the
+  // binding.
+  for (const worker of discovered) {
+    const { service, config } = worker
+
+    const serviceNode = graph.getNodeAttributes(service.node.id) as ServiceNode
+    if (serviceNode.platform !== 'cloudflare') {
+      const updated: ServiceNode = { ...serviceNode, platform: 'cloudflare' }
+      graph.replaceNodeAttributes(service.node.id, updated)
+    }
+
+    let anchorId = service.node.id
+    if (config.main) {
+      const entryRelPath = toPosix(path.normalize(config.main))
+      const { fileNodeId, nodesAdded: fn, edgesAdded: fe } = ensureFileNode(
+        graph,
+        service.pkg.name,
+        service.node.id,
+        entryRelPath,
+      )
+      nodesAdded += fn
+      edgesAdded += fe
+      const fileNode = graph.getNodeAttributes(fileNodeId) as FileNode
+      if (fileNode.platform !== 'cloudflare' || fileNode.platformName !== config.name) {
+        const updated: FileNode = { ...fileNode, platform: 'cloudflare', platformName: config.name }
+        graph.replaceNodeAttributes(fileNodeId, updated)
+      }
+      anchorId = fileNodeId
+    }
+
+    workerIndex.set(config.name!, { anchorId })
+  }
+
+  // Pass 2 — declared resources, wired from each worker's anchor (entry
+  // FileNode, or the ServiceNode when `main` was absent).
+  for (const worker of discovered) {
+    const { config, evidenceFile, raw } = worker
+    const anchorId = workerIndex.get(config.name!)!.anchorId
+
+    // Runtime marker — one shared node every Cloudflare Worker in this scan
+    // RUNS_ON, compat date carried as evidence.snippet (mirrors dockerfile.ts's
+    // image-node + entrypoint-snippet pattern).
+    const runtimeNode = makeInfraNode('workerd', 'cloudflare', 'cloudflare')
+    if (!graph.hasNode(runtimeNode.id)) {
+      graph.addNode(runtimeNode.id, runtimeNode)
+      nodesAdded++
+    }
+    if (runtimeNode.id !== anchorId) {
+      const runsOnId = makeEdgeId(anchorId, runtimeNode.id, EdgeType.RUNS_ON)
+      if (!graph.hasEdge(runsOnId)) {
+        const edge: GraphEdge = {
+          id: runsOnId,
+          source: anchorId,
+          target: runtimeNode.id,
+          type: EdgeType.RUNS_ON,
+          provenance: Provenance.EXTRACTED,
+          confidence: confidenceForExtracted('structural'),
+          evidence: {
+            file: evidenceFile,
+            ...(config.compatibility_date
+              ? { snippet: `compatibility_date = ${config.compatibility_date}`.slice(0, 120) }
+              : {}),
+          },
+        }
+        graph.addEdgeWithKey(runsOnId, edge.source, edge.target, edge)
+        edgesAdded++
+      }
+    }
+
+    // Routes / custom domains — network-reachability, same CONNECTS_TO
+    // semantics dockerfile.ts's EXPOSE→port edge already uses.
+    for (const route of normalizeRoutes(config)) {
+      const result = addResourceEdge(
+        graph,
+        anchorId,
+        EdgeType.CONNECTS_TO,
+        'cloudflare-route',
+        route,
+        evidenceFile,
+        lineContaining(raw, route),
+      )
+      nodesAdded += result.nodesAdded
+      edgesAdded += result.edgesAdded
+    }
+
+    // Bindings — declared runtime dependencies, DEPENDS_ON.
+    const bindingGroups: { kind: string; entries: WranglerBindingLike[]; nameOf: (b: WranglerBindingLike) => string | undefined }[] = [
+      { kind: 'cloudflare-kv', entries: config.kv_namespaces ?? [], nameOf: (b) => b.binding },
+      { kind: 'cloudflare-d1', entries: config.d1_databases ?? [], nameOf: (b) => b.binding },
+      { kind: 'cloudflare-r2', entries: config.r2_buckets ?? [], nameOf: (b) => b.binding },
+      { kind: 'cloudflare-durable-object', entries: config.durable_objects?.bindings ?? [], nameOf: (b) => b.name },
+      { kind: 'cloudflare-queue', entries: config.queues?.producers ?? [], nameOf: (b) => b.queue },
+      { kind: 'cloudflare-queue', entries: config.queues?.consumers ?? [], nameOf: (b) => b.queue },
+    ]
+    for (const group of bindingGroups) {
+      for (const entry of group.entries) {
+        const name = group.nameOf(entry)
+        if (!name) continue
+        const result = addResourceEdge(
+          graph,
+          anchorId,
+          EdgeType.DEPENDS_ON,
+          group.kind,
+          name,
+          evidenceFile,
+          lineContaining(raw, name),
+        )
+        nodesAdded += result.nodesAdded
+        edgesAdded += result.edgesAdded
+      }
+    }
+
+    // Cron triggers.
+    for (const cron of config.triggers?.crons ?? []) {
+      const result = addResourceEdge(
+        graph,
+        anchorId,
+        EdgeType.DEPENDS_ON,
+        'cloudflare-cron',
+        cron,
+        evidenceFile,
+        lineContaining(raw, cron),
+      )
+      nodesAdded += result.nodesAdded
+      edgesAdded += result.edgesAdded
+    }
+
+    // Declared env vars — name only, value never read (ADR-016 spirit).
+    for (const varName of Object.keys(config.vars ?? {})) {
+      const result = addResourceEdge(
+        graph,
+        anchorId,
+        EdgeType.DEPENDS_ON,
+        'cloudflare-env-var',
+        varName,
+        evidenceFile,
+        lineContaining(raw, varName),
+      )
+      nodesAdded += result.nodesAdded
+      edgesAdded += result.edgesAdded
+    }
+
+    // Service bindings — resolve directly onto the target Worker's own entry
+    // node when it's tagged in this same scan (CALLS: this Worker can invoke
+    // that one); otherwise an honest InfraNode fallback, never guessed.
+    for (const svc of config.services ?? []) {
+      if (!svc.service) continue
+      const target = workerIndex.get(svc.service)
+      if (target && target.anchorId !== anchorId) {
+        const edgeId = makeEdgeId(anchorId, target.anchorId, EdgeType.CALLS)
+        if (!graph.hasEdge(edgeId)) {
+          const edge: GraphEdge = {
+            id: edgeId,
+            source: anchorId,
+            target: target.anchorId,
+            type: EdgeType.CALLS,
+            provenance: Provenance.EXTRACTED,
+            confidence: confidenceForExtracted('structural'),
+            evidence: { file: evidenceFile, line: lineContaining(raw, svc.service) },
+          }
+          graph.addEdgeWithKey(edgeId, edge.source, edge.target, edge)
+          edgesAdded++
+        }
+        continue
+      }
+      const result = addResourceEdge(
+        graph,
+        anchorId,
+        EdgeType.DEPENDS_ON,
+        'cloudflare-service-binding',
+        svc.service,
+        evidenceFile,
+        lineContaining(raw, svc.service),
+      )
+      nodesAdded += result.nodesAdded
+      edgesAdded += result.edgesAdded
+    }
+  }
+
+  return { nodesAdded, edgesAdded }
+}

--- a/packages/core/src/extract/infra/index.ts
+++ b/packages/core/src/extract/infra/index.ts
@@ -4,6 +4,7 @@ import { addComposeInfra } from './docker-compose.js'
 import { addDockerfileRuntimes } from './dockerfile.js'
 import { addTerraformResources } from './terraform.js'
 import { addK8sResources } from './k8s.js'
+import { addCloudflareWorkers } from './cloudflare.js'
 
 export interface InfraExtractResult {
   nodesAdded: number
@@ -12,7 +13,10 @@ export interface InfraExtractResult {
 
 // Phase 5 — infrastructure. Runs after services so RUNS_ON edges have a
 // ServiceNode to anchor on. Each sub-source contributes its own nodes/edges
-// independently; nothing here mutates ServiceNodes themselves.
+// independently. `cloudflare.ts` is the one producer here that also tags
+// existing ServiceNode/FileNode attributes (`platform`/`platformName`,
+// ADR-133) rather than only adding new nodes/edges — property updates on
+// existing nodes are allowed by extract producers per ADR-030.
 export async function addInfra(
   graph: NeatGraph,
   scanPath: string,
@@ -22,11 +26,20 @@ export async function addInfra(
   const dockerfile = await addDockerfileRuntimes(graph, services, scanPath)
   const terraform = await addTerraformResources(graph, scanPath)
   const k8s = await addK8sResources(graph, scanPath)
+  const cloudflare = await addCloudflareWorkers(graph, services, scanPath)
 
   return {
     nodesAdded:
-      compose.nodesAdded + dockerfile.nodesAdded + terraform.nodesAdded + k8s.nodesAdded,
+      compose.nodesAdded +
+      dockerfile.nodesAdded +
+      terraform.nodesAdded +
+      k8s.nodesAdded +
+      cloudflare.nodesAdded,
     edgesAdded:
-      compose.edgesAdded + dockerfile.edgesAdded + terraform.edgesAdded + k8s.edgesAdded,
+      compose.edgesAdded +
+      dockerfile.edgesAdded +
+      terraform.edgesAdded +
+      k8s.edgesAdded +
+      cloudflare.edgesAdded,
   }
 }

--- a/packages/core/test/audits/schemas.snapshot.json
+++ b/packages/core/test/audits/schemas.snapshot.json
@@ -1248,6 +1248,9 @@
             "owner": {
               "_optional": "_string"
             },
+            "platform": {
+              "_optional": "_string"
+            },
             "repoPath": {
               "_optional": "_string"
             },
@@ -1363,6 +1366,12 @@
               "_optional": "_string"
             },
             "path": "_string",
+            "platform": {
+              "_optional": "_string"
+            },
+            "platformName": {
+              "_optional": "_string"
+            },
             "service": "_string",
             "type": {
               "_literal": "FileNode"

--- a/packages/core/test/extract-cloudflare.test.ts
+++ b/packages/core/test/extract-cloudflare.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import type { FileNode, GraphEdge, InfraNode, ServiceNode } from '@neat.is/types'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES = path.resolve(__dirname, 'fixtures', 'infra')
+
+describe('Cloudflare Workers/Pages extraction (ADR-133)', () => {
+  beforeEach(() => resetGraph())
+
+  it('tags the ServiceNode and entry FileNode with platform: cloudflare', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'cloudflare'))
+
+    const service = graph.getNodeAttributes('service:orders-worker') as ServiceNode
+    expect(service.platform).toBe('cloudflare')
+
+    const entryFileId = 'file:orders-worker:src/index.ts'
+    expect(graph.hasNode(entryFileId)).toBe(true)
+    const file = graph.getNodeAttributes(entryFileId) as FileNode
+    expect(file.platform).toBe('cloudflare')
+    expect(file.platformName).toBe('orders-api')
+  })
+
+  it('emits a shared workerd runtime node + RUNS_ON edge carrying compatibility_date as evidence', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'cloudflare'))
+
+    const runtimeId = 'infra:workerd:cloudflare'
+    expect(graph.hasNode(runtimeId)).toBe(true)
+    const runtime = graph.getNodeAttributes(runtimeId) as InfraNode
+    expect(runtime.provider).toBe('cloudflare')
+
+    const entryFileId = 'file:orders-worker:src/index.ts'
+    const edgeId = `RUNS_ON:${entryFileId}->${runtimeId}`
+    expect(graph.hasEdge(edgeId)).toBe(true)
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe('EXTRACTED')
+    expect(edge.evidence?.snippet).toContain('2024-09-01')
+
+    // Both fixture workers share the one runtime node — a single Cloudflare
+    // "runs atop workerd" fact, not one per Worker.
+    const notifEntryId = 'file:notifications-worker:src/index.ts'
+    expect(graph.hasEdge(`RUNS_ON:${notifEntryId}->${runtimeId}`)).toBe(true)
+  })
+
+  it('routes/custom domains become cloudflare-route InfraNodes wired CONNECTS_TO from the entry file', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'cloudflare'))
+
+    const routeId = 'infra:cloudflare-route:api.example.com/orders/*'
+    expect(graph.hasNode(routeId)).toBe(true)
+    const entryFileId = 'file:orders-worker:src/index.ts'
+    const edgeId = `CONNECTS_TO:${entryFileId}->${routeId}`
+    expect(graph.hasEdge(edgeId)).toBe(true)
+    expect((graph.getEdgeAttributes(edgeId) as GraphEdge).type).toBe('CONNECTS_TO')
+  })
+
+  it('KV/D1/R2/Durable Object/Queue/cron bindings become InfraNodes wired DEPENDS_ON from the entry file', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'cloudflare'))
+
+    const entryFileId = 'file:orders-worker:src/index.ts'
+    const expected: [string, string][] = [
+      ['infra:cloudflare-kv:SESSIONS', 'cloudflare-kv'],
+      ['infra:cloudflare-d1:ORDERS_DB', 'cloudflare-d1'],
+      ['infra:cloudflare-r2:UPLOADS', 'cloudflare-r2'],
+      ['infra:cloudflare-durable-object:ORDER_COUNTER', 'cloudflare-durable-object'],
+      ['infra:cloudflare-queue:order-events', 'cloudflare-queue'],
+      ['infra:cloudflare-cron:0 0 * * *', 'cloudflare-cron'],
+    ]
+    for (const [nodeId, kind] of expected) {
+      expect(graph.hasNode(nodeId)).toBe(true)
+      expect((graph.getNodeAttributes(nodeId) as InfraNode).kind).toBe(kind)
+      const edgeId = `DEPENDS_ON:${entryFileId}->${nodeId}`
+      expect(graph.hasEdge(edgeId)).toBe(true)
+    }
+  })
+
+  it('declares env-var existence only, never the value', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'cloudflare'))
+
+    const varNodeId = 'infra:cloudflare-env-var:LOG_LEVEL'
+    expect(graph.hasNode(varNodeId)).toBe(true)
+    const varNode = graph.getNodeAttributes(varNodeId) as InfraNode
+    expect(varNode.name).toBe('LOG_LEVEL')
+    // No value anywhere on the node or its declaring edge.
+    expect(JSON.stringify(varNode)).not.toContain('info')
+    const entryFileId = 'file:orders-worker:src/index.ts'
+    const edge = graph.getEdgeAttributes(`DEPENDS_ON:${entryFileId}->${varNodeId}`) as GraphEdge
+    expect(JSON.stringify(edge)).not.toContain('info')
+  })
+
+  it('resolves a service binding directly onto the target Worker entry FileNode when tagged in the same scan (CALLS)', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'cloudflare'))
+
+    const ordersEntry = 'file:orders-worker:src/index.ts'
+    const notifEntry = 'file:notifications-worker:src/index.ts'
+    const edgeId = `CALLS:${ordersEntry}->${notifEntry}`
+    expect(graph.hasEdge(edgeId)).toBe(true)
+    const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+    expect(edge.provenance).toBe('EXTRACTED')
+
+    // No cloudflare-service-binding InfraNode fallback — it resolved to a real node.
+    expect(graph.hasNode('infra:cloudflare-service-binding:notifications-api')).toBe(false)
+  })
+
+  it('falls back to a cloudflare-service-binding InfraNode when the target Worker is not in this scan', async () => {
+    const graph = getGraph()
+    // notifications-worker alone: its own config has no service bindings, so
+    // scan just orders-worker in isolation to exercise the honest fallback.
+    await extractFromDirectory(graph, path.join(FIXTURES, 'cloudflare', 'orders-worker'))
+
+    const fallbackId = 'infra:cloudflare-service-binding:notifications-api'
+    expect(graph.hasNode(fallbackId)).toBe(true)
+    const entryFileId = 'file:orders-worker:src/index.ts'
+    expect(graph.hasEdge(`DEPENDS_ON:${entryFileId}->${fallbackId}`)).toBe(true)
+  })
+
+  it('reads wrangler.jsonc (comments stripped) the same as wrangler.toml', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'cloudflare-jsonc'))
+
+    const service = graph.getNodeAttributes('service:pages-fn') as ServiceNode
+    expect(service.platform).toBe('cloudflare')
+    const entryFileId = 'file:pages-fn:src/index.ts'
+    const file = graph.getNodeAttributes(entryFileId) as FileNode
+    expect(file.platformName).toBe('pages-fn-api')
+    expect(graph.hasNode('infra:cloudflare-env-var:LOG_LEVEL')).toBe(true)
+  })
+
+  it('is idempotent: running extraction twice produces the same node/edge counts', async () => {
+    const graph = getGraph()
+    const first = await extractFromDirectory(graph, path.join(FIXTURES, 'cloudflare'))
+    const nodesAfterFirst = graph.order
+    const edgesAfterFirst = graph.size
+
+    const second = await extractFromDirectory(graph, path.join(FIXTURES, 'cloudflare'))
+    expect(graph.order).toBe(nodesAfterFirst)
+    expect(graph.size).toBe(edgesAfterFirst)
+    expect(first.nodesAdded).toBeGreaterThan(0)
+    expect(second).toBeDefined()
+  })
+})

--- a/packages/core/test/fixtures/infra/cloudflare-jsonc/pages-fn/package.json
+++ b/packages/core/test/fixtures/infra/cloudflare-jsonc/pages-fn/package.json
@@ -1,0 +1,1 @@
+{ "name": "pages-fn", "version": "1.0.0" }

--- a/packages/core/test/fixtures/infra/cloudflare-jsonc/pages-fn/src/index.ts
+++ b/packages/core/test/fixtures/infra/cloudflare-jsonc/pages-fn/src/index.ts
@@ -1,0 +1,5 @@
+export default {
+  async fetch(_request: Request): Promise<Response> {
+    return new Response('ok')
+  },
+}

--- a/packages/core/test/fixtures/infra/cloudflare-jsonc/pages-fn/wrangler.jsonc
+++ b/packages/core/test/fixtures/infra/cloudflare-jsonc/pages-fn/wrangler.jsonc
@@ -1,0 +1,9 @@
+{
+  // JSONC — comments like this one must be stripped before JSON.parse.
+  "name": "pages-fn-api",
+  "main": "src/index.ts",
+  "compatibility_date": "2024-09-01",
+  "vars": {
+    "LOG_LEVEL": "info"
+  }
+}

--- a/packages/core/test/fixtures/infra/cloudflare/notifications-worker/package.json
+++ b/packages/core/test/fixtures/infra/cloudflare/notifications-worker/package.json
@@ -1,0 +1,1 @@
+{ "name": "notifications-worker", "version": "1.0.0" }

--- a/packages/core/test/fixtures/infra/cloudflare/notifications-worker/src/index.ts
+++ b/packages/core/test/fixtures/infra/cloudflare/notifications-worker/src/index.ts
@@ -1,0 +1,5 @@
+export default {
+  async fetch(_request: Request): Promise<Response> {
+    return new Response('ok')
+  },
+}

--- a/packages/core/test/fixtures/infra/cloudflare/notifications-worker/wrangler.toml
+++ b/packages/core/test/fixtures/infra/cloudflare/notifications-worker/wrangler.toml
@@ -1,0 +1,3 @@
+name = "notifications-api"
+main = "src/index.ts"
+compatibility_date = "2024-09-01"

--- a/packages/core/test/fixtures/infra/cloudflare/orders-worker/package.json
+++ b/packages/core/test/fixtures/infra/cloudflare/orders-worker/package.json
@@ -1,0 +1,1 @@
+{ "name": "orders-worker", "version": "1.0.0" }

--- a/packages/core/test/fixtures/infra/cloudflare/orders-worker/src/index.ts
+++ b/packages/core/test/fixtures/infra/cloudflare/orders-worker/src/index.ts
@@ -1,0 +1,5 @@
+export default {
+  async fetch(_request: Request): Promise<Response> {
+    return new Response('ok')
+  },
+}

--- a/packages/core/test/fixtures/infra/cloudflare/orders-worker/wrangler.toml
+++ b/packages/core/test/fixtures/infra/cloudflare/orders-worker/wrangler.toml
@@ -1,0 +1,38 @@
+name = "orders-api"
+main = "src/index.ts"
+compatibility_date = "2024-09-01"
+
+routes = [
+  { pattern = "api.example.com/orders/*" }
+]
+
+[[kv_namespaces]]
+binding = "SESSIONS"
+id = "abc123"
+
+[[d1_databases]]
+binding = "ORDERS_DB"
+database_name = "orders"
+
+[[r2_buckets]]
+binding = "UPLOADS"
+bucket_name = "orders-uploads"
+
+[[durable_objects.bindings]]
+name = "ORDER_COUNTER"
+class_name = "OrderCounter"
+
+[[queues.producers]]
+queue = "order-events"
+binding = "ORDER_EVENTS"
+
+[triggers]
+crons = ["0 0 * * *"]
+
+[vars]
+LOG_LEVEL = "info"
+FEATURE_FLAG_X = "true"
+
+[[services]]
+binding = "NOTIFICATIONS"
+service = "notifications-api"

--- a/packages/types/src/nodes.ts
+++ b/packages/types/src/nodes.ts
@@ -31,6 +31,12 @@ export const ServiceNodeSchema = z.object({
   // Astro). Optional enrichment — `undefined` for lib-only packages and
   // ambiguous repos. See ADR-074 §3 / docs/contracts/framework-installers.md.
   framework: z.string().optional(),
+  // The hosting platform a static extractor recognized this service as
+  // deployed to (`'cloudflare'` today) — a free string, same discipline as
+  // `framework`, so a future platform needs no schema change. This is the
+  // frontend's icon key at the service-rollup level (ADR-133,
+  // docs/contracts/static-extraction.md).
+  platform: z.string().optional(),
   discoveredVia: DiscoveredViaSchema.optional(),
   version: z.string().optional(),
   dbConnectionTarget: z.string().optional(),
@@ -155,6 +161,18 @@ export const FileNodeSchema = z.object({
   // this original `src/...ts` (file-awareness.md §4 / `code.original_filepath`).
   // Absent when the call site was already source-grained.
   originalPath: z.string().optional(),
+  // The hosting platform this file is the entry point for (`'cloudflare'`
+  // today) — set on a Worker/Pages-Function's entry file only, mirroring
+  // ServiceNode's own `platform` field. See `platformName` below.
+  platform: z.string().optional(),
+  // The platform's own name for this file's service, when the platform names
+  // things differently than NEAT's manifest-derived serviceId (a Cloudflare
+  // Worker's wrangler.toml/jsonc `name`, not `package.json#name`). This is the
+  // only identifier the platform's own telemetry carries, so it's what a
+  // connector's resolveTarget looks up against to fuse an OBSERVED signal onto
+  // this exact FileNode (ADR-133, docs/contracts/static-extraction.md /
+  // docs/contracts/connectors.md).
+  platformName: z.string().optional(),
 })
 export type FileNode = z.infer<typeof FileNodeSchema>
 


### PR DESCRIPTION
## Summary

Phase 1 of #737 (design spine in ADR-133, prose landed in #741). Adds `packages/core/src/extract/infra/cloudflare.ts`, wired into the infra extract phase:

- Reads a service's `wrangler.toml` / `wrangler.jsonc` / `wrangler.json` (TOML via `smol-toml`, already a dependency; JSONC via the existing comment-mask helper + `JSON.parse` — no new grammar).
- Stamps `platform: 'cloudflare'` on the ServiceNode, and `platform: 'cloudflare'` + `platformName: <wrangler name>` on the Worker's entry FileNode (resolved from `main`). `platformName` is the only identifier Cloudflare's own telemetry carries — it's what the connector rewire (next PR) looks up against.
- Models declared resources as `InfraNode`s wired from the entry file: routes/custom domains (`CONNECTS_TO`, network-reachability — same shape `dockerfile.ts`'s `EXPOSE`→port edge uses), KV/D1/R2/Durable Object/Queue bindings + cron triggers + declared env-var names (`DEPENDS_ON`), and a shared `infra:workerd:cloudflare` runtime node (`RUNS_ON`, `compatibility_date` carried as `evidence.snippet`, mirroring `dockerfile.ts`'s image-node pattern). No new `NodeType`.
- A service binding to another Worker tagged in the same scan resolves directly onto that Worker's own entry FileNode (`CALLS`) instead of a placeholder — the two-pass discovery builds the full worker-name → entry-file map before any edge is written. A binding to a Worker outside this scan falls back to a `cloudflare-service-binding` InfraNode, honestly.
- Schema growth in `@neat.is/types`: `platform?: string` on `ServiceNodeSchema`, `platform?: string` + `platformName?: string` on `FileNodeSchema` — snapshot regenerated in this PR.

Per-environment `[env.X]` wrangler sections aren't read in v1 (only top-level config) — a scope line named in ADR-133, not a silent gap.

## Test plan

- [x] `npx vitest run --root packages/core test/extract-cloudflare.test.ts` — 9/9 new tests pass (tagging, runtime node, routes, all binding kinds, env-var existence-only, resolved + fallback service bindings, wrangler.jsonc, idempotency)
- [x] `npx vitest run --root packages/core` — full suite: 1445 passed, 2 skipped, 5 todo (no regressions)
- [x] `UPDATE_SNAPSHOT=1 vitest run test/audits/schema-snapshot.test.ts` — snapshot diff is additive-only (two new optional fields)
- [x] `npx turbo lint --filter=@neat.is/core --filter=@neat.is/types` — 0 errors (pre-existing warnings elsewhere, untouched by this PR)
- [x] `npx tsc --noEmit` — no new type errors (confirmed the handful of pre-existing errors elsewhere are present on `main` too, unrelated to this change)

Refs #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)