### PR TITLE
Expose connector status over HTTP for the connector view (ADR-136)

### DIFF
--- a/docs/contracts/connectors.md
+++ b/docs/contracts/connectors.md
@@ -3,7 +3,7 @@ name: connectors
 description: The connectors plane — a second OBSERVED ingestion path (pull) alongside OTLP (push). One provider interface, ambient/passive only, fusion at the same file-grain call site OTLP ingest already targets. Supabase, Railway, Firebase, and Cloudflare Workers/Pages are built providers; every provider's outbound call routes through the shared junction layer (timeout, retry, per-account rate limiting); how a connector gets configured with real credentials lives in the sibling connector-config.md contract.
 governs:
   - "packages/core/src/connectors/**"
-adr: [ADR-124, ADR-127, ADR-128, ADR-129, ADR-130, ADR-131, ADR-132, ADR-133]
+adr: [ADR-124, ADR-127, ADR-128, ADR-129, ADR-130, ADR-131, ADR-132, ADR-133, ADR-136]
 enforcement: [lint, review]
 ---
 
@@ -61,9 +61,34 @@ A connector's config/broker state holds the credential. The graph records existe
 
 The raw provider record a connector's `map.ts` reads (a Railway `httpLogs` row, a Firebase `LogEntry`, a Cloudflare invocation record, a Supabase `edge_logs` row) carries more than the graph needs — a full request/invocation record, not just a count. Each connector emits a `LogEntry` (`logs.md`) for that same raw record, tagged `source: '<provider>'`, in addition to the `ObservedSignal` it already produces. This is additive: `poll()`'s signature, the `ObservedSignal` shape, and every existing signal-mapping test are unaffected — a connector's mapping layer now produces two outputs from one input instead of one, not a different one.
 
+## 8. Connector poll health is queryable — an in-process status tracker + a read-only endpoint (ADR-136)
+
+The poll loop's outcome is a queryable fact, not only a log line. A process-local status tracker (`packages/core/src/connectors/status.ts`) records, per connector id, on **every** tick — success and failure — `lastPollAt`, `lastOutcome` (`ok`/`error`), `lastError` (a short, secret-free string), `signalsLastPoll` (the count the tick returned), and the time of the last successful poll. `startConnectorPollLoop` is the sole writer (it takes the connector's id via `ConnectorRegistration.id` / its `connectorId` option); the connector-status endpoint is the sole reader. This is in-memory live state on the same "OBSERVED is a live signal, not an archive" footing as `logs-store.ts` — a daemon restart drops it and the next poll re-derives it, and it never touches the graph or the snapshot.
+
+`GET /:project/connectors` (dual-mounted per ADR-026, `rest-api.md`) reads `~/.neat/connectors.json`, filters to the project (`connectorMatchesProject`), and returns one entry per connector:
+
+```ts
+{ connectors: Array<{
+  id: string,
+  provider: string,
+  credentialRef: string | Record<string, string>,   // redacted env-ref pointer ("$CF_TOKEN"),
+                                                      // or field→pointer map; a plaintext literal → "****"
+  status: {
+    state: 'idle' | 'healthy' | 'error' | 'stale',    // idle: no poll yet; healthy: recent ok;
+                                                       // error: last tick threw; stale: no ok within the window
+    lastPollAt: string | null,                         // ISO8601
+    lastOutcome: 'ok' | 'error' | null,
+    lastError: string | null,                          // never a credential
+    signalsLastPoll: number,
+  },
+}> }
+```
+
+`credentialRef` reuses the same `isEnvRef`-driven redaction `neat connector list` prints, through a shared `redactCredentialRef` helper (`connectors-config.ts`); the endpoint never calls `resolveCredential`. The never-a-resolved-secret rule (§6) holds on this read surface exactly as it holds in the config file and the snapshot: the pointer is shown, the value never is — not in `credentialRef`, not in `lastError`, not in any log.
+
 ## Authority
 
-`packages/core/src/connectors/index.ts` owns the provider-agnostic pull/map/fuse pipeline. Each `packages/core/src/connectors/<provider>/` owns its own signal-fetch and target-resolution logic and answers to nothing else for that provider's shape.
+`packages/core/src/connectors/index.ts` owns the provider-agnostic pull/map/fuse pipeline. Each `packages/core/src/connectors/<provider>/` owns its own signal-fetch and target-resolution logic and answers to nothing else for that provider's shape. `packages/core/src/connectors/status.ts` owns the in-process poll-status tracker (§8) — the poll loop is its only writer, the connector-status endpoint its only reader. The endpoint itself is a route in `packages/core/src/api.ts`, governed by `rest-api.md`.
 
 ## Enforcement
 

--- a/docs/contracts/rest-api.md
+++ b/docs/contracts/rest-api.md
@@ -3,7 +3,7 @@ name: rest-api
 description: Routes dual-mount at /X and /projects/:project/X per ADR-026. JSON errors. Live graphology only — no graph.json reads at request time. Inbound bodies are Zod-validated. Outbound responses are always JSON objects (never bare arrays) per ADR-061's envelope rule.
 governs:
   - "packages/core/src/api.ts"
-adr: [ADR-040, ADR-026, ADR-061, ADR-110, ADR-116, ADR-132]
+adr: [ADR-040, ADR-026, ADR-061, ADR-110, ADR-116, ADR-132, ADR-136]
 enforcement: [lint, review]
 ---
 
