### PR TITLE
Make the observed=0 overlay's provider buttons clickable again

### DIFF
--- a/packages/web/app/components/Toaster.tsx
+++ b/packages/web/app/components/Toaster.tsx
@@ -32,7 +32,9 @@ export function Toaster() {
         display: 'flex',
         flexDirection: 'column',
         gap: 8,
-        zIndex: 999,
+        // Above .observed-overlay (z-index 1000) so a toast is never buried
+        // behind the observed=0 modal on the graph page.
+        zIndex: 1100,
       }}
     >
       {toasts.map((t) => {

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -1470,7 +1470,12 @@ a:focus-visible, button:focus-visible {
 
 /* ---- THE TWO-MODE OBSERVED OVERLAY (hero honesty screen) --------- */
 .observed-overlay {
-  position: absolute; inset: 0; z-index: 9;
+  /* Must clear the cytoscape-expand-collapse canvas, which the extension
+     appends inside the graph container at z-index: 999 — at anything lower the
+     canvas paints over the modal and swallows clicks on the provider / close /
+     dismiss buttons. Toasts and the command palette are lifted above this in
+     turn (Toaster.tsx, ui/dialog.tsx) so the chrome still layers on top. */
+  position: absolute; inset: 0; z-index: 1000;
   display: flex; align-items: center; justify-content: center;
   background: radial-gradient(ellipse at center, rgba(0,0,0,0.55), rgba(0,0,0,0.88));
 }

--- a/packages/web/components/ui/dialog.tsx
+++ b/packages/web/components/ui/dialog.tsx
@@ -25,12 +25,16 @@ function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
 }
 
+// z-[1100] keeps the dialog (the command palette is the only caller) above the
+// graph page's .observed-overlay, which sits at z-index 1000 so it can clear the
+// cytoscape expand-collapse canvas. A plain z-50 would drop the palette behind
+// that raised overlay.
 function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) {
   return (
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        'fixed inset-0 isolate z-50 bg-black/40 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+        'fixed inset-0 isolate z-[1100] bg-black/40 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
         className,
       )}
       {...props}
@@ -49,7 +53,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          'fixed top-1/2 left-1/2 z-[1100] grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
           className,
         )}
         {...props}

--- a/packages/web/test/observed-overlay.test.tsx
+++ b/packages/web/test/observed-overlay.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 
 // ADR-134 / canvas-layout.md §3a — the overlay's second, parallel path.
 // Drives the real component so a drifted provider list or a broken copy
@@ -37,5 +39,61 @@ describe('ObservedOverlay — the connect-a-provider path', () => {
     render(<ObservedOverlay mode="B" project="demo" onDismiss={vi.fn()} />)
     expect(screen.getByText('connect a provider')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Railway/ })).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #763 — those provider buttons were unclickable in the running app even though
+// the component renders them fine. cytoscape-expand-collapse appends a
+// <canvas class="expand-collapse-canvas"> at z-index 999 inside the graph
+// container; .observed-overlay sat at z-index 9, so the canvas painted over the
+// whole modal and ate every click (document.elementFromPoint at a button's
+// centre returned the canvas). The overlay now rides at z-index 1000, and the
+// chrome that must stay above it — toasts, the command palette — is lifted above
+// 1000 in turn. jsdom doesn't do stacking/paint, so this reads the declared
+// z-indexes off the source and locks the ladder rather than the click.
+// ---------------------------------------------------------------------------
+
+// The z-index cytoscape-expand-collapse hardcodes on the canvas it injects.
+const EXPAND_COLLAPSE_CANVAS_Z = 999
+
+function readSrc(rel: string): string {
+  return readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8')
+}
+
+// z-index declared in the first `{ ... }` block for a CSS selector. Comments
+// are stripped first so prose like "at z-index: 999" doesn't get parsed as the
+// rule's own declaration.
+function cssZIndex(cssRaw: string, selector: string): number {
+  const css = cssRaw.replace(/\/\*[\s\S]*?\*\//g, '')
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const block = css.match(new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`))
+  expect(block, `no rule found for ${selector}`).not.toBeNull()
+  const z = block![1].match(/z-index:\s*(\d+)/)
+  expect(z, `no z-index in ${selector}`).not.toBeNull()
+  return Number(z![1])
+}
+
+describe('observed=0 overlay layering (#763)', () => {
+  const overlayZ = cssZIndex(readSrc('../app/globals.css'), '.observed-overlay')
+
+  it('rides above the expand-collapse canvas so its buttons stay clickable', () => {
+    expect(overlayZ).toBeGreaterThan(EXPAND_COLLAPSE_CANVAS_Z)
+  })
+
+  it('keeps toasts above the overlay', () => {
+    const z = readSrc('../app/components/Toaster.tsx').match(/zIndex:\s*(\d+)/)
+    expect(z, 'no zIndex in Toaster.tsx').not.toBeNull()
+    expect(Number(z![1])).toBeGreaterThan(overlayZ)
+  })
+
+  it('keeps the command-palette dialog above the overlay', () => {
+    const zs = [...readSrc('../components/ui/dialog.tsx').matchAll(/z-\[(\d+)\]/g)].map((m) =>
+      Number(m[1]),
+    )
+    // backdrop and popup both carry an explicit z-index; every layer of the
+    // dialog has to clear the overlay, so check the lowest.
+    expect(zs.length, 'no z-[n] utility in dialog.tsx').toBeGreaterThan(0)
+    expect(Math.min(...zs)).toBeGreaterThan(overlayZ)
   })
 })


### PR DESCRIPTION
On the graph page with no observed layer, the empty-state modal ("run your app, or connect a provider") renders its provider copy buttons, close ×, and "explore the static graph" button — but none of them respond to clicks.

cytoscape-expand-collapse appends a `<canvas class="expand-collapse-canvas">` at `z-index: 999` inside the cytoscape container, and `.observed-overlay` sits at `z-index: 9`. The canvas paints over the whole modal and swallows every click: `document.elementFromPoint` at a button's centre returns the canvas, not the button.

This raises `.observed-overlay` to `z-index: 1000` so it clears that canvas, and lifts the two bits of chrome that should stay on top of the modal — toasts (`Toaster.tsx`) and the command palette (`ui/dialog.tsx`, whose only caller is the palette) — above 1000 in turn, so the layering order stays correct. The command palette can still open over the overlay, and toasts still surface above it.

A test in `test/observed-overlay.test.tsx` reads the declared z-indexes off the source and asserts the ladder — overlay above the 999 canvas layer, toasts and palette above the overlay — so the regression can't come back silently. `rm -rf packages/web/.next && turbo typecheck && turbo build` green; full web suite (93 tests) green.

Refs #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)