### PR TITLE
Fire the CLI on Windows and resolve the daemon entry cross-platform

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1405,9 +1405,11 @@ export async function runQueryVerb(cmd: string, parsed: ParsedArgs): Promise<num
 
 // Only auto-run when invoked as the CLI entry point. Importing this module
 // from tests must not start the parser; otherwise vitest sees a stray
-// `process.exit` from `main()` running with no argv.
+// `process.exit` from `main()` running with no argv. The separator class
+// `[\\/]` matches Windows paths too — the bin shim lands as `…\bin\neat`, so a
+// forward-slash-only check would leave `main()` unfired and the CLI a no-op.
 const entry = process.argv[1] ?? ''
-if (/[\\/]cli\.(?:cjs|js)$/.test(entry) || entry.endsWith('/cli') || entry.endsWith('/neat') || entry.endsWith('/neat.is')) {
+if (/[\\/](?:cli\.(?:cjs|js)|cli|neat|neat\.is)$/.test(entry)) {
   main().catch((err) => {
     console.error(err)
     process.exit(1)

--- a/packages/core/src/neatd.ts
+++ b/packages/core/src/neatd.ts
@@ -265,7 +265,7 @@ async function main(): Promise<void> {
 }
 
 const entry = process.argv[1] ?? ''
-if (/[\\/]neatd\.(?:cjs|js)$/.test(entry) || entry.endsWith('/neatd')) {
+if (/[\\/](?:neatd\.(?:cjs|js)|neatd)$/.test(entry)) {
   main().catch((err) => {
     console.error(err)
     process.exit(1)

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -24,6 +24,7 @@ import { promises as fs } from 'node:fs'
 import http from 'node:http'
 import net from 'node:net'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { spawn } from 'node:child_process'
 import readline from 'node:readline'
 import type { GraphEdge, GraphNode } from '@neat.is/types'
@@ -783,8 +784,10 @@ function spawnDaemonDetached(
   // Resolve the neatd entry inside the @neat.is/core dist next to this
   // file. `import.meta.url` is post-bundling — at runtime, this resolves
   // to `<core>/dist/neatd.{js,cjs}`. We pick the .cjs because tsup ships
-  // it in both forms and node tolerates either.
-  const here = path.dirname(new URL(import.meta.url).pathname)
+  // it in both forms and node tolerates either. `fileURLToPath` (not
+  // `URL().pathname`) so the Windows drive-letter path resolves to
+  // `C:\…\neatd.cjs`, not the invalid `/C:/…` a raw URL pathname yields.
+  const here = path.dirname(fileURLToPath(import.meta.url))
   const candidates = [
     path.join(here, 'neatd.cjs'),
     path.join(here, 'neatd.js'),


### PR DESCRIPTION
The `e2e-windows` smoke caught that `neat.is` is a no-op on Windows. Three path-separator bugs:

- `cli.ts:1410` — `main()` only fired for a forward-slash bin path, so `…\bin\neat` never ran anything.
- `neatd.ts:268` — same assumption in the `neatd` guard.
- `orchestrator.ts:787` — `new URL(import.meta.url).pathname` yields an invalid `/C:/…` on Windows, so the daemon entry wouldn't resolve.

Match both separators in both guards and resolve the orchestrator entry via `fileURLToPath`. Verified the new regexes match Windows + Unix bin paths and cli/neatd .cjs, and still don't fire under the vitest runner. Full suite green.

Refs #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)