### PR TITLE
Stop bouncing a tokenless local daemon to /login

### DIFF
--- a/docs/contracts/one-command-cli.md
+++ b/docs/contracts/one-command-cli.md
@@ -98,17 +98,21 @@ Reference deployments (e.g. `try.neat.is`) want the dashboard publicly readable 
 
 ### `/api/config` — the negotiation surface
 
-`GET /api/config` is **always unauthenticated** — even when the daemon is fully token-gated. It returns exactly two booleans and nothing else:
+`GET /api/config` is **always unauthenticated** — even when the daemon is fully token-gated. It returns exactly three booleans and nothing else:
 
 ```json
-{ "publicRead": true, "authProxy": false }
+{ "publicRead": true, "authProxy": false, "requiresAuth": true }
 ```
 
 - `publicRead` mirrors the `NEAT_PUBLIC_READ` env.
 - `authProxy` mirrors `NEAT_AUTH_PROXY` so the web shell knows when an upstream reverse proxy terminates auth.
-- No project list, no version, no environment info, no whoami. The web UI uses the two booleans to decide whether to push the operator through `/login` and which mutation affordances to render disabled; nothing else belongs on this surface.
+- `requiresAuth` is `true` iff the daemon actually enforces a daemon-side bearer — `NEAT_AUTH_TOKEN` set **and** `NEAT_AUTH_PROXY` unset, the exact condition under which the bearer hook mounts (§3). A tokenless daemon (loopback dev path) and a proxy-terminated one both report `requiresAuth: false`; those two states serve requests with no bearer, so there is nothing to log in with (ADR-139).
+- No project list, no version, no environment info, no whoami. The web UI uses the three booleans to decide whether to push the operator through `/login` and which mutation affordances to render disabled; nothing else belongs on this surface.
 
