### PR TITLE
Let a long file-grained node id reach the REST handler

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -969,7 +969,18 @@ function registerRoutes(scope: FastifyInstance, ctx: RouteContext): void {
 }
 
 export async function buildApi(opts: BuildApiOptions): Promise<FastifyInstance> {
-  const app = Fastify({ logger: false })
+  // Node ids are how the graph is addressed over REST, and under file-awareness
+  // (ADR-087) an id is `code:<filepath>:<symbol>` — which the CLI and MCP
+  // clients URL-encode (every `/` becomes `%2F`) before it lands in a `:id` /
+  // `:nodeId` path param. Fastify's default maxParamLength of 100 then rejects
+  // any realistic file-grained id at the router, before the handler runs, with
+  // a generic "Route not found" 404. To an agent querying blast-radius /
+  // dependencies / root-cause for a real node, that reads as a broken endpoint
+  // rather than "that node isn't in the graph" — the handler's actionable
+  // `{ error: 'node not found', id }` never gets a chance to answer. Raise the
+  // cap so a long-but-real id reaches the handler; 1024 clears any realistic
+  // path + symbol while still bounding a pathological multi-kilobyte URL.
+  const app = Fastify({ logger: false, routerOptions: { maxParamLength: 1024 } })
   await app.register(cors, { origin: true })
 
   // ADR-073 §3/§4 — `buildApi` owns auth enforcement so every listener that

--- a/packages/core/test/api-long-node-id.test.ts
+++ b/packages/core/test/api-long-node-id.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+import { fileId, NodeType } from '@neat.is/types'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { buildApi } from '../src/api.js'
+
+// A daemon that can't be addressed can't be debugged. Under file-awareness
+// (ADR-087) a node id is `file:<service>:<relPath>` (or `code:<file>:<symbol>`),
+// which the CLI and MCP clients URL-encode (every `/` → `%2F`) before it lands
+// in a `:id` / `:nodeId` path param. Fastify's default maxParamLength of 100
+// then rejects any realistic file-grained id at the router — before the handler
+// runs — with a generic `{ message: 'Route ... not found' }` 404. To an agent
+// asking for a node's blast radius or dependencies, that reads as a broken
+// endpoint rather than "that node isn't in the graph," and there's no path to
+// recovery. buildApi raises the cap so a long-but-real id reaches the handler.
+//
+// This is the resilience/self-debuggability guard for issue #818's gate item:
+// a long node id must resolve (or return the handler's actionable not-found
+// shape), never the router's misleading route-not-found.
+describe('REST API — long file-grained node ids reach the handler (maxParamLength)', () => {
+  let app: FastifyInstance
+
+  // A realistic file-grained id: a deep monorepo path. Comfortably past the
+  // 100-char Fastify default once the `file:` prefix and service segment are
+  // counted, and longer still after the client url-encodes the slashes.
+  const longRelPath =
+    'packages/core/src/connectors/providers/cloudflare/analytics-engine-binding-extractor.ts'
+  const longNodeId = fileId('my-really-long-service-name', longRelPath)
+
+  beforeEach(async () => {
+    resetGraph()
+    const graph = getGraph()
+    graph.addNode(longNodeId, {
+      id: longNodeId,
+      type: NodeType.FileNode,
+      service: 'my-really-long-service-name',
+      path: longRelPath,
+    })
+    app = await buildApi({ graph })
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('the id is long enough to trip the Fastify default (sanity)', () => {
+    // Guards the test itself: if the id ever shrank under 100 chars the test
+    // would pass trivially against the old default and prove nothing.
+    expect(encodeURIComponent(longNodeId).length).toBeGreaterThan(100)
+  })
+
+  it('GET /graph/node/:id resolves a long, url-encoded file id', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/graph/node/${encodeURIComponent(longNodeId)}`,
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().node).toMatchObject({ id: longNodeId, type: NodeType.FileNode })
+  })
+
+  it('an unknown long id returns the handler not-found shape, not the router 404', async () => {
+    const missing = fileId('another-long-service', `${longRelPath}.does-not-exist`)
+    const res = await app.inject({
+      method: 'GET',
+      url: `/graph/node/${encodeURIComponent(missing)}`,
+    })
+    // The request reached the handler — which answers with an id an agent can
+    // act on — rather than being rejected by find-my-way with a bare
+    // `{ message: 'Route ... not found' }` that reads as a missing endpoint.
+    expect(res.statusCode).toBe(404)
+    expect(res.json()).toEqual({ error: 'node not found', id: missing })
+  })
+
+  it('blast-radius and dependencies also address a long id via the handler', async () => {
+    const missing = fileId('svc', `${longRelPath}.nope`)
+    for (const route of ['/graph/blast-radius/', '/graph/dependencies/']) {
+      const res = await app.inject({
+        method: 'GET',
+        url: `${route}${encodeURIComponent(missing)}`,
+      })
+      expect(res.statusCode).toBe(404)
+      expect(res.json()).toMatchObject({ error: 'node not found' })
+    }
+  })
+})


### PR DESCRIPTION
## What

Node ids are how the graph gets addressed over REST — `/graph/node/:id`, `/graph/blast-radius/:nodeId`, `/graph/dependencies/:nodeId`, `/graph/root-cause/:nodeId`, and friends. Under file-awareness (ADR-087) an id is `file:<service>:<relPath>`, and both the CLI and MCP clients `encodeURIComponent` it before it lands in the path param (every `/` becomes `%2F`).

Fastify caps a path param at 100 chars by default. A realistic deep-monorepo id blows past that once the slashes are encoded, so the router turns the request away with a bare `{"message":"Route ... not found"}` before the handler runs. An agent asking for that node's blast radius reads it as a dead endpoint rather than "the node isn't in the graph," and a node that genuinely exists can't be addressed at all.

This raises the router's `maxParamLength` to 1024 so a long-but-real id reaches the handler and gets either the real result or the actionable `{"error":"node not found","id":...}`. 1024 clears any realistic path plus symbol while still bounding a pathological multi-kilobyte URL. The change is in `buildApi`, so it covers both the daemon and `neat watch`.

## How it was found

Stress-testing the daemon for the HN-readiness resilience/self-debuggability gate. The daemon held up well across the board — malformed OTLP (garbage JSON/protobuf, nonsense structures), bad REST (nonsense routes, malformed bodies, wrong methods), oversized payloads (clean 413), and port contention (REST collision exits non-zero with a clear `EADDRINUSE`; a held OTLP port steps to the next free one per ADR-112) — never crashing, wedging, or leaking stack traces to clients. Error bodies are legible JSON throughout.

The one legibility gap was this: a valid, long, file-grained node id — the *primary* node identity now — came back as a misleading route-404 the querying agent couldn't act on.

## Test

`packages/core/test/api-long-node-id.test.ts` seeds a FileNode whose url-encoded id is >100 chars and asserts it resolves through `/graph/node/:id`, and that an unknown long id returns the handler's `{ error: 'node not found', id }` rather than the router's route-not-found. Verified against a live daemon too: pre-fix a 136-char encoded id returned route-not-found, post-fix it reaches the handler; health stays green.

Refs #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)