@@ -50,6 +50,7 @@ Bare arrays from REST endpoints are a contract violation. Why: an object can gro
 | `GET /policies` | parsed `policy.json` | `{ version, policies: Policy[] }` |
 | `GET /policies/violations?severity=X&policyId=X` | current violations, filterable | `{ violations: PolicyViolation[] }` |
 | `GET /policies/applicable?node=X` | soft guardrail (ADR-108): policies that govern a node, matched by direct subject/region. Informs, never blocks | `{ node, applicable: ApplicablePolicy[] }` |
+| `GET /connectors` | the project's configured connectors from `~/.neat/connectors.json` (ADR-130), credentials redacted to the env-ref pointer (never resolved), each with its live poll health from the in-process status tracker (ADR-136, `connectors.md` §8) | `ConnectorsStatusResponse` — `{ connectors: ConnectorStatusEntry[] }` |
 | `GET /projects` | the project(s) this daemon serves (single-mount; not dual-mounted). A per-project daemon (ADR-096 §4) returns only its own project; the legacy multi-project daemon returns the machine-wide registry | `Array<RegistryEntry>` *(the one bare-array exception — its consumers (the dashboard's project pin, the CLI's bare-verb resolver) treat it as a list primitive)* |
 | `GET /projects/:project` | singular project lookup | `{ project: RegistryEntry }` |
 | `GET /api/config` | daemon auth-mode negotiation (ADR-073 §3a); always unauthenticated | `{ publicRead: boolean, authProxy: boolean }` |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1625,6 +1625,30 @@ interface LogEntry {
 - `get_logs` costs nothing against the CLI's locked-verb discipline (that lock is CLI-specific) but does spend the MCP tool surface's one open extensibility point for this cut; `neat logs` spends the CLI's eleventh-verb allowance this ADR unlocks.
 - Every consumer (REST, MCP, CLI, frontend) reads through one endpoint with one filter shape — an agent scoping a query to one provider and a developer clicking a filter chip are doing the identical operation against the identical data path.
 
+## ADR-136 — A read-only connector status endpoint, backed by an in-process poll-health tracker
+
+**Status:** Accepted. Refs #755. Amends [`rest-api.md`](contracts/rest-api.md) and [`connectors.md`](contracts/connectors.md); the response type lands in `@neat.is/types`.
+**Contracts:** [`rest-api.md`](contracts/rest-api.md), [`connectors.md`](contracts/connectors.md).
+
+### Context
+
+The connectors plane polls (ADR-124/127/128/129), `neat connector` turns a connector on via `~/.neat/connectors.json` (ADR-130), and the shared junction gives every outbound call its timeout/retry/rate-limit discipline (ADR-131). The one piece a connector view in the web GUI still needs is a read surface: which connectors are configured for a project, and whether each one is actually polling. Today the poll loop (`startConnectorPollLoop`, `connectors/index.ts`) `console.error`s a failed tick and moves on — the outcome reaches the log and nowhere queryable. `neat connector list` reads the config and redacts each credential to its env-ref pointer, but it is terminal-only and says nothing about live poll health. So a dashboard asking "is `cf-prod` healthy, and when did it last poll?" has no answer to render.
+
+### Decision
+
+**1. `GET /:project/connectors`, dual-mounted per ADR-026.** Returns `{ connectors: [...] }`, one entry per `connectors.json` connector that matches the project (`connectorMatchesProject`), each shaped `{ id, provider, credentialRef, status }`. `credentialRef` is the redacted env-ref pointer (`"$CF_TOKEN"`) for a single-field credential, or a field→pointer map for a multi-field one; a plaintext literal shows `"****"` — the same `isEnvRef`-driven redaction `neat connector list` already prints, factored into a shared `redactCredentialRef` helper so the two surfaces can never disagree on what counts as a pointer. Read-only, reads the live config file (no graph read at request time), envelope per ADR-061.
+
+**2. An in-process poll-status tracker.** A process-local module singleton (`connectors/status.ts`) — the same in-memory, daemon-restart-loses-it shape `logs-store.ts` already uses for the daemon's other live surface — that the poll loop writes on **every** tick (success and failure) and the endpoint reads. Per connector id it records `lastPollAt` (ISO), `lastOutcome` (`ok`/`error`), `lastError` (a short, secret-free string, present only on a failing tick), `signalsLastPoll` (the count the tick returned), and the time of the last successful poll. The reported `state` is derived at read time: `idle` (no tick yet), `error` (the last tick threw), `healthy` (a recent successful poll), `stale` (no successful poll within the threshold — a poll loop gone silent or wedged, a connector-poll concept distinct from the per-edge-type `OBSERVED`→`STALE` thresholds; default five poll intervals). The tracker keys by connector id, which flows from the config entry through the `ConnectorRegistration` into the poll loop; a connector without an id (a programmatic `opts.connectors` entry, never in `connectors.json`) records nothing and never appears on this endpoint.
+
+**3. Secret discipline is kept by construction.** The endpoint never calls `resolveCredential` — it only ever reports the pointer, exactly as `neat connector list` does. `lastError` carries the poll error's own message, truncated, never a credential; the resolved secret exists only inside the `ConnectorContext` that flows to `poll()`, precisely as `connector-config.md` §6 and `connectors.md` §6 already require. A regression test asserts that a `$VAR` credential is returned as the literal pointer and that its resolved value appears nowhere in the response.
+
+### Consequences
+
+- The web GUI's connector view (and a future `neat connector list --verbose`, the surface ADR-131's consequences already anticipated) gets a real data path — configured connectors plus live health — where none existed.
+- The poll loop's failed-tick `console.error` becomes a queryable fact without changing what the tick mints or how it advances `since`; the recording is additive and fires only for connectors that carry an id, so programmatic callers are unaffected and every existing connector test keeps passing.
+- No new node, edge, or provenance type: connector status is process-local runtime state, never the graph and never the snapshot — consistent with the "OBSERVED is a live signal, not an archive" framing and the credentials-never-reach-the-snapshot rule the rest of the plane already holds to.
+- A silent or wedged poll loop surfaces as `stale` rather than sitting `healthy` forever, so the view distinguishes "polling and fine" from "configured but not actually running."
+
 ## Closed forward-looking issues referenced here
 
 - **#365** — Lazy project activation (v0.5+, deeper version of ADR-079)

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -55,6 +55,12 @@ import { Projects as ProjectsClass, pathsForProject } from './projects.js'
 import { getProject as getRegistryProject, listProjects as listRegistryProjects } from './registry.js'
 import { handleSse } from './streaming.js'
 import { mountBearerAuth, readAuthEnv } from './auth.js'
