### PR TITLE
Tag Vercel, Railway, and Supabase services with a platform identifier (ADR-138)

### DIFF
--- a/docs/contracts/static-extraction.md
+++ b/docs/contracts/static-extraction.md
@@ -4,7 +4,7 @@ description: Producers under packages/core/src/extract/* read source code and co
 governs:
   - "packages/core/src/extract/**"
   - "packages/core/src/watch.ts"
-adr: [ADR-032, ADR-065, ADR-115, ADR-119, ADR-123, ADR-030, ADR-031, ADR-024, ADR-055, ADR-133]
+adr: [ADR-032, ADR-065, ADR-115, ADR-119, ADR-123, ADR-030, ADR-031, ADR-024, ADR-055, ADR-133, ADR-138]
 enforcement: [lint, review]
 ---
 
@@ -101,6 +101,7 @@ Other extensions are skipped silently by `walkSourceFiles` per `IGNORED_DIRS` an
 | `proto.ts`           | GrpcMethodNode + `service ──CONTAINS──▶ method` from `.proto` (ADR-123) | ✅ |
 | `infra/{docker-compose,dockerfile,k8s,terraform}.ts` | InfraNode + DEPENDS_ON / RUNS_ON / CONNECTS_TO | ✅ (evidence populated) |
 | `infra/cloudflare.ts` | `platform` tag on ServiceNode/FileNode + InfraNode + DEPENDS_ON / RUNS_ON / CONNECTS_TO (ADR-133) | ✅ |
+| `infra/{vercel,railway,supabase}.ts` | `platform` tag on ServiceNode (+ `platformName`) + InfraNode + DEPENDS_ON / RUNS_ON / CONNECTS_TO (ADR-138) | ✅ |
 
 New producers under `calls/` for source-level DB connections (`new pg.Pool(...)`) and inter-service imports land under issue #141. They follow the same interface, same evidence shape, same idempotency.
 
@@ -130,6 +131,8 @@ The table lives in `compat.json` or a sibling data file. Population happens at e
 - `platform?: string` + `platformName?: string` on `FileNodeSchema` — stamped on the Worker's entry file (resolved from wrangler's own `main` field, verbatim; not the SDK installer's eight-step entry-detection precedence). `platformName` is the Worker's own script name (wrangler's `name` field) — the only identifier Cloudflare's telemetry carries, and what the Cloudflare connector's `resolveTarget` looks up against (`connectors.md` §4).
 
 Declared Cloudflare resources — KV/D1/R2/Durable Object/Queue bindings, cron triggers, service bindings, routes/custom domains, declared env-var names (never values) — become `InfraNode`s at `infraId(kind, name)` (kinds: `cloudflare-kv`, `cloudflare-d1`, `cloudflare-r2`, `cloudflare-durable-object`, `cloudflare-queue`, `cloudflare-cron`, `cloudflare-route`, `cloudflare-env-var`, `cloudflare-service-binding`), wired from the entry FileNode: `CONNECTS_TO` for routes (network-reachability, matching `dockerfile.ts`'s EXPOSE→port pattern), `DEPENDS_ON` for everything else declarative, `RUNS_ON` to a single shared `infra:workerd:cloudflare` node carrying `compatibility_date` as `evidence.snippet` (matching `dockerfile.ts`'s image-node + entrypoint-snippet pattern). A service binding resolves directly onto the target Worker's own entry FileNode (`CALLS`) when that Worker is tagged in the same scan; otherwise it falls back to a `cloudflare-service-binding` InfraNode, honestly. No new `NodeType`. Per-environment `[env.X]` wrangler sections are out of scope for v1 — only top-level config is read.
+
+**ADR-138 extends the same `platform` field to three more providers.** `infra/vercel.ts` (`vercel.json`/`vercel.jsonc`, plus `.vercel/project.json` for `platformName`), `infra/railway.ts` (`railway.toml`/`railway.json`/`railway.jsonc` — no `platformName`, since Railway's config names no service), and `infra/supabase.ts` (`supabase/config.toml`, `project_id` → `platformName`) each stamp `platform` on the ServiceNode and model their declared resources — Vercel crons/env-var-names/routes, Railway healthcheck/cron, Supabase functions/storage/auth — as `InfraNode`s wired `DEPENDS_ON`/`RUNS_ON`/`CONNECTS_TO` through the shared `emitPlatformResourceEdge` helper. Same discipline as Cloudflare: no new `NodeType`, env-var values never read, `evidence.file` on every edge. Vercel and Railway have no Worker-style entry file, so the tag and the edges anchor on the ServiceNode itself.
 
 ## Route extraction + HTTP client↔route matching (ADR-119)
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1630,3 +1630,25 @@ interface LogEntry {
 - **#365** — Lazy project activation (v0.5+, deeper version of ADR-079)
 - **#366** — Strategic question on single-daemon vs project-scoped daemons (future, post-hosted-SaaS pressure)
 - **#367–#371** — v0.4.4 implementation issues for ADR-076, ADR-077, ADR-078, ADR-079
+
+## ADR-138 — Extend the platform identifier to Vercel, Railway, and Supabase
+
+### Context
+
+ADR-133 gave Cloudflare Workers/Pages a `platform` identifier at extract time — a static tag on the ServiceNode (and the Worker's entry FileNode) that the frontend service-rollup badge keys on and the connector fuses OBSERVED edges onto. It landed Cloudflare-only: `extract/infra/cloudflare.ts` reads `wrangler.toml` and stamps `platform: cloudflare`. The other three connector providers — Vercel, Railway, Supabase — had connectors but no static platform tag, so their services carried no badge, and the "static system becomes live" spine existed for one provider out of four.
+
+### Decision
+
+Three detector-extractors join `cloudflare.ts` under `extract/infra/`, each reading the provider's own declared config and stamping the same `platform` field — no new NodeType, no new provenance, property updates on existing nodes (allowed per ADR-030):
+
+- **`vercel.ts`** — `vercel.json`/`vercel.jsonc`, plus `.vercel/project.json` for the linked project name → `platformName`. Models crons, env-var names, and routes/rewrites as InfraNodes. Vercel apps have no Worker-style entry file, so the tag and edges anchor on the ServiceNode itself.
+- **`railway.ts`** — `railway.toml`/`railway.json`/`railway.jsonc`. Models the healthcheck path and cron schedule. Railway's config names no service (that lives in Railway's own system, which the connector resolves by `deploymentId`), so no `platformName` is stamped here.
+- **`supabase.ts`** — `supabase/config.toml`, using `project_id` as `platformName` (the ref the Supabase connector resolves against). Models edge functions, storage, and auth as InfraNodes.
+
+Declared-resource edges route through one shared helper, `emitPlatformResourceEdge` in `infra/shared.ts` — named out of the `add<Word>` producer-entry-point namespace the static-extraction audit scans, because it is an internal emitter, not a producer entry point. Env-var values are never read (names only, ADR-016 spirit). Every edge carries `evidence.file`.
+
+### Consequences
+
+- The `platform` badge (#752) renders for all four providers, keyed on a real extracted config file — honest, static, nothing inferred.
+- The connector-fusion path is unchanged: the same tagged nodes these extractors stamp are what each connector later lights up with OBSERVED edges. Extraction now feeds every provider's target resolution, not just Cloudflare's.
+- The tag stays a free string on ServiceNode/FileNode (ADR-133's discipline) — a fifth provider is a new detector file, not a schema change.

--- a/packages/core/src/extract/infra/index.ts
+++ b/packages/core/src/extract/infra/index.ts
@@ -5,6 +5,9 @@ import { addDockerfileRuntimes } from './dockerfile.js'
 import { addTerraformResources } from './terraform.js'
 import { addK8sResources } from './k8s.js'
 import { addCloudflareWorkers } from './cloudflare.js'
+import { addVercelServices } from './vercel.js'
+import { addRailwayServices } from './railway.js'
+import { addSupabaseProjects } from './supabase.js'
 
 export interface InfraExtractResult {
   nodesAdded: number
@@ -13,10 +16,10 @@ export interface InfraExtractResult {
 
 // Phase 5 — infrastructure. Runs after services so RUNS_ON edges have a
 // ServiceNode to anchor on. Each sub-source contributes its own nodes/edges
-// independently. `cloudflare.ts` is the one producer here that also tags
-// existing ServiceNode/FileNode attributes (`platform`/`platformName`,
-// ADR-133) rather than only adding new nodes/edges — property updates on
-// existing nodes are allowed by extract producers per ADR-030.
+// independently. The platform producers (`cloudflare.ts`, `vercel.ts`,
+// `railway.ts`, `supabase.ts`) also tag existing ServiceNode/FileNode
+// attributes (`platform`/`platformName`, ADR-133) rather than only adding new
+// nodes/edges — property updates on existing nodes are allowed per ADR-030.
 export async function addInfra(
   graph: NeatGraph,
   scanPath: string,
@@ -27,6 +30,9 @@ export async function addInfra(
   const terraform = await addTerraformResources(graph, scanPath)
   const k8s = await addK8sResources(graph, scanPath)
   const cloudflare = await addCloudflareWorkers(graph, services, scanPath)
+  const vercel = await addVercelServices(graph, services, scanPath)
+  const railway = await addRailwayServices(graph, services, scanPath)
+  const supabase = await addSupabaseProjects(graph, services, scanPath)
 
   return {
     nodesAdded:
@@ -34,12 +40,18 @@ export async function addInfra(
       dockerfile.nodesAdded +
       terraform.nodesAdded +
       k8s.nodesAdded +
-      cloudflare.nodesAdded,
+      cloudflare.nodesAdded +
+      vercel.nodesAdded +
+      railway.nodesAdded +
+      supabase.nodesAdded,
     edgesAdded:
       compose.edgesAdded +
       dockerfile.edgesAdded +
       terraform.edgesAdded +
       k8s.edgesAdded +
-      cloudflare.edgesAdded,
+      cloudflare.edgesAdded +
+      vercel.edgesAdded +
+      railway.edgesAdded +
+      supabase.edgesAdded,
   }
 }

--- a/packages/core/src/extract/infra/railway.ts
+++ b/packages/core/src/extract/infra/railway.ts
@@ -1,0 +1,100 @@
+// Railway service extraction. Stamps the `platform: railway` identifier the
+// frontend service-rollup badge keys on (mirroring ADR-133 for Cloudflare) when a
+// service carries a `railway.toml`/`railway.json`/`railway.jsonc`, and models the
+// config's declared surfaces — the healthcheck path and a cron schedule — as
+// InfraNodes wired from the ServiceNode. No new NodeType. Railway's config names
+// no service (that lives in Railway's own system, which the connector resolves by
+// deploymentId), so no platformName is stamped here.
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { parse as parseToml } from 'smol-toml'
+import type { ServiceNode } from '@neat.is/types'
+import { EdgeType, EdgeTypeValue } from '@neat.is/types'
+import type { NeatGraph } from '../../graph.js'
+import { exists, maskCommentsInSource, type DiscoveredService } from '../shared.js'
+import { recordExtractionError } from '../errors.js'
+import { toPosix } from '../calls/shared.js'
+import { emitPlatformResourceEdge, lineContaining } from './shared.js'
+
+interface RailwayDeploy {
+  healthcheckPath?: string
+  cronSchedule?: string
+}
+
+interface RailwayConfig {
+  deploy?: RailwayDeploy
+}
+
+const RAILWAY_FILENAMES = ['railway.toml', 'railway.json', 'railway.jsonc']
+
+interface RailwayRead {
+  config: RailwayConfig
+  relFile: string
+  raw: string
+}
+
+async function readRailwayConfig(dir: string): Promise<RailwayRead | null> {
+  for (const filename of RAILWAY_FILENAMES) {
+    const abs = path.join(dir, filename)
+    if (!(await exists(abs))) continue
+    const raw = await fs.readFile(abs, 'utf8')
+    const config =
+      filename === 'railway.toml'
+        ? (parseToml(raw) as unknown as RailwayConfig)
+        : (JSON.parse(maskCommentsInSource(raw)) as RailwayConfig)
+    return { config, relFile: filename, raw }
+  }
+  return null
+}
+
+export async function addRailwayServices(
+  graph: NeatGraph,
+  services: DiscoveredService[],
+  scanPath: string,
+): Promise<{ nodesAdded: number; edgesAdded: number }> {
+  let nodesAdded = 0
+  let edgesAdded = 0
+
+  for (const service of services) {
+    let read: RailwayRead | null = null
+    try {
+      read = await readRailwayConfig(service.dir)
+    } catch (err) {
+      recordExtractionError('infra railway', path.relative(scanPath, service.dir), err)
+      continue
+    }
+    if (!read) continue
+
+    const serviceNode = graph.getNodeAttributes(service.node.id) as ServiceNode
+    if (serviceNode.platform !== 'railway') {
+      graph.replaceNodeAttributes(service.node.id, { ...serviceNode, platform: 'railway' })
+    }
+
+    const anchorId = service.node.id
+    const { config, relFile, raw } = read
+    const evidenceFile = toPosix(path.relative(scanPath, path.join(service.dir, relFile)))
+
+    const add = (edgeType: EdgeTypeValue, kind: string, name: string | undefined): void => {
+      if (!name) return
+      const result = emitPlatformResourceEdge(
+        graph,
+        anchorId,
+        edgeType,
+        kind,
+        name,
+        'railway',
+        evidenceFile,
+        lineContaining(raw, name),
+      )
+      nodesAdded += result.nodesAdded
+      edgesAdded += result.edgesAdded
+    }
+
+    add(EdgeType.RUNS_ON, 'railway', 'railway')
+    add(EdgeType.CONNECTS_TO, 'railway-route', config.deploy?.healthcheckPath)
+    add(EdgeType.DEPENDS_ON, 'railway-cron', config.deploy?.cronSchedule)
+  }
+
+  return { nodesAdded, edgesAdded }
+}

--- a/packages/core/src/extract/infra/shared.ts
+++ b/packages/core/src/extract/infra/shared.ts
@@ -1,5 +1,7 @@
-import type { InfraNode } from '@neat.is/types'
-import { NodeType, infraId } from '@neat.is/types'
+import type { GraphEdge, InfraNode } from '@neat.is/types'
+import { EdgeTypeValue, NodeType, Provenance, confidenceForExtracted, infraId } from '@neat.is/types'
+import type { NeatGraph } from '../../graph.js'
+import { makeEdgeId } from '../shared.js'
 
 // ADR-010 reserves the `infra:` prefix; the kind segment lets traversal and
 // MCP tools sub-type without inventing a new top-level NodeType per source.
@@ -34,4 +36,55 @@ export function classifyImage(image: string): string {
   if (last.startsWith('kafka') || last.includes('kafka')) return 'kafka'
   if (last.startsWith('memcached')) return 'memcached'
   return 'container'
+}
+
+// Best-effort 1-indexed line for a declared value in a config file's raw text —
+// the same "read config as data" text search cloudflare.ts and terraform.ts use
+// rather than a real AST.
+export function lineContaining(raw: string, needle: string | undefined): number | undefined {
+  if (!needle) return undefined
+  const idx = raw.indexOf(needle)
+  if (idx === -1) return undefined
+  let line = 1
+  for (let i = 0; i < idx; i++) if (raw[i] === '\n') line++
+  return line
+}
+
+// One declared-resource InfraNode + an edge from the anchor (a ServiceNode or an
+// entry FileNode). Idempotent; every edge carries evidence.file. Shared by the
+// platform extractors (vercel/railway/supabase); cloudflare.ts predates this and
+// keeps its own local copy. No self-loop when a resource id equals the anchor.
+export function emitPlatformResourceEdge(
+  graph: NeatGraph,
+  anchorId: string,
+  edgeType: EdgeTypeValue,
+  kind: string,
+  name: string,
+  provider: string,
+  evidenceFile: string,
+  line?: number,
+): { nodesAdded: number; edgesAdded: number } {
+  let nodesAdded = 0
+  let edgesAdded = 0
+  const node = makeInfraNode(kind, name, provider)
+  if (!graph.hasNode(node.id)) {
+    graph.addNode(node.id, node)
+    nodesAdded++
+  }
+  if (node.id === anchorId) return { nodesAdded, edgesAdded }
+  const edgeId = makeEdgeId(anchorId, node.id, edgeType)
+  if (!graph.hasEdge(edgeId)) {
+    const edge: GraphEdge = {
+      id: edgeId,
+      source: anchorId,
+      target: node.id,
+      type: edgeType,
+      provenance: Provenance.EXTRACTED,
+      confidence: confidenceForExtracted('structural'),
+      evidence: { file: evidenceFile, ...(line !== undefined ? { line } : {}) },
+    }
+    graph.addEdgeWithKey(edgeId, edge.source, edge.target, edge)
+    edgesAdded++
+  }
+  return { nodesAdded, edgesAdded }
 }

--- a/packages/core/src/extract/infra/supabase.ts
+++ b/packages/core/src/extract/infra/supabase.ts
@@ -1,0 +1,100 @@
+// Supabase project extraction. Stamps the `platform: supabase` identifier the
+// frontend service-rollup badge keys on (mirroring ADR-133 for Cloudflare) when a
+// service carries a `supabase/config.toml`, using the config's `project_id` as
+// platformName (the ref the Supabase connector resolves against), and models the
+// declared surfaces — edge functions, storage, auth — as InfraNodes wired from
+// the ServiceNode. No new NodeType.
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { parse as parseToml } from 'smol-toml'
+import type { ServiceNode } from '@neat.is/types'
+import { EdgeType, EdgeTypeValue } from '@neat.is/types'
+import type { NeatGraph } from '../../graph.js'
+import { exists, type DiscoveredService } from '../shared.js'
+import { recordExtractionError } from '../errors.js'
+import { toPosix } from '../calls/shared.js'
+import { emitPlatformResourceEdge, lineContaining } from './shared.js'
+
+interface SupabaseConfig {
+  project_id?: string
+  functions?: Record<string, unknown>
+  storage?: Record<string, unknown>
+  auth?: Record<string, unknown>
+}
+
+interface SupabaseRead {
+  config: SupabaseConfig
+  relFile: string
+  raw: string
+}
+
+// Supabase's config lives at <service>/supabase/config.toml, not the service root.
+async function readSupabaseConfig(dir: string): Promise<SupabaseRead | null> {
+  const relFile = path.join('supabase', 'config.toml')
+  const abs = path.join(dir, relFile)
+  if (!(await exists(abs))) return null
+  const raw = await fs.readFile(abs, 'utf8')
+  const config = parseToml(raw) as unknown as SupabaseConfig
+  return { config, relFile, raw }
+}
+
+export async function addSupabaseProjects(
+  graph: NeatGraph,
+  services: DiscoveredService[],
+  scanPath: string,
+): Promise<{ nodesAdded: number; edgesAdded: number }> {
+  let nodesAdded = 0
+  let edgesAdded = 0
+
+  for (const service of services) {
+    let read: SupabaseRead | null = null
+    try {
+      read = await readSupabaseConfig(service.dir)
+    } catch (err) {
+      recordExtractionError('infra supabase', path.relative(scanPath, service.dir), err)
+      continue
+    }
+    if (!read) continue
+
+    const { config, relFile, raw } = read
+    const projectId = typeof config.project_id === 'string' ? config.project_id : undefined
+
+    const serviceNode = graph.getNodeAttributes(service.node.id) as ServiceNode
+    if (serviceNode.platform !== 'supabase' || (projectId && serviceNode.platformName !== projectId)) {
+      graph.replaceNodeAttributes(service.node.id, {
+        ...serviceNode,
+        platform: 'supabase',
+        ...(projectId ? { platformName: projectId } : {}),
+      })
+    }
+
+    const anchorId = service.node.id
+    const evidenceFile = toPosix(path.relative(scanPath, path.join(service.dir, relFile)))
+
+    const add = (edgeType: EdgeTypeValue, kind: string, name: string | undefined): void => {
+      if (!name) return
+      const result = emitPlatformResourceEdge(
+        graph,
+        anchorId,
+        edgeType,
+        kind,
+        name,
+        'supabase',
+        evidenceFile,
+        lineContaining(raw, name),
+      )
+      nodesAdded += result.nodesAdded
+      edgesAdded += result.edgesAdded
+    }
+
+    add(EdgeType.RUNS_ON, 'supabase', 'supabase')
+    // Edge functions — each [functions.X] section becomes a declared function.
+    for (const fn of Object.keys(config.functions ?? {})) add(EdgeType.DEPENDS_ON, 'supabase-function', fn)
+    // Managed surfaces the project declares.
+    if (config.storage) add(EdgeType.DEPENDS_ON, 'supabase-storage', 'storage')
+    if (config.auth) add(EdgeType.DEPENDS_ON, 'supabase-auth', 'auth')
+  }
+
+  return { nodesAdded, edgesAdded }
+}

--- a/packages/core/src/extract/infra/vercel.ts
+++ b/packages/core/src/extract/infra/vercel.ts
@@ -1,0 +1,141 @@
+// Vercel project extraction. Stamps the `platform: vercel` identifier the
+// frontend service-rollup badge keys on (static-extraction.md, mirroring ADR-133
+// for Cloudflare) whenever a service carries a `vercel.json`/`vercel.jsonc` or a
+// linked `.vercel/project.json`, and models the config's declared resources —
+// crons, env-var names, routes/rewrites — as InfraNodes wired from the
+// ServiceNode. No new NodeType; env-var values are never read (ADR-016 spirit),
+// only names. Vercel apps have no single Worker-style entry file, so the tag and
+// the resource edges anchor on the ServiceNode itself.
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import type { ServiceNode } from '@neat.is/types'
+import { EdgeType, EdgeTypeValue } from '@neat.is/types'
+import type { NeatGraph } from '../../graph.js'
+import { exists, maskCommentsInSource, type DiscoveredService } from '../shared.js'
+import { recordExtractionError } from '../errors.js'
+import { toPosix } from '../calls/shared.js'
+import { emitPlatformResourceEdge, lineContaining } from './shared.js'
+
+interface VercelCron {
+  path?: string
+  schedule?: string
+}
+
+interface VercelRoute {
+  source?: string
+  src?: string
+}
+
+interface VercelConfig {
+  crons?: VercelCron[]
+  env?: Record<string, unknown>
+  build?: { env?: Record<string, unknown> }
+  rewrites?: VercelRoute[]
+  redirects?: VercelRoute[]
+  routes?: VercelRoute[]
+}
+
+const VERCEL_CONFIG_FILENAMES = ['vercel.json', 'vercel.jsonc']
+
+interface VercelRead {
+  config: VercelConfig
+  relFile: string
+  raw: string
+}
+
+async function readVercelConfig(dir: string): Promise<VercelRead | null> {
+  for (const filename of VERCEL_CONFIG_FILENAMES) {
+    const abs = path.join(dir, filename)
+    if (!(await exists(abs))) continue
+    const raw = await fs.readFile(abs, 'utf8')
+    const config = JSON.parse(maskCommentsInSource(raw)) as VercelConfig
+    return { config, relFile: filename, raw }
+  }
+  return null
+}
+
+// `vercel link` writes `.vercel/project.json` — a strong platform signal even
+// when the repo carries no vercel.json, and the only place the human-readable
+// project name lives (the equivalent of a Worker's script name).
+async function readLinkedProjectName(dir: string): Promise<string | undefined> {
+  const abs = path.join(dir, '.vercel', 'project.json')
+  if (!(await exists(abs))) return undefined
+  const parsed = JSON.parse(await fs.readFile(abs, 'utf8')) as { projectName?: unknown }
+  return typeof parsed.projectName === 'string' ? parsed.projectName : undefined
+}
+
+function routeSource(route: VercelRoute): string | undefined {
+  return route.source ?? route.src
+}
+
+export async function addVercelServices(
+  graph: NeatGraph,
+  services: DiscoveredService[],
+  scanPath: string,
+): Promise<{ nodesAdded: number; edgesAdded: number }> {
+  let nodesAdded = 0
+  let edgesAdded = 0
+
+  for (const service of services) {
+    let read: VercelRead | null = null
+    let projectName: string | undefined
+    try {
+      read = await readVercelConfig(service.dir)
+      projectName = await readLinkedProjectName(service.dir)
+    } catch (err) {
+      recordExtractionError('infra vercel', path.relative(scanPath, service.dir), err)
+      continue
+    }
+    // A Vercel service is one with a vercel.json or a linked .vercel/project.json.
+    if (!read && !projectName) continue
+
+    const serviceNode = graph.getNodeAttributes(service.node.id) as ServiceNode
+    if (serviceNode.platform !== 'vercel' || (projectName && serviceNode.platformName !== projectName)) {
+      const updated: ServiceNode = {
+        ...serviceNode,
+        platform: 'vercel',
+        ...(projectName ? { platformName: projectName } : {}),
+      }
+      graph.replaceNodeAttributes(service.node.id, updated)
+    }
+
+    const anchorId = service.node.id
+    if (!read) continue // linked but no config file to mine resources from
+    const { config, relFile, raw } = read
+    const evidenceFile = toPosix(path.relative(scanPath, path.join(service.dir, relFile)))
+
+    const add = (edgeType: EdgeTypeValue, kind: string, name: string | undefined): void => {
+      if (!name) return
+      const result = emitPlatformResourceEdge(
+        graph,
+        anchorId,
+        edgeType,
+        kind,
+        name,
+        'vercel',
+        evidenceFile,
+        lineContaining(raw, name),
+      )
+      nodesAdded += result.nodesAdded
+      edgesAdded += result.edgesAdded
+    }
+
+    // Runtime marker — one shared node every Vercel service RUNS_ON.
+    add(EdgeType.RUNS_ON, 'vercel', 'vercel')
+
+    // Scheduled functions.
+    for (const cron of config.crons ?? []) add(EdgeType.DEPENDS_ON, 'vercel-cron', cron.path ?? cron.schedule)
+
+    // Declared env vars — names only, value never read.
+    for (const varName of Object.keys(config.env ?? {})) add(EdgeType.DEPENDS_ON, 'vercel-env-var', varName)
+    for (const varName of Object.keys(config.build?.env ?? {})) add(EdgeType.DEPENDS_ON, 'vercel-env-var', varName)
+
+    // Routes / rewrites / redirects — network-reachability, CONNECTS_TO.
+    for (const route of [...(config.rewrites ?? []), ...(config.redirects ?? []), ...(config.routes ?? [])]) {
+      add(EdgeType.CONNECTS_TO, 'vercel-route', routeSource(route))
+    }
+  }
+
+  return { nodesAdded, edgesAdded }
+}

--- a/packages/core/test/extract-railway.test.ts
+++ b/packages/core/test/extract-railway.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import type { GraphEdge, InfraNode, ServiceNode } from '@neat.is/types'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES = path.resolve(__dirname, 'fixtures', 'infra')
+
+describe('Railway service extraction (platform tag)', () => {
+  beforeEach(() => resetGraph())
+
+  it('tags the ServiceNode with platform: railway', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'railway'))
+    const service = graph.getNodeAttributes('service:railway-api') as ServiceNode
+    expect(service.platform).toBe('railway')
+  })
+
+  it('emits a railway runtime node + RUNS_ON edge from the service', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'railway'))
+    const runtimeId = 'infra:railway:railway'
+    expect(graph.hasNode(runtimeId)).toBe(true)
+    expect((graph.getNodeAttributes(runtimeId) as InfraNode).provider).toBe('railway')
+
+    const edgeId = `RUNS_ON:service:railway-api->${runtimeId}`
+    expect(graph.hasEdge(edgeId)).toBe(true)
+    expect((graph.getEdgeAttributes(edgeId) as GraphEdge).provenance).toBe('EXTRACTED')
+  })
+
+  it('healthcheck path becomes a railway-route CONNECTS_TO; cron becomes railway-cron DEPENDS_ON', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'railway'))
+
+    const routeId = 'infra:railway-route:/healthz'
+    expect(graph.hasNode(routeId)).toBe(true)
+    expect(graph.hasEdge(`CONNECTS_TO:service:railway-api->${routeId}`)).toBe(true)
+
+    const cronId = 'infra:railway-cron:0 2 * * *'
+    expect(graph.hasNode(cronId)).toBe(true)
+    expect(graph.hasEdge(`DEPENDS_ON:service:railway-api->${cronId}`)).toBe(true)
+  })
+})

--- a/packages/core/test/extract-supabase.test.ts
+++ b/packages/core/test/extract-supabase.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import type { InfraNode, ServiceNode } from '@neat.is/types'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES = path.resolve(__dirname, 'fixtures', 'infra')
+
+describe('Supabase project extraction (platform tag)', () => {
+  beforeEach(() => resetGraph())
+
+  it('tags the ServiceNode with platform: supabase and platformName from project_id', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'supabase'))
+    const service = graph.getNodeAttributes('service:supabase-app') as ServiceNode
+    expect(service.platform).toBe('supabase')
+    expect(service.platformName).toBe('shop-backend')
+  })
+
+  it('emits a supabase runtime node + RUNS_ON edge from the service', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'supabase'))
+    const runtimeId = 'infra:supabase:supabase'
+    expect(graph.hasNode(runtimeId)).toBe(true)
+    expect((graph.getNodeAttributes(runtimeId) as InfraNode).provider).toBe('supabase')
+    expect(graph.hasEdge(`RUNS_ON:service:supabase-app->${runtimeId}`)).toBe(true)
+  })
+
+  it('each [functions.X] section becomes a supabase-function InfraNode wired DEPENDS_ON', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'supabase'))
+    for (const fn of ['send-email', 'process-webhook']) {
+      const id = `infra:supabase-function:${fn}`
+      expect(graph.hasNode(id)).toBe(true)
+      expect(graph.hasEdge(`DEPENDS_ON:service:supabase-app->${id}`)).toBe(true)
+    }
+  })
+
+  it('declared storage and auth surfaces become DEPENDS_ON InfraNodes', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'supabase'))
+    expect(graph.hasNode('infra:supabase-storage:storage')).toBe(true)
+    expect(graph.hasNode('infra:supabase-auth:auth')).toBe(true)
+  })
+})

--- a/packages/core/test/extract-vercel.test.ts
+++ b/packages/core/test/extract-vercel.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import type { GraphEdge, InfraNode, ServiceNode } from '@neat.is/types'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES = path.resolve(__dirname, 'fixtures', 'infra')
+
+describe('Vercel project extraction (platform tag)', () => {
+  beforeEach(() => resetGraph())
+
+  it('tags the ServiceNode with platform: vercel and platformName from .vercel/project.json', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'vercel'))
+
+    const service = graph.getNodeAttributes('service:vercel-shop') as ServiceNode
+    expect(service.platform).toBe('vercel')
+    expect(service.platformName).toBe('shop-prod')
+  })
+
+  it('emits a shared vercel runtime node + RUNS_ON edge from the service', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'vercel'))
+
+    const runtimeId = 'infra:vercel:vercel'
+    expect(graph.hasNode(runtimeId)).toBe(true)
+    expect((graph.getNodeAttributes(runtimeId) as InfraNode).provider).toBe('vercel')
+
+    const edgeId = `RUNS_ON:service:vercel-shop->${runtimeId}`
+    expect(graph.hasEdge(edgeId)).toBe(true)
+    expect((graph.getEdgeAttributes(edgeId) as GraphEdge).provenance).toBe('EXTRACTED')
+  })
+
+  it('crons and env-var names become DEPENDS_ON InfraNodes; the value is never read', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'vercel'))
+
+    const cronId = 'infra:vercel-cron:/api/cron/digest'
+    expect(graph.hasNode(cronId)).toBe(true)
+    expect(graph.hasEdge(`DEPENDS_ON:service:vercel-shop->${cronId}`)).toBe(true)
+
+    const envId = 'infra:vercel-env-var:API_KEY'
+    expect(graph.hasNode(envId)).toBe(true)
+    // name only — the value "@api-key" is never a node.
+    expect(graph.hasNode('infra:vercel-env-var:@api-key')).toBe(false)
+  })
+
+  it('rewrites become vercel-route InfraNodes wired CONNECTS_TO from the service', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'vercel'))
+
+    const routeId = 'infra:vercel-route:/legacy/:path*'
+    expect(graph.hasNode(routeId)).toBe(true)
+    const edgeId = `CONNECTS_TO:service:vercel-shop->${routeId}`
+    expect(graph.hasEdge(edgeId)).toBe(true)
+    expect((graph.getEdgeAttributes(edgeId) as GraphEdge).type).toBe('CONNECTS_TO')
+  })
+
+  it('leaves a non-Vercel service untouched (no platform tag)', async () => {
+    const graph = getGraph()
+    await extractFromDirectory(graph, path.join(FIXTURES, 'cloudflare'))
+
+    // The cloudflare fixture's services must not pick up a vercel tag.
+    const service = graph.getNodeAttributes('service:orders-worker') as ServiceNode
+    expect(service.platform).not.toBe('vercel')
+  })
+})

--- a/packages/core/test/fixtures/infra/railway/package.json
+++ b/packages/core/test/fixtures/infra/railway/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "railway-api",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "express": "^4.19.0"
+  }
+}

--- a/packages/core/test/fixtures/infra/railway/railway.toml
+++ b/packages/core/test/fixtures/infra/railway/railway.toml
@@ -1,0 +1,8 @@
+[build]
+builder = "NIXPACKS"
+
+[deploy]
+startCommand = "node server.js"
+healthcheckPath = "/healthz"
+cronSchedule = "0 2 * * *"
+restartPolicyType = "ON_FAILURE"

--- a/packages/core/test/fixtures/infra/supabase/package.json
+++ b/packages/core/test/fixtures/infra/supabase/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "supabase-app",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.0"
+  }
+}

--- a/packages/core/test/fixtures/infra/supabase/supabase/config.toml
+++ b/packages/core/test/fixtures/infra/supabase/supabase/config.toml
@@ -1,0 +1,17 @@
+project_id = "shop-backend"
+
+[api]
+enabled = true
+port = 54321
+
+[auth]
+enabled = true
+
+[storage]
+enabled = true
+
+[functions.send-email]
+verify_jwt = true
+
+[functions.process-webhook]
+verify_jwt = false

--- a/packages/core/test/fixtures/infra/vercel/.vercel/project.json
+++ b/packages/core/test/fixtures/infra/vercel/.vercel/project.json
@@ -1,0 +1,5 @@
+{
+  "projectId": "prj_abc123",
+  "orgId": "team_xyz",
+  "projectName": "shop-prod"
+}

--- a/packages/core/test/fixtures/infra/vercel/package.json
+++ b/packages/core/test/fixtures/infra/vercel/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "vercel-shop",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "next": "^14.2.0"
+  }
+}

--- a/packages/core/test/fixtures/infra/vercel/vercel.json
+++ b/packages/core/test/fixtures/infra/vercel/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [{ "path": "/api/cron/digest", "schedule": "0 9 * * *" }],
+  "env": {
+    "API_KEY": "@api-key",
+    "DATABASE_URL": "@db-url"
+  },
+  "rewrites": [{ "source": "/legacy/:path*", "destination": "/api/:path*" }]
+}


### PR DESCRIPTION
Extends ADR-133's `platform` identifier from Cloudflare to the other three connector providers, so the service-rollup badge (#752) renders for all four — the "static system becomes live" spine now covers every provider, not just Cloudflare.

Three detector-extractors join `cloudflare.ts` under `extract/infra/`:
- **`vercel.ts`** — `vercel.json`/`vercel.jsonc` (+ `.vercel/project.json` for the linked project name); models crons, env-var names, routes/rewrites.
- **`railway.ts`** — `railway.toml`/`railway.json`/`railway.jsonc`; models the healthcheck path and cron.
- **`supabase.ts`** — `supabase/config.toml` (`project_id` → `platformName`); models edge functions, storage, auth.

Each stamps `platform` on the ServiceNode and wires declared resources as InfraNodes through a shared `emitPlatformResourceEdge` helper. No new node type; env-var values are never read; `evidence.file` on every edge. ADR-138 + the static-extraction contract are amended.

Tests: 12 new extractor assertions (Vercel 5, Railway 3, Supabase 4); full core suite green (one unrelated daemon-lifecycle flake, ADR-071, passes in isolation).

Part of the **held connector-frontend bundle** (with the #752 badge, #757 status endpoint, and the connector status view) — please land it with that bundle, not solo.

Refs #738, #739, #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)
