### PR TITLE
Fuse the Cloudflare connector onto the extracted platform tag (ADR-133)

### DIFF
--- a/packages/core/src/connectors/cloudflare/client.ts
+++ b/packages/core/src/connectors/cloudflare/client.ts
@@ -79,5 +79,17 @@ export async function queryWorkerInvocations(
     throw new Error(`cloudflare connector: telemetry query returned an error (${message})`)
   }
 
-  return payload.result?.events?.events ?? []
+  // `success: true` with no `result.events.events` array at all is shape
+  // drift — a real API-contract change, not the ordinary "no events this
+  // window" case (which arrives as an *empty* array here and warrants no
+  // warning). Silently treating both the same way hid an API change behind a
+  // quiet [] return; this distinguishes them so a real drift is loud.
+  const events = payload.result?.events?.events
+  if (events === undefined) {
+    console.warn(
+      '[neat connector] cloudflare: telemetry query returned success:true but no result.events.events array — the response shape may have changed; treating as zero events this tick',
+    )
+    return []
+  }
+  return events
 }

--- a/packages/core/src/connectors/cloudflare/connector.ts
+++ b/packages/core/src/connectors/cloudflare/connector.ts
@@ -5,9 +5,12 @@
 // signal's targetKind/targetName to a NEAT node id
 // (`createCloudflareResolveTarget`). Everything downstream — resolving a
 // static call site, minting the OBSERVED edge — is the shared pipeline in
-// connectors/index.ts; this module never mutates the graph itself.
+// connectors/index.ts; this module never mutates the graph itself (ADR-030 —
+// the honest-fallback case below declares a need via `ensureInfraNode`
+// instead of creating anything directly, docs/contracts/connectors.md §4a).
 
-import { EdgeType, fileId } from '@neat.is/types'
+import { EdgeType, NodeType, fileId, infraId } from '@neat.is/types'
+import type { NeatGraph } from '../../graph.js'
 import type { ResolveConnectorTarget, ResolvedConnectorTarget } from '../index.js'
 import type { ConnectorContext, ObservedConnector } from '../types.js'
 import { queryWorkerInvocations } from './client.js'
@@ -50,6 +53,25 @@ export class CloudflareConnector implements ObservedConnector {
   }
 }
 
+// Scan the live graph for the entry FileNode ADR-133's `extract/infra/
+// cloudflare.ts` tagged with this exact Worker script name
+// (`platform === 'cloudflare' && platformName === workerName`). A plain scan,
+// not a cached index — mirrors `reconcileObservedRelPath`'s own
+// `graph.forEachNode` walk (ingest.ts); per-project Worker counts are small
+// enough that this isn't worth a cache the live graph would have to
+// invalidate on every re-extraction.
+function findTaggedWorkerFileNode(graph: NeatGraph, workerName: string): string | null {
+  let found: string | null = null
+  graph.forEachNode((id, attrs) => {
+    if (found) return
+    const a = attrs as { type?: string; platform?: string; platformName?: string }
+    if (a.type === NodeType.FileNode && a.platform === 'cloudflare' && a.platformName === workerName) {
+      found = id
+    }
+  })
+  return found
+}
+
 // Provider-specific target resolution (README.md's pipeline step 2). Per
 // docs/connectors/cloudflare.md §Fusion, the signal's target is the Worker's
 // single entry FileNode — not the caller, since this API carries no caller