+import {
+  connectorMatchesProject,
+  readConnectorsConfig,
+  redactCredentialRef,
+} from './connectors-config.js'
+import { getConnectorStatus } from './connectors/status.js'
 
 export interface BuildApiOptions {
   // Multi-project shape. Optional — when absent we synthesise a single-
@@ -96,6 +102,13 @@ export interface BuildApiOptions {
   // spawn-reuse identity check. Absent → the legacy multi-project daemon, whose
   // `/projects` is the machine-wide registry passthrough.
   singleProject?: { name: string; path: string }
+
+  // ADR-136 — the resolved NEAT_HOME the connector-status endpoint
+  // (`GET /:project/connectors`) reads `~/.neat/connectors.json` from. The
+  // daemon passes the same home its slot bootstrap read the file from. Absent
+  // falls back to the env-based resolution in connectors-config.ts (the CLI /
+  // test path), so callers that never touch connectors need not set it.
+  connectorsHome?: string
 }
 
 interface SerializedGraph {
@@ -209,6 +222,9 @@ interface RouteContext {
   // (and `default`-named) requests resolve to it instead of the `default`
   // project. Absent for the legacy multi-project daemon.
   singleProject?: string
+  // ADR-136 — where the connector-status route reads connectors.json from.
+  // Undefined uses connectors-config.ts's env-based home resolution.
+  connectorsHome?: string
 }
 
 // Registers every project-scoped route on `scope`. Called twice from
@@ -445,6 +461,35 @@ function registerRoutes(scope: FastifyInstance, ctx: RouteContext): void {
         : LOGS_QUERY_DEFAULT_LIMIT
     const sliced = filtered.slice(0, safeLimit)
     return { count: sliced.length, total, logs: sliced }
+  })
+
+  // Connector status (docs/contracts/rest-api.md, connectors.md §8, ADR-136).
+  // Read-only view backing the web GUI's connector view: the connectors
+  // configured for this project in ~/.neat/connectors.json, each with its
+  // credential redacted to the env-ref pointer (never a resolved secret) and
+  // the live poll health the in-process status tracker recorded. Reads the live
+  // config file, never the graph; dual-mounted per ADR-026 like every route.
+  scope.get<{ Params: { project?: string } }>('/connectors', async (req, reply) => {
+    const proj = resolveProject(registry, req, reply, ctx.bootstrap, ctx.singleProject)
+    if (!proj) return
+    let entries
+    try {
+      entries = (await readConnectorsConfig(ctx.connectorsHome)).connectors
+    } catch (err) {
+      return reply.code(500).send({
+        error: 'connectors.json failed to read',
+        details: (err as Error).message,
+      })
+    }
+    const connectors = entries
+      .filter((entry) => connectorMatchesProject(entry, proj.name))
+      .map((entry) => ({
+        id: entry.id,
+        provider: entry.provider,
+        credentialRef: redactCredentialRef(entry.credential),
+        status: getConnectorStatus(entry.id),
+      }))
+    return { connectors }
   })
 
   // One handler, two paths: `/incidents/:nodeId` is the original REST name and
@@ -996,6 +1041,7 @@ export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> 
     policyFilePathFor,
     bootstrap: opts.bootstrap,
     singleProject: opts.singleProject?.name,
+    connectorsHome: opts.connectorsHome,
   }
 
   // Daemon-wide /health (issue #343). Per ADR-049 the daemon is the unit of

