### PR TITLE
Fuse ORM databases so Prisma apps stop showing a false missing-observed (ADR-141)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1834,3 +1834,34 @@ This is asymmetric by design. `getBlastRadius` continues to report `CONTAINS`: w
 - `get_blast_radius` output is unchanged (the #392 and demo-graph blast tests still pass), preserving file-grained dependents plus the owning service.
 - §36 is amended to state the asymmetry explicitly; the file-first promise still holds for the edges that carry a real relationship.
 - Pinned by `packages/core/test/graph-dependencies.test.ts`.
+
+## ADR-141 — ORM env-URL resolution + host-less OBSERVED database fusion (Prisma support)
+
+**Status:** Accepted. Refs #801. Amends [`static-extraction.md`](contracts/static-extraction.md) and [`otel-ingest.md`](contracts/otel-ingest.md).
+**Contract:** [`static-extraction.md`](contracts/static-extraction.md), [`otel-ingest.md`](contracts/otel-ingest.md).
+
+### Context
+
+ORMs like Prisma declare their datasource through an env indirection — `url = env("DATABASE_URL")` — and their query engine emits OTel spans that carry `db.system` but **no peer host** (Prisma's Rust engine backdates the span off the connection, ADR-118's motivating case for in-process DBs but here for a *networked* one). Two failures compound for a real Prisma app, confirmed live against Brief:
+
+1. **Extraction mints two DatabaseNodes for one database.** The prisma parser can't resolve `env("DATABASE_URL")`, so it falls back to a placeholder host and mints `database:postgresql-prisma`; the dotenv parser reads the same `DATABASE_URL` and mints `database:<real-host>`. Drizzle and Knex carry the same `<engine>-<orm>` placeholder fallback.
+2. **Ingest can't host-match the OBSERVED span.** The host-less `db.system` span resolves no peer, so `ensureLocalDatabaseNode` mints a third, service-scoped node (`database:<svc>/postgresql`).
+
+The three never fuse. The declared `CONNECTS_TO` has no OBSERVED twin on the same `(source, target, type)` triple, so it surfaces as a false `missing-observed` divergence — NEAT reporting "you declared a database you never connect to" for a DB the app hammers. That breaks the flagship divergence query for essentially every Prisma/Drizzle/Knex backend.
+
+### Decision
+
+Three coordinated changes so an ORM DB dependency forms **one** fused node carrying both EXTRACTED and OBSERVED provenance, and its declared/observed edges compare cleanly:
+
+1. **ORM env-URL resolution (extraction).** When Prisma's datasource declares its URL via `env("VAR")`, the parser resolves `VAR` from the service's `.env` files and parses the real connection string — a shared helper (`resolveEnvVar`) reusing the same `.env` read the dotenv parser performs. The placeholder-host fallback survives only when the variable is genuinely absent. The Prisma node and the dotenv node then share the real host and dedup to one declared node (`index.ts`, first-wins-on-identical-host). Per ADR-016 the resolved value is transient — it derives the DatabaseNode host and never lands in a ConfigNode or snapshot. **Scope: Prisma only for now** — Drizzle and Knex reference their URL through `process.env.X` in a JS/TS config rather than `env("VAR")`, so each needs its own env-reference detection; wiring the shared helper into them is follow-up, not done here.
+
+2. **Host-less OBSERVED DB fusion (ingest).** When a `db.system` span carries no peer host, before minting a service-local node, look for a database the emitting service already declares (an EXTRACTED `CONNECTS_TO` from the service or one of the files it `CONTAINS`) with the *same engine*. If exactly one matches, land the OBSERVED `CONNECTS_TO` on **that** node. Ambiguous (two-plus same-engine declared DBs) or no match falls back to the ADR-118 service-local node, unchanged.
+
+3. **Service-grain comparison for database CONNECTS_TO (divergence).** A database is *declared* in a config file (the connection string) but *executed* from a code file (the query call site) — inherently different files, so a file-grained `(source, target)` comparison flags both a `missing-observed` (on the config edge) and a `missing-extracted` (on the code edge) even after the target fuses. The divergence bucketer rolls a database `CONNECTS_TO`'s source up to its owning service, so the declared and observed edges compare at the grain they share. This is scoped to database targets — a route or service edge keeps its file/route grain (ADR-119). The file-grained edges stay in the graph untouched; only the comparison coarsens.
+
+### Consequences
+
+- A Prisma service's DB dependency is one node with both EXTRACTED and OBSERVED `CONNECTS_TO`. The false `missing-observed` disappears; a genuinely-unused declared DB still surfaces (no observed same-engine connection to fuse).
+- The fusion is engine-scoped and single-match-only, so it never silently merges two distinct databases — the ambiguous case degrades to today's behaviour, not to a wrong merge.
+- The env-resolution is Prisma-only for now; Drizzle and Knex (which reference the URL via `process.env.X`) keep their placeholder-host fallback until their env-syntax detection is added — tracked as follow-up on #801.
+- Pinned by unit tests (a Prisma-shaped host-less `db.system` span fuses onto the declared node; the ambiguous case does not) and the live `e2e/brief` OBSERVED harness, which now passes with the DB dependency observed rather than divergent.

--- a/packages/core/src/divergences.ts
+++ b/packages/core/src/divergences.ts
@@ -26,7 +26,9 @@ import {
   EdgeType,
   NodeType,
   parseEdgeId,
+  parseFileId,
   Provenance,
+  serviceId,
 } from '@neat.is/types'
 import type { NeatGraph } from './graph.js'
 import {
@@ -64,6 +66,25 @@ function bucketKey(source: string, target: string, type: string): string {
   return `${type}|${source}|${target}`
 }
 
+// A database CONNECTS_TO is *declared* in a config file (its connection string)
+// but *executed* from a code file (the query call site) — inherently different
+// files. Comparing them at file grain would flag both a `missing-observed` (on
+// the config-file edge) and a `missing-extracted` (on the code-file edge) for a
+// database the service both declares and drives — a false pair on every ORM app
+// (ADR-141). So roll a database CONNECTS_TO's source up to its owning service:
+// declared and observed then compare at the grain they actually share. The
+// file-grained edges stay in the graph untouched — only this comparison
+// coarsens, and only for database targets (a route or service edge keeps its
+// file grain per the ADR-119 route-grained comparison).
+function bucketSourceFor(graph: NeatGraph, edge: GraphEdge): string {
+  if (edge.type !== EdgeType.CONNECTS_TO) return edge.source
+  const parsed = parseFileId(edge.source)
+  if (!parsed || !graph.hasNode(edge.target)) return edge.source
+  const target = graph.getNodeAttributes(edge.target) as GraphNode
+  if (target.type !== NodeType.DatabaseNode) return edge.source
+  return serviceId(parsed.service)
+}
+
 function bucketEdges(graph: NeatGraph): Map<string, EdgeBucket> {
   const buckets = new Map<string, EdgeBucket>()
   graph.forEachEdge((id, attrs) => {
@@ -72,9 +93,10 @@ function bucketEdges(graph: NeatGraph): Map<string, EdgeBucket> {
     // parseEdgeId can fall through to EXTRACTED for unknown shapes — fall
     // back to the edge's own provenance when the id doesn't parse cleanly.
     const provenance = parsed?.provenance ?? e.provenance
-    const key = bucketKey(e.source, e.target, e.type)
+    const source = bucketSourceFor(graph, e)
+    const key = bucketKey(source, e.target, e.type)
     const cur =
-      buckets.get(key) ?? { source: e.source, target: e.target, type: e.type }
+      buckets.get(key) ?? { source, target: e.target, type: e.type }
     switch (provenance) {
       case Provenance.EXTRACTED:
         cur.extracted = e

--- a/packages/core/src/extract/databases/prisma.ts
+++ b/packages/core/src/extract/databases/prisma.ts
@@ -1,5 +1,11 @@
 import path from 'node:path'
-import { readIfExists, parseConnectionString, schemeToEngine, type DbConfig } from './shared.js'
+import {
+  readIfExists,
+  parseConnectionString,
+  resolveEnvVar,
+  schemeToEngine,
+  type DbConfig,
+} from './shared.js'
 
 // Prisma's schema file declares datasources of the form:
 //
@@ -8,9 +14,12 @@ import { readIfExists, parseConnectionString, schemeToEngine, type DbConfig } fr
 //     url      = env("DATABASE_URL")
 //   }
 //
-// We match the provider directly. URLs come in via env() so we can't resolve
-// them statically; host/database fall back to placeholders so the DatabaseNode
-// id remains deterministic per service.
+// We match the provider directly. The url is almost always an env() indirection,
+// so we resolve the referenced variable from the service's .env to recover the
+// real host — that keys the DatabaseNode on the same host the dotenv parser
+// mints, so the two fuse to one declared node instead of a placeholder twin
+// (ADR-141). Only when the url is a literal, or the env var is absent, do we
+// fall back (literal parse, then a deterministic per-service placeholder).
 export async function parse(serviceDir: string): Promise<DbConfig[]> {
   const schemaPath = path.join(serviceDir, 'prisma', 'schema.prisma')
   const content = await readIfExists(schemaPath)
@@ -29,6 +38,15 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
   if (urlMatch) {
     const config = parseConnectionString(urlMatch[1]!)
     if (config) return [{ ...config, sourceFile: schemaPath }]
+  }
+
+  const envMatch = body.match(/url\s*=\s*env\(\s*"([^"]+)"\s*\)/)
+  if (envMatch) {
+    const resolved = await resolveEnvVar(serviceDir, envMatch[1]!)
+    if (resolved) {
+      const config = parseConnectionString(resolved)
+      if (config) return [{ ...config, sourceFile: schemaPath }]
+    }
   }
 
   return [

--- a/packages/core/src/extract/databases/shared.ts
+++ b/packages/core/src/extract/databases/shared.ts
@@ -67,6 +67,42 @@ export async function readIfExists(filePath: string): Promise<string | null> {
   }
 }
 
+// Resolve an env variable an ORM datasource references indirectly — Prisma's
+// `url = env("DATABASE_URL")`, Drizzle/Knex reading `process.env.DATABASE_URL`
+// — from the service's `.env` files, so the parser can recover the real host
+// instead of falling back to a placeholder (ADR-141). Precedence follows the
+// dotenv convention: `.env.local` overrides `.env`, then any other `.env.*`.
+// Per ADR-016 the value is transient — it only derives the DatabaseNode host and
+// never lands in a ConfigNode or the snapshot.
+export async function resolveEnvVar(serviceDir: string, name: string): Promise<string | null> {
+  const entries = await fs.readdir(serviceDir, { withFileTypes: true }).catch(() => [])
+  const envNames = entries
+    .filter((e) => e.isFile() && (e.name === '.env' || e.name.startsWith('.env.')))
+    .map((e) => e.name)
+  const rank = (n: string): number => (n === '.env.local' ? 0 : n === '.env' ? 1 : 2)
+  envNames.sort((a, b) => rank(a) - rank(b) || a.localeCompare(b))
+  for (const fileName of envNames) {
+    const content = await readIfExists(path.join(serviceDir, fileName))
+    if (!content) continue
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const eq = trimmed.indexOf('=')
+      if (eq < 0) continue
+      if (trimmed.slice(0, eq).trim() !== name) continue
+      let value = trimmed.slice(eq + 1).trim()
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1)
+      }
+      return value || null
+    }
+  }
+  return null
+}
+
 export async function findFirst(
   serviceDir: string,
   candidates: string[],

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -1147,6 +1147,45 @@ function ensureLocalDatabaseNode(
   return id
 }
 
+// ADR-141 — an ORM such as Prisma emits a `db.system` span with no peer host
+// (its query engine backdates the span off the connection), so a host-less span
+// would mint a fresh service-local DatabaseNode and leave the service's
+// statically declared database — the one parsed from its connection string / ORM
+// schema — with no OBSERVED twin: a false `missing-observed` divergence for a DB
+// the service demonstrably hammers. Before minting a local node, fuse onto the
+// service's already-declared database of the same engine when there is exactly
+// one. Ambiguous (two-plus same-engine declared DBs) or none falls back to the
+// ADR-118 service-local node — the fusion never guesses which of several it is.
+function findDeclaredDatabaseForService(
+  graph: NeatGraph,
+  serviceNodeId: string,
+  engine: string,
+): string | null {
+  if (!graph.hasNode(serviceNodeId)) return null
+  // A declared database CONNECTS_TO is file-grained by design — it originates
+  // from the config file that named the connection (databases/index.ts,
+  // file-awareness §7), not the service node. So scan the service node and every
+  // file it CONTAINS for a same-engine EXTRACTED CONNECTS_TO target.
+  const sources = [serviceNodeId]
+  for (const edgeId of graph.outboundEdges(serviceNodeId)) {
+    const e = graph.getEdgeAttributes(edgeId) as GraphEdge
+    if (e.type === EdgeType.CONTAINS) sources.push(e.target)
+  }
+  const matches = new Set<string>()
+  for (const src of sources) {
+    if (!graph.hasNode(src)) continue
+    for (const edgeId of graph.outboundEdges(src)) {
+      const edge = graph.getEdgeAttributes(edgeId) as GraphEdge
+      if (edge.type !== EdgeType.CONNECTS_TO || edge.provenance !== Provenance.EXTRACTED) continue
+      if (!graph.hasNode(edge.target)) continue
+      const target = graph.getNodeAttributes(edge.target) as DatabaseNode
+      if (target.type !== NodeType.DatabaseNode || target.engine !== engine) continue
+      matches.add(edge.target)
+    }
+  }
+  return matches.size === 1 ? [...matches][0]! : null
+}
+
 function ensureFrontierNode(graph: NeatGraph, host: string, ts: string): string {
   const id = frontierIdFor(host)
   if (graph.hasNode(id)) {
@@ -1631,15 +1670,24 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
         ensureDatabaseNode(ctx.graph, host, span.dbSystem)
         targetId = databaseId(host)
       } else {
-        // No peer host — an in-process DB. Name the node by its logical
-        // database (db.name) when the span carries one, the engine otherwise.
-        const localName = span.dbName ?? span.dbSystem
-        targetId = ensureLocalDatabaseNode(
-          ctx.graph,
-          span.service,
-          localName,
-          span.dbSystem,
-        )
+        // No peer host. Prefer fusing onto the service's declared database of
+        // the same engine (ADR-141) so an ORM's host-less span confirms the
+        // static dependency instead of minting a divergent twin. Falls back to a
+        // service-local node (ADR-118) for a genuinely embedded DB (SQLite) or an
+        // ambiguous declaration. Name the local node by its logical database
+        // (db.name) when the span carries one, the engine otherwise.
+        const declared = findDeclaredDatabaseForService(ctx.graph, sourceId, span.dbSystem)
+        if (declared) {
+          targetId = declared
+        } else {
+          const localName = span.dbName ?? span.dbSystem
+          targetId = ensureLocalDatabaseNode(
+            ctx.graph,
+            span.service,
+            localName,
+            span.dbSystem,
+          )
+        }
       }
       const result = upsertObservedEdge(
         ctx.graph,

--- a/packages/core/test/db-orm-fusion.test.ts
+++ b/packages/core/test/db-orm-fusion.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import { handleSpan, type IngestContext } from '../src/ingest.js'
+import { computeDivergences } from '../src/divergences.js'
+import { EdgeType, Provenance, type GraphEdge } from '@neat.is/types'
+import type { ParsedSpan } from '../src/otel.js'
+
+// ADR-141 — an ORM (Prisma) declares its DB via env("DATABASE_URL") and emits
+// host-less db.system spans. These tests pin the three coordinated pieces
+// against a REAL extracted graph, and — the point of the after-the-fact audit —
+// exercise the cases that were only reasoned about before: the ambiguous
+// fallback and that a genuinely-unused DB still diverges (no over-suppression).
+
+async function writePrismaService(
+  dir: string,
+  opts: { url?: string; env?: Record<string, string>; extraEnvKeys?: Record<string, string> } = {},
+): Promise<void> {
+  const svc = path.join(dir, 'api')
+  await fs.mkdir(path.join(svc, 'prisma'), { recursive: true })
+  await fs.writeFile(
+    path.join(svc, 'package.json'),
+    JSON.stringify({ name: 'orders', version: '1.0.0', dependencies: { '@prisma/client': '6.0.0' } }),
+  )
+  const url = opts.url ?? 'env("DATABASE_URL")'
+  await fs.writeFile(
+    path.join(svc, 'prisma', 'schema.prisma'),
+    `generator client { provider = "prisma-client-js" }\ndatasource db {\n  provider = "postgresql"\n  url = ${url}\n}\n`,
+  )
+  const env = opts.env ?? { DATABASE_URL: 'postgres://u:p@db.prod.example.com:5432/orders' }
+  const lines = Object.entries({ ...env, ...(opts.extraEnvKeys ?? {}) }).map(([k, v]) => `${k}=${v}`)
+  await fs.writeFile(path.join(svc, '.env'), lines.join('\n') + '\n')
+}
+
+function hostlessPgSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
+  // A Prisma engine db_query span: db.system present, NO server.address.
+  return {
+    service: 'orders',
+    traceId: 't1',
+    spanId: 's1',
+    name: 'prisma:engine:db_query',
+    kind: 3,
+    startTimeUnixNano: '0',
+    endTimeUnixNano: '0',
+    durationNanos: 0n,
+    env: 'unknown',
+    attributes: { 'db.system': 'postgresql' },
+    dbSystem: 'postgresql',
+    statusCode: 0,
+    ...overrides,
+  }
+}
+
+function dbNodes(): string[] {
+  const g = getGraph()
+  return g.filterNodes((id) => id.startsWith('database:'))
+}
+
+describe('ORM host-less DB fusion (ADR-141)', () => {
+  let dir: string
+  let ctx: IngestContext
+
+  beforeEach(async () => {
+    resetGraph()
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-orm-fusion-'))
+    ctx = { graph: getGraph(), errorsPath: path.join(dir, 'errors.ndjson'), scanPath: dir }
+  })
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('resolves Prisma env("DATABASE_URL") to the real host — one DB node, not a placeholder', async () => {
+    await writePrismaService(dir)
+    await extractFromDirectory(ctx.graph, dir)
+    const dbs = dbNodes()
+    expect(dbs).toEqual(['database:db.prod.example.com'])
+    expect(dbs).not.toContain('database:postgresql-prisma')
+  })
+
+  it('fuses a host-less db.system span onto the declared DB, and the divergence clears', async () => {
+    await writePrismaService(dir)
+    await extractFromDirectory(ctx.graph, dir)
+    await handleSpan(ctx, hostlessPgSpan())
+
+    // The OBSERVED CONNECTS_TO landed on the DECLARED node, not a fresh local one.
+    const observedToDeclared = ctx.graph
+      .filterEdges((_id, e: GraphEdge) => e.provenance === Provenance.OBSERVED && e.type === EdgeType.CONNECTS_TO)
+      .map((id) => ctx.graph.getEdgeAttributes(id) as GraphEdge)
+    expect(observedToDeclared.map((e) => e.target)).toContain('database:db.prod.example.com')
+    // No service-local node minted (that would be the un-fused fallback).
+    expect(dbNodes().filter((id) => id.includes('/postgresql'))).toHaveLength(0)
+
+    // The declared DB no longer diverges — declared and observed compare at
+    // service grain, so no missing-observed AND no missing-extracted for it.
+    const { divergences } = computeDivergences(ctx.graph)
+    expect(divergences.filter((d) => d.target === 'database:db.prod.example.com')).toHaveLength(0)
+  })
+
+  it('AUDIT: falls back to a service-local node when the service declares TWO same-engine DBs', async () => {
+    // Two postgres connection strings → two declared DB nodes → ambiguous.
+    await writePrismaService(dir, {
+      env: {
+        DATABASE_URL: 'postgres://u:p@db-a.example.com:5432/orders',
+        POSTGRES_URL: 'postgres://u:p@db-b.example.com:5432/orders',
+      },
+    })
+    await extractFromDirectory(ctx.graph, dir)
+    expect(dbNodes().length).toBeGreaterThanOrEqual(2)
+
+    await handleSpan(ctx, hostlessPgSpan())
+    // Ambiguous → the fusion must NOT guess; it mints the service-local node.
+    expect(dbNodes().some((id) => id.includes('/postgresql'))).toBe(true)
+  })
+
+  it('AUDIT: a genuinely-unused declared DB STILL surfaces as missing-observed (no over-suppression)', async () => {
+    await writePrismaService(dir)
+    await extractFromDirectory(ctx.graph, dir)
+    // No span driven — nothing observed. The roll-up must not hide the gap.
+    const { divergences } = computeDivergences(ctx.graph)
+    const miss = divergences.find(
+      (d) => d.type === 'missing-observed' && d.target === 'database:db.prod.example.com',
+    )
+    expect(miss, 'an unused declared DB must still diverge').toBeDefined()
+  })
+})


### PR DESCRIPTION
A real Prisma app's declared database was falsely reported as `missing-observed` — "you declared a DB you never connect to" — for a database it demonstrably hammers. That breaks the flagship divergence query for the Prisma/ORM ecosystem. Confirmed and fixed live against the Brief app.

**Root cause (three compounding failures):**
1. The prisma parser couldn't resolve `url = env("DATABASE_URL")`, so it minted a placeholder-host node (`database:postgresql-prisma`) separate from the `.env` parser's real-host node.
2. Prisma's engine spans carry `db.system` but no peer host, so ingest minted a third, service-local node.
3. Even fused, the config-file EXTRACTED edge and the code-file OBSERVED edge compared at file grain and never matched.

**Fix (coordinated across extraction, ingest, divergence):**
- **Extraction** — the prisma parser resolves `env("VAR")` from the service's `.env` (shared `resolveEnvVar`) → its node keys on the real host → dedups to one declared node. **Prisma only for now**; Drizzle/Knex reference the URL via `process.env.X` and need their own detection (follow-up on #801).
- **Ingest** — a host-less `db.system` span fuses onto the service's single declared DB of the same engine (scanning the service + its `CONTAINS` files). Ambiguous (2+ same-engine declared DBs) or none → the ADR-118 service-local node, unchanged. Never guesses.
- **Divergence** — a database `CONNECTS_TO`'s source rolls up to its owning service so declared/observed compare at the grain they share. File-grained edges stay in the graph; only the comparison coarsens. Scoped to DB targets (routes/services keep file grain).

**Verified (ran it):** live Brief graph → one DB node, EXTRACTED+OBSERVED, no false divergence, via REST *and* the MCP tools. Full core suite 1530 passed. `db-orm-fusion.test.ts` pins the extraction, fusion, the **ambiguous→local fallback**, and that a **genuinely-unused declared DB still diverges** (no over-suppression).

Ships as 0.5.0 (Prisma support). Refs #801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)