### PR TITLE
Give the Incidents page the shared empty-state voice

### DIFF
--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -1257,14 +1257,6 @@ html, body {
   color: var(--fg);
   max-width: 440px;
 }
-.incidents-empty {
-  font-family: var(--font-body);
-  font-style: italic;
-  font-size: 1rem;
-  color: var(--fg-muted);
-  padding: 48px 0;
-  text-align: center;
-}
 .incidents-nav-link {
   color: var(--fg-muted);
   text-decoration: none;

--- a/packages/web/app/incidents/IncidentsClient.tsx
+++ b/packages/web/app/incidents/IncidentsClient.tsx
@@ -110,21 +110,24 @@ export function IncidentsClient() {
         </div>
 
         {loading && (
-          <div className="incidents-empty">loading…</div>
+          <div className="page-empty">loading incidents…</div>
         )}
 
         {!loading && !error && !data && (
-          <div className="incidents-empty">no project registered</div>
+          <div className="page-empty">no project registered</div>
         )}
 
         {error && (
-          <div className="incidents-empty" style={{ color: '#e87a7a' }}>
+          <div className="page-empty" style={{ color: '#e87a7a' }}>
             failed to load: {error}
           </div>
         )}
 
         {!loading && !error && data && data.events.length === 0 && (
-          <div className="incidents-empty">no incidents recorded</div>
+          <div className="page-empty">
+            No incidents yet — OTel error events recorded against your services
+            show up here, most recent first.
+          </div>
         )}
 
         {!loading && !error && data && data.events.length > 0 && (

--- a/packages/web/test/incidents-client.test.tsx
+++ b/packages/web/test/incidents-client.test.tsx
@@ -95,3 +95,60 @@ describe('#699 — Incidents table renders the canonical fixture shape and is ke
     expect(screen.queryByText(stackMarker, { exact: false })).not.toBeInTheDocument()
   })
 })
+
+describe('#762 — Incidents shows the shared page-empty voice when a project has zero incidents', () => {
+  function stubFetch(incidents: unknown) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        if (url.includes('/api/profiles')) {
+          return jsonResponse([
+            { project: 'demo', endpoint: 'http://127.0.0.1:8080', status: 'running' },
+          ])
+        }
+        if (url.includes('/api/health')) return jsonResponse({ ok: true })
+        if (url.includes('/api/incidents')) return jsonResponse(incidents)
+        return jsonResponse({})
+      }),
+    )
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('renders the honest empty-state message and no table on an empty payload', async () => {
+    stubFetch({ count: 0, total: 0, events: [] })
+    render(<IncidentsClient />)
+
+    expect(await screen.findByText(/No incidents yet/i)).toBeInTheDocument()
+    // The empty state stands in for the table — not an empty table with a header row.
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    expect(screen.queryByRole('row')).not.toBeInTheDocument()
+  })
+
+  it('still renders a row per event when the payload is non-empty', async () => {
+    stubFetch({
+      count: 1,
+      total: 1,
+      events: [
+        {
+          id: 'evt-1',
+          timestamp: '2026-07-12T10:00:00.000Z',
+          service: 'checkout',
+          errorType: 'TimeoutError',
+          errorMessage: 'upstream timed out',
+          affectedNode: 'svc:checkout',
+        },
+      ],
+    })
+    render(<IncidentsClient />)
+
+    expect(await screen.findByRole('link', { name: 'svc:checkout' })).toBeInTheDocument()
+    // header row + one data row, and the empty message stays away.
+    expect(screen.getAllByRole('row')).toHaveLength(2)
+    expect(screen.queryByText(/No incidents yet/i)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
The Incidents page is the last list view that doesn't lean on the shared `.page-empty` pattern. When a project has no OTel error events it shows a page-local class and a terse `no incidents recorded`, while Logs, Divergences, Policies, and Find all use `.page-empty` with a sentence that tells you what would fill the view.

This puts Incidents on the same footing: the loading / no-project / error / empty states all move to `.page-empty`, and the empty state now reads "No incidents yet — OTel error events recorded against your services show up here, most recent first." The orphaned `.incidents-empty` rule comes out with it.

A new test asserts the empty payload renders that message with no table, and that a non-empty payload still renders a row per event.

Refs #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)