--- a/packages/core/src/connectors-config.ts
+++ b/packages/core/src/connectors-config.ts
@@ -316,6 +316,26 @@ export function isEnvRef(value: string): boolean {
 }
 
 /**
+ * Redact a credential ref to its env-ref pointer for a read surface — the
+ * connector-status endpoint (`GET /:project/connectors`, ADR-136) and any other
+ * caller that must show a connector's credential without ever resolving it. A
+ * single-field credential redacts to one string; a multi-field one to a
+ * field→pointer map. An env-ref (`$VAR`) is safe to show verbatim — it names the
+ * variable, not the secret; a plaintext literal shows `****`. Reuses `isEnvRef`,
+ * the same predicate the daemon resolver and `describeCredential` rely on, so no
+ * read surface can drift from what actually counts as a pointer. This never
+ * touches the environment — the secret value is never read here (connectors.md
+ * §6, connector-config.md §2).
+ */
+export function redactCredentialRef(ref: CredentialRef): string | Record<string, string> {
+  const one = (value: string): string => (isEnvRef(value) ? value : '****')
+  if (typeof ref === 'string') return one(ref)
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(ref)) out[key] = one(value)
+  return out
+}
+
+/**
  * tmp + fsync + rename, with the tmp file created mode `0600` so the bytes are
  * never briefly readable by group/other before the rename swaps them in. An
  * explicit `chmod(0o600)` on the handle backs the open-mode up in case a umask

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -30,6 +30,7 @@ import {
   type CallSite,
 } from '../ingest.js'
 import type { ConnectorContext, ObservedConnector, ObservedSignal } from './types.js'
+import { recordConnectorPoll, sanitizePollError } from './status.js'
 
 export type {
   ConnectorCallSite,
@@ -192,6 +193,11 @@ export async function runConnectorPoll(
 export interface ConnectorPollLoopOptions {
   intervalMs?: number
   onError?: (err: unknown) => void
+  // The connector's config-entry id (ADR-130). When set, every tick — success
+  // and failure — is recorded to the in-process status tracker (status.ts) the
+  // connector-status endpoint reads (ADR-136). A programmatic connector with no
+  // id records nothing and never appears on that endpoint.
+  connectorId?: string
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 60_000
@@ -218,6 +224,7 @@ export function startConnectorPollLoop(
   let stopped = false
   let since = ctx.since
   const intervalMs = options.intervalMs ?? DEFAULT_POLL_INTERVAL_MS
+  const connectorId = options.connectorId
   const onError =
     options.onError ??
     ((err: unknown) => console.error(`[neatd] connector poll failed (${connector.provider})`, err))
@@ -227,10 +234,29 @@ export function startConnectorPollLoop(
     void (async () => {
       const tickStartedAt = new Date().toISOString()
       try {
-        await runConnectorPoll(connector, { ...ctx, since }, graph, resolveTarget)
+        const result = await runConnectorPoll(connector, { ...ctx, since }, graph, resolveTarget)
         since = tickStartedAt
+        // Record the successful tick for the status endpoint (ADR-136). This is
+        // additive to the poll — it never changes what the tick mints or how
+        // `since` advances.
+        if (connectorId) {
+          recordConnectorPoll(connectorId, {
+            outcome: 'ok',
+            at: tickStartedAt,
+            signalsLastPoll: result.signalCount,
+          })
+        }
       } catch (err) {
         onError(err)
+        // The failed tick becomes a queryable fact instead of only a log line.
+        // `sanitizePollError` keeps the recorded message short and secret-free.
+        if (connectorId) {
+          recordConnectorPoll(connectorId, {
+            outcome: 'error',
+            at: tickStartedAt,
+            error: sanitizePollError(err),
+          })
+        }
       }
     })()
   }
@@ -251,6 +277,11 @@ export function startConnectorPollLoop(
  * wires a connector through.
  */
 export interface ConnectorRegistration {
+  // The config-entry id this registration was built from, when it came from
+  // ~/.neat/connectors.json (ADR-130). The daemon threads it into the poll loop
+  // so every tick is recorded per-id for the connector-status endpoint
+  // (ADR-136). Absent for a programmatic registration a caller passes directly.
+  id?: string
   connector: ObservedConnector
   credentials: Record<string, unknown>
   resolveTarget: ResolveConnectorTarget

--- a/packages/core/src/connectors/registry.ts
+++ b/packages/core/src/connectors/registry.ts
@@ -353,6 +353,9 @@ export function buildRegistration(
   return {
     ok: true,
     registration: {
+      // Carry the entry id so the daemon can key this connector's poll-status
+      // records to it (ADR-136).
+      id: entry.id,
       connector: built.connector,
       credentials,
       resolveTarget: built.resolveTarget,

--- a/packages/core/src/connectors/status.ts
+++ b/packages/core/src/connectors/status.ts
@@ -1,0 +1,125 @@
+// Connector poll-status tracker — the in-process record of each connector's
+// most recent poll tick (docs/contracts/connectors.md §8, ADR-136).
+//
+// The connector poll loop (`startConnectorPollLoop`, index.ts) writes here on
+// EVERY tick, success and failure; the connector-status endpoint
+// (`GET /:project/connectors`, api.ts) reads here. A process-local module
+// singleton is the right shape for the same reason `logs-store.ts` is: this is
+// live runtime state, not graph or snapshot state — a daemon restart loses it
+// and re-derives it on the next poll, exactly the "OBSERVED is a live signal,
+// not an archive" trade the rest of the connectors plane already makes.
+//
+// Nothing here ever holds a credential. The tracker records an id, an outcome,
+// a short error string, a signal count, and timestamps — the resolved secret
+// stays inside the `ConnectorContext` that flows to `poll()` and never reaches
+// this module (connectors.md §6, connector-config.md §6).
+
+import type { ConnectorPollState, ConnectorStatus } from '@neat.is/types'
+
+// A connector polls on a 60s default cadence (`DEFAULT_POLL_INTERVAL_MS`,
+// index.ts). Five intervals of silence is the point past which "hasn't polled
+// recently" is worth surfacing as `stale` rather than a healthy connector that
+// simply hasn't ticked yet. This is a connector-poll concept, deliberately
+// distinct from the per-edge-type OBSERVED→STALE thresholds (ingest.ts) — those
+// decay graph edges; this flags a poll loop that has gone quiet or wedged.
+export const CONNECTOR_STALE_THRESHOLD_MS = 5 * 60_000
+
+// One connector's last recorded tick. `lastOkAt` is kept separately from
+// `lastPollAt` so a run of failing ticks can still tell how long it has been
+// since the connector last actually succeeded — that gap is what `stale` reads.
+interface PollRecord {
+  lastPollAt: string
+  lastOutcome: 'ok' | 'error'
+  lastError: string | null
+  signalsLastPoll: number
+  lastOkAt: string | null
+}
+
+const records = new Map<string, PollRecord>()
+
+const MAX_ERROR_LEN = 200
+
+/**
+ * Reduce a poll error to a short, single-line string safe to expose on the
+ * status endpoint. Collapses whitespace and truncates — a poll error carries a
+ * provider name and HTTP status, never a credential (the junction's own error
+ * strings are secret-free by construction, connectors/registry.ts §authProbe),
+ * and the truncation caps any accidental verbosity.
+ */
+export function sanitizePollError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err)
+  const collapsed = msg.replace(/\s+/g, ' ').trim()
+  return collapsed.length > MAX_ERROR_LEN ? `${collapsed.slice(0, MAX_ERROR_LEN - 1)}…` : collapsed
+}
+
+export interface PollTick {
+  outcome: 'ok' | 'error'
+  // The tick's own start time, ISO8601.
+  at: string
+  // Signals the tick returned — recorded on a successful tick, 0 otherwise.
+  signalsLastPoll?: number
+  // Short, secret-free message on a failing tick; ignored on a successful one.
+  error?: string | null
+}
+
+/**
+ * Record one poll tick for connector `id`. Called by the poll loop on every
+ * tick. A successful tick advances `lastOkAt`; a failing tick leaves the prior
+ * `lastOkAt` in place so `stale` still measures time-since-last-success.
+ */
+export function recordConnectorPoll(id: string, tick: PollTick): void {
+  const prev = records.get(id)
+  records.set(id, {
+    lastPollAt: tick.at,
+    lastOutcome: tick.outcome,
+    lastError: tick.outcome === 'error' ? (tick.error ?? null) : null,
+    signalsLastPoll: tick.signalsLastPoll ?? 0,
+    lastOkAt: tick.outcome === 'ok' ? tick.at : (prev?.lastOkAt ?? null),
+  })
+}
+
+// Derive the reported state from the raw record + wall clock. `error` wins over
+// `stale` because "the last tick threw" is the fresher, more actionable signal;
+// `stale` is for a connector whose last *success* has aged out of the window
+// (a loop that stopped ticking, so no fresh error either).
+function deriveState(rec: PollRecord, now: number, thresholdMs: number): ConnectorPollState {
+  if (rec.lastOutcome === 'error') return 'error'
+  const okAt = rec.lastOkAt ? Date.parse(rec.lastOkAt) : NaN
+  if (!Number.isNaN(okAt) && now - okAt > thresholdMs) return 'stale'
+  return 'healthy'
+}
+
+/**
+ * The live status for connector `id`. An id with no recorded tick is `idle`
+ * with null timestamps — the honest "configured but not yet polled" state, the
+ * same shape the endpoint returns for a freshly added connector. `now` and
+ * `thresholdMs` are injectable for deterministic tests.
+ */
+export function getConnectorStatus(
+  id: string,
+  now: number = Date.now(),
+  thresholdMs: number = CONNECTOR_STALE_THRESHOLD_MS,
+): ConnectorStatus {
+  const rec = records.get(id)
+  if (!rec) {
+    return {
+      state: 'idle',
+      lastPollAt: null,
+      lastOutcome: null,
+      lastError: null,
+      signalsLastPoll: 0,
+    }
+  }
+  return {
+    state: deriveState(rec, now, thresholdMs),
+    lastPollAt: rec.lastPollAt,
+    lastOutcome: rec.lastOutcome,
+    lastError: rec.lastError,
+    signalsLastPoll: rec.signalsLastPoll,
+  }
+}
+
+/** Drop every recorded status. Test-only — the daemon never clears mid-run. */
+export function resetConnectorStatus(): void {
+  records.clear()
+}

--- a/packages/core/src/daemon.ts
+++ b/packages/core/src/daemon.ts
@@ -578,7 +578,11 @@ async function bootstrapProject(
         { projectDir: entry.path, credentials: registration.credentials },
         graph,
         registration.resolveTarget,
-        { intervalMs: registration.intervalMs },
+        // `connectorId` is threaded through so every tick lands in the
+        // in-process status tracker the connector-status endpoint reads
+        // (ADR-136). Undefined for a programmatic registration, which records
+        // nothing.
+        { intervalMs: registration.intervalMs, connectorId: registration.id },
       ),
     )
     const stopConnectors = (): void => {
@@ -964,6 +968,11 @@ export async function startDaemon(opts: DaemonOptions = {}): Promise<DaemonHandl
           singleProject && singleProjectPath
             ? { name: singleProject, path: singleProjectPath }
             : undefined,
+        // ADR-136 — the connector-status endpoint reads ~/.neat/connectors.json
+        // through the same resolved home the slot bootstrap read it from, so a
+        // daemon given an explicit NEAT_HOME serves status for the same file it
+        // polls.
+        connectorsHome: home,
       })
       restAddress = await restApp.listen({ port: restPort, host })
       // Fastify reports a 0.0.0.0 bind back as http://127.0.0.1:port, so the

