### PR TITLE
Find instrumentation hooks in subdirectories so /extend sees an instrumented app

### DIFF
--- a/packages/core/src/extend/index.ts
+++ b/packages/core/src/extend/index.ts
@@ -78,15 +78,74 @@ async function readPackageJson(scanPath: string): Promise<PackageJson> {
   return JSON.parse(raw) as PackageJson
 }
 
+// Directories the hook-file walk never descends into: dependency trees, VCS
+// metadata, build output, and NEAT's own output dir. None can hold a user's
+// instrumentation hook, and node_modules especially would make the walk crawl.
+// Every dot-prefixed directory (`.git`, `.next`, `.turbo`, `.vercel`, …) is
+// skipped too — a generated hook never lands in one.
+const HOOK_WALK_SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  'out',
+  'coverage',
+  'neat-out',
+])
+
+// Locate every OTel init hook in the project: a file whose basename starts with
+// `instrumentation` or `otel-init` in any JS/TS module flavor (js/ts/cjs/mjs).
+// The orchestrator writes the hook adjacent to the resolved entry — commonly a
+// subdirectory like `src/otel-init.cjs` for an app whose entry is
+// `src/index.js` — and the Next branch writes `instrumentation.node.{ts,js}`
+// under `src/` for --src-dir layouts, so the search walks the whole tree rather
+// than reading the root alone (#823). Paths come back relative to scanPath;
+// every caller re-joins them with `path.join(scanPath, file)`.
 async function findHookFiles(scanPath: string): Promise<string[]> {
-  const entries = await fs.readdir(scanPath)
-  return entries
-    .filter(
-      (e) =>
-        (e.startsWith('instrumentation') || e.startsWith('otel-init')) &&
-        /\.(ts|js)$/.test(e),
-    )
-    .sort()
+  const found: string[] = []
+  const walk = async (dir: string): Promise<void> => {
+    const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (entry.name.startsWith('.') || HOOK_WALK_SKIP_DIRS.has(entry.name)) continue
+        await walk(path.join(dir, entry.name))
+      } else if (entry.isFile()) {
+        if (
+          (entry.name.startsWith('instrumentation') || entry.name.startsWith('otel-init')) &&
+          /\.(ts|js|cjs|mjs)$/.test(entry.name)
+        ) {
+          const rel = path.relative(scanPath, path.join(dir, entry.name))
+          // Normalise to forward slashes so the returned path is stable across
+          // platforms and re-joins cleanly (path.join accepts `/` everywhere).
+          found.push(rel.split(path.sep).join('/'))
+        }
+      }
+    }
+  }
+  await walk(scanPath)
+  return found.sort()
+}
+
+// Choose which hook file the registration snippet splices into. A project can
+// carry several (Next writes instrumentation.{,node,edge}.{ts,js}; a monorepo
+// may keep one per package), but only the file that constructs the SDK has an
+// insertion point — the edge file registers via `@vercel/otel` and sorts first
+// alphabetically, so `hookFiles[0]` would be the wrong target. Prefer the first
+// hook file that splices cleanly and hand back its patched contents; fall back
+// to the first hook file so the caller still emits a precise "no insertion
+// point" error naming a real file.
+async function pickPrimaryHookFile(
+  scanPath: string,
+  hookFiles: string[],
+  snippet: string,
+): Promise<{ file: string; content: string; patched: string | null }> {
+  let fallback: { file: string; content: string } | null = null
+  for (const file of hookFiles) {
+    const content = await fs.readFile(path.join(scanPath, file), 'utf8')
+    const patched = splicedContent(content, snippet)
+    if (patched !== null) return { file, content, patched }
+    if (fallback === null) fallback = { file, content }
+  }
+  return { file: fallback!.file, content: fallback!.content, patched: null }
 }
 
 function extendLogPath(): string {
@@ -219,7 +278,17 @@ export async function applyExtension(
     }
   }
 
-  const primaryFile = hookFiles[0]!
+  // Resolve the hook file to splice into, and confirm it has an insertion point
+  // BEFORE touching package.json — otherwise a snippet that can't splice would
+  // leave a dep added with no matching registration.
+  const primary = await pickPrimaryHookFile(ctx.scanPath, hookFiles, args.registration_snippet)
+  if (primary.patched === null) {
+    throw new Error(
+      `Could not find instrumentation insertion point in ${hookFiles.join(', ')}. ` +
+        'Expected __INSTRUMENTATION_BLOCK__, instrumentations.push(, or new NodeSDK(.',
+    )
+  }
+  const primaryFile = primary.file
   const primaryPath = path.join(ctx.scanPath, primaryFile)
   const filesTouched: string[] = []
   const depsAdded: string[] = []
@@ -234,16 +303,8 @@ export async function applyExtension(
     depsAdded.push(`${args.instrumentation_package}@${args.version}`)
   }
 
