### PR TITLE
Stop the command palette showing a shipped page as "not built yet" (#804)

### DIFF
--- a/docs/gui-honesty-audit.md
+++ b/docs/gui-honesty-audit.md
@@ -1,0 +1,40 @@
+# GUI honesty audit (#804)
+
+Every user-reachable surface in `packages/web/app`, classified **REAL** (renders live daemon data), **STUB** (placeholder/hardcoded), or **DEAD** (unreachable). Checked against the live Brief daemon (237 nodes, 1604 incidents) on 2026-07-20, not just fixtures — fixtures are exactly what masked the bugs #809 caught.
+
+## Nav pages
+
+Every entry in `lib/nav.ts` is `kind: 'page'` — there are **no `todo` pages**, so nothing should ever render StubPage's "not built yet".
+
+| Surface | Verdict | Evidence |
+|---|---|---|
+| Graph | REAL | AppShell branch → `/api/graph` → daemon `/graph` (237 nodes live) |
+| Divergences | REAL | AppShell branch → `/api/divergences` |
+| Policies | REAL | AppShell branch → `/api/policies` |
+| Incidents | REAL | standalone `/incidents` route → `/api/incidents` → daemon `/incidents` (1604 live). **Was reachable as StubPage via ⌘K — fixed here.** |
+| Connectors | REAL | AppShell branch → `ConnectorsPage` → `/api/connectors` (ADR-136) |
+| Logs | REAL | AppShell branch → `/api/logs` |
+| Find | REAL | AppShell branch → `/api/search` (shape fixed in #811) |
+| Settings | REAL | AppShell branch → `SettingsPage` (ADR-135) |
+
+## Components / overlays
+
+| Surface | Verdict | Evidence |
+|---|---|---|
+| Inspector → root cause | REAL | `/api/graph/root-cause/:id`, reads `rootCauseReason` (#811); verified live returns a real reason |
+| Inspector → blast radius / deps | REAL | `/api/graph/blast-radius`, `/api/graph/dependencies` |
+| ObservedOverlay / GraphCanvas → instrumentation | HONEST-DEGRADED | daemon has no `/instrumentation` endpoint yet (404); `/api/instrumentation` returns `{ engaged: null }` neutrally, never fabricates a diagnosis. A richer overlay needs a core endpoint — follow-up, not a lie. |
+| Rail.tsx | REAL | imported by LogsPage, GraphCanvas, ObservedOverlay (the audit's "dead Rail.tsx" hunch was wrong) |
+
+## Dead / orphan
+
+| Surface | Verdict | Action |
+|---|---|---|
+| `/api/stale-events` | DEAD (orphan) | no consumer in `app/`; safe to remove — deferred to a follow-up to keep this PR to the visible lie |
+| `StubPage` | DORMANT | no live caller after this fix; kept intentionally as the mechanism for the next `todo` page (ADR-135) |
+
+## The one live lie, and the fix
+
+`lib/nav.ts` marks Incidents as a standalone route (`/incidents`). The **sidebar** honored that (`router.push`), but the **CommandPalette** sent every page through `onNavigate`, so selecting Incidents from ⌘K hit a nonexistent AppShell branch and rendered StubPage's "not built yet" — a shipped page (1604 real incidents behind it) looking unbuilt. The two nav surfaces disagreed.
+
+Fix: the standalone-route map moved to `lib/nav.ts` as the single source of truth (`NAV_ROUTES`); both the sidebar and the palette read it. Guarded by tests in `nav-reachability.test.tsx` so the two surfaces can't drift again.

--- a/packages/web/app/components/CommandPalette.tsx
+++ b/packages/web/app/components/CommandPalette.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import {
   CommandDialog,
   CommandEmpty,
@@ -12,7 +13,7 @@ import {
   useCommandQuery,
 } from '@/components/ui/command'
 import { authedFetch } from '../../lib/authed-fetch'
-import { ALL_NAV, type NavId } from '../../lib/nav'
+import { ALL_NAV, NAV_ROUTES, type NavId } from '../../lib/nav'
 
 // ⌘K command palette (jedorini command, cmdk-free). Jump to a page or search
 // for a node (semantic_search via /api/search). This is the "Find" capability;
@@ -41,6 +42,7 @@ export function CommandPalette({
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<SearchResult[]>([])
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const router = useRouter()
 
   // node search — project-scoped, idle until a project resolves (#461).
   useEffect(() => {
@@ -87,7 +89,14 @@ export function CommandPalette({
               key={p.id}
               value={`${p.label} ${p.hint}`}
               onSelect={() => {
-                onNavigate(p.id)
+                // Honor the same standalone-route map the sidebar uses. Without
+                // this, a shipped page that lives at its own route (Incidents →
+                // /incidents) gets sent through onNavigate to a nonexistent
+                // AppShell branch and lands on StubPage's "not built yet" copy
+                // — a real page looking unbuilt (#804).
+                const route = NAV_ROUTES[p.id]
+                if (route) router.push(route)
+                else onNavigate(p.id)
                 onOpenChange(false)
               }}
             >

--- a/packages/web/app/components/PageSidebar.tsx
+++ b/packages/web/app/components/PageSidebar.tsx
@@ -26,7 +26,7 @@ import {
   SidebarSeparator,
   SidebarTrigger,
 } from '@/components/ui/sidebar'
-import { NAV_GROUPS, type NavId } from '../../lib/nav'
+import { NAV_GROUPS, NAV_ROUTES, type NavId } from '../../lib/nav'
 
 // The icon rail became a real labeled page-nav sidebar (jedorini sidebar). The
 // graph is one spatial page among list/table views — that's the multi-page
@@ -41,15 +41,6 @@ const ICONS: Record<NavId, React.ComponentType<{ className?: string }>> = {
   logs: ScrollTextIcon,
   find: SearchIcon,
   settings: SettingsIcon,
-}
-
-// Most nav ids are views AppShell switches between in place (graph, policies,
-// and the StubPage-rendered siblings). Incidents is the one nav id that's
-// actually a standalone route (app/incidents/page.tsx) rather than an
-// AppShell-internal view, so it needs a real navigation instead of the
-// in-shell onNavigate callback.
-const ROUTES: Partial<Record<NavId, string>> = {
-  incidents: '/incidents',
 }
 
 interface PageSidebarProps {
@@ -81,7 +72,7 @@ export function PageSidebar({ active, onNavigate, badges = {} }: PageSidebarProp
                   const Icon = ICONS[item.id]
                   const isTodo = item.kind === 'todo'
                   const badge = badges[item.id]
-                  const route = ROUTES[item.id]
+                  const route = NAV_ROUTES[item.id]
                   return (
                     <SidebarMenuItem key={item.id}>
                       <SidebarMenuButton

--- a/packages/web/lib/nav.ts
+++ b/packages/web/lib/nav.ts
@@ -102,3 +102,14 @@ export const NAV_GROUPS: { label: string; items: NavItem[] }[] = [
 ]
 
 export const ALL_NAV: NavItem[] = NAV_GROUPS.flatMap((g) => g.items)
+
+// Most nav ids are views AppShell switches between in place (graph, divergences,
+// …) via its `onNavigate` callback. A few are standalone Next routes instead
+// (app/incidents/page.tsx), so they need a real navigation, not the in-shell
+// switch. Both the sidebar AND the command palette read this one map — if only
+// one of them knows a page is a standalone route, the other sends it through
+// `onNavigate` to a nonexistent AppShell branch and it lands on StubPage's
+// "not built yet" copy, i.e. a shipped page looking unbuilt (#804).
+export const NAV_ROUTES: Partial<Record<NavId, string>> = {
+  incidents: '/incidents',
+}

--- a/packages/web/test/nav-reachability.test.tsx
+++ b/packages/web/test/nav-reachability.test.tsx
@@ -18,6 +18,7 @@ vi.mock('next/navigation', () => ({
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { PageSidebar } from '../app/components/PageSidebar'
+import { CommandPalette } from '../app/components/CommandPalette'
 import { ALL_NAV } from '../lib/nav'
 
 function renderSidebar() {
@@ -84,5 +85,48 @@ describe('#697 — PageSidebar: every entry is clickable, not disabled', () => {
     await user.click(button)
     expect(pushMock).toHaveBeenCalledWith('/incidents')
     expect(onNavigate).not.toHaveBeenCalled()
+  })
+})
+
+// #804 — the CommandPalette (⌘K) has to honor the same standalone-route map the
+// sidebar does. It didn't: it sent every page through onNavigate, so selecting
+// Incidents there hit a nonexistent AppShell branch and rendered StubPage's
+// "not built yet" — a shipped page looking unbuilt, reachable from ⌘K while the
+// sidebar routed it correctly. These guard that the two nav surfaces agree.
+describe('#804 — CommandPalette agrees with the sidebar on standalone routes', () => {
+  it('selecting Incidents in the palette navigates to /incidents, never onNavigate → StubPage', async () => {
+    const onNavigate = vi.fn()
+    render(
+      <CommandPalette
+        open
+        onOpenChange={vi.fn()}
+        project="brief"
+        onNavigate={onNavigate}
+        onNodeSelect={vi.fn()}
+      />,
+    )
+    const user = userEvent.setup()
+    await user.click(await screen.findByText('Incidents'))
+
+    expect(pushMock).toHaveBeenCalledWith('/incidents')
+    expect(onNavigate).not.toHaveBeenCalledWith('incidents')
+  })
+
+  it('selecting an in-shell page (Graph) still uses onNavigate, not a route push', async () => {
+    const onNavigate = vi.fn()
+    render(
+      <CommandPalette
+        open
+        onOpenChange={vi.fn()}
+        project="brief"
+        onNavigate={onNavigate}
+        onNodeSelect={vi.fn()}
+      />,
+    )
+    const user = userEvent.setup()
+    await user.click(await screen.findByText('Graph'))
+
+    expect(onNavigate).toHaveBeenCalledWith('graph')
+    expect(pushMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## The lie

Incidents is a real, shipped page at its own route (`/incidents`) with **1604 real events** behind it on the live daemon. The **sidebar** navigated there correctly (`router.push('/incidents')`), but the **⌘K command palette** sent every page through `onNavigate` — so selecting Incidents from the palette hit a nonexistent AppShell branch and rendered `StubPage`'s "not built yet" copy. A shipped feature, reachable from ⌘K, looking unbuilt — while the sidebar told the truth.

## The fix

The standalone-route map now lives in `lib/nav.ts` (`NAV_ROUTES`) as the single source of truth both the sidebar and the palette read, so the two nav surfaces can't disagree again. Added CommandPalette tests next to the existing sidebar ones in `nav-reachability.test.tsx`.

## The wider audit (`docs/gui-honesty-audit.md`)

Since #804 asked for a works-vs-stub sweep, I classified every reachable surface against the **live** daemon (not fixtures — fixtures are what masked #809):

- **Every nav page is REAL** — graph, divergences, policies, incidents, connectors, logs, find, settings all render live daemon data.
- Search + root-cause shape reads are **already correct** (fixed in #811, verified live: root-cause returns a real `rootCauseReason`).
- `Rail.tsx` is **live**, not dead (the audit's hunch was wrong — imported by LogsPage/GraphCanvas/ObservedOverlay).
- `/api/instrumentation` **degrades honestly**: the daemon has no such endpoint yet (404), and the route returns `{ engaged: null }` neutrally rather than fabricating a diagnosis.
- `/api/stale-events` is a genuine **orphan** (no consumer) — left for a follow-up to keep this PR to the visible lie.

## Verification

- Full web suite green (105 tests, 23 files); the 2 new palette guards pass.
- `/incidents` renders live against the Brief daemon (HTTP 200, real incident content); the branch build emits the route.
- Honest gap: I verified the routing via unit tests + the target page live, but did **not** click ⌘K in a browser against this build.

Refs #804
Refs #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)