### PR TITLE
Add a Hono route recognizer to routes.ts (ADR-133 $5)

### DIFF
--- a/docs/connectors/cloudflare.md
+++ b/docs/connectors/cloudflare.md
@@ -119,21 +119,19 @@ and WebSocket channels were (ADR-031).
 
 ## Static extractor gap this connector exposes
 
-`routes.ts` recognizes Express, Fastify, and Next.js today — "mainstream routers only...
-coverage grows one router at a time." Neither of the two dominant in-Worker routing libraries,
-Hono and itty-router, nor a raw manual `fetch(request)` dispatch (a `switch`/`if` on
-`url.pathname`) is on that list. That gap is exactly why this connector's edges land at
-whole-file grain rather than per-route: there's no static route table on the Worker side yet for
-the Telemetry Query API's `trigger` string to resolve against.
-
-**v2, a distinct fast-follow, not part of this connector's build:** add a Hono recognizer to
-`routes.ts`'s router registry — `hono.get('/path', handler)`, `hono.post(...)`, and so on,
-gated on the `hono` manifest dependency, the same shape the existing Express/Fastify
-recognizers already take. Once that recognizer lands, a multi-route Hono Worker resolves to
-real `RouteNode`s and this connector's edges sharpen to route grain automatically — no
-connector-side change needed, because the fusion step already reconciles onto whatever static
-call site exists for a given file/line. itty-router and unrecognized manual routing stay
-file-grain-only until a recognizer for one of them earns its own slot in the registry.
+`routes.ts` recognizes Express, Fastify, Hono, and Next.js (ADR-133 §5 lands the Hono
+recognizer — `hono.get('/path', handler)`, `hono.post(...)`, and so on, gated on the `hono`
+manifest dependency, the same shape the Express/Fastify recognizers already take). A
+multi-route Hono Worker now resolves to real `RouteNode`s and this connector's edges sharpen
+to route grain automatically — no connector-side change needed, because the fusion step
+already reconciles onto whatever static call site exists for a given file/line. itty-router,
+`app.on([...methods], '/path', handler)`, and a raw manual `fetch(request)` dispatch (a
+`switch`/`if` on `url.pathname`) are still off that list, so a Worker using one of those shapes
+still lands at whole-file grain — there's no static route table on the Worker side for the
+Telemetry Query API's `trigger` string to resolve against. itty-router and unrecognized manual
+routing stay file-grain-only until a recognizer for one of them earns its own slot in the
+registry, the same "coverage grows one router at a time" discipline `routes.ts` already
+documents.
 
 ## Out of scope for this cut
 

--- a/docs/contracts/static-extraction.md
+++ b/docs/contracts/static-extraction.md
@@ -141,6 +141,7 @@ Static extraction reaches route grain. Two producers turn the two static islands
 |---|---|
 | Express | `app.<method>('/path', …)` / `router.<method>('/path', …)` |
 | Fastify | `fastify.<method>('/path', …)` and `fastify.route({ method, url })` |
+| Hono | `app.<method>('/path', …)` — same call shape as Express, gated on the `hono` manifest dependency (ADR-133 §5). `app.on([...methods], '/path', …)` isn't recognised — a Cloudflare Worker using it stays at the whole-file grain the connector already falls back to |
 | Next.js | app-router `app/**/route.*` handler exports (`GET`/`POST`/…), pages `pages/api/**` handlers |
 
 The declared template is kept verbatim on the node (`/users/:id`), so a future OBSERVED server span carrying the same `http.route` lands on the same node. Mount-prefix resolution (`app.use('/api', router)`) and intra-file call-graph resolution are out of scope for this slice — the declared path is captured as-is. Coverage grows one router at a time through the registry, the same way instrumentation coverage grows; exhaustive router heuristics are a non-goal.

--- a/packages/core/src/extract/routes.ts
+++ b/packages/core/src/extract/routes.ts
@@ -185,24 +185,30 @@ function fastifyRouteMethods(objNode: Parser.SyntaxNode): string[] {
   return []
 }
 
-// ── Express / Fastify call-expression routes ────────────────────────────────
+// ── Express / Fastify / Hono call-expression routes ─────────────────────────
 
 // Recognise route registrations of the shape `<router>.<method>('/path', …)`
