### PR TITLE
Sharpen the Cloudflare connector to route grain when a RouteNode matches (ADR-133 $5)

### DIFF
--- a/docs/connectors/cloudflare.md
+++ b/docs/connectors/cloudflare.md
@@ -52,9 +52,13 @@ optional filters/group-bys and returns per-invocation records carrying, among ot
 - `statusCode`, `duration`, `traceDuration` — response status and timing.
 - `service` — the Worker script name that produced the event.
 
-This connector's v1 parses only the HTTP method token off the front of `trigger` (`"GET"` out
-of `"GET /users"`) for edge metadata — no attempt to match the remainder against a route table,
-since no static route table for the framework shapes below exists yet.
+This connector parses the HTTP method token off the front of `trigger` (`"GET"` out of
+`"GET /users"`) plus the remainder as a path (ADR-133 §5). The path is matched against the
+resolved Worker's own `RouteNode`s — real for a Hono-routed Worker (the recognizer `routes.ts`
+now has) — and the edge sharpens to route grain on a match; it lands at the whole-file grain
+below otherwise (unrecognized router, or the path simply doesn't line up with a declared
+route). See [`static-extraction.md`](../contracts/static-extraction.md)'s router table for
+which shapes resolve today.
 
 - **Enablement:** a `wrangler.toml`/`wrangler.jsonc` deploy flag —
   `observability = { enabled = true, invocation_logs = true }` — with zero application code
@@ -99,22 +103,29 @@ poll it.
   path, URL, route, or HTTP method field at all. Even if the push-shape problem didn't apply,
   this dataset wouldn't carry the signal this connector needs.
 
-## Fusion — node identity
+## Fusion — node identity (rewired onto extraction by ADR-133)
 
 Cloudflare's Worker/script name (the `name` field in `wrangler.toml`/`wrangler.jsonc`, and the
 `service` field the Telemetry Query API returns) does not generally match NEAT's
 manifest-derived `serviceId(name)` (`package.json#name`) — the same gap Railway's connector
-design (ADR-127) names for its own provider-specific service name. Resolving that gap is an
-explicit config-time mapping, not a guess: the project's `wrangler.toml`/`wrangler.jsonc` `name`
-field is read alongside `package.json#name` at connector-configuration time, and the pair is
-recorded once, the same way a Railway project's service mapping is recorded once.
+design (ADR-127) names for its own provider-specific service name. This connector no longer
+resolves that gap as a hand-maintained config mapping: `extract/infra/cloudflare.ts` (ADR-133)
+reads the project's `wrangler.toml`/`wrangler.jsonc` `name` field itself and stamps it
+(`platformName`) directly on the Worker's entry `FileNode`, alongside `platform: 'cloudflare'`
+on both the `FileNode` and its owning `ServiceNode`. `createCloudflareResolveTarget` resolves a
+telemetry event's `scriptName` against that tag — no config entry needed for a project NEAT has
+scanned. A `connectors.json` `workers` mapping still works as an explicit override for a repo
+NEAT hasn't scanned, or a naming edge case auto-discovery can't cover
+(`docs/contracts/connectors.md` §4a).
 
-Once the Worker's NEAT service is known, its entry `FileNode` is `fileId(service, relPath)` —
-`relPath` resolved from the same `wrangler.toml`/`wrangler.jsonc` `main` field the installer
-already reads. Edge type is `CALLS`, minted file-grained via the same
-`upsertObservedEdge`/`reconcileObservedRelPath` path OTLP-derived edges use
-(connectors.md §4), with the parsed HTTP method and `statusCode`/`duration` carried as edge
-metadata. No new `NodeType` — this is additive the same way GraphQL operations, gRPC methods,
+The entry `FileNode`'s id is `fileId(service, relPath)` — `relPath` resolved from the same
+`wrangler.toml`/`wrangler.jsonc` `main` field the installer's own entry-detection reads.
+Resolution is name-based, not call-site-based — this connector's signal carries no `file`/`line`
+the way an OTel span does, so it never goes through the `reconcileObservedRelPath` path OTLP
+ingest uses; `resolveTarget` names the target FileNode (or, once a Hono-routed Worker's
+`RouteNode`s exist and the invocation's parsed path matches one, that `RouteNode` — ADR-133 §5)
+directly. Edge type is `CALLS`, with the parsed HTTP method and `statusCode`/`duration` carried
+as edge metadata. No new `NodeType` — this is additive the same way GraphQL operations, gRPC methods,
 and WebSocket channels were (ADR-031).
 
 ## Static extractor gap this connector exposes

--- a/packages/core/src/connectors/cloudflare/connector.ts
+++ b/packages/core/src/connectors/cloudflare/connector.ts
@@ -11,6 +11,7 @@
 
 import { EdgeType, NodeType, fileId, infraId } from '@neat.is/types'
 import type { NeatGraph } from '../../graph.js'
+import { normalizePathTemplate } from '../../extract/routes.js'
 import type { ResolveConnectorTarget, ResolvedConnectorTarget } from '../index.js'
 import type { ConnectorContext, ObservedConnector } from '../types.js'
 import { queryWorkerInvocations } from './client.js'
@@ -72,15 +73,42 @@ function findTaggedWorkerFileNode(graph: NeatGraph, workerName: string): string 
   return found
 }
 
