### PR TITLE
Fix the frontend search + root-cause reads to match the daemon's shapes (#809)

### DIFF
--- a/packages/web/app/api/search/route.ts
+++ b/packages/web/app/api/search/route.ts
@@ -3,11 +3,32 @@ import { fixtureSearch } from '../../../lib/fixtures'
 
 // ADR-101 — search runs against the selected profile's daemon at the ROOT
 // (`/search`, no `/projects/:name` prefix).
+//
+// #809 — the daemon returns `{ matches: [{...node, score}] }` (flattened nodes),
+// while the UI (and the demo fixture) read `{ results: [{ node, score }] }`.
+// Normalize the live shape here so search works against a real daemon; the
+// fixture path already matches and passes straight through.
 export async function GET(request: Request): Promise<Response> {
   const q = new URL(request.url).searchParams.get('q') ?? ''
-  return proxyProfile(
+  const res = await proxyProfile(
     request,
     `/search?q=${encodeURIComponent(q)}`,
     () => Response.json(fixtureSearch(q)),
   )
+  let body: unknown
+  try {
+    body = await res.clone().json()
+  } catch {
+    return res
+  }
+  const b = body as { matches?: unknown; results?: unknown }
+  const raw = Array.isArray(b.matches) ? b.matches : Array.isArray(b.results) ? b.results : null
+  if (raw === null) return res
+  const results = raw.map((m) => {
+    const item = m as { node?: unknown; id?: string; type?: string; name?: string; score?: number }
+    return item.node
+      ? item
+      : { node: { id: item.id, type: item.type, name: item.name }, score: item.score }
+  })
+  return Response.json({ results })
 }

--- a/packages/web/app/components/Inspector.tsx
+++ b/packages/web/app/components/Inspector.tsx
@@ -9,7 +9,10 @@ import { buildModel, callsFrom, importsFrom, filesOf } from './graph-model'
 interface RootCauseResult {
   origin: string
   rootCauseNode: string | null
-  reason: string
+  // #809 — the live daemon emits `rootCauseReason`; the demo fixture uses
+  // `reason`. Accept both so the reason line renders against a real daemon.
+  reason?: string
+  rootCauseReason?: string
   fixRecommendation: string | null
   confidence: number
   traversalPath: string[]
@@ -471,7 +474,7 @@ export function Inspector({ project, selectedNodeId, graphData, onNodeSelect, on
                 <div className="root-cause-block">
                   <div className="rc-label">divergence detected</div>
                   <div className="rc-node">{rootCause.rootCauseNode ?? ''}</div>
-                  <div className="rc-reason">{rootCause.reason}</div>
+                  <div className="rc-reason">{rootCause.reason ?? rootCause.rootCauseReason ?? ''}</div>
                   {rootCause.fixRecommendation && <div className="rc-fix">{rootCause.fixRecommendation}</div>}
                 </div>
               </section>


### PR DESCRIPTION
Two GUI panels worked against the demo fixtures but broke against a real daemon — the fixtures had been shaped to the frontend's (wrong) expectation, so the bugs never showed until you point it at a live daemon. Found by the #804 audit, verified here.

- **Search returned empty live.** `CommandPalette` + `FindPage` read `{ results: [{ node, score }] }`, but the daemon's `/search` returns `{ matches: [{ ...node, score }] }` (flattened). The search proxy route now normalizes the live shape to the `{ results }` the UI reads; the demo-fixture path is untouched.
- **Inspector root-cause reason rendered blank live.** It read `reason`, but the daemon emits `rootCauseReason`. Reads either now.

**Verified (ran it):** against the live Brief daemon, `/api/search?q=brief` returns 99 results with the correct shape (was empty before). Refs #809, #804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)