-  // 2. Splice registration snippet into hook file
-  const hookContent = await fs.readFile(primaryPath, 'utf8')
-  const patched = splicedContent(hookContent, args.registration_snippet)
-  if (!patched) {
-    throw new Error(
-      `Could not find instrumentation insertion point in ${primaryFile}. ` +
-        'Expected __INSTRUMENTATION_BLOCK__, instrumentations.push(, or new NodeSDK(.',
-    )
-  }
-  await fs.writeFile(primaryPath, patched, 'utf8')
+  // 2. Splice registration snippet into the resolved hook file
+  await fs.writeFile(primaryPath, primary.patched, 'utf8')
   filesTouched.push(primaryFile)
 
   // 3. Run package manager install
@@ -305,7 +366,7 @@ export async function dryRunExtension(
     }
   }
 
-  const primaryFile = hookFiles[0]!
+  const primary = await pickPrimaryHookFile(ctx.scanPath, hookFiles, args.registration_snippet)
   const filesTouched: string[] = []
   const depsToAdd: string[] = []
   let packageJsonPatch: object = {}
@@ -318,10 +379,8 @@ export async function dryRunExtension(
     filesTouched.push('package.json')
   }
 
-  const hookContent = await fs.readFile(path.join(ctx.scanPath, primaryFile), 'utf8')
-  const patched = splicedContent(hookContent, args.registration_snippet)
-  if (patched) {
-    filesTouched.push(primaryFile)
+  if (primary.patched !== null) {
+    filesTouched.push(primary.file)
     templatePatch = `+ ${args.registration_snippet}`
   } else {
     templatePatch = 'Could not find insertion point in hook file.'

--- a/packages/core/test/audits/contracts.test.ts
+++ b/packages/core/test/audits/contracts.test.ts
@@ -13754,6 +13754,91 @@ describe('extend-skill contract', () => {
       delete process.env.NEAT_EXTEND_LOG
     }
   })
+
+  it('describe + apply find a hook at src/otel-init.cjs (subdirectory + .cjs, #823)', async () => {
+    const { describeProjectInstrumentation, applyExtension } = await import('../../src/extend/index.js')
+    const { promises: fs2 } = await import('node:fs')
+    const os2 = await import('node:os')
+    const path2 = await import('node:path')
+    const logPath = path2.join(os2.tmpdir(), `extend-log-${Date.now()}-cjs.ndjson`)
+    process.env.NEAT_EXTEND_LOG = logPath
+    // Exactly what the orchestrator generates for an app whose entry is
+    // src/index.js: the hook lands at src/otel-init.cjs — a subdirectory, and
+    // a .cjs extension. The old root-only, .ts|.js-only scan missed it and both
+    // describe and apply wrongly reported "no instrumentation hook files found".
+    const dir = await makeFixture({
+      'package.json': PRISMA_PKG,
+      'src/index.js': "require('./otel-init')",
+      'src/otel-init.cjs': OTEL_INIT_CONTENT,
+    })
+    const args = {
+      library: '@prisma/client',
+      instrumentation_package: '@prisma/instrumentation',
+      version: '^6.0.0',
+      registration_snippet:
+        "instrumentations.push(new (require('@prisma/instrumentation').PrismaInstrumentation)())",
+    }
+    try {
+      const state = await describeProjectInstrumentation({ project: 'test', scanPath: dir })
+      expect(state.hookFiles).toContain('src/otel-init.cjs')
+
+      const result = await applyExtension(
+        { project: 'test', scanPath: dir },
+        args,
+        { runInstall: stubRunInstall },
+      )
+      expect(result.alreadyApplied).toBe(false)
+      expect(result.filesTouched).toContain('src/otel-init.cjs')
+      const hookAfter = await fs2.readFile(path2.join(dir, 'src/otel-init.cjs'), 'utf8')
+      expect(hookAfter).toContain(args.registration_snippet)
+    } finally {
+      delete process.env.NEAT_EXTEND_LOG
+    }
+  })
+
+  it('apply/dry-run target the hook file that has an insertion point, not hookFiles[0]', async () => {
+    const { applyExtension, dryRunExtension } = await import('../../src/extend/index.js')
+    const { promises: fs2 } = await import('node:fs')
+    const os2 = await import('node:os')
+    const path2 = await import('node:path')
+    const logPath = path2.join(os2.tmpdir(), `extend-log-${Date.now()}-multi.ndjson`)
+    process.env.NEAT_EXTEND_LOG = logPath
+    // Next-style layout: three hook files. Only instrumentation.node.js builds
+    // the NodeSDK; instrumentation.edge.js (which sorts first) registers via
+    // @vercel/otel and has no insertion point. The picker must skip it.
+    const dir = await makeFixture({
+      'package.json': PRISMA_PKG,
+      'src/instrumentation.js': '// gate\nexport async function register() {}',
+      'src/instrumentation.edge.js': "import { registerOTel } from '@vercel/otel'\nregisterOTel()",
+      'src/instrumentation.node.js': OTEL_INIT_CONTENT,
+    })
+    const args = {
+      library: '@prisma/client',
+      instrumentation_package: '@prisma/instrumentation',
+      version: '^6.0.0',
+      registration_snippet:
+        "instrumentations.push(new (require('@prisma/instrumentation').PrismaInstrumentation)())",
+    }
+    try {
+      const diff = await dryRunExtension({ project: 'test', scanPath: dir }, args)
+      expect(diff.filesTouched).toContain('src/instrumentation.node.js')
+      expect(diff.filesTouched).not.toContain('src/instrumentation.edge.js')
+
+      const result = await applyExtension(
+        { project: 'test', scanPath: dir },
+        args,
+        { runInstall: stubRunInstall },
+      )
+      expect(result.filesTouched).toContain('src/instrumentation.node.js')
+      expect(result.filesTouched).not.toContain('src/instrumentation.edge.js')
+      const edgeAfter = await fs2.readFile(path2.join(dir, 'src/instrumentation.edge.js'), 'utf8')
+      expect(edgeAfter).not.toContain(args.registration_snippet)
+      const nodeAfter = await fs2.readFile(path2.join(dir, 'src/instrumentation.node.js'), 'utf8')
+      expect(nodeAfter).toContain(args.registration_snippet)
+    } finally {
+      delete process.env.NEAT_EXTEND_LOG
+    }
+  })
 })
 
 describe('ADR-075 — OBSERVED-tier live e2e against Brief', () => {


### PR DESCRIPTION
## What

`/neat extend`'s six MCP tools first ask NEAT where a project's OTel init hook lives (via `findHookFiles`). The search read only the repo root and matched only `.ts`/`.js`. That misses exactly what the orchestrator generates for a normal app whose entry is `src/index.js`: the hook lands at `src/otel-init.cjs` — a subdirectory, and a `.cjs` extension. So on an app that is fully instrumented and emitting spans, `neat_describe_project_instrumentation` and `neat_apply_extension` both fall back to *"No instrumentation hook files found — run `neat init` first"*, which is simply false.

`findHookFiles` now walks the tree (skipping `node_modules`, `dist`/`build`/`out`, `coverage`, `neat-out`, and dot-dirs), matches `js`/`ts`/`cjs`/`mjs`, and returns paths relative to the scan path so every caller keeps its `path.join(scanPath, file)` contract. Returned paths are normalised to forward slashes for cross-platform stability.

## Related gap fixed in the same pass

Once the walk surfaces multi-file frameworks (Next writes `instrumentation.{,node,edge}.js`), `apply`/`dry-run` picking `hookFiles[0]` is wrong — `instrumentation.edge.js` sorts first alphabetically and registers via `@vercel/otel`, so it has no `NodeSDK` / insertion point. They now pick the first hook file that actually splices cleanly. The insertion-point check also moved ahead of the `package.json` edit, so a snippet that can't splice no longer leaves a dependency added with no matching registration.

## Tests

Two new cases in the `extend-skill contract` suite: a hook at `src/otel-init.cjs` is found by `describe` and spliced by `apply`; and with three Next-style hook files, `apply`/`dry-run` target `instrumentation.node.js`, never the edge file. All 7 extend-skill tests pass; the full `contracts.test.ts` (745 tests) stays green.

## End-to-end verification

Instrumented a fresh express + mongoose + prisma + openai app with the built CLI (`init --apply` wrote `src/otel-init.cjs` + injected `require('./otel-init.cjs')` into `src/index.js`), started a `neat watch` daemon on its own ports (REST 9191 / OTLP 9190), and drove the tools through the daemon:

- `describe` → `hookFiles: ["src/otel-init.cjs"]` + `envNeat` + `installedDeps` (before this fix: empty `hookFiles`).
- `list-uninstrumented` → `@prisma/client` (first-party) and `openai` (third-party) — the real gaps.
- `dry-run` (openai) → would touch `package.json` + `src/otel-init.cjs`, no writes.
- `apply` (openai) → spliced `instrumentations.push(new (require('@traceloop/node-server-sdk').OpenAIInstrumentation)())` into the real `src/otel-init.cjs`, leaving the auto-registered Prisma push intact, and added the dep.
- idempotent re-apply → `alreadyApplied: true`, no writes.

## Known remaining gap (not touched here)

Remix's SDK-constructing hook is `app/otel.server.{ts,js}`; that basename starts with neither `instrumentation` nor `otel-init`, so the walk still won't find it. Widening the basename set touches the extend-skill contract's file-scope wording (§4), so it belongs in its own contract-first change rather than this fix.

Refs #823

🤖 Generated with [Claude Code](https://claude.com/claude-code)