@@ -60,18 +82,45 @@ export class CloudflareConnector implements ObservedConnector {
 // reached" (connectors.md §4's fusion identity applies the same way here as
 // it does when a future extractor recognizes the same Worker's routes).
 //
-// A script with no entry in `config.workers` resolves to `null` — an honest
-// miss (connectors.md's own "never fabricates a node or edge" discipline),
-// not a guess at which service/file it might belong to.
-export function createCloudflareResolveTarget(config: CloudflareConnectorConfig): ResolveConnectorTarget {
+// Resolution order (ADR-133 §3, docs/contracts/connectors.md §4a):
+//   1. `config.workers[scriptName]` — an explicit override, wins outright.
+//   2. The extracted graph's own `platform`/`platformName` tag — the derived
+//      default, no config entry needed at all for a scanned project.
+//   3. Honest fallback — Cloudflare observed a Worker this scan never
+//      declared. Lands a real edge via `ensureInfraNode` (surfacing as a
+//      `missing-extracted` divergence) instead of a silent `null` drop.
+export function createCloudflareResolveTarget(
+  config: CloudflareConnectorConfig,
+  graph: NeatGraph,
+): ResolveConnectorTarget {
   return (signal): ResolvedConnectorTarget | null => {
     if (signal.targetKind !== CLOUDFLARE_TARGET_KIND) return null
-    const mapping = config.workers[signal.targetName]
-    if (!mapping) return null
+    const scriptName = signal.targetName
+
+    const mapping = config.workers?.[scriptName]
+    if (mapping) {
+      return {
+        targetNodeId: fileId(mapping.service, mapping.entryFile),
+        serviceName: mapping.service,
+        edgeType: EdgeType.CALLS,
+      }
+    }
+
+    const taggedFileId = findTaggedWorkerFileNode(graph, scriptName)
+    if (taggedFileId) {
+      const fileNode = graph.getNodeAttributes(taggedFileId) as { service: string }
+      return {
+        targetNodeId: taggedFileId,
+        serviceName: fileNode.service,
+        edgeType: EdgeType.CALLS,
+      }
+    }
+
     return {
-      targetNodeId: fileId(mapping.service, mapping.entryFile),
-      serviceName: mapping.service,
+      targetNodeId: infraId('cloudflare-worker', scriptName),
+      serviceName: scriptName,
       edgeType: EdgeType.CALLS,
+      ensureInfraNode: { kind: 'cloudflare-worker', name: scriptName, provider: 'cloudflare' },
     }
   }
 }

--- a/packages/core/src/connectors/cloudflare/types.ts
+++ b/packages/core/src/connectors/cloudflare/types.ts
@@ -1,8 +1,6 @@
 // Cloudflare Workers/Pages connector — provider-specific shapes
-// (docs/connectors/cloudflare.md, ADR-129). v1 ships at whole-file grain: no
-// route table, no Hono/itty-router recognizer — see the design doc's
-// §Static extractor gap for why, and packages/core/src/extract/routes.ts is
-// untouched by this cut.
+// (docs/connectors/cloudflare.md, ADR-129; resolution rewired onto the
+// extracted graph's platform tag by ADR-133).
 
 import type { ObservedSignal } from '../types.js'
 
@@ -12,17 +10,12 @@ import type { ObservedSignal } from '../types.js'
 export const CLOUDFLARE_TARGET_KIND = 'cloudflare-worker-invocation'
 
 // One Cloudflare Worker/Pages script's mapping onto a NEAT service + file.
-// Cloudflare's own telemetry only ever names the script (`$workers.scriptName`
-// / `$metadata.service`) — it has no idea which repo, service, or file that
-// script's code lives in. That mapping is genuinely not inferrable from the
-// telemetry itself, so it's supplied here, once, at connector-configuration
-// time (docs/connectors/cloudflare.md §Fusion): `service` is the NEAT
-// manifest name (package.json#name) the design doc says gets paired against
-// the Worker's `wrangler.toml`/`wrangler.jsonc` `name` field, and `entryFile`
-// is the service-relative path to the file containing
-// `export default { fetch(request, env, ctx) { ... } }`, resolved from that
-// same manifest's `main` field the same way NEAT's Node installer already
-// resolves an entry point.
+// ADR-133's `extract/infra/cloudflare.ts` now derives this pairing
+// automatically — it reads the Worker's `wrangler.toml`/`wrangler.jsonc`
+// `name` field and stamps it (`platformName`) on the entry FileNode
+// `createCloudflareResolveTarget` resolves against directly. This shape
+// survives as the explicit *override* for the config entries below: a repo
+// NEAT hasn't scanned, or a naming edge case auto-discovery can't cover.
 export interface CloudflareWorkerMapping {
   service: string
   entryFile: string
@@ -30,11 +23,12 @@ export interface CloudflareWorkerMapping {
 
 export interface CloudflareConnectorConfig {
   accountId: string
-  // Cloudflare script name → the NEAT service/file it maps to. One connector
-  // instance covers every Worker/Pages script in one Cloudflare account's
-  // telemetry; scripts with no entry here are honestly unresolved rather than
-  // guessed at (see createCloudflareResolveTarget in connector.ts).
-  workers: Record<string, CloudflareWorkerMapping>
+  // Explicit override, checked before the graph's own platform tag (see
+  // createCloudflareResolveTarget in connector.ts). Optional — most projects
+  // need no entry here at all now that extraction auto-discovers the pairing;
+  // scripts with neither an override nor a tagged match fall back to an
+  // honest placeholder InfraNode rather than being silently dropped.
+  workers?: Record<string, CloudflareWorkerMapping>
   // Cap on how far an absent `since` backfills, ms. Cloudflare's docs don't
   // confirm the Telemetry Query API's own max lookback window
   // (docs/connectors/cloudflare.md flags this needs-endpoint-testing); default

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -22,6 +22,7 @@
 import type { EdgeTypeValue } from '@neat.is/types'
 import type { NeatGraph } from '../graph.js'
 import {
+  ensureInfraNode,
   ensureObservedFileNode,
   ensureServiceNode,
   reconcileObservedRelPath,
@@ -62,6 +63,16 @@ export interface ResolvedConnectorTarget {
   targetNodeId: string
   serviceName: string
   edgeType: EdgeTypeValue
+  /**
+   * Set when `targetNodeId` names an InfraNode no static extractor has (yet)
+   * declared — the honest "observed but undeclared" fallback
+   * (docs/contracts/connectors.md §4a, ADR-133). A provider's `resolveTarget`
+   * has no mutation authority of its own (ADR-030), so it declares the need
+   * here instead of creating the node itself; the generic pipeline below
+   * calls `ensureInfraNode` before minting the edge. `targetNodeId` MUST equal
+   * `infraId(kind, name)` when this is set.
+   */
+  ensureInfraNode?: { kind: string; name: string; provider: string }
 }
 
 export type ResolveConnectorTarget = (
@@ -103,6 +114,14 @@ export async function runConnectorPoll(
     if (!resolved) {
       unresolved++
       continue
+    }
+
+    // Honest-fallback declaration (§ResolvedConnectorTarget doc) — ensure the
+    // InfraNode exists before the upsert below needs it to. Idempotent no-op
+    // once the node is created on a later poll.
+    if (resolved.ensureInfraNode) {
+      const { kind, name, provider } = resolved.ensureInfraNode
+      ensureInfraNode(graph, kind, name, provider)
     }
 
     // Same shape ingest.ts's handleSpan uses for every span: auto-create a

--- a/packages/core/src/connectors/registry.ts
+++ b/packages/core/src/connectors/registry.ts
@@ -235,13 +235,18 @@ export const PROVIDER_DISPATCH: Record<string, ProviderDispatch> = {
     provider: 'cloudflare',
     primaryCredentialKey: 'apiToken',
     requiredCredentialFields: ['apiToken'],
-    requiredOptionFields: ['accountId', 'workers'],
-    build(_graph, options) {
+    // `workers` dropped as a required field (ADR-133) — the mapping is now
+    // derived from the extracted graph's platform tag; an `options.workers`
+    // entry still works as an explicit override
+    // (CloudflareConnectorConfig.workers).
+    requiredOptionFields: ['accountId'],
+    build(graph, options) {
       const config = options as unknown as CloudflareConnectorConfig
-      // Class + separate resolveTarget factory; resolveTarget needs no graph.
+      // Class + separate resolveTarget factory; resolveTarget now closes over
+      // the graph to resolve against the platform tag (ADR-133).
       return {
         connector: new CloudflareConnector(config),
-        resolveTarget: createCloudflareResolveTarget(config),
+        resolveTarget: createCloudflareResolveTarget(config, graph),
       }
     },
     // GET /user/tokens/verify — Cloudflare's own purpose-built "is this API

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -1071,6 +1071,31 @@ export function ensureServiceNode(
   return id
 }
 
+// Exported so a connector's generic pipeline (connectors/index.ts) can create
+// an honest placeholder InfraNode for a provider-named resource no static
+// extractor has (yet) declared — a provider module has no mutation authority
+// of its own (ADR-030), so `resolveTarget` declares this need instead of
+// creating the node itself (ADR-133 §4a, docs/contracts/connectors.md).
+// Idempotent, same shape as `ensureServiceNode`.
+export function ensureInfraNode(
+  graph: NeatGraph,
+  kind: string,
+  name: string,
+  provider: string,
+): string {
+  const id = infraId(kind, name)
+  if (graph.hasNode(id)) return id
+  const node: InfraNode = {
+    id,
+    type: NodeType.InfraNode,
+    name,
+    provider,
+    kind,
+  }
+  graph.addNode(id, node)
+  return id
+}
+
 // Same shape for unseen db.system + host pairs. Engine comes off the OTel
 // attribute as a string per Rule 8 — no hardcoded engine list. compatibleDrivers
 // is empty until static extraction merges in the matrix-derived drivers.

--- a/packages/core/test/connectors-cloudflare.test.ts
+++ b/packages/core/test/connectors-cloudflare.test.ts
@@ -14,6 +14,7 @@ import {
 } from '@neat.is/types'
 import { runConnectorPoll, type ConnectorContext } from '../src/connectors/index.js'
 import type { NeatGraph } from '../src/graph.js'
+import { computeDivergences } from '../src/divergences.js'
 import {
   CloudflareConnector,
   createCloudflareResolveTarget,
@@ -225,11 +226,51 @@ describe('queryWorkerInvocations', () => {
       ),
     ).rejects.toThrow(/bad token/)
   })
+
+  it('warns on shape drift — success:true with no result.events.events array, instead of silently returning []', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ success: true }), { status: 200 }))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const events = await queryWorkerInvocations(
+        baseCtx(),
+        baseConfig(),
+        { fromMs: 1000, toMs: 2000 },
+        fetchImpl as unknown as typeof fetch,
+      )
+      expect(events).toEqual([])
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0]?.[0]).toContain('response shape may have changed')
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('does not warn when result.events.events is legitimately an empty array (no events this window)', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ success: true, result: { events: { count: 0, events: [] } } }), {
+          status: 200,
+        }),
+    )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const events = await queryWorkerInvocations(
+        baseCtx(),
+        baseConfig(),
+        { fromMs: 1000, toMs: 2000 },
+        fetchImpl as unknown as typeof fetch,
+      )
+      expect(events).toEqual([])
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
 })
 
