### PR TITLE
Give MCP tool calls a deadline so a wedged daemon can't hang them

### DIFF
--- a/packages/mcp/CLAUDE.md
+++ b/packages/mcp/CLAUDE.md
@@ -51,6 +51,8 @@ When neither env var is set, the server resolves the **per-project daemon** for 
 
 `NEAT_RESOURCE_POLL_MS` — interval in ms for the `neat://incidents/recent` change-detection poll. Default `5000`. `0` disables it.
 
+`NEAT_CORE_TIMEOUT_MS` — per-request deadline for every call to the daemon. Default `30000`. A daemon that has bound its port but isn't answering yet — mid-boot, wedged mid-extraction, or behind a proxy that black-holes the request — would otherwise hold a tool call open until undici's 5-minute headers timeout, which reads as a hang. The deadline turns that into a clean, bounded `isError` response the agent can act on. Raise it for a genuinely slow or large-graph daemon.
+
 `NEAT_DEFAULT_PROJECT` — the project this MCP instance reports against when a tool call doesn't pass `project`. Unset means "the core's `default` project" via legacy unprefixed URLs (back-compat with pre-#83 cores). Set this when one neat-core hosts multiple projects and a given Claude Code session should pin to one.
 
 ## Multi-project

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -9,19 +9,80 @@ export interface HttpClient {
   post?<T>(path: string, body: unknown): Promise<T>
 }
 
+// A daemon that has bound its port but isn't answering yet — mid-boot, wedged
+// mid-extraction, deadlocked, or sitting behind a proxy that black-holes the
+// request — accepts the TCP connection and then never writes a response. With
+// no deadline on the fetch, undici only gives up at its 5-minute headers
+// timeout, which to an interactive agent is indistinguishable from a hang. The
+// MCP surface must stay queryable "at all times": a slow or wedged daemon has
+// to surface as a clean, bounded error the agent can act on, never an open-
+// ended wait. So every request carries a deadline; when it trips we translate
+// the abort into a plain-language error the tool layer formats as isError.
+const DEFAULT_TIMEOUT_MS = 30_000
+
+function resolveTimeoutMs(explicit?: number): number {
+  if (typeof explicit === 'number' && explicit > 0) return explicit
+  const fromEnv = Number(process.env.NEAT_CORE_TIMEOUT_MS)
+  if (Number.isFinite(fromEnv) && fromEnv > 0) return fromEnv
+  return DEFAULT_TIMEOUT_MS
+}
+
+// AbortSignal.timeout rejects the fetch with a DOMException named
+// 'TimeoutError'; a caller-triggered abort surfaces as 'AbortError'. Match on
+// the name rather than the type so this holds across Node's DOMException /
+// Error representations.
+function isTimeoutAbort(err: unknown): boolean {
+  const name = (err as { name?: string } | null)?.name
+  return name === 'TimeoutError' || name === 'AbortError'
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+  method: string,
+  path: string,
+): Promise<Response> {
+  try {
+    return await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) })
+  } catch (err) {
+    if (isTimeoutAbort(err)) {
+      throw new RequestTimeoutError(
+        `Timed out after ${timeoutMs}ms waiting for neat-core on ${method} ${path} — ` +
+          `the daemon may be starting up, busy, or wedged. Confirm it is reachable ` +
+          `(curl its /health endpoint) or raise NEAT_CORE_TIMEOUT_MS.`,
+      )
+    }
+    throw err
+  }
+}
+
 // ADR-073 §3 — the MCP server is a first-party read client, so it carries the
 // operator's bearer on every call the same way the CLI does. `bearerToken`
 // comes from `NEAT_AUTH_TOKEN` (sourced once in index.ts). Empty / undefined
 // keeps the header off, so an unauthenticated loopback dev daemon still works.