-The web shell hits `/api/config` before any bearer-carrying call, caches the result in a module-level singleton, and renders `public read-only` in the StatusBar when `publicRead === true`. The dashboard mounts read-only; mutation buttons disable; the login redirect on 401 is suppressed.
+The web shell hits `/api/config` before any bearer-carrying call, caches the result in a module-level singleton, and renders `public read-only` in the StatusBar when `publicRead === true`. Two separate decisions ride the payload, and they are kept apart (ADR-139):
+
+- **Login redirect** is suppressed when the daemon needs no bearer — `publicRead`, `authProxy`, **or** `requiresAuth === false` (a tokenless local daemon has no bearer to paste, so bouncing it to `/login` is the bug). When `/api/config` is unreachable, `requiresAuth` defaults to `true` — assume secured, keep the gate.
+- **Read-only rendering** stays gated on `publicRead` alone. A `NEAT_PUBLIC_READ=true` reference deployment mounts read-only with mutation buttons disabled; a tokenless local daemon renders fully writable, because anonymous writes actually work there.
 
 ## 4. OTLP ingest honors the same bearer; `NEAT_OTEL_TOKEN` rotates independently
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1748,3 +1748,38 @@ Declared-resource edges route through one shared helper, `emitPlatformResourceEd
 - The `platform` badge (#752) renders for all four providers, keyed on a real extracted config file — honest, static, nothing inferred.
 - The connector-fusion path is unchanged: the same tagged nodes these extractors stamp are what each connector later lights up with OBSERVED edges. Extraction now feeds every provider's target resolution, not just Cloudflare's.
 - The tag stays a free string on ServiceNode/FileNode (ADR-133's discipline) — a fifth provider is a new detector file, not a schema change.
+
+## ADR-139 — `/api/config` separates "no login required" from "read-only" (amends ADR-073 §3a)
+
+**Status:** Accepted. Refs #761. Amends [`one-command-cli.md`](contracts/one-command-cli.md) §3a.
+**Contract:** [`one-command-cli.md`](contracts/one-command-cli.md).
+
+### Context
+
+A daemon started without `NEAT_AUTH_TOKEN` serves every request anonymously. `mountBearerAuth` (ADR-073 §3) early-returns when no token is set, so there is no bearer hook at all — reads and writes both go through. That is the laptop dev path, and it is meant to work with zero setup.
+
+The web shell, though, still pushes the operator to `/login` on that daemon. `/api/config` (the ADR-073 §3a negotiation surface) reports `publicRead` straight off `NEAT_PUBLIC_READ`, so a tokenless daemon answers `{ publicRead: false, authProxy: false }`. `useAuthGate` reads no stored token plus `publicRead: false` and redirects to `/login?next=…` — asking the operator for a bearer that the daemon neither issued nor checks. Whatever they paste is meaningless, so it appears to "reset," and a daemon that would serve them freely traps them at a login screen.
+
+The root confusion is that `/api/config` only ever spoke one bit — `publicRead` — and the web layered two distinct decisions on it:
+
+- **Does the operator need to log in?** No, for a tokenless daemon (nothing to log in with) or a proxy-terminated one (the proxy already authed them). Yes, for a token-gated daemon.
+- **Should the UI render read-only?** Yes, only for a `NEAT_PUBLIC_READ=true` reference deployment, where anonymous reads are allowed but writes stay gated.
+
+A tokenless local daemon is the case that breaks: no login needed *and* fully writable. `publicRead` cannot express it — `false` forces the login bounce, `true` would wrongly disable every mutation affordance (`useReadOnly()` keys off `publicRead`). The stopgap of widening `publicRead` to cover the tokenless case trades a login trap for a read-only lie. The two questions need two signals.
+
+### Decision
+
+**1. `/api/config` gains a third boolean, `requiresAuth`.** The surface now returns `{ publicRead, authProxy, requiresAuth }`. `requiresAuth` is `true` iff the daemon actually enforces a daemon-side bearer — `authToken !== undefined && !trustProxy` — which is exactly the condition under which `mountBearerAuth` mounts its hook. A tokenless daemon and a proxy-terminated one both report `requiresAuth: false`; a token-gated daemon reports `requiresAuth: true`, whether or not `publicRead` is also set. `publicRead` and `authProxy` keep their existing meaning untouched. The field threads through the web proxy route (`packages/web/app/api/config/route.ts`) and the `DaemonAuthConfig` type + loader in `public-read-mode.ts`.
+
+**2. `useAuthGate` skips the `/login` redirect when the daemon requires no auth**, independent of `publicRead`. The gate already bailed on a discovered token, on `NEXT_PUBLIC_NEAT_AUTH_PROXY`, and on `publicRead`; it now also bails on `requiresAuth === false`. A tokenless daemon loads the dashboard directly.
+
+**3. `useReadOnly()` / `publicRead` stay exactly as they were.** Read-only rendering remains gated on `publicRead` alone, so a `NEAT_PUBLIC_READ=true` reference deployment still renders read-only with its mutation affordances disabled and its "public read-only" badge, while a tokenless local daemon renders fully writable — because it is.
+
+The conservative default is unchanged: when `/api/config` is unreachable or an older field-less daemon answers, `requiresAuth` reads `true` (assume secured, keep the login gate). Only an explicit `requiresAuth: false` from the daemon suppresses the redirect.
+
+### Consequences
+
+- A tokenless local daemon on loopback loads the dashboard with no `/login` bounce and no read-only badge — the laptop dev path works end to end, which it did not before.
+- A genuine public-read reference deployment (`NEAT_PUBLIC_READ=true`) is unaffected: still no login bounce, still read-only, still badged.
+- A token-gated daemon still gates to `/login` exactly as before — `requiresAuth: true` there, and the existing per-profile-token short-circuit (#637) still runs first.
+- `/api/config` grows from two booleans to three. The contract's "exactly two booleans and nothing else" line becomes "exactly three," and the surface stays whoami-free / project-list-free / version-free per the ADR-073 §3a discipline.

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -996,13 +996,24 @@ export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> 
     publicRead,
   })
 
-  // ADR-073 §3 amendment — `/api/config` is always unauthenticated. The web
+  // ADR-073 §3a / ADR-139 — `/api/config` is always unauthenticated. The web
   // shell hits it before any bearer-carrying request to learn which mode the
-  // daemon is in. Exposes exactly two booleans — `publicRead` and
-  // `authProxy` — and nothing else; no project list, no version, no env.
+  // daemon is in. Exposes exactly three booleans — `publicRead`, `authProxy`,
+  // and `requiresAuth` — and nothing else; no project list, no version, no env.
+  //
+  // `requiresAuth` is true iff this daemon actually mounts a bearer hook, which
+  // is exactly `mountBearerAuth`'s own condition: a token is set and we're not
+  // trusting an upstream proxy. A tokenless daemon (the loopback dev path) and
+  // a proxy-terminated one both serve every request anonymously — there is no
+  // bearer to log in with — so the web gate must not bounce them to /login.
+  // This is distinct from `publicRead`: a public-read reference deployment
+  // still requires auth for writes and renders read-only, while a tokenless
+  // local daemon requires no auth at all and stays fully writable.
+  const requiresAuth = authToken !== undefined && authToken.length > 0 && trustProxy !== true
   app.get('/api/config', async () => ({
     publicRead: publicRead === true,
     authProxy: trustProxy === true,
+    requiresAuth,
   }))
 
   const startedAt = opts.startedAt ?? Date.now()

--- a/packages/core/test/api-config-requires-auth.test.ts
+++ b/packages/core/test/api-config-requires-auth.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { buildApi } from '../src/api.js'
+
+// ADR-139 — `/api/config` gains `requiresAuth`, separating "no login required"
+// from "read-only". `requiresAuth` is true iff the daemon actually mounts a
+// bearer hook (`mountBearerAuth`'s own condition: a token is set and we're not
+// trusting an upstream proxy). A tokenless daemon serves every request
+// anonymously, so it reports `requiresAuth: false` and the web must not push
+// the operator to /login. `publicRead` keeps its own meaning untouched.
+
+const AUTH_VARS = ['NEAT_AUTH_TOKEN', 'NEAT_AUTH_PROXY', 'NEAT_PUBLIC_READ', 'NEAT_OTEL_TOKEN'] as const
+
+describe('ADR-139 — /api/config requiresAuth signal', () => {
+  let app: FastifyInstance | undefined
+  let saved: Partial<Record<(typeof AUTH_VARS)[number], string | undefined>>
+
+  beforeEach(() => {
+    // Clear the auth env so a value inherited from the shell can't leak into the
+    // `opts.x ?? env.x` fallbacks and make a scenario non-deterministic.
+    saved = {}
+    for (const k of AUTH_VARS) {
+      saved[k] = process.env[k]
+      delete process.env[k]
+    }
+    resetGraph()
+  })
+
+  afterEach(async () => {
+    if (app) {
+      await app.close()
+      app = undefined
+    }
+    for (const k of AUTH_VARS) {
+      const v = saved[k]
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+  })
+
+  async function readConfig(opts: {
+    authToken?: string
+    trustProxy?: boolean
+    publicRead?: boolean
+  }): Promise<{ publicRead: boolean; authProxy: boolean; requiresAuth: boolean }> {
+    const graph = getGraph()
+    app = await buildApi({ graph, scanPath: process.cwd(), ...opts })
+    const res = await app.inject({ method: 'GET', url: '/api/config' })
+    expect(res.statusCode).toBe(200)
+    return res.json()
+  }
+
+  it('a tokenless daemon reports requiresAuth:false (nothing to log in with)', async () => {
+    const body = await readConfig({})
+    expect(body).toEqual({ publicRead: false, authProxy: false, requiresAuth: false })
+  })
+
+  it('a token-gated daemon reports requiresAuth:true', async () => {
+    const body = await readConfig({ authToken: 'secret' })
+    expect(body).toEqual({ publicRead: false, authProxy: false, requiresAuth: true })
+  })
+
+  it('public-read still requires auth for writes: publicRead:true, requiresAuth:true', async () => {
+    // A NEAT_PUBLIC_READ reference deployment serves anonymous reads but keeps
+    // the bearer on writes — so it both renders read-only *and* requires auth.
+    const body = await readConfig({ authToken: 'secret', publicRead: true })
+    expect(body).toEqual({ publicRead: true, authProxy: false, requiresAuth: true })
+  })
+
+  it('a proxy-terminated daemon reports requiresAuth:false (proxy already authed)', async () => {
+    const body = await readConfig({ authToken: 'secret', trustProxy: true })
+    expect(body).toEqual({ publicRead: false, authProxy: true, requiresAuth: false })
+  })
+
+  it('the surface stays exactly three booleans, nothing else', async () => {
+    const body = await readConfig({ authToken: 'secret' })
+    expect(Object.keys(body).sort()).toEqual(['authProxy', 'publicRead', 'requiresAuth'])
+  })
+})

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -10607,7 +10607,7 @@ describe('ADR-073 — one-command CLI + deployment-target + delegated auth', () 
       }
     })
 
-    it('GET /api/config is always unauthenticated and returns exactly { publicRead, authProxy }', async () => {
+    it('GET /api/config is always unauthenticated and returns exactly { publicRead, authProxy, requiresAuth }', async () => {
       const { buildApi } = await import('../../src/api.js')
       const { resetGraph, getGraph } = await import('../../src/graph.js')
       resetGraph()
@@ -10620,7 +10620,9 @@ describe('ADR-073 — one-command CLI + deployment-target + delegated auth', () 
         const res = await app.inject({ method: 'GET', url: '/api/config' })
         expect(res.statusCode).toBe(200)
         const body = res.json() as Record<string, unknown>
-        expect(body).toEqual({ publicRead: true, authProxy: false })
+        // ADR-139 — public-read still requires the bearer on writes, so it both
+        // renders read-only *and* requires auth.
+        expect(body).toEqual({ publicRead: true, authProxy: false, requiresAuth: true })
       } finally {
         await app.close()
       }
@@ -10635,7 +10637,9 @@ describe('ADR-073 — one-command CLI + deployment-target + delegated auth', () 
         const res = await proxyApp.inject({ method: 'GET', url: '/api/config' })
         expect(res.statusCode).toBe(200)
         const body = res.json() as Record<string, unknown>
-        expect(body).toEqual({ publicRead: false, authProxy: true })
+        // ADR-139 — a proxy-terminated daemon mounts no bearer hook, so it needs
+        // no login: requiresAuth is false.
+        expect(body).toEqual({ publicRead: false, authProxy: true, requiresAuth: false })
       } finally {
         await proxyApp.close()
       }

--- a/packages/web/app/api/config/route.ts
+++ b/packages/web/app/api/config/route.ts
@@ -7,14 +7,16 @@ import { discoverProfiles, firstReachableEndpoint, proxyGet } from '../../../lib
 // URL can't silently make it cacheable.
 export const dynamic = 'force-dynamic'
 
-// ADR-073 §3 amendment — `/api/config` is the daemon's auth-mode negotiation
-// endpoint. Always unauthenticated, returns `{ publicRead, authProxy }`. Under
-// ADR-101 there is no single core URL, so we resolve the daemon the same way
-// the rest of the proxy does: the `?project=<label>` profile if named, else the
-// first *running* discovered daemon (web-multi-project §2.3 — never blindly the
-// first profile, or the browser negotiates auth against a stopped daemon while a
-// live one waits later in the list). With no daemon discovered, fall back to the
-// conservative default so the browser still gets one stable answer.
+// ADR-073 §3a / ADR-139 — `/api/config` is the daemon's auth-mode negotiation
+// endpoint. Always unauthenticated, returns `{ publicRead, authProxy,
+// requiresAuth }`. Under ADR-101 there is no single core URL, so we resolve the
+// daemon the same way the rest of the proxy does: the `?project=<label>`
+// profile if named, else the first *running* discovered daemon
+// (web-multi-project §2.3 — never blindly the first profile, or the browser
+// negotiates auth against a stopped daemon while a live one waits later in the
+// list). With no daemon discovered, fall back to the conservative default so
+// the browser still gets one stable answer — `requiresAuth: true` there keeps
+// the login gate in place when we can't confirm the daemon is open.
 export async function GET(request: Request): Promise<Response> {
   const project = new URL(request.url).searchParams.get('project')
   const profiles = await discoverProfiles()
@@ -22,11 +24,11 @@ export async function GET(request: Request): Promise<Response> {
     (project ? profiles.find((p) => p.project === project)?.endpoint : undefined) ??
     firstReachableEndpoint(profiles)
   if (!endpoint) {
-    return Response.json({ publicRead: false, authProxy: false })
+    return Response.json({ publicRead: false, authProxy: false, requiresAuth: true })
   }
   return proxyGet(
     `${endpoint}/api/config`,
-    () => Response.json({ publicRead: false, authProxy: false }),
+    () => Response.json({ publicRead: false, authProxy: false, requiresAuth: true }),
     request,
   )
 }

--- a/packages/web/lib/public-read-mode.ts
+++ b/packages/web/lib/public-read-mode.ts
@@ -5,10 +5,10 @@ import { useEffect, useState } from 'react'
 /**
  * Daemon auth-mode awareness (ADR-073 §3 amendment).
  *
- * The daemon exposes `GET /api/config` unauthenticated. It returns two
- * booleans — `publicRead` and `authProxy` — and nothing else. The web shell
- * reads it once on first interest and caches the result, so subsequent
- * checks are synchronous and don't fan out into N requests.
+ * The daemon exposes `GET /api/config` unauthenticated. It returns three
+ * booleans — `publicRead`, `authProxy`, and `requiresAuth` — and nothing else.
+ * The web shell reads it once on first interest and caches the result, so
+ * subsequent checks are synchronous and don't fan out into N requests.
  *
  * `publicRead === true` means the daemon serves anonymous GETs (reference
  * deployments at e.g. try.neat.is). The dashboard renders read-only without
@@ -17,16 +17,27 @@ import { useEffect, useState } from 'react'
  * `authProxy === true` means an upstream reverse proxy already terminates
  * auth and the daemon-side bearer check is bypassed. Surfaced here so the
  * UI can also avoid the localStorage-token dance in that environment.
+ *
+ * `requiresAuth === false` means the daemon mounts no bearer hook at all — a
+ * tokenless loopback dev daemon or a proxy-terminated one. Every request is
+ * served anonymously, so there is no bearer to log in with and the gate must
+ * not bounce the operator to /login (ADR-139). This is separate from
+ * `publicRead`: a tokenless daemon is fully writable, so read-only rendering
+ * stays keyed on `publicRead` alone.
  */
 export interface DaemonAuthConfig {
   publicRead: boolean
   authProxy: boolean
+  requiresAuth: boolean
 }
 
 let cached: DaemonAuthConfig | null = null
 let inflight: Promise<DaemonAuthConfig> | null = null
 
-const DEFAULT_CONFIG: DaemonAuthConfig = { publicRead: false, authProxy: false }
+// Conservative default: assume the daemon requires auth. When `/api/config` is
+// unreachable we'd rather keep the login gate than skip it against a secured
+// daemon we couldn't reach.
+const DEFAULT_CONFIG: DaemonAuthConfig = { publicRead: false, authProxy: false, requiresAuth: true }
 
 export async function loadDaemonAuthConfig(): Promise<DaemonAuthConfig> {
   if (cached) return cached
@@ -42,6 +53,9 @@ export async function loadDaemonAuthConfig(): Promise<DaemonAuthConfig> {
       cached = {
         publicRead: body.publicRead === true,
         authProxy: body.authProxy === true,
+        // Only an explicit `requiresAuth: false` opens the gate. A field-less
+        // response (an older daemon) reads as "requires auth" — the safe side.
+        requiresAuth: body.requiresAuth !== false,
       }
       return cached
     } catch {

--- a/packages/web/lib/use-auth-gate.ts
+++ b/packages/web/lib/use-auth-gate.ts
@@ -40,9 +40,12 @@ async function tokenForDiscoveredProfile(): Promise<string | null> {
  * the deploy platform).
  *
  * Public-read reference deployments (ADR-073 §3a) also skip the redirect.
- * The dashboard renders read-only without forcing a login. The negotiation
- * happens against the daemon's `/api/config` endpoint and is cached after
- * the first call, so the latency hit is paid once per session.
+ * The dashboard renders read-only without forcing a login. So do daemons that
+ * mount no bearer at all — a tokenless loopback dev daemon or a proxy-terminated
+ * one report `requiresAuth: false`, and there is no bearer to log in with, so
+ * bouncing them to /login is the bug (ADR-139). The negotiation happens against
+ * the daemon's `/api/config` endpoint and is cached after the first call, so the
+ * latency hit is paid once per session.
  *
  * Mount this from any client-only page subtree that lives behind the bearer.
  * /login itself does not call it (the page is the destination of the redirect).
@@ -73,7 +76,12 @@ export function useAuthGate(): void {
 
       const cfg = await loadDaemonAuthConfig()
       if (cancelled) return
+      // Public-read reference deployment: render read-only, don't force login.
       if (cfg.publicRead) return
+      // Tokenless / proxy-terminated daemon: no bearer hook is mounted, so
+      // there is nothing to log in with — loading the dashboard directly is
+      // correct, and bouncing to /login is the bug this guards against (ADR-139).
+      if (!cfg.requiresAuth) return
 
       const next = encodeURIComponent(path + window.location.search)
       window.location.href = `/login?next=${next}`

--- a/packages/web/test/auth-gate-bare-root.test.tsx
+++ b/packages/web/test/auth-gate-bare-root.test.tsx
@@ -58,7 +58,7 @@ afterEach(() => {
   setActiveProfile(null)
 })
 
-function stubFetch(opts: { profiles: unknown; publicRead?: boolean }): void {
+function stubFetch(opts: { profiles: unknown; publicRead?: boolean; requiresAuth?: boolean }): void {
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: RequestInfo | URL) => {
@@ -70,10 +70,19 @@ function stubFetch(opts: { profiles: unknown; publicRead?: boolean }): void {
         })
       }
       if (url.includes('/api/config')) {
-        return new Response(JSON.stringify({ publicRead: opts.publicRead === true, authProxy: false }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        })
+        // Omitted requiresAuth reads as `true` (a token-gated daemon), matching
+        // the conservative default the loader applies to a field-less response.
+        return new Response(
+          JSON.stringify({
+            publicRead: opts.publicRead === true,
+            authProxy: false,
+            requiresAuth: opts.requiresAuth !== false,
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        )
       }
       return new Response('{}', { status: 200 })
     }),
@@ -116,5 +125,45 @@ describe('#637 — auth gate on a bare `/` entry', () => {
 
     await new Promise((r) => setTimeout(r, 20))
     expect(location.href).toBe('')
+  })
+})
+
+// ADR-139 — a tokenless local daemon serves everything anonymously: no bearer
+// hook, so nothing to log in with. `/api/config` reports `requiresAuth: false`
+// and the gate must load the dashboard directly instead of bouncing to /login
+// for a token that doesn't exist. `publicRead` is a separate axis — a tokenless
+// daemon is fully writable (`publicRead: false`), so this is not the read-only
+// path.
+describe('ADR-139 — tokenless daemon needs no login', () => {
+  it('does not redirect when the daemon requires no auth, even with no token and not public-read', async () => {
+    stubFetch({
+      profiles: [{ project: 'alpha', endpoint: 'http://127.0.0.1:8080', status: 'running' }],
+      publicRead: false,
+      requiresAuth: false,
+    })
+
+    render(<Gated />)
+
+    // Let discovery + config settle, then assert no bounce — the tokenless
+    // daemon loads the dashboard directly.
+    await waitFor(() => {
+      expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0)
+    })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(location.href).toBe('')
+  })
+
+  it('still redirects when the daemon requires auth and no token is stored', async () => {
+    stubFetch({
+      profiles: [{ project: 'alpha', endpoint: 'http://127.0.0.1:8080', status: 'running' }],
+      publicRead: false,
+      requiresAuth: true,
+    })
+
+    render(<Gated />)
+
+    await waitFor(() => {
+      expect(location.href).toContain('/login')
+    })
   })
 })

--- a/packages/web/test/read-only-mode.test.tsx
+++ b/packages/web/test/read-only-mode.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, render, screen, waitFor } from '@testing-library/react'
+
+// ADR-139 — read-only rendering stays keyed on `publicRead` alone, kept apart
+// from the new `requiresAuth` gate. A NEAT_PUBLIC_READ reference deployment
+// renders read-only; a tokenless local daemon (requiresAuth:false but
+// publicRead:false) is fully writable and must NOT render read-only. This is
+// the invariant the rejected "widen publicRead to cover tokenless" stopgap
+// would have broken.
+
+import { useReadOnly, resetDaemonAuthConfigForTests } from '../lib/public-read-mode'
+
+function ReadOnlyProbe() {
+  const readOnly = useReadOnly()
+  return <div data-testid="probe">{readOnly ? 'read-only' : 'writable'}</div>
+}
+
+function stubConfig(body: { publicRead?: boolean; authProxy?: boolean; requiresAuth?: boolean }): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (!url.includes('/api/config')) {
+        return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+      }
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }),
+  )
+}
+
+beforeEach(() => {
+  resetDaemonAuthConfigForTests()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('ADR-139 — useReadOnly keys on publicRead, not requiresAuth', () => {
+  it('renders read-only for a NEAT_PUBLIC_READ deployment (publicRead:true)', async () => {
+    stubConfig({ publicRead: true, authProxy: false, requiresAuth: true })
+    render(<ReadOnlyProbe />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe').textContent).toBe('read-only')
+    })
+  })
+
+  it('stays writable for a tokenless daemon (requiresAuth:false, publicRead:false)', async () => {
+    stubConfig({ publicRead: false, authProxy: false, requiresAuth: false })
+    render(<ReadOnlyProbe />)
+
+    // Let the /api/config negotiation resolve (flushing the state update inside
+    // act), then assert it never flips to read-only — a tokenless local daemon
+    // serves anonymous writes.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20))
+    })
+    expect(screen.getByTestId('probe').textContent).toBe('writable')
+  })
+})