+// Route-grain sharpening (ADR-133 §5): once a Hono (or future-recognized)
+// Worker's routes exist as RouteNodes, an invocation whose parsed
+// (method, path) matches one lands on that RouteNode instead of the whole
+// entry file — the same param-agnostic comparison `route-match.ts` already
+// uses for cross-service HTTP client↔route matching. No match (no route
+// recognizer covers this Worker's router, or the path doesn't line up) keeps
+// the existing whole-file target — sharpens automatically when the static
+// side supports it, stays honest when it doesn't.
+function findMatchingRouteNode(
+  graph: NeatGraph,
+  serviceName: string,
+  method: string,
+  path: string,
+): string | null {
+  const normalizedPath = normalizePathTemplate(path)
+  let found: string | null = null
+  graph.forEachNode((id, attrs) => {
+    if (found) return
+    const a = attrs as { type?: string; service?: string; method?: string; pathTemplate?: string }
+    if (a.type !== NodeType.RouteNode || a.service !== serviceName) return
+    if (!a.pathTemplate || normalizePathTemplate(a.pathTemplate) !== normalizedPath) return
+    const routeMethod = (a.method ?? '').toUpperCase()
+    if (routeMethod !== 'ALL' && routeMethod !== method) return
+    found = id
+  })
+  return found
+}
+
 // Provider-specific target resolution (README.md's pipeline step 2). Per
 // docs/connectors/cloudflare.md §Fusion, the signal's target is the Worker's
-// single entry FileNode — not the caller, since this API carries no caller
-// identity at all, only "this script was invoked". The edge that results,
-// `service --CALLS--> entryFile`, mirrors the WebSocket channel precedent
-// (ADR-125): a liveness signal minted from a service onto its own child node,
-// reusing an existing edge verb rather than inventing one for "this file got
-// reached" (connectors.md §4's fusion identity applies the same way here as
-// it does when a future extractor recognizes the same Worker's routes).
+// single entry FileNode by default — not the caller, since this API carries
+// no caller identity at all, only "this script was invoked". The edge that
+// results, `service --CALLS--> entryFile`, mirrors the WebSocket channel
+// precedent (ADR-125): a liveness signal minted from a service onto its own
+// child node, reusing an existing edge verb rather than inventing one for
+// "this file got reached".
 //
 // Resolution order (ADR-133 §3, docs/contracts/connectors.md §4a):
 //   1. `config.workers[scriptName]` — an explicit override, wins outright.
@@ -89,6 +117,10 @@ function findTaggedWorkerFileNode(graph: NeatGraph, workerName: string): string 
 //   3. Honest fallback — Cloudflare observed a Worker this scan never
 //      declared. Lands a real edge via `ensureInfraNode` (surfacing as a
 //      `missing-extracted` divergence) instead of a silent `null` drop.
