### PR TITLE
Resolve env-URL connection strings in the Drizzle and Knex parsers (#807)

### DIFF
--- a/packages/core/src/extract/databases/drizzle.ts
+++ b/packages/core/src/extract/databases/drizzle.ts
@@ -1,4 +1,11 @@
-import { findFirst, readIfExists, parseConnectionString, schemeToEngine, type DbConfig } from './shared.js'
+import {
+  findFirst,
+  readIfExists,
+  parseConnectionString,
+  resolveEnvVar,
+  schemeToEngine,
+  type DbConfig,
+} from './shared.js'
 
 const DIALECT_TO_ENGINE: Record<string, string> = {
   postgresql: 'postgresql',
@@ -34,6 +41,19 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
   )
   if (urlMatch) {
     const config = parseConnectionString(urlMatch[1]!)
+    if (config) return [{ ...config, sourceFile: filePath }]
+  }
+  // `url: process.env.DATABASE_URL` (or `connectionString:`, bracket form) — the
+  // common env-driven shape. Resolve it from the service's .env so the node keys
+  // on the real host and dedups with the dotenv parser instead of a placeholder
+  // (ADR-141, #807).
+  const urlEnvMatch = content.match(
+    /(?:url|connectionString)\s*:\s*process\.env(?:\.([A-Za-z_$][\w$]*)|\[\s*['"]([^'"]+)['"]\s*\])/,
+  )
+  if (urlEnvMatch) {
+    const varName = urlEnvMatch[1] ?? urlEnvMatch[2]
+    const resolved = varName ? await resolveEnvVar(serviceDir, varName) : null
+    const config = resolved ? parseConnectionString(resolved) : null
     if (config) return [{ ...config, sourceFile: filePath }]
   }
   const hostMatch = content.match(/host\s*:\s*['"`]([^'"`]+)['"`]/)

--- a/packages/core/src/extract/databases/knex.ts
+++ b/packages/core/src/extract/databases/knex.ts
@@ -1,4 +1,10 @@
-import { findFirst, readIfExists, parseConnectionString, type DbConfig } from './shared.js'
+import {
+  findFirst,
+  readIfExists,
+  parseConnectionString,
+  resolveEnvVar,
+  type DbConfig,
+} from './shared.js'
 
 const CLIENT_TO_ENGINE: Record<string, string> = {
   pg: 'postgresql',
@@ -34,6 +40,21 @@ export async function parse(serviceDir: string): Promise<DbConfig[]> {
   )
   if (urlMatch) {
     const config = parseConnectionString(urlMatch[1]!)
+    if (config) return [{ ...config, sourceFile: filePath }]
+  }
+
+  // `connection: process.env.DATABASE_URL` (bracket form too) — the whole
+  // connection is a URL from env. Resolve it from the service's .env so the node
+  // keys on the real host and dedups instead of a placeholder (ADR-141, #807).
+  // `connection: { host: process.env.DB_HOST }` deliberately does not match — an
+  // object of env fields keeps the placeholder rather than a fabricated URL.
+  const urlEnvMatch = content.match(
+    /connection\s*:\s*process\.env(?:\.([A-Za-z_$][\w$]*)|\[\s*['"]([^'"]+)['"]\s*\])/,
+  )
+  if (urlEnvMatch) {
+    const varName = urlEnvMatch[1] ?? urlEnvMatch[2]
+    const resolved = varName ? await resolveEnvVar(serviceDir, varName) : null
+    const config = resolved ? parseConnectionString(resolved) : null
     if (config) return [{ ...config, sourceFile: filePath }]
   }
 

--- a/packages/core/test/db-orm-fusion.test.ts
+++ b/packages/core/test/db-orm-fusion.test.ts
@@ -35,6 +35,21 @@ async function writePrismaService(
   await fs.writeFile(path.join(svc, '.env'), lines.join('\n') + '\n')
 }
 
+async function writeConfigService(
+  dir: string,
+  configName: string,
+  configBody: string,
+): Promise<void> {
+  const svc = path.join(dir, 'api')
+  await fs.mkdir(svc, { recursive: true })
+  await fs.writeFile(
+    path.join(svc, 'package.json'),
+    JSON.stringify({ name: 'orders', version: '1.0.0' }),
+  )
+  await fs.writeFile(path.join(svc, configName), configBody)
+  await fs.writeFile(path.join(svc, '.env'), 'DATABASE_URL=postgres://u:p@db.prod.example.com:5432/orders\n')
+}
+
 function hostlessPgSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
   // A Prisma engine db_query span: db.system present, NO server.address.
   return {
@@ -124,5 +139,27 @@ describe('ORM host-less DB fusion (ADR-141)', () => {
       (d) => d.type === 'missing-observed' && d.target === 'database:db.prod.example.com',
     )
     expect(miss, 'an unused declared DB must still diverge').toBeDefined()
+  })
+
+  it('resolves a Drizzle `url: process.env.X` to the real host — one DB node, not a placeholder (#807)', async () => {
+    await writeConfigService(
+      dir,
+      'drizzle.config.ts',
+      'export default { dialect: "postgresql", dbCredentials: { url: process.env.DATABASE_URL! } }\n',
+    )
+    await extractFromDirectory(ctx.graph, dir)
+    expect(dbNodes()).toEqual(['database:db.prod.example.com'])
+    expect(dbNodes()).not.toContain('database:postgresql-drizzle')
+  })
+
+  it('resolves a Knex `connection: process.env.X` to the real host — one DB node, not a placeholder (#807)', async () => {
+    await writeConfigService(
+      dir,
+      'knexfile.js',
+      "module.exports = { client: 'pg', connection: process.env.DATABASE_URL }\n",
+    )
+    await extractFromDirectory(ctx.graph, dir)
+    expect(dbNodes()).toEqual(['database:db.prod.example.com'])
+    expect(dbNodes()).not.toContain('database:postgresql-knex')
   })
 })


### PR DESCRIPTION
ADR-141 follow-up. Prisma resolves `url = env("DATABASE_URL")` so its DB node keys on the real host and dedups; Drizzle and Knex had the same placeholder problem (`postgresql-drizzle` / `-knex`) but reference the URL via `process.env.X` in a JS/TS config, which the literal-URL regex missed.

Both parsers now match the `process.env.VAR` / `process.env['VAR']` shape — Drizzle on `url:` / `connectionString:`, Knex on `connection:` — resolve it via the shared `resolveEnvVar`, and parse the real connection string. Knex deliberately does **not** match `connection: { host: process.env.DB_HOST }` (an object of env fields, not a URL), keeping its placeholder rather than fabricating a URL.

**Verified (ran it):** live drizzle parse of `url: process.env.DATABASE_URL` → real host; full core suite 1532 passed; two new cases in `db-orm-fusion.test.ts` pin drizzle + knex → one DB node, no placeholder.

Implemented from the design in the #807 spike. Refs #807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)