--- a/packages/core/test/connectors-status-api.test.ts
+++ b/packages/core/test/connectors-status-api.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+import path from 'node:path'
+import os from 'node:os'
+import { promises as fs } from 'node:fs'
+import { ConnectorsStatusResponseSchema } from '@neat.is/types'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { buildApi } from '../src/api.js'
+import {
+  CONNECTOR_STALE_THRESHOLD_MS,
+  recordConnectorPoll,
+  resetConnectorStatus,
+} from '../src/connectors/status.js'
+
+// docs/contracts/rest-api.md + connectors.md §8 (ADR-136) — GET /:project/
+// connectors: the project's configured connectors from ~/.neat/connectors.json,
+// credentials redacted to their env-ref pointer, each with live poll health.
+
+interface ConnectorEntryInput {
+  id: string
+  provider: string
+  project?: string
+  credential: string | Record<string, string>
+  options?: Record<string, unknown>
+}
+
+function iso(offsetMs: number): string {
+  return new Date(Date.now() + offsetMs).toISOString()
+}
+
+describe('GET /connectors (connector status)', () => {
+  let app: FastifyInstance
+  let home: string
+
+  async function writeConnectors(connectors: ConnectorEntryInput[]): Promise<void> {
+    await fs.writeFile(
+      path.join(home, 'connectors.json'),
+      JSON.stringify({ version: 1, connectors }, null, 2),
+    )
+  }
+
+  beforeEach(async () => {
+    resetGraph()
+    resetConnectorStatus()
+    home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'neat-conn-status-')))
+    app = await buildApi({ graph: getGraph(), connectorsHome: home })
+  })
+
+  afterEach(async () => {
+    await app.close()
+    resetConnectorStatus()
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('returns an empty wrapped list when no connectors.json exists', async () => {
+    const res = await app.inject({ method: 'GET', url: '/connectors' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ connectors: [] })
+  })
+
+  it('lists a configured connector, credential redacted to its env-ref pointer, idle before any poll', async () => {
+    await writeConnectors([
+      { id: 'cf-prod', provider: 'cloudflare', credential: '$CF_TOKEN', options: { accountId: 'acct1' } },
+    ])
+    const res = await app.inject({ method: 'GET', url: '/connectors' })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body).toEqual({
+      connectors: [
+        {
+          id: 'cf-prod',
+          provider: 'cloudflare',
+          credentialRef: '$CF_TOKEN',
+          status: { state: 'idle', lastPollAt: null, lastOutcome: null, lastError: null, signalsLastPoll: 0 },
+        },
+      ],
+    })
+    const parsed = ConnectorsStatusResponseSchema.safeParse(body)
+    expect(parsed.success, parsed.success ? '' : JSON.stringify(parsed.error.format())).toBe(true)
+  })
+
+  it('never resolves or leaks a credential value — only the pointer is returned', async () => {
+    const secret = 'super-secret-token-value-do-not-leak'
+    process.env.CF_TOKEN = secret
+    try {
+      await writeConnectors([
+        { id: 'cf-prod', provider: 'cloudflare', credential: '$CF_TOKEN', options: { accountId: 'acct1' } },
+      ])
+      const res = await app.inject({ method: 'GET', url: '/connectors' })
+      const raw = res.payload
+      expect(res.json().connectors[0].credentialRef).toBe('$CF_TOKEN')
+      // The resolved secret must appear nowhere in the serialized response.
+      expect(raw).not.toContain(secret)
+    } finally {
+      delete process.env.CF_TOKEN
+    }
+  })
+
+  it('redacts a plaintext literal to **** and a multi-field credential field-by-field', async () => {
+    await writeConnectors([
+      { id: 'sb-brief', provider: 'supabase', credential: 'literal-secret-here', options: { apiProjectRef: 'r' } },
+      {
+        id: 'fb-app',
+        provider: 'firebase',
+        credential: { projectId: '$FB_PROJECT', accessToken: '$FB_TOKEN' },
+      },
+    ])
+    const body = (await app.inject({ method: 'GET', url: '/connectors' })).json()
+    const byId = Object.fromEntries(body.connectors.map((c: { id: string }) => [c.id, c]))
+    expect(byId['sb-brief'].credentialRef).toBe('****')
+    expect(byId['fb-app'].credentialRef).toEqual({ projectId: '$FB_PROJECT', accessToken: '$FB_TOKEN' })
+    // The plaintext literal is masked, never echoed.
+    expect((await app.inject({ method: 'GET', url: '/connectors' })).payload).not.toContain('literal-secret-here')
+  })
+
+  it('reflects each derived poll state — healthy / error / stale — from the tracker', async () => {
+    await writeConnectors([
+      { id: 'healthy-one', provider: 'railway', credential: '$R', options: {} },
+      { id: 'error-one', provider: 'railway', credential: '$R', options: {} },
+      { id: 'stale-one', provider: 'railway', credential: '$R', options: {} },
+      { id: 'idle-one', provider: 'railway', credential: '$R', options: {} },
+    ])
+    recordConnectorPoll('healthy-one', { outcome: 'ok', at: iso(0), signalsLastPoll: 7 })
+    recordConnectorPoll('error-one', { outcome: 'error', at: iso(0), error: 'railway auth check returned HTTP 401' })
+    recordConnectorPoll('stale-one', { outcome: 'ok', at: iso(-(CONNECTOR_STALE_THRESHOLD_MS + 60_000)), signalsLastPoll: 2 })
+
+    const body = (await app.inject({ method: 'GET', url: '/connectors' })).json()
+    const byId = Object.fromEntries(body.connectors.map((c: { id: string }) => [c.id, c]))
+    expect(byId['healthy-one'].status.state).toBe('healthy')
+    expect(byId['healthy-one'].status.signalsLastPoll).toBe(7)
+    expect(byId['error-one'].status.state).toBe('error')
+    expect(byId['error-one'].status.lastError).toBe('railway auth check returned HTTP 401')
+    expect(byId['stale-one'].status.state).toBe('stale')
+    expect(byId['idle-one'].status.state).toBe('idle')
+  })
+
+  it('is dual-mounted at /connectors and /projects/:project/connectors', async () => {
+    await writeConnectors([{ id: 'cf-prod', provider: 'cloudflare', credential: '$CF_TOKEN', options: {} }])
+    const root = await app.inject({ method: 'GET', url: '/connectors' })
+    const scoped = await app.inject({ method: 'GET', url: '/projects/default/connectors' })
+    expect(root.statusCode).toBe(200)
+    expect(scoped.statusCode).toBe(200)
+    expect(root.json()).toEqual(scoped.json())
+  })
+
+  it('filters to the project — a connector bound to another project is excluded, a project-less one is included', async () => {
+    await writeConnectors([
+      { id: 'mine', provider: 'railway', credential: '$R', options: {} }, // no project → matches default
+      { id: 'default-bound', provider: 'railway', project: 'default', credential: '$R', options: {} },
+      { id: 'elsewhere', provider: 'railway', project: 'other-project', credential: '$R', options: {} },
+    ])
+    const body = (await app.inject({ method: 'GET', url: '/connectors' })).json()
+    const ids = body.connectors.map((c: { id: string }) => c.id).sort()
+    expect(ids).toEqual(['default-bound', 'mine'])
+  })
+})

