### PR TITLE
Extract Supabase .from()/.rpc() call sites as table-grained edges (#803 part 1)

### DIFF
--- a/packages/core/src/extract/calls/supabase.ts
+++ b/packages/core/src/extract/calls/supabase.ts
@@ -73,6 +73,23 @@ function constructorMatchesImport(name: string, ctx: ImportContext): boolean {
   return ctx.hasSupabaseSsr
 }
 
+// Variables assigned from a Supabase client constructor in this file, e.g.
+// `const supabase = createClient(...)`. We scope `.from()` / `.rpc()` matching to
+// these so `supabase.from('orders')` (a table query) is recognized while
+// `Array.from(...)` or an unrelated `.from` never mints a phantom table node.
+const SUPABASE_CLIENT_ASSIGN_RE =
+  /(?:const|let|var)\s+(\w+)\s*=\s*(?:await\s+)?(createClient|createServerClient|createBrowserClient)\s*\(/g
+
+function supabaseClientVars(content: string, ctx: ImportContext): Set<string> {
+  const vars = new Set<string>()
+  SUPABASE_CLIENT_ASSIGN_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = SUPABASE_CLIENT_ASSIGN_RE.exec(content)) !== null) {
+    if (constructorMatchesImport(m[2]!, ctx)) vars.add(m[1]!)
+  }
+  return vars
+}
+
 export function supabaseEndpointsFromFile(
   file: SourceFile,
   serviceDir: string,
@@ -117,5 +134,40 @@ export function supabaseEndpointsFromFile(
       },
     })
   }
+
+  // `<client>.from('<table>')` / `<client>.rpc('<fn>')` — table/RPC-grained call
+  // sites (#803). These give a production-observed supabase-table access a
+  // file-grained static twin to fuse onto (the Supabase connector otherwise
+  // observes the table but not the calling file). Scoped to the client vars found
+  // above so `Array.from` and unrelated `.from` never mint a phantom table.
+  const clientVars = supabaseClientVars(file.content, ctx)
+  for (const clientVar of clientVars) {
+    const accessRe = new RegExp(
+      `\\b${clientVar}\\s*\\.\\s*(from|rpc)\\s*\\(\\s*['"\`]([\\w.-]+)['"\`]`,
+      'g',
+    )
+    let am: RegExpExecArray | null
+    while ((am = accessRe.exec(file.content)) !== null) {
+      const kind = am[1] === 'rpc' ? 'supabase-rpc' : 'supabase-table'
+      const resource = am[2]!
+      const key = `${kind}/${resource}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      const line = lineOf(file.content, am[0])
+      out.push({
+        infraId: infraId(kind, resource),
+        name: resource,
+        kind,
+        edgeType: 'CALLS',
+        confidenceKind: 'verified-call-site',
+        evidence: {
+          file: path.relative(serviceDir, file.path),
+          line,
+          snippet: snippet(file.content, line),
+        },
+      })
+    }
+  }
+
   return out
 }

--- a/packages/core/test/calls.test.ts
+++ b/packages/core/test/calls.test.ts
@@ -114,6 +114,19 @@ describe('call extraction beyond HTTP', () => {
     const envEdgeId =
       'CALLS:file:fixture-supabase-service:index.ts->infra:supabase:env'
     expect(graph.hasEdge(envEdgeId)).toBe(true)
+
+    // #803 — `supabase.from('orders')` is a table-grained call site: a file→table
+    // CALLS edge the Supabase connector's observation can later fuse onto for
+    // file-grain, instead of stopping at the coarse client edge.
+    expect(graph.hasNode('infra:supabase-table:orders')).toBe(true)
+    expect(
+      graph.hasEdge(
+        'CALLS:file:fixture-supabase-service:index.ts->infra:supabase-table:orders',
+      ),
+    ).toBe(true)
+    // `direct.storage.from('avatars')` is a storage bucket, not a table — the
+    // client-var scoping must not mint a phantom table node from it.
+    expect(graph.hasNode('infra:supabase-table:avatars')).toBe(false)
   })
 
   it('does not emit supabase edges from a test file (test-scope exclusion)', async () => {


### PR DESCRIPTION
Part 1 of real Supabase connector file-grain. The static extractor knew a service *constructs* a Supabase client (`createClient`), but not which **file** touches which **table** — so the connector, which observes the table, had no file-grained static twin to land on and stayed service-coarse.

**Change:** parse `<client>.from('<table>')` / `<client>.rpc('<fn>')`, scoped to the Supabase client vars assigned in the file, and mint a `file → infra:supabase-table:<table>` / `infra:supabase-rpc:<fn>` EXTRACTED CALLS edge (verified-call-site grade) with the call-site evidence.

- **Precision:** client-var-scoped, so `Array.from(...)` and `direct.storage.from('bucket')` (a storage bucket, not a table) never mint a phantom table node — asserted in the test.
- This is the static twin **part 2 (the connector attribution)** will land the observation on, upgrading the Supabase connector edge from `service→` to `file→`.

**Verified:** unit/integration test over the calls fixture (`supabase.from('orders')` → table node + edge; `storage.from('avatars')` excluded); full core suite 1533 passed. **Honest caveat:** no live Supabase env on this machine, so unit/integration-verified, not prod. Refs #803.

🤖 Generated with [Claude Code](https://claude.com/claude-code)