-// and Fastify's `<fastify>.route({ method, url })`. The guard that keeps this
-// off `db.get('key')` / `_.get(obj, path)` is a string first argument that
-// starts with '/', combined with the caller-side dep gate in addRoutes (only
-// services that depend on express / fastify reach here). Mount-prefix
-// resolution (`app.use('/api', router)`) and `.route().get()` chaining are out
-// of scope for this slice — the literal declared path is captured as-is.
+// — Express, Fastify, and Hono (`hono.get('/path', handler)` etc.) all share
+// this exact call shape (ADR-133 §5: same registry pattern, Cloudflare
+// Worker's route-grain fast-follow) — and Fastify's own generic
+// `<fastify>.route({ method, url })` form. The guard that keeps this off
+// `db.get('key')` / `_.get(obj, path)` is a string first argument that starts
+// with '/', combined with the caller-side dep gate in addRoutes (only
+// services that depend on express / fastify / hono reach here). Mount-prefix
+// resolution (`app.use('/api', router)`), `.route().get()` chaining, and
+// Hono's own `app.on([...methods], '/path', handler)` form are out of scope
+// for this slice — the literal declared path is captured as-is. Coverage
+// grows one router at a time, same discipline as the rest of this registry.
 export function serverRoutesFromSource(
   source: string,
   parser: Parser,
   hasExpress: boolean,
   hasFastify: boolean,
+  hasHono = false,
 ): ExtractedRoute[] {
   const tree = parseSource(parser, source)
   const out: ExtractedRoute[] = []
-  const framework = hasExpress ? 'express' : 'fastify'
+  const framework = hasExpress ? 'express' : hasFastify ? 'fastify' : hasHono ? 'hono' : 'unknown'
   walk(tree.rootNode, (node) => {
     if (node.type !== 'call_expression') return
     const fn = node.childForFieldName('function')
@@ -391,8 +397,9 @@ export async function addRoutes(
     }
     const hasExpress = deps['express'] !== undefined
     const hasFastify = deps['fastify'] !== undefined
+    const hasHono = deps['hono'] !== undefined
     const hasNext = deps['next'] !== undefined
-    if (!hasExpress && !hasFastify && !hasNext) continue
+    if (!hasExpress && !hasFastify && !hasHono && !hasNext) continue
 
     const files = await loadSourceFiles(service.dir)
     for (const file of files) {
@@ -406,8 +413,8 @@ export async function addRoutes(
       try {
         if (hasNext && (isNextAppRouteFile(relFile) || isNextPagesApiFile(relFile))) {
           routes = nextRoutesFromFile(file.content, relFile, jsParser)
-        } else if (hasExpress || hasFastify) {
-          routes = serverRoutesFromSource(file.content, jsParser, hasExpress, hasFastify)
+        } else if (hasExpress || hasFastify || hasHono) {
+          routes = serverRoutesFromSource(file.content, jsParser, hasExpress, hasFastify, hasHono)
         } else {
           routes = []
         }

--- a/packages/core/test/extract-routes.test.ts
+++ b/packages/core/test/extract-routes.test.ts
@@ -61,6 +61,24 @@ describe('route extraction + client↔route matching (ADR-119)', () => {
     expect((graph.getNodeAttributes(del) as RouteNode).framework).toBe('fastify')
   })
 
+  it('extracts Hono routes — same call shape as Express, gated on the hono manifest dependency (ADR-133 §5)', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, FIXTURES)
+
+    const getWidget = routeId('hono-server', 'GET', '/widgets/:id')
+    expect(graph.hasNode(getWidget)).toBe(true)
+    const node = graph.getNodeAttributes(getWidget) as RouteNode
+    expect(node.framework).toBe('hono')
+    expect(node.method).toBe('GET')
+    expect(node.pathTemplate).toBe('/widgets/:id')
+
+    expect(graph.hasNode(routeId('hono-server', 'POST', '/widgets'))).toBe(true)
+
+    // Owned through CONTAINS, same as every other recognised router.
+    const containsId = extractedEdgeId(serviceId('hono-server'), getWidget, EdgeType.CONTAINS)
+    expect(graph.hasEdge(containsId)).toBe(true)
+  })
+
   it('extracts Next.js app-router and pages-api routes from file convention', async () => {
     const graph = getGraph()
     await extractFromDirectory(graph, FIXTURES)

--- a/packages/core/test/fixtures/routes/hono-server/index.ts
+++ b/packages/core/test/fixtures/routes/hono-server/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from 'hono'
+
+const app = new Hono()
+
+app.get('/widgets/:id', (c) => c.json({ id: c.req.param('id') }))
+
+app.post('/widgets', async (c) => c.json({ created: true }))
+
+export default app

--- a/packages/core/test/fixtures/routes/hono-server/package.json
+++ b/packages/core/test/fixtures/routes/hono-server/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "hono-server",
+  "version": "1.0.0",
+  "dependencies": {
+    "hono": "^4.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

Phase 3a of #737. `docs/connectors/cloudflare.md` (ADR-129) named this gap explicitly: "mainstream routers only... Hono and itty-router... aren't registered," which is why the Cloudflare connector ships at whole-file grain rather than per-route. This closes the Hono half.

- `routes.ts`'s `serverRoutesFromSource` takes a `hasHono` flag; Hono's `app.get('/path', handler)` / `app.post(...)` registration is the identical `<router>.<method>('/path', …)` call shape Express already matches, so this is a dependency gate + a framework label, not new AST work.
- `addRoutes` gates on the `hono` manifest dependency the same way it gates on `express`/`fastify`.
- A multi-route Hono Worker now resolves to real `RouteNode`s. The Cloudflare connector needs zero changes for this to sharpen its edges to route grain — the fuse step already reconciles onto whatever static call site exists for a file/line.
- Updated `docs/contracts/static-extraction.md`'s router table and `docs/connectors/cloudflare.md`'s "Static extractor gap" section to reflect Hono no longer being an open gap (itty-router, `app.on([...methods], ...)`, and raw manual dispatch remain out of scope, named plainly).

## Test plan

- [x] `npx vitest run --root packages/core test/extract-routes.test.ts` — 7/7 pass (new Hono test: method + path-template + CONTAINS ownership)
- [x] `npx vitest run --root packages/core` — full suite: 1446 passed, 2 skipped, 5 todo
- [x] `npx turbo lint --filter=@neat.is/core --filter=@neat.is/types` — 0 errors

Refs #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)