--- a/packages/core/test/connectors-status-tracker.test.ts
+++ b/packages/core/test/connectors-status-tracker.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  CONNECTOR_STALE_THRESHOLD_MS,
+  getConnectorStatus,
+  recordConnectorPoll,
+  resetConnectorStatus,
+  sanitizePollError,
+} from '../src/connectors/status.js'
+
+// docs/contracts/connectors.md §8 / ADR-136 — the in-process poll-status
+// tracker. The poll loop writes on every tick; the connector-status endpoint
+// reads. State is derived at read time from the raw record + wall clock.
+
+function iso(offsetMs: number): string {
+  return new Date(Date.now() + offsetMs).toISOString()
+}
+
+describe('connector poll-status tracker', () => {
+  beforeEach(() => resetConnectorStatus())
+
+  it('reports idle with null fields for an id that has never polled', () => {
+    expect(getConnectorStatus('cf-prod')).toEqual({
+      state: 'idle',
+      lastPollAt: null,
+      lastOutcome: null,
+      lastError: null,
+      signalsLastPoll: 0,
+    })
+  })
+
+  it('records a successful tick as healthy, carrying the signal count', () => {
+    const at = iso(0)
+    recordConnectorPoll('cf-prod', { outcome: 'ok', at, signalsLastPoll: 12 })
+    expect(getConnectorStatus('cf-prod')).toEqual({
+      state: 'healthy',
+      lastPollAt: at,
+      lastOutcome: 'ok',
+      lastError: null,
+      signalsLastPoll: 12,
+    })
+  })
+
+  it('records a failing tick as error, keeping the message and zeroing signals', () => {
+    const at = iso(0)
+    recordConnectorPoll('cf-prod', { outcome: 'error', at, error: 'cloudflare auth check returned HTTP 500' })
+    const status = getConnectorStatus('cf-prod')
+    expect(status.state).toBe('error')
+    expect(status.lastOutcome).toBe('error')
+    expect(status.lastError).toBe('cloudflare auth check returned HTTP 500')
+    expect(status.signalsLastPoll).toBe(0)
+    expect(status.lastPollAt).toBe(at)
+  })
+
+  it('derives stale when the last successful poll is beyond the threshold', () => {
+    const at = iso(0)
+    recordConnectorPoll('cf-prod', { outcome: 'ok', at, signalsLastPoll: 3 })
+    // Within the window: healthy.
+    const now = Date.parse(at)
+    expect(getConnectorStatus('cf-prod', now + CONNECTOR_STALE_THRESHOLD_MS - 1).state).toBe('healthy')
+    // Past the window with no newer successful tick: stale.
+    expect(getConnectorStatus('cf-prod', now + CONNECTOR_STALE_THRESHOLD_MS + 1).state).toBe('stale')
+  })
+
+  it('reports stale from a real old timestamp against the default threshold', () => {
+    recordConnectorPoll('cf-prod', { outcome: 'ok', at: iso(-(CONNECTOR_STALE_THRESHOLD_MS + 60_000)) })
+    expect(getConnectorStatus('cf-prod').state).toBe('stale')
+  })
+
+  it('lets error win over stale — a fresh throw is the more actionable signal', () => {
+    // A success long ago, then a failing tick now: the endpoint should surface
+    // the error, not the age.
+    recordConnectorPoll('cf-prod', { outcome: 'ok', at: iso(-(CONNECTOR_STALE_THRESHOLD_MS + 60_000)) })
+    recordConnectorPoll('cf-prod', { outcome: 'error', at: iso(0), error: 'boom' })
+    expect(getConnectorStatus('cf-prod').state).toBe('error')
+  })
+
+  it('advances healthy again after a recovering success following an error', () => {
+    recordConnectorPoll('cf-prod', { outcome: 'error', at: iso(-1000), error: 'transient' })
+    recordConnectorPoll('cf-prod', { outcome: 'ok', at: iso(0), signalsLastPoll: 5 })
+    const status = getConnectorStatus('cf-prod')
+    expect(status.state).toBe('healthy')
+    expect(status.lastError).toBeNull()
+    expect(status.signalsLastPoll).toBe(5)
+  })
+
+  it('tracks each connector id independently', () => {
+    recordConnectorPoll('cf-prod', { outcome: 'ok', at: iso(0), signalsLastPoll: 1 })
+    recordConnectorPoll('supabase-brief', { outcome: 'error', at: iso(0), error: 'nope' })
+    expect(getConnectorStatus('cf-prod').state).toBe('healthy')
+    expect(getConnectorStatus('supabase-brief').state).toBe('error')
+    expect(getConnectorStatus('railway-api').state).toBe('idle')
+  })
+
+  it('sanitizePollError collapses whitespace and truncates long messages', () => {
+    expect(sanitizePollError(new Error('one\n  two   three'))).toBe('one two three')
+    const long = 'x'.repeat(500)
+    const out = sanitizePollError(new Error(long))
+    expect(out.length).toBeLessThanOrEqual(200)
+    expect(out.endsWith('…')).toBe(true)
+    expect(sanitizePollError('a plain string')).toBe('a plain string')
+  })
+})