-export function createHttpClient(baseUrl: string, bearerToken?: string): HttpClient {
+// `timeoutMs` bounds every request; it defaults to NEAT_CORE_TIMEOUT_MS or 30s
+// and is overridable for tests.
+export function createHttpClient(
+  baseUrl: string,
+  bearerToken?: string,
+  timeoutMs?: number,
+): HttpClient {
   const root = baseUrl.replace(/\/$/, '')
-  const authHeader =
+  const deadline = resolveTimeoutMs(timeoutMs)
+  const authHeader: Record<string, string> =
     bearerToken && bearerToken.length > 0
       ? { authorization: `Bearer ${bearerToken}` }
       : {}
   return {
     async get<T>(path: string): Promise<T> {
-      const res = await fetch(`${root}${path}`, { headers: { ...authHeader } })
+      const res = await fetchWithTimeout(
+        `${root}${path}`,
+        { headers: { ...authHeader } },
+        deadline,
+        'GET',
+        path,
+      )
       if (!res.ok) {
         const body = await res.text().catch(() => '')
         throw new HttpError(res.status, `${res.status} ${res.statusText} on GET ${path}: ${body}`)
@@ -29,11 +90,17 @@ export function createHttpClient(baseUrl: string, bearerToken?: string): HttpCli
       return (await res.json()) as T
     },
     async post<T>(path: string, body: unknown): Promise<T> {
-      const res = await fetch(`${root}${path}`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json', ...authHeader },
-        body: JSON.stringify(body),
-      })
+      const res = await fetchWithTimeout(
+        `${root}${path}`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', ...authHeader },
+          body: JSON.stringify(body),
+        },
+        deadline,
+        'POST',
+        path,
+      )
       if (!res.ok) {
         const text = await res.text().catch(() => '')
         throw new HttpError(res.status, `${res.status} ${res.statusText} on POST ${path}: ${text}`)
@@ -50,5 +117,15 @@ export class HttpError extends Error {
   ) {
     super(message)
     this.name = 'HttpError'
+  }
+}
+
+// Thrown when a request exceeds its deadline. Not an HttpError — there was no
+// HTTP response — so the tool layer's 404 fallback doesn't swallow it; it lands
+// in the generic branch and surfaces as a formatted isError the agent can read.
+export class RequestTimeoutError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RequestTimeoutError'
   }
 }

--- a/packages/mcp/test/client-timeout.test.ts
+++ b/packages/mcp/test/client-timeout.test.ts
@@ -1,0 +1,109 @@
+import net from 'node:net'
+import { createServer, type Server } from 'node:http'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createHttpClient, HttpError, RequestTimeoutError } from '../src/client.js'
+
+// The MCP surface has to stay queryable "at all times" — a daemon that has
+// bound its port but isn't answering (mid-boot, wedged mid-extraction, behind a
+// black-holing proxy) accepts the connection and then goes silent. Without a
+// deadline the fetch only gives up at undici's 5-minute headers timeout, which
+// is a hang from the agent's seat. These tests stand up real sockets rather
+// than stubbing fetch, because the behaviour under test is the fetch deadline
+// itself.
+
+let blackhole: net.Server | undefined
+let responsive: Server | undefined
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => {
+    if (!blackhole) return resolve()
+    blackhole.close(() => resolve())
+  })
+  await new Promise<void>((resolve) => {
+    if (!responsive) return resolve()
+    responsive.close(() => resolve())
+  })
+  blackhole = undefined
+  responsive = undefined
+})
+
+// A server that accepts the TCP connection, swallows the request, and never
+// writes a byte back. This is the wedged / mid-boot daemon.
+async function startBlackhole(): Promise<number> {
+  blackhole = net.createServer((sock) => {
+    sock.on('data', () => {})
+    sock.on('error', () => {})
+  })
+  await new Promise<void>((resolve) => blackhole!.listen(0, '127.0.0.1', resolve))
+  return (blackhole!.address() as net.AddressInfo).port
+}
+
+async function startResponsive(): Promise<number> {
+  responsive = createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ ok: true }))
+  })
+  await new Promise<void>((resolve) => responsive!.listen(0, '127.0.0.1', resolve))
+  return (responsive!.address() as net.AddressInfo).port
+}
+
+describe('MCP createHttpClient request timeout', () => {
+  it('rejects a wedged (accepts-but-never-responds) daemon within the deadline, not after 5 minutes', async () => {
+    const port = await startBlackhole()
+    const client = createHttpClient(`http://127.0.0.1:${port}`, undefined, 150)
+    const t0 = Date.now()
+    await expect(client.get('/graph/dependencies/service:x?depth=3')).rejects.toBeInstanceOf(
+      RequestTimeoutError,
+    )
+    // Bounded: well under undici's default 5-minute headers timeout.
+    expect(Date.now() - t0).toBeLessThan(3_000)
+  })
+
+  it('gives an agent-readable message naming the method, path, and the knob to raise', async () => {
+    const port = await startBlackhole()
+    const client = createHttpClient(`http://127.0.0.1:${port}`, undefined, 150)
+    await client.get('/graph/divergences').then(
+      () => expect.fail('expected a timeout'),
+      (err: Error) => {
+        expect(err).toBeInstanceOf(RequestTimeoutError)
+        expect(err.message).toContain('GET /graph/divergences')
+        expect(err.message).toContain('150ms')
+        expect(err.message).toContain('NEAT_CORE_TIMEOUT_MS')
+      },
+    )
+  })
+
+  it('also bounds POST requests (dry-run / extend paths)', async () => {
+    const port = await startBlackhole()
+    const client = createHttpClient(`http://127.0.0.1:${port}`, undefined, 150)
+    await expect(client.post!('/policies/check', { hypotheticalAction: null })).rejects.toBeInstanceOf(
+      RequestTimeoutError,
+    )
+  })
+
+  it('a connection-refused daemon still rejects fast — and is not misreported as a timeout', async () => {
+    // Port 1 has nothing listening: the connection is refused, which is a
+    // different failure than a wedged daemon and must not be dressed up as one.
+    const client = createHttpClient('http://127.0.0.1:1', undefined, 5_000)
+    const t0 = Date.now()
+    await expect(client.get('/graph')).rejects.not.toBeInstanceOf(RequestTimeoutError)
+    expect(Date.now() - t0).toBeLessThan(3_000)
+  })
+
+  it('a responsive daemon well inside the deadline returns normally', async () => {
+    const port = await startResponsive()
+    const client = createHttpClient(`http://127.0.0.1:${port}`, undefined, 5_000)
+    await expect(client.get<{ ok: boolean }>('/health')).resolves.toEqual({ ok: true })
+  })
+
+  it('leaves real HTTP error statuses as HttpError, not timeouts', async () => {
+    responsive = createServer((_req, res) => {
+      res.writeHead(404, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ error: 'node not found' }))
+    })
+    await new Promise<void>((resolve) => responsive!.listen(0, '127.0.0.1', resolve))
+    const port = (responsive.address() as net.AddressInfo).port
+    const client = createHttpClient(`http://127.0.0.1:${port}`, undefined, 5_000)
+    await expect(client.get('/graph/root-cause/service:x')).rejects.toBeInstanceOf(HttpError)
+  })
+})


