### PR TITLE
Make the tart macOS fresh-install e2e run green end to end

### DIFF
--- a/e2e/tart/fixture/server.cjs
+++ b/e2e/tart/fixture/server.cjs
@@ -32,10 +32,18 @@ const fs = require('node:fs')
 const PORT = Number.parseInt(process.env.PORT_APP || process.env.FIXTURE_PORT || '8080', 10)
 
 // The upstream the app "calls". Default is a local stub we start below on
-// STUB_PORT, addressed by an explicit host so the frontier node has a name.
-// Override with a public httpbin-style endpoint to test the real-internet path.
+// STUB_PORT, but addressed by a NON-loopback NAME (upstream.neat.local) rather
+// than 127.0.0.1. That distinction is load-bearing: NEAT deliberately suppresses
+// a loopback peer on a CLIENT span — a call to 127.0.0.1/localhost is the app
+// talking to itself, not a distinct upstream (ingest.ts isLoopbackHost, issues
+// #590/#577) — so a 127.0.0.1 upstream would form NO CALLS->frontier edge. The
+// name resolves to the local stub via an /etc/hosts entry the harness adds; the
+// stub still binds loopback. Set UPSTREAM_URL to a real external endpoint to test
+// the real-internet path (that also disables the built-in stub).
 const STUB_PORT = Number.parseInt(process.env.STUB_PORT || String(PORT + 1), 10)
-const UPSTREAM_URL = process.env.UPSTREAM_URL || `http://127.0.0.1:${STUB_PORT}`
+const EXTERNAL_UPSTREAM = process.env.UPSTREAM_URL
+const UPSTREAM_HOST = process.env.UPSTREAM_HOST || 'upstream.neat.local'
+const UPSTREAM_URL = EXTERNAL_UPSTREAM || `http://${UPSTREAM_HOST}:${STUB_PORT}`
 
 // SQLite lives in a writable temp dir so a read-only mount never blocks it.
 const DB_PATH =
@@ -205,7 +213,7 @@ function startApp() {
   })
 }
 