--- a/packages/types/src/responses.ts
+++ b/packages/types/src/responses.ts
@@ -88,6 +88,50 @@ export const SingleProjectResponseSchema = z.object({
 })
 export type SingleProjectResponse = z.infer<typeof SingleProjectResponseSchema>
 
+// GET /:project/connectors response (docs/contracts/rest-api.md, connectors.md
+// §8, ADR-136). One entry per `~/.neat/connectors.json` connector matching the
+// project, credential redacted to its env-ref pointer (never a resolved value),
+// carrying the live poll health the in-process status tracker records.
+
+// The derived poll state the endpoint reports:
+//   idle    — no poll tick has run yet
+//   healthy — the most recent tick succeeded within the stale window
+//   error   — the most recent tick threw
+//   stale   — no successful poll within the stale window (a wedged/silent loop)
+export const ConnectorPollStateSchema = z.enum(['idle', 'healthy', 'error', 'stale'])
+export type ConnectorPollState = z.infer<typeof ConnectorPollStateSchema>
+
+// The per-connector live health block. `lastPollAt`/`lastOutcome`/`lastError`
+// are null until the first tick; `lastError` is null on a successful tick and a
+// short, secret-free string on a failing one (connectors.md §6 — never a
+// credential). `signalsLastPoll` is the count the last tick returned (0 before
+// any poll).
+export const ConnectorStatusSchema = z.object({
+  state: ConnectorPollStateSchema,
+  lastPollAt: z.string().nullable(),
+  lastOutcome: z.enum(['ok', 'error']).nullable(),
+  lastError: z.string().nullable(),
+  signalsLastPoll: z.number().int().nonnegative(),
+})
+export type ConnectorStatus = z.infer<typeof ConnectorStatusSchema>
+
+// `credentialRef` is the redacted env-ref pointer — a single string
+// (`"$CF_TOKEN"`) for a single-field credential, or a field→pointer map for a
+// multi-field one. A plaintext literal redacts to `"****"`. Never a resolved
+// secret (ADR-136 §3).
+export const ConnectorStatusEntrySchema = z.object({
+  id: z.string(),
+  provider: z.string(),
+  credentialRef: z.union([z.string(), z.record(z.string(), z.string())]),
+  status: ConnectorStatusSchema,
+})
+export type ConnectorStatusEntry = z.infer<typeof ConnectorStatusEntrySchema>
+
+export const ConnectorsStatusResponseSchema = z.object({
+  connectors: z.array(ConnectorStatusEntrySchema),
+})
+export type ConnectorsStatusResponse = z.infer<typeof ConnectorsStatusResponseSchema>
+
 // /search matches are graph nodes with an added per-match score. The
 // schema keeps `score` mandatory and lets the underlying node shape pass
 // through — GraphNodeSchema is a discriminated union and tightening here