+// Whichever of (1)/(2) resolves, a route-grain match (ADR-133 §5) is
+// attempted against that service's own RouteNodes before falling back to the
+// whole-file target — sharpening happens automatically once a static router
+// recognizer covers this Worker, never forced when it doesn't.
 export function createCloudflareResolveTarget(
   config: CloudflareConnectorConfig,
   graph: NeatGraph,
@@ -96,11 +128,18 @@ export function createCloudflareResolveTarget(
   return (signal): ResolvedConnectorTarget | null => {
     if (signal.targetKind !== CLOUDFLARE_TARGET_KIND) return null
     const scriptName = signal.targetName
+    const { method, path } = signal as CloudflareObservedSignal
+
+    const resolveRouteGrain = (serviceName: string, wholeFileId: string): string => {
+      if (!method || !path) return wholeFileId
+      return findMatchingRouteNode(graph, serviceName, method, path) ?? wholeFileId
+    }
 
     const mapping = config.workers?.[scriptName]
     if (mapping) {
+      const wholeFileId = fileId(mapping.service, mapping.entryFile)
       return {
-        targetNodeId: fileId(mapping.service, mapping.entryFile),
+        targetNodeId: resolveRouteGrain(mapping.service, wholeFileId),
         serviceName: mapping.service,
         edgeType: EdgeType.CALLS,
       }
@@ -110,7 +149,7 @@ export function createCloudflareResolveTarget(
     if (taggedFileId) {
       const fileNode = graph.getNodeAttributes(taggedFileId) as { service: string }
       return {
-        targetNodeId: taggedFileId,
+        targetNodeId: resolveRouteGrain(fileNode.service, taggedFileId),
         serviceName: fileNode.service,
         edgeType: EdgeType.CALLS,
       }

--- a/packages/core/src/connectors/cloudflare/index.ts
+++ b/packages/core/src/connectors/cloudflare/index.ts
@@ -1,11 +1,12 @@
 // Cloudflare Workers/Pages connector (docs/connectors/cloudflare.md, ADR-129).
-// v1 ships at whole-file grain, deliberately — see connector.ts and map.ts
-// for why. Re-exports the module's public surface for daemon/CLI wiring and
-// for tests.
+// Ships at whole-file grain by default, sharpening to route grain when a
+// static router recognizer covers the Worker (ADR-133 §5) — see connector.ts
+// and map.ts. Re-exports the module's public surface for daemon/CLI wiring
+// and for tests.
 
 export { CloudflareConnector, createCloudflareResolveTarget } from './connector.js'
 export { queryWorkerInvocations, type TelemetryWindow } from './client.js'
-export { mapEventToSignal, parseHttpMethodFromTrigger } from './map.js'
+export { mapEventToSignal, parseHttpMethodFromTrigger, parsePathFromTrigger } from './map.js'
 export {
   CLOUDFLARE_TARGET_KIND,
   type CloudflareConnectorConfig,

--- a/packages/core/src/connectors/cloudflare/map.ts
+++ b/packages/core/src/connectors/cloudflare/map.ts
@@ -1,16 +1,20 @@
-// Maps one Telemetry Query API invocation record to an ObservedSignal at
-// whole-file grain (docs/connectors/cloudflare.md §Fusion, ADR-129).
+// Maps one Telemetry Query API invocation record to an ObservedSignal
+// (docs/connectors/cloudflare.md §Fusion, ADR-129).
 //
 // The only route-shaped field this API exposes is `$metadata.trigger`
 // ("GET /users", "POST /orders", or a non-HTTP trigger like "queue message").
-// v1 parses the leading HTTP method token off it for metadata only — the
-// remainder is never matched against a route table, because no static route
-// recognizer exists yet for the in-Worker router shapes (Hono, itty-router,
-// manual `fetch(request)` dispatch) that would make such a match meaningful
-// (design doc's §Static extractor gap). A trigger that isn't HTTP-shaped
-// (cron, queue, alarm, ...) carries no method to parse and is out of scope
-// for this cut (§Out of scope) — dropped here, honestly, rather than
-// fabricating a method or forcing it through as an unresolvable signal.
+// The leading HTTP method token is parsed off it, and — now that a static
+// route recognizer exists for at least one in-Worker router shape (Hono,
+// ADR-133 §5) — the remainder is carried as `path` too, so
+// `createCloudflareResolveTarget` (connector.ts) can attempt a route-grain
+// match against that Worker's own RouteNodes. When no match resolves, the
+// signal still fuses at whole-file grain — the same "sharpens automatically
+// once the static side supports it" pattern the rest of the connectors plane
+// already follows (route-match.ts's own client↔route matching). A trigger
+// that isn't HTTP-shaped (cron, queue, alarm, ...) carries no method to parse
+// and is out of scope for this cut (§Out of scope) — dropped here, honestly,
+// rather than fabricating a method or forcing it through as an unresolvable
+// signal.
 
 import { CLOUDFLARE_TARGET_KIND, type CloudflareObservedSignal, type CloudflareTelemetryEvent } from './types.js'
 
@@ -42,6 +46,21 @@ export function parseHttpMethodFromTrigger(trigger: string | undefined): string 
   return HTTP_METHODS.has(method) ? method : null
 }
 
+// The path portion of an HTTP-shaped trigger — everything after the leading
+// method token, e.g. "GET /users/123" → "/users/123". Only called once
+// `parseHttpMethodFromTrigger` has already confirmed the leading token is a
+// real method, so there's no risk of misreading a non-HTTP trigger's own
+// text as a path. A query string, if present, rides along; route matching
+// canonicalises it away the same way a declared RouteNode template does
+// (routes.ts's `canonicalizeTemplate`).
+export function parsePathFromTrigger(trigger: string): string | undefined {
+  const trimmed = trigger.trim()
+  const spaceIdx = trimmed.indexOf(' ')
+  if (spaceIdx === -1) return undefined
+  const rest = trimmed.slice(spaceIdx + 1).trim()
+  return rest.length > 0 ? rest : undefined
+}
+
 // 5xx is treated as the unambiguous failure threshold for this connector's
 // own errorCount, mirroring the span-derived `isError` convention elsewhere
 // in ingest.ts (a bare 4xx is often correct app behavior — an auth probe, a
@@ -66,6 +85,7 @@ export function mapEventToSignal(event: CloudflareTelemetryEvent): CloudflareObs
 
   const statusCode = metadata?.statusCode
   const isError = typeof statusCode === 'number' && statusCode >= ERROR_STATUS_THRESHOLD
+  const path = metadata?.trigger ? parsePathFromTrigger(metadata.trigger) : undefined
 
   return {
     targetKind: CLOUDFLARE_TARGET_KIND,
@@ -74,6 +94,7 @@ export function mapEventToSignal(event: CloudflareTelemetryEvent): CloudflareObs
     errorCount: isError ? 1 : 0,
     lastObservedIso: new Date(timestampMs).toISOString(),
     method,
+    ...(path ? { path } : {}),
     ...(typeof statusCode === 'number' ? { statusCode } : {}),
     ...(typeof metadata?.duration === 'number' ? { duration: metadata.duration } : {}),
   }

--- a/packages/core/src/connectors/cloudflare/types.ts
+++ b/packages/core/src/connectors/cloudflare/types.ts
@@ -96,16 +96,16 @@ export interface CloudflareTelemetryQueryResponse {
 }
 
 // ObservedSignal, widened with the fields this connector's own mapping step
-// carries for metadata/testing purposes — `method` (parsed from `trigger`),
-// `statusCode`, `duration`. None of these are read by the generic
-// connectors pipeline (connectors/index.ts only consumes the base
-// ObservedSignal shape); they exist so map.ts's own output — and, through
-// it, `CloudflareConnector.poll()` — stays inspectable for exactly what
-// docs/connectors/cloudflare.md promises: "parses only the HTTP method token
-// off the front of trigger ... for edge metadata — no attempt to match the
-// remainder against a route table".
+// carries — `method` and `path` (parsed from `trigger`), `statusCode`,
+// `duration`. None of these are read by the generic connectors pipeline
+// (connectors/index.ts only consumes the base ObservedSignal shape); `method`/
+// `statusCode`/`duration` exist for metadata/testing purposes, while `path` is
+// read by this provider's own `createCloudflareResolveTarget` (connector.ts)
+// to attempt a route-grain match against the Worker's RouteNodes (ADR-133 §5)
+// before falling back to the whole-file target ADR-129 shipped.
 export interface CloudflareObservedSignal extends ObservedSignal {
   method: string
+  path?: string
   statusCode?: number
   duration?: number
 }

--- a/packages/core/test/connectors-cloudflare.test.ts
+++ b/packages/core/test/connectors-cloudflare.test.ts
@@ -6,10 +6,12 @@ import {
   Provenance,
   fileId,
   observedEdgeId,
+  routeId,
   serviceId,
   type FileNode,
   type GraphEdge,
   type GraphNode,
+  type RouteNode,
   type ServiceNode,
 } from '@neat.is/types'
 import { runConnectorPoll, type ConnectorContext } from '../src/connectors/index.js'
@@ -20,8 +22,10 @@ import {
   createCloudflareResolveTarget,
   mapEventToSignal,
   parseHttpMethodFromTrigger,
+  parsePathFromTrigger,
   queryWorkerInvocations,
   type CloudflareConnectorConfig,
+  type CloudflareObservedSignal,
   type CloudflareTelemetryEvent,
   type CloudflareTelemetryQueryResponse,
 } from '../src/connectors/cloudflare/index.js'
@@ -141,6 +145,17 @@ describe('parseHttpMethodFromTrigger', () => {
   })
 })
 
+describe('parsePathFromTrigger (ADR-133 §5)', () => {
+  it('returns everything after the leading method token', () => {
+    expect(parsePathFromTrigger('GET /users')).toBe('/users')
+    expect(parsePathFromTrigger('POST /orders/123')).toBe('/orders/123')
+  })
+
+  it('returns undefined when the trigger carries no path at all', () => {
+    expect(parsePathFromTrigger('GET')).toBeUndefined()
+  })
+})
+
 describe('mapEventToSignal (docs/connectors/cloudflare.md §Fusion)', () => {
   it('maps an ok HTTP invocation to a whole-file-grain signal with the method parsed out of trigger', () => {
     const signal = mapEventToSignal(TELEMETRY_RESPONSE.result!.events!.events[0])
@@ -153,11 +168,11 @@ describe('mapEventToSignal (docs/connectors/cloudflare.md §Fusion)', () => {
     expect(signal!.callCount).toBe(1)
     expect(signal!.errorCount).toBe(0)
     expect(signal!.lastObservedIso).toBe(new Date(1751566800000).toISOString())
-    // No route-matching attempt: the signal carries no path/route field at
-    // all, only the parsed method — confirms the mapper never touches the
-    // remainder of `trigger` beyond the leading method token.
+    // The path rides along too (ADR-133 §5) — parsed, not matched, here;
+    // matching against a Worker's own RouteNodes is
+    // createCloudflareResolveTarget's job (connector.ts), not the mapper's.
+    expect(signal!.path).toBe('/users')
     expect(signal).not.toHaveProperty('route')
-    expect(signal).not.toHaveProperty('path')
   })
 
   it('maps a failing (5xx) HTTP invocation with errorCount 1', () => {
@@ -370,6 +385,104 @@ describe('createCloudflareResolveTarget (ADR-133 resolution order)', () => {
       baseCtx(),
     )
     expect(resolved).toBeNull()
+  })
+
+  it('4. sharpens to route grain when the signal (method, path) matches a RouteNode owned by the resolved service (ADR-133 §5)', () => {
+    const graph = newGraph()
+    const route = routeId(SERVICE, 'GET', '/users/:id')
+    graph.addNode(route, {
+      id: route,
+      type: NodeType.RouteNode,
+      name: 'GET /users/:id',
+      service: SERVICE,
+      method: 'GET',
+      pathTemplate: '/users/:id',
+      path: ENTRY_FILE,
+      framework: 'hono',
+    } satisfies RouteNode)
+
+    // Resolved via the config.workers override (baseConfig()) — route-grain
+    // sharpening applies the same way regardless of which branch resolved
+    // the whole-file target first.
+    const resolveTarget = createCloudflareResolveTarget(baseConfig(), graph)
+    const resolved = resolveTarget(
+      {
+        targetKind: 'cloudflare-worker-invocation',
+        targetName: SERVICE,
+        callCount: 1,
+        errorCount: 0,
+        lastObservedIso: new Date().toISOString(),
+        method: 'GET',
+        path: '/users/123',
+      } satisfies CloudflareObservedSignal,
+      baseCtx(),
+    )
+
+    expect(resolved).toEqual({ targetNodeId: route, serviceName: SERVICE, edgeType: EdgeType.CALLS })
+  })
+
+  it('falls back to the whole-file target when no RouteNode matches (method or path differ)', () => {
+    const graph = newGraph()
+    const route = routeId(SERVICE, 'POST', '/users')
+    graph.addNode(route, {
+      id: route,
+      type: NodeType.RouteNode,
+      name: 'POST /users',
+      service: SERVICE,
+      method: 'POST',
+      pathTemplate: '/users',
+      path: ENTRY_FILE,
+      framework: 'hono',
+    } satisfies RouteNode)
+
+    const resolveTarget = createCloudflareResolveTarget(baseConfig(), graph)
+    const resolved = resolveTarget(
+      {
+        targetKind: 'cloudflare-worker-invocation',
+        targetName: SERVICE,
+        callCount: 1,
+        errorCount: 0,
+        lastObservedIso: new Date().toISOString(),
+        method: 'GET',
+        path: '/users/123',
+      } satisfies CloudflareObservedSignal,
+      baseCtx(),
+    )
+
+    expect(resolved).toEqual({
+      targetNodeId: fileId(SERVICE, ENTRY_FILE),
+      serviceName: SERVICE,
+      edgeType: EdgeType.CALLS,
+    })
+  })
+
+  it('falls back to the whole-file target when the signal carries no path at all', () => {
+    const graph = newGraph()
+    graph.addNode(routeId(SERVICE, 'GET', '/users/:id'), {
+      id: routeId(SERVICE, 'GET', '/users/:id'),
+      type: NodeType.RouteNode,
+      name: 'GET /users/:id',
+      service: SERVICE,
+      method: 'GET',
+      pathTemplate: '/users/:id',
+      path: ENTRY_FILE,
+      framework: 'hono',
+    } satisfies RouteNode)
+
+    const resolveTarget = createCloudflareResolveTarget(baseConfig(), graph)
+    const resolved = resolveTarget(
+      {
+        targetKind: 'cloudflare-worker-invocation',
+        targetName: SERVICE,
+        callCount: 1,
+        errorCount: 0,
+        lastObservedIso: new Date().toISOString(),
+        method: 'GET',
+      } satisfies CloudflareObservedSignal,
+      baseCtx(),
+    )
+
+    expect(resolved?.targetNodeId).toBe(fileId(SERVICE, ENTRY_FILE))
   })
 })
 

--- a/packages/core/test/divergences-cloudflare.test.ts
+++ b/packages/core/test/divergences-cloudflare.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import { computeDivergences } from '../src/divergences.js'
+import { runConnectorPoll } from '../src/connectors/index.js'
+import {
+  CloudflareConnector,
+  createCloudflareResolveTarget,
+  type CloudflareConnectorConfig,
+} from '../src/connectors/cloudflare/index.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES = path.resolve(__dirname, 'fixtures', 'infra')
+
+// The three real leads an agent uses get_divergences for on a Cloudflare
+// project (ADR-133 §Divergence surfacing), proven against the same
+// orders-worker/notifications-worker fixture Phase 1's extractor tests use.
+describe('get_divergences on a Cloudflare project (ADR-133)', () => {
+  beforeEach(() => resetGraph())
+
+  it('a wrangler-declared route with no matching production traffic surfaces as missing-observed', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'cloudflare'))
+
+    const { divergences } = computeDivergences(graph)
+    const entryFileId = 'file:orders-worker:src/index.ts'
+
+    // CONNECTS_TO is in the divergence engine's observable-edge-type allowlist
+    // (divergences.ts), so a declared route with no OBSERVED counterpart
+    // (no connector poll ran in this test at all) surfaces exactly the way
+    // any other declared-but-unobserved CONNECTS_TO edge would.
+    const routeMissing = divergences.find(
+      (d) =>
+        d.type === 'missing-observed' &&
+        d.source === entryFileId &&
+        d.target === 'infra:cloudflare-route:api.example.com/orders/*',
+    )
+    expect(routeMissing).toBeDefined()
+  })
+
+  it('a declared KV/D1/R2/DO/Queue/cron binding does NOT surface as missing-observed — DEPENDS_ON is deliberately excluded, honestly, not a Cloudflare-specific gap', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'cloudflare'))
+
+    const { divergences } = computeDivergences(graph)
+    const entryFileId = 'file:orders-worker:src/index.ts'
+
+    // divergences.ts's OBSERVABLE_EDGE_TYPES allowlist deliberately excludes
+    // DEPENDS_ON (and RUNS_ON) project-wide — the same reason a docker-compose
+    // depends_on edge never flags missing-observed either: there is no runtime
+    // span shape for "this deploys alongside that", so including it would flag
+    // every declared dependency everywhere as noise. Bindings inherit that
+    // exclusion rather than getting a Cloudflare-specific carve-out — asserted
+    // here so a future OBSERVABLE_EDGE_TYPES change doesn't silently start
+    // (or stop) surfacing these without a test noticing.
+    const kvMissing = divergences.find(
+      (d) => d.type === 'missing-observed' && d.source === entryFileId && d.target === 'infra:cloudflare-kv:SESSIONS',
+    )
+    expect(kvMissing).toBeUndefined()
+  })
+
+  it('a deployed Worker absent from wrangler surfaces as missing-extracted, not a silent connector-log line', async () => {
+    const graph = getGraph()
+    // Only orders-worker is declared in this scan; notifications-worker is
+    // deliberately excluded so its telemetry has no declared graph to land on.
+    await extractFromDirectory(graph, path.join(FIXTURES, 'cloudflare', 'orders-worker'))
+
+    const config: CloudflareConnectorConfig = { accountId: 'acct-123' }
+    const connector = new CloudflareConnector(config)
+    const resolveTarget = createCloudflareResolveTarget(config, graph)
+
+    const fetchImpl = async () =>
+      new Response(
+        JSON.stringify({
+          success: true,
+          result: {
+            events: {
+              count: 1,
+              events: [
+                {
+                  timestamp: Date.now(),
+                  $metadata: { service: 'shadow-worker', trigger: 'GET /', statusCode: 200 },
+                  $workers: { scriptName: 'shadow-worker', outcome: 'ok' },
+                },
+              ],
+            },
+          },
+        }),
+        { status: 200 },
+      )
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = fetchImpl as unknown as typeof fetch
+    try {
+      await runConnectorPoll(connector, { projectDir: '/repo', credentials: { apiToken: 't' } }, graph, resolveTarget)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+
+    const { divergences } = computeDivergences(graph)
+    const found = divergences.find(
+      (d) =>
+        d.type === 'missing-extracted' &&
+        d.source === 'service:shadow-worker' &&
+        d.target === 'infra:cloudflare-worker:shadow-worker',
+    )
+    expect(found).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #746 (the Hono recognizer). The design doc's claim was that landing a static router recognizer would sharpen this connector's edges to route grain "automatically... no connector-side change needed" — that's true for connectors whose signals carry a call site (`file`/`line`), because the generic pipeline's `reconcileObservedRelPath` fuses those onto whatever static call site exists. Cloudflare's Telemetry Query API signal carries neither — resolution is entirely name-based (`resolveTarget` names the target directly) — so the recognizer landing alone didn't actually produce route-grain edges. This PR closes that gap for real:

- `map.ts` now carries the path portion of `trigger` (`"GET /users"` → `path: "/users"`) alongside the already-parsed method, via a new `parsePathFromTrigger`.
- `createCloudflareResolveTarget` attempts a route-grain match — same param-agnostic `(method, path)` comparison `route-match.ts` already uses for cross-service HTTP client↔route matching — against the resolved service's own `RouteNode`s (real once a Hono-routed Worker exists, per #746) before falling back to the whole-file target. No match (unrecognized router, or the path just doesn't line up) keeps today's whole-file edge — sharpens automatically when the static side supports it, never forced when it doesn't.
- Corrected `docs/connectors/cloudflare.md`'s fusion section, which both described the pre-ADR-133 manual-mapping design and inaccurately claimed file-grain fusion went through `reconcileObservedRelPath` (it doesn't — this connector's signal has no call site to reconcile).

Flagging this explicitly since it's slightly beyond the literal Hono-recognizer ask: the recognizer alone doesn't deliver the route-grain payoff the design doc promised without this piece, so I built it rather than ship a "done" recognizer that doesn't actually sharpen anything.

## Test plan

- [x] `npx vitest run --root packages/core test/connectors-cloudflare.test.ts` — 22/22 pass (new: `parsePathFromTrigger` unit tests, route-grain match/no-match/no-path fallback tests)
- [x] `npx vitest run --root packages/core` — full suite: 1457 passed, 2 skipped, 5 todo
- [x] `npx turbo lint --filter=@neat.is/core --filter=@neat.is/types` — 0 errors
- [x] `npx tsc --noEmit` — no new type errors

Refs #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)