### PR TITLE
Tell the skill docs OBSERVED can come from a connector

### DIFF
--- a/packages/claude-skill/SKILL.md
+++ b/packages/claude-skill/SKILL.md
@@ -34,6 +34,17 @@ Sixteen MCP tools, served by `@neat.is/mcp` over stdio — ten read-only graph q
 
 The ten read tools read from the live graph the daemon maintains in memory. No fs reads of `graph.json` at request time. The extend tools modify instrumentation files, `package.json`, and the lockfile only; NEAT never calls an LLM and the agent reasons over their output (ADR-084).
 
+## Where OBSERVED comes from
+
+The observed-facing read tools — `get_observed_dependencies`, `get_divergences`, `get_incident_history`, `get_recent_stale_edges` — reflect two OBSERVED sources, not one:
+
+- **OTel spans** — pushed by the instrumented app at runtime. The `/neat extend` tools above are how that gets wired up.
+- **Pull connectors** — NEAT polls a provider's own API and folds what it finds into the same OBSERVED layer. Supabase, Railway, Cloudflare, and Firebase are supported. So an integration NEAT never saw a span for can still carry OBSERVED edges, incidents, and staleness — sourced from the platform, not the trace.
+
+Connectors are configured out of band, not through this skill: `neat connector add <provider>` / `list` / `remove <id>` / `test <id>` (ADR-130). Credentials are stored as an env-var reference (`$VAR`) resolved at run time and redacted everywhere, so the agent reads the resulting OBSERVED data but never sees a secret. `GET /:project/connectors` reports each connector's poll health over REST if you need it.
+
+A `ServiceNode` also carries a `platform` string when the extractor recognized the host — `'cloudflare'`, `'vercel'`, `'railway'`, or `'supabase'`, read from a `wrangler.toml` / `vercel.json` / `railway.toml` / `supabase/config.toml`. It's a static (EXTRACTED) signal, surfaced as the provider badge on the dashboard's service nodes.
+
 ## Install
 
 The simplest path: add the snippet from `claude_code_config.json` to your Claude Code MCP config.

--- a/packages/mcp/skill.md
+++ b/packages/mcp/skill.md
@@ -128,7 +128,13 @@ Inputs: `library`.
 
 ## Provenance and confidence
 
-Every edge in the graph — and every result that comes out of these tools — carries a provenance: OBSERVED (live OTel traffic, confidence 1.0), INFERRED (derived from other edges, confidence 0.6), EXTRACTED (read from source, confidence 0.5), or STALE (was OBSERVED, hasn't been seen recently, confidence 0.3). Tools surface this in their text output so you can weight claims accordingly. See [PROVENANCE.md](../../PROVENANCE.md) at the repo root for the full model.
+Every edge in the graph — and every result that comes out of these tools — carries a provenance: OBSERVED (a live signal — an OTel span or a pull connector's poll of a provider API, confidence 1.0), INFERRED (derived from other edges, confidence 0.6), EXTRACTED (read from source, confidence 0.5), or STALE (was OBSERVED, hasn't been seen recently, confidence 0.3). Tools surface this in their text output so you can weight claims accordingly. See [PROVENANCE.md](../../PROVENANCE.md) at the repo root for the full model.
+
+## Connectors and platform
+
+OBSERVED has two sources: OTel spans the app pushes, and **pull connectors** that poll a provider's own API and fold the result into the same OBSERVED layer — Supabase, Railway, Cloudflare, Firebase. An integration with no spans can still show OBSERVED edges, incidents, and staleness if a connector covers it, so `get_observed_dependencies` / `get_divergences` / `get_recent_stale_edges` reflect connector-sourced signal too. Connectors are configured outside this skill with `neat connector add <provider>` / `list` / `remove <id>` / `test <id>` (ADR-130); credentials are env-var references, redacted everywhere — you read the resulting data, never a secret.
+
+A `ServiceNode` may also carry a `platform` string — `'cloudflare'`, `'vercel'`, `'railway'`, or `'supabase'` — when the extractor recognized the host config (`wrangler.toml` / `vercel.json` / `railway.toml` / `supabase/config.toml`). A static EXTRACTED signal, shown as the provider badge on the dashboard's service nodes.
 
 ## Configuration
 


### PR DESCRIPTION
Both skill surfaces (`packages/claude-skill/SKILL.md` and the `packages/mcp/skill.md` manifest the agent loads) defined OBSERVED as OTel-only. Now that the connector on-ramp is shipped (`neat connector add/list/remove/test`, ADR-130) with the Supabase/Railway/Cloudflare/Firebase engines, an agent reading those docs would miss that a pull connector folds a provider's own API into the same OBSERVED layer — an integration with no spans can still carry OBSERVED edges, incidents, and staleness.

Adds a short section to each: the two OBSERVED sources, the `neat connector` on-ramp (credentials stay `$VAR` refs, redacted — the agent reads data, never a secret), and the `ServiceNode.platform` badge signal. Fixes the OBSERVED definition in the manifest's provenance section too. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)