### PR TITLE
Tell a connecting agent what NEAT's data is on the MCP handshake

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -53,10 +53,29 @@ const projectField = z
     'Project name when the core hosts more than one (set NEAT_PROJECTS=...). Omit to use the default project.',
   )
 
-const server = new McpServer({
-  name: 'neat',
-  version: '0.1.0',
-})
+// Server-level orientation the MCP `initialize` handshake hands the connecting
+// agent, so it knows what NEAT's data *is* before it reads a tool result. NEAT
+// is one server among however many the agent has wired up — some of them
+// (Supabase, Cloudflare, ...) may be the very platforms NEAT's connectors pull
+// from. The line to draw: NEAT's tools answer from its own fused graph, not a
+// live connection to those platforms, and every answer carries provenance so
+// the agent can weigh it. The agent's other servers, and their overlap with
+// NEAT's view, are the agent's own to reconcile — NEAT can't see its peers and
+// doesn't try to; it just says plainly what its own data is.
+const serverInstructions = [
+  'NEAT serves a fused semantic graph of one software system — static code (EXTRACTED) and live runtime behavior (OBSERVED) in a single model — for the one project this daemon owns. Every tool answers from that graph.',
+  'A result is a graph fact, not a live call to the underlying system. Each edge and result carries a provenance — OBSERVED (seen via OTel), INFERRED (stitched, ~0.6 confidence), EXTRACTED (from source/config), STALE (was observed, gone quiet) — plus a confidence. Trust a claim by its provenance.',
+  'Some OBSERVED data is pulled by connectors from a provider that runs its own telemetry (Supabase, Railway, Firebase, Cloudflare). That is NEAT\'s own view of the provider, keyed on the provider node (an InfraNode carries `provider`; a service/file carries `platform`). If you also have that provider\'s own MCP server, NEAT is not it and does not replace it — NEAT tells you how the graph relates, the provider server acts on the live system.',
+  'Reach for NEAT before grepping source for architecture-level questions: dependencies, runtime traffic, recent failures, blast radius, divergence between declared and observed. If a query comes back empty, confirm the daemon is up before falling back to reading files.',
+].join('\n\n')
+
+const server = new McpServer(
+  {
+    name: 'neat',
+    version: '0.1.0',
+  },
+  { instructions: serverInstructions },
+)
 
 // Register every MCP tool through this wrapper, not server.tool directly.
 // The tool name is constrained to MCP_TOOL_NAMES in @neat.is/types — add the

--- a/packages/mcp/test/stdio-smoke.test.ts
+++ b/packages/mcp/test/stdio-smoke.test.ts
@@ -68,6 +68,18 @@ describe('MCP server stdio smoke', () => {
     expect(info?.name).toBe('neat')
   })
 
+  it('hands the agent server-level instructions orienting it on the graph + provenance', () => {
+    // The initialize handshake carries a server `instructions` string the host
+    // injects into the model's context. It's how a connecting agent learns what
+    // NEAT's data *is* — a fused graph, provenance-bearing, one project — before
+    // it reads a single tool result, and how NEAT stays distinct from the
+    // provider MCP servers the agent may also hold.
+    const instructions = client.getInstructions()
+    expect(instructions).toBeTruthy()
+    expect(instructions).toContain('graph')
+    expect(instructions).toContain('provenance')
+  })
+
   it('lists exactly the manifest tool surface (all 16 names)', async () => {
     const { tools } = await client.listTools()
     const names = tools.map((t) => t.name).sort()


### PR DESCRIPTION
## What

The MCP `initialize` handshake can return a server-level `instructions` string the host injects into the connecting model's context. We built the server with no options, so it was empty — an agent that wired up NEAT got no framing of what its data was until it called a tool.

This fills it in. The string says plainly: NEAT serves a fused static + runtime graph for the one project this daemon owns; every answer carries provenance (OBSERVED / INFERRED / EXTRACTED / STALE) so the agent can weigh it; connector-sourced OBSERVED data is NEAT's own view of a provider, keyed on the provider node; and if the agent also holds that provider's own MCP server, NEAT is not it and doesn't replace it.

The stdio smoke test now asserts the handshake surfaces the instructions.

## Why

This came out of a multi-system-isolation assessment (HN docket gate item #6 — "the agent will have other MCP servers at its disposal; the graph should make good care such that the agent knows the MCP's data is the graph"). The finding: **isolation itself is a non-issue.** Cross-project isolation is airtight by the per-project-daemon boundary (ADR-096) — two projects are two daemons, two graphs, two MCP endpoints, no shared slot map. Provider identity is already carried on nodes (`InfraNode.provider`, `ServiceNode`/`FileNode.platform`) and embedded in node ids (`infra:supabase:<ref>`). And "the agent knows it has other MCP servers" is the host's concern — a server can't see its peers.

The one small, NEAT-owned gap the assessment surfaced is this empty `instructions` string: the single protocol-native lever NEAT has to tell a connecting agent what its data is. So that's all this changes.

## Scope

Deliberately minimal. No schema change, no new node/edge field, no per-edge connector attribution (that would contradict the connectors contract's "connector edges carry the same provenance as span edges"), no touching the vestigial legacy `project` routing (that's the daemon-refactor arc). Just the one string + a test.

Refs #835
Refs #6-context (HN docket gate item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)