-const usingLocalStub = !process.env.UPSTREAM_URL
+const usingLocalStub = !EXTERNAL_UPSTREAM
 if (usingLocalStub) {
   // A deterministic httpbin-ish stub: GET /get echoes a small JSON body.
   const stub = http.createServer((req, res) => {

--- a/e2e/tart/run.sh
+++ b/e2e/tart/run.sh
@@ -42,7 +42,12 @@ tart list | awk '{print $2}' | grep -qx "$BASE_VM" || {
 
 # sshpass keeps the SSH non-interactive with the default creds. Fall back to a
 # clear message if it isn't installed.
-SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10)
+# PubkeyAuthentication=no + PreferredAuthentications=password force the password
+# sshpass supplies and skip every agent/default key — otherwise ssh floods the VM
+# with pubkey attempts and trips its MaxAuthTries ("Too many authentication
+# failures") before the password is ever tried, an intermittent boot-time flake.
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10
+          -o PubkeyAuthentication=no -o PreferredAuthentications=password)
 if command -v sshpass >/dev/null 2>&1; then
   SSH() { sshpass -p "$VM_PASS" ssh "${SSH_OPTS[@]}" "$VM_USER@$1" "$2"; }
 else
@@ -114,7 +119,9 @@ run_one() {
   # provisioned PATH (node@20, global playwright) is in scope.
   local mount='/Volumes/My Shared Files/neat'
   say "running scenario.sh inside $vm"
-  if SSH "$ip" "bash -lc 'export NEAT_MOUNT=\"$mount/e2e/tart\"; chmod +x \"$mount/e2e/tart/scenario.sh\"; \"$mount/e2e/tart/scenario.sh\" $version'"; then
+  # scenario.sh treats NEAT_MOUNT as the repo root and appends e2e/tart/... itself,
+  # so pass the mount root here — suffixing /e2e/tart doubles the path.
+  if SSH "$ip" "bash -lc 'export NEAT_MOUNT=\"$mount\"; chmod +x \"$mount/e2e/tart/scenario.sh\"; \"$mount/e2e/tart/scenario.sh\" $version'"; then
     say "$vm scenario PASSED"
     RESULTS+=("$version: PASS")
   else

--- a/e2e/tart/scenario.sh
+++ b/e2e/tart/scenario.sh
@@ -160,6 +160,17 @@ done
 # ── 3. Start the instrumented fixture app ──────────────────────────────────
 note ""
 note "[3] starting the instrumented fixture on :$APP_PORT"
+# The fixture calls its stub by a NON-loopback name so NEAT forms a real
+# CALLS->frontier edge (a 127.0.0.1 peer is deliberately suppressed — see the
+# fixture header + ingest.ts isLoopbackHost, issues #590/#577). Map that name to
+# loopback where the stub actually binds. This is a throwaway VM, so editing
+# /etc/hosts is safe; sudo -n avoids hanging if a password were somehow required.
+UPSTREAM_HOST="upstream.neat.local"
+if ! grep -q "$UPSTREAM_HOST" /etc/hosts 2>/dev/null; then
+  echo "127.0.0.1 $UPSTREAM_HOST" | sudo -n tee -a /etc/hosts >/dev/null 2>&1 \
+    && note "    mapped $UPSTREAM_HOST -> 127.0.0.1 (so the CALLS->frontier edge forms)" \
+    || note "    WARN: could not add $UPSTREAM_HOST to /etc/hosts — the CALLS edge may not form"
+fi
 (
   cd "$FIXTURE" || exit 1
   PORT_APP="$APP_PORT" STUB_PORT="$((APP_PORT + 1))" \
@@ -197,14 +208,22 @@ sleep 10
 note ""
 note "[5] NEAT operations and queries"
 
+# The virgin VM installed NEAT via `npx neat.is@$VERSION` — there is no global
+# `neat` on PATH, and the orchestrator doesn't add one. Invoke the CLI the same
+# way a first-time user's later commands would: through npx, which serves it from
+# the cache step [2] already populated (offline-fast). The query verbs are daemon
+# clients and reach the running daemon at NEAT_API_URL (:8080) with no --project,
+# exercising the bare-verb single-project resolution.
+NEAT() { npx -y "neat.is@$VERSION" "$@"; }
+
 # 5a. Bare-verb resolution — `neat divergences` with NO --project must resolve
 # to the single registered project, not 404. This is exactly the bare-verb fix.
 note ""
 note "[5a] neat divergences  (BARE verb — no --project; the bare-verb fix)"
 DIV_OUT="$ARTIFACTS/05a-divergences.txt"
-neat divergences > "$DIV_OUT" 2>&1
+NEAT divergences > "$DIV_OUT" 2>&1
 DIV_RC=$?
-neat divergences --json > "$ARTIFACTS/05a-divergences.json" 2>&1 || true
+NEAT divergences --json > "$ARTIFACTS/05a-divergences.json" 2>&1 || true
 sed 's/^/  /' "$DIV_OUT" | head -20 >> "$SUMMARY"
 if [ "$DIV_RC" -eq 0 ] && ! grep -qiE '404|not found|several projects|could not pick|pass --project' "$DIV_OUT"; then
   pass "divergences: bare verb resolved to '$PROJECT' (no 404, no ambiguity)"
@@ -215,7 +234,7 @@ fi
 # 5b. semantic search — a term that exists in the graph.
 note ""
 note "[5b] neat search server"
-neat search server > "$ARTIFACTS/05b-search.txt" 2>&1 \
+NEAT search server > "$ARTIFACTS/05b-search.txt" 2>&1 \
   && pass "search: returned (rc 0)" \
   || fail "search: non-zero exit (see 05b)"
 sed 's/^/  /' "$ARTIFACTS/05b-search.txt" | head -10 >> "$SUMMARY"
@@ -257,7 +276,7 @@ note "node id for traversals: ${NODE_ID:-<none found>}"
 note ""
 note "[5c] neat root-cause $NODE_ID"
 if [ -n "$NODE_ID" ]; then
-  neat root-cause "$NODE_ID" > "$ARTIFACTS/05c-root-cause.txt" 2>&1 \
+  NEAT root-cause "$NODE_ID" > "$ARTIFACTS/05c-root-cause.txt" 2>&1 \
     && pass "root-cause: ran (rc 0)" \
     || fail "root-cause: non-zero exit (see 05c)"
   sed 's/^/  /' "$ARTIFACTS/05c-root-cause.txt" | head -8 >> "$SUMMARY"
@@ -265,20 +284,31 @@ else
   fail "root-cause: no node id resolved from the graph"
 fi
 
-# 5d. blast-radius — outbound BFS; should reach the database node downstream.
+# 5d. blast-radius — INBOUND dependents ("what breaks if this node changes"),
+# not a downstream walk. The sharp demonstration is the shared database: its
+# blast radius is every node that depends on it — the file that opens the
+# connection and, keeping CONTAINS (file-awareness §36), that file's owning
+# service. Resolve the OBSERVED database node the traffic just minted and assert
+# the owning service surfaces as a dependent.
 note ""
-note "[5d] neat blast-radius $NODE_ID"
-if [ -n "$NODE_ID" ]; then
-  neat blast-radius "$NODE_ID" > "$ARTIFACTS/05d-blast-radius.txt" 2>&1
+DB_NODE_ID="$(node -e '
+  try{const g=JSON.parse(require("fs").readFileSync(process.argv[1]));
+    const n=(g.nodes||[]).find(x=>x.id&&x.id.startsWith("database:"));
+    process.stdout.write(n?n.id:"");
+  }catch(_e){process.stdout.write("")}
+' "$GRAPH_JSON")"
+note "[5d] neat blast-radius $DB_NODE_ID  (dependents of the shared database)"
+if [ -n "$DB_NODE_ID" ]; then
+  NEAT blast-radius "$DB_NODE_ID" > "$ARTIFACTS/05d-blast-radius.txt" 2>&1
   BR_RC=$?
   sed 's/^/  /' "$ARTIFACTS/05d-blast-radius.txt" | head -10 >> "$SUMMARY"
-  if [ "$BR_RC" -eq 0 ] && grep -qiE 'database:|affected' "$ARTIFACTS/05d-blast-radius.txt"; then
-    pass "blast-radius: reached downstream nodes (incl. database)"
+  if [ "$BR_RC" -eq 0 ] && grep -qE 'service:neat-tart-fixture' "$ARTIFACTS/05d-blast-radius.txt"; then
+    pass "blast-radius: the db's dependents reached the owning service"
   else
-    fail "blast-radius: rc=$BR_RC or no downstream reach (see 05d)"
+    fail "blast-radius: rc=$BR_RC or owning service absent from the db's blast radius (see 05d)"
   fi
 else
-  fail "blast-radius: no node id resolved from the graph"
+  fail "blast-radius: no database node resolved from the graph"
 fi
 
 # ── 6. The correctness core — assert OBSERVED edges exist (>0) ─────────────


### PR DESCRIPTION
The tart harness boots a virgin macOS VM, cold-installs `npx neat.is@<version>`, drives traffic across every tier, and asserts the OBSERVED edges and query verbs a first-time user would run. This gets it finishing a full pass — **14/14 against 0.4.29 on a fresh Mac**.

What it now proves on a virgin Mac, first-run:
- `npx neat.is@<version> <app>` one-command flow: discover → instrument → build graph → spawn daemon → dashboard.
- Bare-verb resolution, `search`, `root-cause`, `blast-radius` — all through npx, reaching the daemon.
- OBSERVED lands both edge types: `CALLS -> frontier:upstream.neat.local` **and** `CONNECTS_TO -> database:sqlite.local` (24 spans each).
- Dashboard screenshots captured.

The fixes, all harness-side:
- **Doubled mount path** — `run.sh` passed `NEAT_MOUNT` with `/e2e/tart` already on it, which `scenario.sh` appends to again, so the fixture copy failed before anything ran. Passes the mount root now.
- **Bare `neat`** — the query steps assumed a global binary a virgin npx install never creates. They go through `npx neat.is@<version>` (cached by the orchestrator step).
- **Loopback upstream** — the fixture called its stub on `127.0.0.1`, which NEAT deliberately doesn't turn into a frontier (`isLoopbackHost`, #590/#577), so no CALLS edge formed. It addresses the stub by a name mapped to loopback now, so the flagship CALLS→frontier edge forms. This also *validates* the #590/#577 suppression holds on a fresh Mac.
- **blast-radius direction** — asked the wrong node the wrong way. It now asks for the shared database's dependents and confirms they reach the owning service — what blast radius actually answers.
- **SSH** forces password auth so agent keys don't trip the VM's `MaxAuthTries`.

Refs #795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)