### PR TITLE
Bump to 0.4.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10692,7 +10692,7 @@
     },
     "packages/claude-skill": {
       "name": "@neat.is/claude-skill",
-      "version": "0.4.29",
+      "version": "0.4.30",
       "license": "BUSL-1.1",
       "engines": {
         "node": ">=20"
@@ -10700,14 +10700,14 @@
     },
     "packages/core": {
       "name": "@neat.is/core",
-      "version": "0.4.29",
+      "version": "0.4.30",
       "license": "BUSL-1.1",
       "dependencies": {
         "@fastify/cors": "^10.0.0",
         "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
         "@neat.is/instrumentation-registry": "^1.0.0",
-        "@neat.is/types": "^0.4.29",
+        "@neat.is/types": "^0.4.30",
         "chokidar": "^4.0.3",
         "fastify": "^5.0.0",
         "graphology": "^0.25.4",
@@ -10825,11 +10825,11 @@
     },
     "packages/mcp": {
       "name": "@neat.is/mcp",
-      "version": "0.4.29",
+      "version": "0.4.30",
       "license": "BUSL-1.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@neat.is/types": "^0.4.29",
+        "@neat.is/types": "^0.4.30",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -10847,13 +10847,13 @@
       }
     },
     "packages/neat.is": {
-      "version": "0.4.29",
+      "version": "0.4.30",
       "license": "BUSL-1.1",
       "dependencies": {
-        "@neat.is/claude-skill": "^0.4.29",
-        "@neat.is/core": "^0.4.29",
-        "@neat.is/mcp": "^0.4.29",
-        "@neat.is/web": "^0.4.29"
+        "@neat.is/claude-skill": "^0.4.30",
+        "@neat.is/core": "^0.4.30",
+        "@neat.is/mcp": "^0.4.30",
+        "@neat.is/web": "^0.4.30"
       },
       "bin": {
         "neat": "bin/neat",
@@ -10867,7 +10867,7 @@
     },
     "packages/types": {
       "name": "@neat.is/types",
-      "version": "0.4.29",
+      "version": "0.4.30",
       "license": "BUSL-1.1",
       "dependencies": {
         "zod": "^3.23.8"
@@ -10883,11 +10883,11 @@
     },
     "packages/web": {
       "name": "@neat.is/web",
-      "version": "0.4.29",
+      "version": "0.4.30",
       "license": "BUSL-1.1",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
-        "@neat.is/types": "^0.4.29",
+        "@neat.is/types": "^0.4.30",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cytoscape": "^3.33.3",

--- a/packages/claude-skill/package.json
+++ b/packages/claude-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/claude-skill",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "description": "Claude Code skill drop-in for NEAT — wires the @neat.is/mcp server into Claude's MCP config",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/core",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "description": "NEAT graph engine: tree-sitter extraction, OTel ingest, REST API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -51,7 +51,7 @@
     "@fastify/cors": "^10.0.0",
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
-    "@neat.is/types": "^0.4.29",
+    "@neat.is/types": "^0.4.30",
     "chokidar": "^4.0.3",
     "fastify": "^5.0.0",
     "graphology": "^0.25.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/mcp",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "description": "NEAT MCP server: exposes graph queries to AI agents over stdio",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@neat.is/types": "^0.4.29",
+    "@neat.is/types": "^0.4.30",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/neat.is/package.json
+++ b/packages/neat.is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neat.is",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "description": "NEAT — live semantic graph of a software system, queryable from AI agents over MCP. Install once, get the neat / neatd / neat-mcp CLIs.",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -26,9 +26,9 @@
     "README.md"
   ],
   "dependencies": {
-    "@neat.is/core": "^0.4.29",
-    "@neat.is/mcp": "^0.4.29",
-    "@neat.is/claude-skill": "^0.4.29",
-    "@neat.is/web": "^0.4.29"
+    "@neat.is/core": "^0.4.30",
+    "@neat.is/mcp": "^0.4.30",
+    "@neat.is/claude-skill": "^0.4.30",
+    "@neat.is/web": "^0.4.30"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/types",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "description": "Shared Zod schemas, types, and runtime constants for NEAT",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neat.is/web",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "description": "NEAT web shell — minimal Next.js app fronting the core API",
   "license": "BUSL-1.1",
   "homepage": "https://neat.is",
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
-    "@neat.is/types": "^0.4.29",
+    "@neat.is/types": "^0.4.30",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cytoscape": "^3.33.3",


### PR DESCRIPTION
Lockstep bump of the six published packages 0.4.29 → 0.4.30 (versions + internal `@neat.is/*` pins); `package-lock.json` synced. Root `neat` and `@neat.is/instrumentation-registry` untouched.

Ships since 0.4.29:
- Cloudflare telemetry query runs ad-hoc so the connector works against the real API (#779)
- Railway connector hardened against a real project (#749)
- `get_dependencies` no longer reports a service's own files as dependencies (ADR-140, #782)
- Real-graph query-correctness coverage: root-cause (#784), divergences (#783), dependencies (#781), blast-radius (#799)
- tart macOS fresh-install e2e runs green end to end (#798); gated live-connector CI (#785); e2e-capture on the ADR-096 lifecycle (#777)

Tag `v0.4.30` after merge to trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)