### PR TITLE
Add gated live-connector CI (Cloudflare + Supabase)

### DIFF
--- a/.github/workflows/e2e-connectors.yml
+++ b/.github/workflows/e2e-connectors.yml
@@ -1,0 +1,96 @@
+name: e2e-connectors
+
+# Live connector proofs: build NEAT from source, drive real provider traffic,
+# poll the real provider API, and assert a real OBSERVED edge lands in the graph.
+# This is the durable version of the one-time local proofs — it catches provider
+# API drift (like the Cloudflare telemetry-query shape that had never worked).
+#
+# Each provider job is gated twice: the CONNECTORS_LIVE_ENABLED repo variable must
+# be 'true' AND the provider's own credential secret must be present. A missing
+# secret skips that provider's job green rather than failing — so Cloudflare can
+# run before Supabase's dedicated token is wired, and no job ever ships red for a
+# credential the maintainer hasn't provisioned.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cloudflare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Gate
+        id: gate
+        env:
+          TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ "${{ vars.CONNECTORS_LIVE_ENABLED }}" = "true" ] && [ -n "$TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "CONNECTORS_LIVE_ENABLED != true or CLOUDFLARE_API_TOKEN unset — skipping"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.enabled == 'true'
+      - uses: actions/setup-node@v4
+        if: steps.gate.outputs.enabled == 'true'
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install + build
+        if: steps.gate.outputs.enabled == 'true'
+        run: |
+          npm ci
+          npx turbo build --filter=@neat.is/core
+      - name: Cloudflare connector live e2e
+        if: steps.gate.outputs.enabled == 'true'
+        working-directory: packages/core
+        env:
+          CLOUDFLARE_CONNECTOR_LIVE: '1'
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_WORKER_NAME: ${{ vars.CLOUDFLARE_WORKER_NAME }}
+          CLOUDFLARE_WORKER_URL: ${{ vars.CLOUDFLARE_WORKER_URL }}
+        run: npx vitest run connectors-cloudflare-live
+
+  supabase:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Gate
+        id: gate
+        env:
+          TOKEN: ${{ secrets.SUPABASE_MGMT_TOKEN }}
+        run: |
+          if [ "${{ vars.CONNECTORS_LIVE_ENABLED }}" = "true" ] && [ -n "$TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "CONNECTORS_LIVE_ENABLED != true or SUPABASE_MGMT_TOKEN unset — skipping"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.enabled == 'true'
+      - uses: actions/setup-node@v4
+        if: steps.gate.outputs.enabled == 'true'
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install + build
+        if: steps.gate.outputs.enabled == 'true'
+        run: |
+          npm ci
+          npx turbo build --filter=@neat.is/core
+          # The live test drives PostgREST traffic via @supabase/supabase-js.
+          # Pinned to 2.39.8: newer realtime-js needs native WebSocket, which the
+          # Node 20 toolchain lacks. --no-save keeps it out of the lockfile.
+          npm install --no-save @supabase/supabase-js@2.39.8
+      - name: Supabase connector live e2e
+        if: steps.gate.outputs.enabled == 'true'
+        working-directory: packages/core
+        env:
+          SUPABASE_CONNECTOR_LIVE: '1'
+          SUPABASE_MGMT_TOKEN: ${{ secrets.SUPABASE_MGMT_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF }}
+          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: npx vitest run connectors-supabase-live


### PR DESCRIPTION
Makes the one-time local connector proofs durable. A gated workflow builds NEAT from source, drives real provider traffic, polls the real API, and asserts a real OBSERVED edge — catching provider API drift (like the Cloudflare telemetry-query bug that had never worked live) on demand.

Double-gated per provider (`CONNECTORS_LIVE_ENABLED` var + the provider's credential secret present), so a job skips green rather than failing for an unprovisioned credential. Cloudflare is fully wired (token + account + worker vars set) and runs now; Supabase runs once its dedicated management token lands. Supabase job pins `@supabase/supabase-js@2.39.8` (Node-20 WebSocket compat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)