### PR TITLE
Build the container image for arm64 too, not just amd64 (#821)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -216,6 +216,14 @@ jobs:
       # ghcr.io alongside the npm release, then smoke the bearer path against
       # the just-built image. Tag `latest` and the exact version so deploy
       # consumers can pin either way.
+      # arm64 alongside amd64 so `docker run` works on Apple Silicon — a large
+      # share of the developer audience — not just x86 servers (#821). QEMU
+      # provides the arm64 build environment on the amd64 runner; tree-sitter's
+      # native addons resolve from prebuilds, so no slow under-emulation compile.
+      - name: Set up QEMU
+        if: env.DRY_RUN != 'true'
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         if: env.DRY_RUN != 'true'
         uses: docker/setup-buildx-action@v3
@@ -234,6 +242,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/neat-technologies/neat:${{ github.ref_name }}
             ghcr.io/neat-technologies/neat:latest


### PR DESCRIPTION
## What I found

Making the ghcr package public (thanks!) let me re-verify the README's server quickstart — and it's **broken on Apple Silicon**. The published manifest is `linux/amd64` only:

```
docker pull ghcr.io/neat-technologies/neat:latest
→ no matching manifest for linux/arm64/v8 in the manifest list entries
```

A big chunk of the HN dev audience is on arm64 Macs, so `docker run ghcr.io/…neat:latest` fails for them on line one. The image itself is fine (CI smoke-tests it booting + auth on amd64) — it's just never built for arm64.

## Fix

The build step had no `platforms:`, so buildx built only the runner's native amd64. This adds QEMU and builds `linux/amd64,linux/arm64`. tree-sitter's native addons resolve from prebuilds, so the arm64 leg shouldn't need a slow under-emulation compile. The auth-smoke still runs on the amd64 runner against the amd64 variant — unchanged.

## Honest caveats

- **Validates only on a real publish run** — the docker build is gated out of dry-run and doesn't run on PR CI. So this PR's green checks don't prove the arm64 build succeeds; the next tagged publish does.
- **Takes effect on the next release.** The 0.6.0 launch image will be multi-arch. The current `:latest` (0.5.2) stays amd64-only until a publish re-runs with this change.
- If the arm64 leg turns out slow/fragile under QEMU despite the prebuilds, the fallback is a native arm64 runner + manifest merge — noted for follow-up if the first multi-arch publish struggles.

Refs #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)