### PR DESCRIPTION
A daemon started without \`NEAT_AUTH_TOKEN\` serves every request anonymously — the bearer hook never mounts, so reads and writes both go through. That is the laptop dev path, and it should just load the dashboard. Today it doesn't: \`/api/config\` only ever spoke one bit, \`publicRead\`, so a tokenless daemon answered \`{ publicRead: false, authProxy: false }\`, and \`useAuthGate\` — seeing no stored token — pushed the operator to \`/login\` asking for a bearer the daemon neither issued nor checks. Whatever they pasted was meaningless, so it appeared to "reset."

The root confusion is that one boolean carried two different decisions:

- **Does the operator need to log in?** No for a tokenless or proxy-terminated daemon; yes for a token-gated one.
- **Should the UI render read-only?** Yes only for a \`NEAT_PUBLIC_READ=true\` reference deployment.

A tokenless local daemon is exactly the case that breaks — no login needed *and* fully writable — and \`publicRead\` can't express it. Widening \`publicRead\` to cover it would trade a login trap for a read-only lie (\`useReadOnly()\` keys off \`publicRead\`, so every mutation affordance would disable on a daemon where anonymous writes actually work).

This separates the two signals:

- \`/api/config\` gains \`requiresAuth\`, true only when the daemon actually mounts a bearer hook — \`NEAT_AUTH_TOKEN\` set and \`NEAT_AUTH_PROXY\` unset, the same condition \`mountBearerAuth\` uses. Threaded through the daemon handler, the web proxy route, and the \`DaemonAuthConfig\` type + loader.
- \`useAuthGate\` skips the \`/login\` redirect when the daemon requires no auth, independent of \`publicRead\`.
- \`useReadOnly()\` / \`publicRead\` stay exactly as-is, so a tokenless local daemon renders fully writable and a public-read reference deployment still renders read-only.

Amends the ADR-073 §3a auth-mode contract; recorded as **ADR-139** in \`docs/decisions.md\` with the \`/api/config\` shape update in \`one-command-cli.md\`.

### Verification

- \`npx turbo build\` and \`npx turbo typecheck\` green (web \`.next\` cleared first).
- New core test \`api-config-requires-auth.test.ts\` and updated ADR-073 §3a audit: a tokenless daemon reports \`requiresAuth: false\`, token-gated reports \`true\`, public-read reports \`{ publicRead: true, requiresAuth: true }\`, proxy-terminated reports \`{ authProxy: true, requiresAuth: false }\`.
- Web: \`auth-gate-bare-root.test.tsx\` gains cases proving no \`/login\` bounce for a tokenless daemon and a still-bounce for a token-gated one; new \`read-only-mode.test.tsx\` proves \`useReadOnly()\` stays writable for tokenless and read-only for public-read. Full web suite 94/94 green.
- Driven over real HTTP against a live daemon on \`127.0.0.1\` for all four auth modes — the tokenless case returns \`requiresAuth: false\` with \`publicRead: false\`.

Refs #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)