### PR DESCRIPTION
The web GUI's connector view needs a read-only surface: which connectors are configured for a project, with credentials redacted, and how each one is actually polling. This adds it.

## What lands

- **`GET /:project/connectors`** (dual-mounted per ADR-026) returns `{ connectors: [...] }`, one entry per `~/.neat/connectors.json` connector matching the project. Each is `{ id, provider, credentialRef, status }` — `credentialRef` is the redacted env-ref pointer (`"$CF_TOKEN"`, or a field→pointer map for a multi-field credential; a plaintext literal shows `"****"`). Reads the live config file, never the graph, envelope per ADR-061.
- **An in-process poll-status tracker** (`connectors/status.ts`) the poll loop now writes on every tick — success and failure — and the endpoint reads. Per connector id it records `lastPollAt`, `lastOutcome`, `lastError` (short, secret-free), `signalsLastPoll`, and the time of the last success. `state` is derived at read time: `idle` / `healthy` / `error` / `stale`.

## Reuse over rebuild

- The credential redaction is the same `isEnvRef`-driven logic `neat connector list` prints, factored into a shared `redactCredentialRef` helper so the two surfaces can't drift.
- The endpoint follows the existing per-project route pattern in `api.ts`; the tracker mirrors the in-memory, restart-loses-it shape `logs-store.ts` already uses.

## Secret discipline

The endpoint never calls `resolveCredential` — the pointer is shown, the resolved value never is, in the response, in `lastError`, or in any log. A test asserts a `$VAR` credential comes back as the literal pointer and its resolved value appears nowhere in the response.

## Prose first

ADR-136 lands in `docs/decisions.md`; `connectors.md` (new §8) and `rest-api.md` are amended with the endpoint and status shape. The response type is in `@neat.is/types`. No new node, edge, or provenance type.

## Tests

`vitest run --root packages/core` is green — 79 files, 1480 passed (2 skipped, 5 todo), including the connectors-plane contract audit. New coverage: the endpoint (list, redaction, each state, dual-mount, project filter, secret non-leak) and the tracker (records ok/error, derives state, stale threshold).

Refs #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)