-describe('createCloudflareResolveTarget', () => {
-  it('resolves a mapped script to the Worker entry FileNode, service-sourced', () => {
-    const resolveTarget = createCloudflareResolveTarget(baseConfig())
+describe('createCloudflareResolveTarget (ADR-133 resolution order)', () => {
+  it('1. resolves via the explicit config.workers override', () => {
+    const resolveTarget = createCloudflareResolveTarget(baseConfig(), newGraph())
     const signal = mapEventToSignal(TELEMETRY_RESPONSE.result!.events!.events[0])!
     const resolved = resolveTarget(signal, baseCtx())
 
@@ -240,12 +281,88 @@ describe('createCloudflareResolveTarget', () => {
     })
   })
 
-  it('returns null for a script with no configured mapping — honest miss, never guessed', () => {
-    const resolveTarget = createCloudflareResolveTarget(baseConfig())
+  it('2. resolves via the extracted graph platform tag when no override is configured', () => {
+    const graph = newGraph()
+    const taggedService = 'tagged-orders-worker'
+    const taggedEntry = 'src/entry.ts'
+    const taggedFileId = fileId(taggedService, taggedEntry)
+    const fileNode: FileNode = {
+      id: taggedFileId,
+      type: NodeType.FileNode,
+      service: taggedService,
+      path: taggedEntry,
+      platform: 'cloudflare',
+      platformName: 'tagged-script',
+    }
+    graph.addNode(taggedFileId, fileNode)
+
+    const resolveTarget = createCloudflareResolveTarget({ accountId: 'acct-123' }, graph)
+    const resolved = resolveTarget(
+      {
+        targetKind: 'cloudflare-worker-invocation',
+        targetName: 'tagged-script',
+        callCount: 1,
+        errorCount: 0,
+        lastObservedIso: new Date().toISOString(),
+      },
+      baseCtx(),
+    )
+
+    expect(resolved).toEqual({
+      targetNodeId: taggedFileId,
+      serviceName: taggedService,
+      edgeType: EdgeType.CALLS,
+    })
+  })
+
+  it('override wins even when the graph also carries a tagged match for the same script', () => {
+    const graph = newGraph()
+    // Tag a *different* FileNode under the same script name the config also maps.
+    const taggedFileId = fileId('other-service', 'src/other.ts')
+    graph.addNode(taggedFileId, {
+      id: taggedFileId,
+      type: NodeType.FileNode,
+      service: 'other-service',
+      path: 'src/other.ts',
+      platform: 'cloudflare',
+      platformName: SERVICE,
+    } satisfies FileNode)
+
+    const resolveTarget = createCloudflareResolveTarget(baseConfig(), graph)
+    const signal = mapEventToSignal(TELEMETRY_RESPONSE.result!.events!.events[0])!
+    const resolved = resolveTarget(signal, baseCtx())
+
+    expect(resolved?.targetNodeId).toBe(fileId(SERVICE, ENTRY_FILE))
+  })
+
+  it('3. honest fallback: a script with neither an override nor a tagged match declares ensureInfraNode instead of dropping silently', () => {
+    const resolveTarget = createCloudflareResolveTarget(baseConfig(), newGraph())
     const resolved = resolveTarget(
       {
         targetKind: 'cloudflare-worker-invocation',
         targetName: 'some-other-worker',
+        callCount: 1,
+        errorCount: 0,
+        lastObservedIso: new Date().toISOString(),
+      },
+      baseCtx(),
+    )
+
+    expect(resolved).not.toBeNull()
+    expect(resolved).toEqual({
+      targetNodeId: 'infra:cloudflare-worker:some-other-worker',
+      serviceName: 'some-other-worker',
+      edgeType: EdgeType.CALLS,
+      ensureInfraNode: { kind: 'cloudflare-worker', name: 'some-other-worker', provider: 'cloudflare' },
+    })
+  })
+
+  it('returns null outright for a signal of the wrong targetKind', () => {
+    const resolveTarget = createCloudflareResolveTarget(baseConfig(), newGraph())
+    const resolved = resolveTarget(
+      {
+        targetKind: 'some-other-provider-kind',
+        targetName: SERVICE,
         callCount: 1,
         errorCount: 0,
         lastObservedIso: new Date().toISOString(),
@@ -268,7 +385,7 @@ describe('CloudflareConnector end-to-end via runConnectorPoll', () => {
     globalThis.fetch = fetchImpl as unknown as typeof fetch
     try {
       const graph = newGraph()
-      const resolveTarget = createCloudflareResolveTarget(config)
+      const resolveTarget = createCloudflareResolveTarget(config, graph)
       const result = await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
 
       // 3 raw events in, 1 dropped (queue message) — 2 HTTP signals reach the
@@ -301,6 +418,61 @@ describe('CloudflareConnector end-to-end via runConnectorPoll', () => {
       // 2 invocations replayed (GET 200 + POST 500) — one error.
       expect(edge.signal?.spanCount).toBe(2)
       expect(edge.signal?.errorCount).toBe(1)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
+describe('honest fallback surfaces as a missing-extracted divergence (ADR-133 §3)', () => {
+  it('an observed-but-undeclared Worker lands a real edge, not a silent drop, and get_divergences reports it', async () => {
+    // An empty graph — this scan never declared "undeclared-worker" anywhere.
+    const graph: NeatGraph = new MultiDirectedGraph<GraphNode, GraphEdge>({ allowSelfLoops: false })
+    const config: CloudflareConnectorConfig = { accountId: 'acct-123' }
+    const connector = new CloudflareConnector(config)
+    const resolveTarget = createCloudflareResolveTarget(config, graph)
+
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          success: true,
+          result: {
+            events: {
+              count: 1,
+              events: [
+                {
+                  timestamp: 1751566800000,
+                  $metadata: { service: 'undeclared-worker', trigger: 'GET /', statusCode: 200 },
+                  $workers: { scriptName: 'undeclared-worker', outcome: 'ok' },
+                },
+              ],
+            },
+          },
+        } satisfies CloudflareTelemetryQueryResponse),
+        { status: 200 },
+      ),
+    )
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = fetchImpl as unknown as typeof fetch
+    try {
+      const result = await runConnectorPoll(connector, baseCtx(), graph, resolveTarget)
+      expect(result.unresolved).toBe(0)
+      expect(result.edgesCreated).toBe(1)
+
+      const infraId = 'infra:cloudflare-worker:undeclared-worker'
+      expect(graph.hasNode(infraId)).toBe(true)
+      const serviceNodeId = serviceId('undeclared-worker')
+      expect(graph.hasNode(serviceNodeId)).toBe(true)
+      const edgeId = observedEdgeId(serviceNodeId, infraId, EdgeType.CALLS)
+      expect(graph.hasEdge(edgeId)).toBe(true)
+
+      // No EXTRACTED twin exists on this (source, target, type) triple — the
+      // exact shape `missing-extracted` detects.
+      const { divergences } = computeDivergences(graph)
+      const found = divergences.find(
+        (d) => d.type === 'missing-extracted' && d.source === serviceNodeId && d.target === infraId,
+      )
+      expect(found).toBeDefined()
     } finally {
       globalThis.fetch = originalFetch
     }


### PR DESCRIPTION
## Summary

Phase 2 + 3b of #737, on top of #742's extractor.

- `createCloudflareResolveTarget(config, graph)` now resolves in three tiers: (1) `config.workers[scriptName]` — an explicit override, wins outright; (2) the extracted graph's own `platform`/`platformName` tag (ADR-133) — the derived default, no config entry needed; (3) an honest fallback for a Worker neither overridden nor tagged.
- `registry.ts`'s cloudflare dispatch drops `workers` from `requiredOptionFields` — `accountId` alone is enough to turn the connector on now that the mapping derives from the scan.
- The honest fallback no longer returns `null` (a silent drop only visible in connector logs). `ResolvedConnectorTarget` gains an optional `ensureInfraNode` field a provider's `resolveTarget` can declare — since a provider module has no mutation authority of its own (ADR-030) — and the generic pipeline (`connectors/index.ts`, which already holds ingest.ts's mutation authority) creates the placeholder `InfraNode` via a new exported `ensureInfraNode` (`ingest.ts`, mirroring the existing `ensureServiceNode`/`ensureDatabaseNode` shape) before minting the edge. The result: an observed-but-undeclared Worker lands a real edge with no EXTRACTED twin — a `missing-extracted` divergence `get_divergences` surfaces, not a connector-log line.
- Phase 3b, small enough to ride along: `client.ts`'s telemetry query no longer conflates "no events this window" (a legitimate empty array) with an unexpected `success: true` response missing `result.events.events` entirely (real API shape drift) — the latter now warns instead of silently returning `[]`.

## Test plan

- [x] `npx vitest run --root packages/core test/connectors-cloudflare.test.ts` — 17/17 pass (override precedence, tag resolution, override-wins-over-tag, honest fallback + `ensureInfraNode` shape, end-to-end `missing-extracted` divergence proof, shape-drift warn/no-warn)
- [x] `npx vitest run --root packages/core` — full suite: 1451 passed, 2 skipped, 5 todo
- [x] `npx turbo lint --filter=@neat.is/core --filter=@neat.is/types` — 0 errors
- [x] `npx tsc --noEmit` — no new type errors

Refs #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)