### PR TITLE
Bump to 0.4.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7238,6 +7238,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7259,6 +7260,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7280,6 +7282,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7301,6 +7304,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7322,6 +7326,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7343,6 +7348,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7364,6 +7370,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7385,6 +7392,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7406,6 +7414,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7427,6 +7436,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7448,6 +7458,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10681,7 +10692,7 @@
     },
     "packages/claude-skill": {
       "name": "@neat.is/claude-skill",
-      "version": "0.4.26",
+      "version": "0.4.28",
       "license": "BUSL-1.1",
       "engines": {
         "node": ">=20"
@@ -10689,14 +10700,14 @@
     },
     "packages/core": {
       "name": "@neat.is/core",
-      "version": "0.4.26",
+      "version": "0.4.28",
       "license": "BUSL-1.1",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
         "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
         "@neat.is/instrumentation-registry": "^1.0.0",
-        "@neat.is/types": "^0.4.26",
+        "@neat.is/types": "^0.4.28",
         "chokidar": "^4.0.3",
         "fastify": "^5.0.0",
         "graphology": "^0.25.4",
@@ -10814,11 +10825,11 @@
     },
     "packages/mcp": {
       "name": "@neat.is/mcp",
-      "version": "0.4.26",
+      "version": "0.4.28",
       "license": "BUSL-1.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@neat.is/types": "^0.4.26",
+        "@neat.is/types": "^0.4.28",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -10836,13 +10847,13 @@
       }
     },
     "packages/neat.is": {
-      "version": "0.4.26",
+      "version": "0.4.28",
       "license": "BUSL-1.1",
       "dependencies": {
-        "@neat.is/claude-skill": "^0.4.26",
-        "@neat.is/core": "^0.4.26",
-        "@neat.is/mcp": "^0.4.26",
-        "@neat.is/web": "^0.4.26"
+        "@neat.is/claude-skill": "^0.4.28",
+        "@neat.is/core": "^0.4.28",
+        "@neat.is/mcp": "^0.4.28",
+        "@neat.is/web": "^0.4.28"
       },
       "bin": {
         "neat": "bin/neat",
@@ -10856,7 +10867,7 @@
     },
     "packages/types": {
       "name": "@neat.is/types",
-      "version": "0.4.26",
+      "version": "0.4.28",
       "license": "BUSL-1.1",
       "dependencies": {
         "zod": "^3.23.8"
@@ -10872,11 +10883,11 @@
     },
     "packages/web": {
       "name": "@neat.is/web",
-      "version": "0.4.26",
+      "version": "0.4.28",
       "license": "BUSL-1.1",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
-        "@neat.is/types": "^0.4.26",
+        "@neat.is/types": "^0.4.28",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cytoscape": "^3.33.3",

--- a/packages/claude-skill/package.json
+++ b/packages/claude-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/claude-skill",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "Claude Code skill drop-in for NEAT — wires the @neat.is/mcp server into Claude's MCP config",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/core",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "NEAT graph engine: tree-sitter extraction, OTel ingest, REST API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -51,7 +51,7 @@
     "@fastify/cors": "^10.0.0",
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
-    "@neat.is/types": "^0.4.27",
+    "@neat.is/types": "^0.4.28",
     "chokidar": "^4.0.3",
     "fastify": "^5.0.0",
     "graphology": "^0.25.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/mcp",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "NEAT MCP server: exposes graph queries to AI agents over stdio",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@neat.is/types": "^0.4.27",
+    "@neat.is/types": "^0.4.28",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/neat.is/package.json
+++ b/packages/neat.is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neat.is",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "NEAT — live semantic graph of a software system, queryable from AI agents over MCP. Install once, get the neat / neatd / neat-mcp CLIs.",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -26,9 +26,9 @@
     "README.md"
   ],
   "dependencies": {
-    "@neat.is/core": "^0.4.27",
-    "@neat.is/mcp": "^0.4.27",
-    "@neat.is/claude-skill": "^0.4.27",
-    "@neat.is/web": "^0.4.27"
+    "@neat.is/core": "^0.4.28",
+    "@neat.is/mcp": "^0.4.28",
+    "@neat.is/claude-skill": "^0.4.28",
+    "@neat.is/web": "^0.4.28"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/types",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "Shared Zod schemas, types, and runtime constants for NEAT",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/web",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "NEAT web shell — minimal Next.js app fronting the core API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
-    "@neat.is/types": "^0.4.27",
+    "@neat.is/types": "^0.4.28",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cytoscape": "^3.33.3",


### PR DESCRIPTION
Cuts the frontend release: the connectors status page (#758), real-logo service badges (#767), and the skill-doc connector context (#768), on top of the modal / auth / incidents fixes already on main (#764/#765/#766).

Bumps the six lockstep packages (`types, core, mcp, claude-skill, web, neat.is`) and their `@neat.is` dep ranges to 0.4.28; `instrumentation-registry` stays on its own line. Also resyncs the workspace versions in `package-lock.json`, which had drifted to 0.4.26.

Verified locally uncached: build 5/5, typecheck, lint 6/6, test 11/11 all green. Tag `v0.4.28` after merge triggers the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)