### PR DESCRIPTION
## What

The MCP surface has to stay queryable *at all times* (HN gate #3). Probing the failure modes against a live daemon turned up one that broke that promise: a daemon that has bound its port but isn't answering — mid-boot, stuck mid-extraction, or behind a proxy that black-holes the request — accepts the TCP connection and then goes silent. The MCP HTTP client put no deadline on its `fetch`, so undici only gave up at its five-minute headers timeout. Every tool call sat open that whole time, which from the agent's seat is a hang.

This adds a per-request deadline to the MCP HTTP client. When it trips, the call comes back as a clean `isError` naming the method, the path, and the knob to raise, so the agent learns the daemon is slow or wedged instead of waiting on silence.

- Default 30s, tunable with `NEAT_CORE_TIMEOUT_MS`.
- Applies to both GET and POST (so the extend / dry-run paths are bounded too).
- Connection-refused and real HTTP statuses are untouched — a 404 still lands as the friendly "not found" message, a refused connection still fails fast. Only the accepts-but-never-answers case moves off the hang path.

## How it was found / verified

Stood up a real `neat watch` daemon on a small fresh repo and drove the built MCP server (`dist/index.cjs`, stdio) against it end-to-end. Read tools returned clean answers on the happy path, on missing nodes (friendly "not found"), on an empty OBSERVED layer, and against a connection-refused port (fast `isError`). A black-hole server that accepts the connection and never responds was the one case that hung — before this change the tool call did not return; after it, it comes back at the deadline with the message above. The old default-project 404 papercut did not reproduce under the per-project daemon model: both the root path and `/projects/default/…` resolve.

## Tests

`packages/mcp/test/client-timeout.test.ts` stands up real in-process sockets (a black-hole and a responsive server) and asserts: a wedged daemon rejects within the deadline (not five minutes) with an agent-readable message, POST is bounded too, connection-refused rejects fast and is *not* mislabeled a timeout, a responsive daemon returns normally, and a 404 still surfaces as `HttpError`. Full `@neat.is/mcp` suite green (95 tests).

Refs #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)