### PR TITLE
Recognize MONGODB_URL so an app's own Mongo connection gets extracted (#832)

### DIFF
--- a/packages/core/src/extract/databases/dotenv.ts
+++ b/packages/core/src/extract/databases/dotenv.ts
@@ -3,16 +3,29 @@ import path from 'node:path'
 import { isConfigFile } from '../shared.js'
 import { parseConnectionString, type DbConfig } from './shared.js'
 
+// Both the `_URL` and `_URI` spellings for every engine — apps split roughly
+// evenly between them and the two are interchangeable. `MONGODB_URL` in
+// particular is the single most common Mongo env-var name (the Mongoose docs
+// and most boilerplates use it), and its earlier absence meant an app's own
+// database connection went unextracted, so the runtime span had nothing to fuse
+// onto and minted a standalone `database:<host>` node instead (#832).
 const CONNECTION_KEYS = new Set([
   'DATABASE_URL',
+  'DATABASE_URI',
   'DB_URL',
+  'DB_URI',
   'POSTGRES_URL',
+  'POSTGRES_URI',
   'POSTGRESQL_URL',
+  'POSTGRESQL_URI',
   'MYSQL_URL',
+  'MYSQL_URI',
+  'MONGODB_URL',
   'MONGODB_URI',
   'MONGO_URL',
   'MONGO_URI',
   'REDIS_URL',
+  'REDIS_URI',
 ])
 
 // Per ADR-016, .env contents do not land in any snapshot. We read them here

--- a/packages/core/test/db-parsers.test.ts
+++ b/packages/core/test/db-parsers.test.ts
@@ -16,7 +16,7 @@ const FIXTURES = path.resolve(__dirname, 'fixtures', 'db')
 describe('database source parsers', () => {
   it('reads DATABASE_URL out of .env', async () => {
     const configs = await parseDotenv(path.join(FIXTURES, 'dotenv'))
-    expect(configs).toHaveLength(2)
+    expect(configs).toHaveLength(3)
     expect(configs[0]).toMatchObject({
       engine: 'postgresql',
       host: 'db.internal',
@@ -30,6 +30,15 @@ describe('database source parsers', () => {
       port: 6379,
       database: '',
       engineVersion: 'unknown',
+    })
+    // #832 — MONGODB_URL is the most common Mongo env-var name and was missing
+    // from the recognized keys, so an app's own DB connection went unextracted
+    // and the runtime span minted a twin `database:<host>` instead of fusing.
+    expect(configs[2]).toMatchObject({
+      engine: 'mongodb',
+      host: 'mongo.internal',
+      port: 27017,
+      database: 'events',
     })
     // Every parsed config carries the source file it came from (#140).
     expect(configs[0]!.sourceFile).toMatch(/\.env$/)

--- a/packages/core/test/fixtures/db/dotenv/.env
+++ b/packages/core/test/fixtures/db/dotenv/.env
@@ -1,3 +1,4 @@
 DATABASE_URL=postgres://app:s3cret@db.internal:5432/orders
 REDIS_URL=redis://cache.internal:6379
+MONGODB_URL=mongodb://mongo.internal:27017/events
 SOME_OTHER_VAR=not-a-db


### PR DESCRIPTION
## The bug (and a corrected diagnosis)

Running the first-run on a mongoose app, the graph ended up with **two Mongo nodes**: a declared `database:mongodb` (from the docker-compose service) and a separate `database:127.0.0.1` minted from the runtime span — instead of one fused node.

I originally filed #832 guessing it was a fusion-reconciliation bug ("match the observed host to the declared node"). Digging in, the real cause was narrower and simpler: `dotenv.ts`'s recognized-key set had `MONGO_URL`, `MONGO_URI`, and `MONGODB_URI` — **but not `MONGODB_URL`**, the single most common Mongo env-var name (Mongoose's own docs and most boilerplates use it). So the app's own connection string (`MONGODB_URL=mongodb://127.0.0.1:27017/…`) was never extracted, the OTel span had no static call site to fuse onto, and it minted a standalone `database:<host>`.

## Fix

Add `MONGODB_URL`, and fill in the missing symmetric `_URI`/`_URL` spellings for the other engines while here — the omissions were clearly accidental. Now the `.env` connection extracts a `database:<host>` node keyed exactly the way the runtime span keys it, so the two fuse.

## Verified end-to-end

Ran the full cycle on the repro (extract → instrument → run → traffic). The `database:127.0.0.1` node now carries:
- `[EXTRACTED] .env ──CONNECTS_TO──▶ database:127.0.0.1` (the fix)
- `[OBSERVED/file] src/app.js ──CONNECTS_TO──▶ database:127.0.0.1`
- `[OBSERVED/file] src/models/user.model.js ──CONNECTS_TO──▶ database:127.0.0.1`

One node, EXTRACTED **and** OBSERVED — fused. The `database:mongodb` (docker-compose) correctly stays a separate declared-infra node. Unit test pins the `MONGODB_URL` parse; the 4 db-parser/fusion test files stay green.

Refs #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)