### PR TITLE
Keep the four pull-connectors robust when a provider's payload drifts

### DIFF
--- a/packages/core/src/connectors/cloudflare/client.ts
+++ b/packages/core/src/connectors/cloudflare/client.ts
@@ -89,9 +89,11 @@ export async function queryWorkerInvocations(
   // drift — a real API-contract change, not the ordinary "no events this
   // window" case (which arrives as an *empty* array here and warrants no
   // warning). Silently treating both the same way hid an API change behind a
-  // quiet [] return; this distinguishes them so a real drift is loud.
+  // quiet [] return; this distinguishes them so a real drift is loud. A
+  // non-array `events` (drift handing back an object) is the same class of
+  // change — caught here rather than crashing poll()'s `for..of` on it.
   const events = payload.result?.events?.events
-  if (events === undefined) {
+  if (!Array.isArray(events)) {
     console.warn(
       '[neat connector] cloudflare: telemetry query returned success:true but no result.events.events array — the response shape may have changed; treating as zero events this tick',
     )

--- a/packages/core/src/connectors/cloudflare/map.ts
+++ b/packages/core/src/connectors/cloudflare/map.ts
@@ -37,8 +37,11 @@ const HTTP_METHODS = new Set([
 
 const LEADING_TOKEN_RE = /^(\S+)\s+\S/
 
-export function parseHttpMethodFromTrigger(trigger: string | undefined): string | null {
-  if (!trigger) return null
+export function parseHttpMethodFromTrigger(trigger: unknown): string | null {
+  // `trigger` is typed a string upstream, but this maps a raw JSON response —
+  // a shape drift that hands us a number or object here drops honestly rather
+  // than throwing on `.trim()` (connectors.md §4 honest-miss discipline).
+  if (typeof trigger !== 'string') return null
   const match = LEADING_TOKEN_RE.exec(trigger.trim())
   const token = match?.[1]
   if (!token) return null
@@ -67,7 +70,10 @@ export function parsePathFromTrigger(trigger: string): string | undefined {
 // conditional fetch — and isn't held against the edge's own error tally).
 const ERROR_STATUS_THRESHOLD = 500
 
-export function mapEventToSignal(event: CloudflareTelemetryEvent): CloudflareObservedSignal | null {
+export function mapEventToSignal(event: CloudflareTelemetryEvent | null | undefined): CloudflareObservedSignal | null {
+  // A shape-drifted response can hand a poll tick a null/garbage array slot;
+  // drop it honestly rather than throwing on `.$metadata` (connectors.md §4).
+  if (!event || typeof event !== 'object') return null
   const metadata = event.$metadata
   const workers = event.$workers
 
@@ -76,12 +82,19 @@ export function mapEventToSignal(event: CloudflareTelemetryEvent): CloudflareObs
 
   // `$workers.scriptName` and `$metadata.service` are both documented as
   // "Worker script name" — prefer the Workers-Runtime-specific field when
-  // present, fall back to the always-present metadata field.
+  // present, fall back to the always-present metadata field. A non-string
+  // value (shape drift) drops honestly rather than riding through as a
+  // non-string targetName the graph would then have to carry.
   const scriptName = workers?.scriptName ?? metadata?.service
-  if (!scriptName) return null
+  if (typeof scriptName !== 'string' || scriptName.length === 0) return null
 
   const timestampMs = event.timestamp ?? metadata?.startTime
   if (typeof timestampMs !== 'number' || !Number.isFinite(timestampMs)) return null
+  // A finite-but-out-of-range epoch (a value in ns/µs, or a bogus one) makes
+  // an Invalid Date whose `.toISOString()` throws — drop it honestly rather
+  // than fabricating a timestamp or crashing the whole tick.
+  const observedAt = new Date(timestampMs)
+  if (Number.isNaN(observedAt.getTime())) return null
 
   const statusCode = metadata?.statusCode
   const isError = typeof statusCode === 'number' && statusCode >= ERROR_STATUS_THRESHOLD
@@ -92,7 +105,7 @@ export function mapEventToSignal(event: CloudflareTelemetryEvent): CloudflareObs
     targetName: scriptName,
     callCount: 1,
     errorCount: isError ? 1 : 0,
-    lastObservedIso: new Date(timestampMs).toISOString(),
+    lastObservedIso: observedAt.toISOString(),
     method,
     ...(path ? { path } : {}),
     ...(typeof statusCode === 'number' ? { statusCode } : {}),

--- a/packages/core/src/connectors/firebase/logging-api.ts
+++ b/packages/core/src/connectors/firebase/logging-api.ts
@@ -199,7 +199,10 @@ export async function fetchHttpRequestLogEntries(
       throw new Error(`Cloud Logging entries.list failed: ${res.status} ${res.statusText}`)
     }
     const json = (await res.json()) as EntriesListResponse
-    out.push(...(json.entries ?? []))
+    // A well-formed page carries an array (absent when the window is empty);
+    // a shape drift handing back a non-array `entries` drops honestly rather
+    // than throwing on `push(...nonIterable)` (connectors.md §4).
+    if (Array.isArray(json.entries)) out.push(...json.entries)
     if (!json.nextPageToken) break
     pageToken = json.nextPageToken
   }

--- a/packages/core/src/connectors/firebase/map.ts
+++ b/packages/core/src/connectors/firebase/map.ts
@@ -75,8 +75,11 @@ function resourceNameFor(
 // the value is neither a bare path nor a parseable absolute URL, the same
 // "honest miss, never guessed" discipline `pathOf` uses in
 // extract/calls/route-match.ts.
-function pathFromRequestUrl(requestUrl: string | undefined): string | null {
-  if (!requestUrl) return null
+function pathFromRequestUrl(requestUrl: unknown): string | null {
+  // Typed a string upstream, but this reads a raw Cloud Logging record — a
+  // shape drift handing a number/object here drops honestly rather than
+  // throwing on `.startsWith` (connectors.md §4).
+  if (typeof requestUrl !== 'string' || requestUrl.length === 0) return null
   if (requestUrl.startsWith('/')) {
     const withoutQuery = requestUrl.split('?')[0]
     return withoutQuery && withoutQuery.length > 0 ? withoutQuery : '/'
@@ -102,7 +105,10 @@ const ERROR_STATUS_THRESHOLD = 500
 // type (filter should already exclude these, but never trust the filter
 // alone), a resource with no identity label, or an httpRequest missing the
 // method/path a signal needs. Nothing here is guessed or fabricated.
-export function mapLogEntryToSignal(entry: LogEntry): ObservedSignal | null {
+export function mapLogEntryToSignal(entry: LogEntry | null | undefined): ObservedSignal | null {
+  // A shape-drifted response can carry a null/garbage slot; drop it honestly
+  // rather than throwing on `.resource` (connectors.md §4).
+  if (!entry || typeof entry !== 'object') return null
   const resourceType = entry.resource?.type
   if (!resourceType || !isFirebaseResourceType(resourceType)) return null
 
@@ -111,13 +117,13 @@ export function mapLogEntryToSignal(entry: LogEntry): ObservedSignal | null {
 
   const req = entry.httpRequest
   if (!req) return null
-  if (!req.requestMethod) return null
+  if (typeof req.requestMethod !== 'string' || req.requestMethod.length === 0) return null
   const method = req.requestMethod.toUpperCase()
   const path = pathFromRequestUrl(req.requestUrl)
   if (path === null) return null
 
   const timestamp = entry.timestamp
-  if (!timestamp) return null
+  if (typeof timestamp !== 'string' || timestamp.length === 0) return null
 
   const isError = typeof req.status === 'number' && req.status >= ERROR_STATUS_THRESHOLD
 

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -208,8 +208,13 @@ export async function runConnectorPoll(
     // them, ADR-066 — land the same as if `callCount` individual spans had
     // arrived, rather than undercounting a batched signal down to +1.
     const calls = Math.trunc(signal.callCount)
-    if (calls < 1) continue // nothing observed this window — not even a miss
-    const errors = Math.min(Math.max(Math.trunc(signal.errorCount), 0), calls)
+    // A non-finite count (NaN/Infinity from a provider's shape drift) is
+    // neither an observation nor an honest miss — drop it rather than letting
+    // a zero-iteration loop below tally a phantom edge update (gate #8).
+    if (!Number.isFinite(calls) || calls < 1) continue
+    const errors = Number.isFinite(signal.errorCount)
+      ? Math.min(Math.max(Math.trunc(signal.errorCount), 0), calls)
+      : 0
 
     let created = false
     let ok = true

--- a/packages/core/src/connectors/railway/index.ts
+++ b/packages/core/src/connectors/railway/index.ts
@@ -147,8 +147,16 @@ export function mapRailwayHttpLogsToSignals(
   routeIndex: RailwayRouteIndexEntry[],
 ): ObservedSignal[] {
   const buckets = new Map<string, SignalBucket>()
+  if (!Array.isArray(entries)) return []
 
   for (const entry of entries) {
+    // Drop a null/garbage slot or a row missing the method/path/timestamp a
+    // signal needs, honestly, rather than throwing on `.toUpperCase()` /
+    // normalizePathTemplate's `.split()` (connectors.md §4).
+    if (!entry || typeof entry !== 'object') continue
+    if (typeof entry.method !== 'string' || typeof entry.path !== 'string' || typeof entry.timestamp !== 'string') {
+      continue
+    }
     const method = entry.method.toUpperCase()
     const normalizedPath = normalizePathTemplate(entry.path)
     const match = findRailwayRoute(routeIndex, method, normalizedPath)
@@ -204,9 +212,15 @@ export function mapRailwayNetworkFlowLogsToSignals(
   entries: RailwayNetworkFlowLogEntry[],
 ): ObservedSignal[] {
   const buckets = new Map<string, SignalBucket>()
+  if (!Array.isArray(entries)) return []
 
   for (const entry of entries) {
-    if (!entry.peerServiceId) continue
+    // A null/garbage slot, or a record with no Railway-internal peer (public
+    // egress carries a null peerServiceId), drops honestly rather than
+    // throwing or being guessed at (connectors.md §4, railway.md §Fusion).
+    if (!entry || typeof entry !== 'object') continue
+    if (typeof entry.peerServiceId !== 'string' || entry.peerServiceId.length === 0) continue
+    if (typeof entry.timestamp !== 'string') continue
     const isError = entry.dropCause !== null && entry.dropCause !== ''
     upsertBucket(buckets, entry.peerServiceId, isError, entry.timestamp, () => ({
       targetKind: PEER_SERVICE_TARGET_KIND,

--- a/packages/core/src/connectors/supabase/map.ts
+++ b/packages/core/src/connectors/supabase/map.ts
@@ -62,8 +62,16 @@ interface Bucket {
 
 export function mapEdgeLogRowsToSignals(rows: SupabaseEdgeLogRow[]): ObservedSignal[] {
   const buckets = new Map<string, Bucket>()
+  if (!Array.isArray(rows)) return []
 
   for (const row of rows) {
+    // A shape-drifted response can carry a null/garbage slot or a row missing
+    // the path/timestamp a signal needs — drop it honestly rather than
+    // throwing (connectors.md §4). Timestamp is required: a signal claiming an
+    // observation with no time to stand on isn't a truthful one (the same
+    // `if (!timestamp) return null` firebase/map.ts already applies).
+    if (!row || typeof row !== 'object') continue
+    if (typeof row.path !== 'string' || typeof row.timestamp !== 'string') continue
     const target = targetFromRestPath(row.path)
     // Not a `/rest/v1/...` PostgREST path — Auth/Storage/Realtime/Functions
     // traffic on the same project, out of scope for this cut (supabase.md
@@ -169,10 +177,19 @@ export function diffPgStatStatementsToSignals(
 ): ObservedSignal[] {
   const signals: ObservedSignal[] = []
   const seen = new Set<string>()
+  if (!Array.isArray(rows)) return signals
 
   for (const row of rows) {
-    seen.add(row.queryid)
+    // Drop a null/garbage slot or a row with no usable queryid honestly rather
+    // than throwing on `.queryid` (connectors.md §4).
+    if (!row || typeof row !== 'object' || typeof row.queryid !== 'string') continue
     const calls = Number(row.calls)
+    // A non-numeric `calls` (shape drift) can't produce an honest delta — skip
+    // it entirely rather than diffing NaN into a NaN-valued callCount signal
+    // the downstream pipeline would mis-tally (gate #8 truthful counts).
+    if (!Number.isFinite(calls)) continue
+
+    seen.add(row.queryid)
     const prior = previous.get(row.queryid)
     previous.set(row.queryid, { calls })
 

--- a/packages/core/test/connectors-cloudflare.test.ts
+++ b/packages/core/test/connectors-cloudflare.test.ts
@@ -198,6 +198,43 @@ describe('mapEventToSignal (docs/connectors/cloudflare.md §Fusion)', () => {
   })
 })
 
+describe('mapEventToSignal — shape-drift robustness (never crashes a poll tick)', () => {
+  // A single malformed record must not throw: a throw here escapes the whole
+  // poll tick, dropping every good signal alongside the bad one and — since
+  // `since` never advances on a failed tick — repeating forever. Each drifted
+  // shape drops honestly (null) instead (connectors.md §4).
+  it('drops a null / undefined / empty event slot', () => {
+    expect(mapEventToSignal(null)).toBeNull()
+    expect(mapEventToSignal(undefined)).toBeNull()
+    expect(mapEventToSignal({})).toBeNull()
+  })
+
+  it('drops a non-string trigger instead of throwing on .trim()', () => {
+    expect(parseHttpMethodFromTrigger(123 as unknown as string)).toBeNull()
+    expect(parseHttpMethodFromTrigger({} as unknown as string)).toBeNull()
+    expect(
+      mapEventToSignal({
+        timestamp: 1751566800000,
+        $metadata: { trigger: 123 as unknown as string, service: 's' },
+      }),
+    ).toBeNull()
+  })
+
+  it('drops an out-of-range epoch (a value in ns/µs) instead of throwing on an Invalid Date', () => {
+    expect(mapEventToSignal({ timestamp: 1.7e18, $metadata: { trigger: 'GET /x', service: 's' } })).toBeNull()
+    expect(mapEventToSignal({ timestamp: -1e18, $metadata: { trigger: 'GET /x', service: 's' } })).toBeNull()
+  })
+
+  it('drops an event whose script name drifts non-string, never carrying a non-string targetName', () => {
+    expect(
+      mapEventToSignal({
+        timestamp: 1751566800000,
+        $metadata: { trigger: 'GET /x', service: 5 as unknown as string },
+      }),
+    ).toBeNull()
+  })
+})
+
 describe('queryWorkerInvocations', () => {
   it('sends a bearer-token-authed query and returns the response events', async () => {
     const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
@@ -255,6 +292,28 @@ describe('queryWorkerInvocations', () => {
       expect(events).toEqual([])
       expect(warnSpy).toHaveBeenCalledTimes(1)
       expect(warnSpy.mock.calls[0]?.[0]).toContain('response shape may have changed')
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('treats a non-array result.events.events (shape drift) as zero events instead of crashing poll on it', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ success: true, result: { events: { events: { unexpected: 'object' } } } }), {
+          status: 200,
+        }),
+    )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const events = await queryWorkerInvocations(
+        baseCtx(),
+        baseConfig(),
+        { fromMs: 1000, toMs: 2000 },
+        fetchImpl as unknown as typeof fetch,
+      )
+      expect(events).toEqual([])
+      expect(warnSpy).toHaveBeenCalledTimes(1)
     } finally {
       warnSpy.mockRestore()
     }

--- a/packages/core/test/connectors-firebase.test.ts
+++ b/packages/core/test/connectors-firebase.test.ts
@@ -24,7 +24,7 @@ import {
   packFirebaseTargetName,
   parseFirebaseTargetName,
 } from '../src/connectors/firebase/index.js'
-import type { EntriesListResponse } from '../src/connectors/firebase/logging-api.js'
+import type { EntriesListResponse, LogEntry } from '../src/connectors/firebase/logging-api.js'
 import type { FirebaseServiceMap } from '../src/connectors/firebase/resolve.js'
 import type { NeatGraph } from '../src/graph.js'
 
@@ -172,6 +172,31 @@ describe('Firebase connector — mapping (docs/connectors/firebase.md, ADR-128)'
       { httpRequest: { requestMethod: 'GET', requestUrl: '/x' }, timestamp: 't' }, // no resource
     ])
     expect(signals).toEqual([])
+  })
+
+  // One malformed entry must not throw the whole tick (see the Cloudflare
+  // block's note for why a thrown tick is worse than a dropped entry) —
+  // connectors.md §4.
+  it('drops null / empty entries in the batch honestly rather than throwing on .resource', () => {
+    expect(mapLogEntriesToSignals([null as unknown as LogEntry])).toEqual([])
+    expect(mapLogEntriesToSignals([{} as LogEntry])).toEqual([])
+  })
+
+  it('drops an entry whose httpRequest method/url drift non-string, never throwing on .toUpperCase()/.startsWith()', () => {
+    const base = {
+      resource: { type: 'cloud_function', labels: { function_name: 'f' } },
+      timestamp: '2026-07-03T10:00:00.000Z',
+    }
+    expect(
+      mapLogEntriesToSignals([
+        { ...base, httpRequest: { requestMethod: 123 as unknown as string, requestUrl: '/x' } } as LogEntry,
+      ]),
+    ).toEqual([])
+    expect(
+      mapLogEntriesToSignals([
+        { ...base, httpRequest: { requestMethod: 'GET', requestUrl: 123 as unknown as string } } as LogEntry,
+      ]),
+    ).toEqual([])
   })
 })
 

--- a/packages/core/test/connectors-railway.test.ts
+++ b/packages/core/test/connectors-railway.test.ts
@@ -193,6 +193,39 @@ describe('Railway connector — httpLogs/networkFlowLogs → ObservedSignal mapp
   })
 })
 
+describe('Railway mapping — shape-drift robustness (never crashes a poll tick)', () => {
+  // One malformed row must not throw the whole tick (see the Cloudflare block's
+  // note for why a thrown tick is worse than a dropped row) — connectors.md §4.
+  it('drops null / empty httpLogs rows, and rows missing method/path/timestamp', () => {
+    expect(mapRailwayHttpLogsToSignals([null as unknown as RailwayHttpLogEntry], [])).toEqual([])
+    expect(mapRailwayHttpLogsToSignals([{} as RailwayHttpLogEntry], [])).toEqual([])
+    expect(
+      mapRailwayHttpLogsToSignals(
+        [{ method: 123 as unknown as string, path: '/x', httpStatus: 200, timestamp: 't' } as RailwayHttpLogEntry],
+        [],
+      ),
+    ).toEqual([])
+    expect(
+      mapRailwayHttpLogsToSignals(
+        [{ method: 'GET', path: 123 as unknown as string, httpStatus: 200, timestamp: 't' } as RailwayHttpLogEntry],
+        [],
+      ),
+    ).toEqual([])
+  })
+
+  it('drops null / empty networkFlowLogs rows honestly rather than throwing', () => {
+    expect(mapRailwayNetworkFlowLogsToSignals([null as unknown as RailwayNetworkFlowLogEntry])).toEqual([])
+    expect(mapRailwayNetworkFlowLogsToSignals([{} as RailwayNetworkFlowLogEntry])).toEqual([])
+  })
+
+  it('drops a non-array body honestly rather than throwing on for..of', () => {
+    expect(mapRailwayHttpLogsToSignals(undefined as unknown as RailwayHttpLogEntry[], [])).toEqual([])
+    expect(
+      mapRailwayNetworkFlowLogsToSignals(undefined as unknown as RailwayNetworkFlowLogEntry[]),
+    ).toEqual([])
+  })
+})
+
 describe('Railway connector — createRailwayResolveTarget (ADR-127)', () => {
   it('resolves a matched route signal to the RouteNode with a CALLS edge', () => {
     const resolveTarget = createRailwayResolveTarget(config())

--- a/packages/core/test/connectors-supabase.test.ts
+++ b/packages/core/test/connectors-supabase.test.ts
@@ -240,6 +240,55 @@ describe('Supabase connector — pg_stat_statements mapping and delta diffing (d
   })
 })
 
+describe('Supabase mapping — shape-drift robustness (never crashes a poll tick)', () => {
+  // One malformed row must not throw the whole tick (see the Cloudflare block's
+  // note for why a thrown tick is worse than a dropped row) — connectors.md §4.
+  it('drops null / empty edge-log rows, and rows missing a usable path or timestamp', () => {
+    expect(mapEdgeLogRowsToSignals([null as unknown as SupabaseEdgeLogRow])).toEqual([])
+    expect(mapEdgeLogRowsToSignals([{} as SupabaseEdgeLogRow])).toEqual([])
+    // path drifts non-string
+    expect(
+      mapEdgeLogRowsToSignals([{ path: 123 as unknown as string, status_code: 200, timestamp: 't' } as SupabaseEdgeLogRow]),
+    ).toEqual([])
+    // path present but no timestamp — a signal with no observation time to
+    // stand on isn't a truthful one, so it drops rather than riding through
+    // with an undefined lastObservedIso.
+    expect(
+      mapEdgeLogRowsToSignals([{ path: '/rest/v1/orders', status_code: 200 } as unknown as SupabaseEdgeLogRow]),
+    ).toEqual([])
+  })
+
+  it('drops a non-array edge-log body honestly rather than throwing on for..of', () => {
+    expect(mapEdgeLogRowsToSignals(undefined as unknown as SupabaseEdgeLogRow[])).toEqual([])
+    expect(mapEdgeLogRowsToSignals({} as unknown as SupabaseEdgeLogRow[])).toEqual([])
+  })
+
+  it('never emits a NaN callCount when pg_stat `calls` drifts non-numeric against a baseline (gate #8 truthful counts)', () => {
+    const baselines = new Map<string, StatementBaseline>([['q1', { calls: 5 }]])
+    const signals = diffPgStatStatementsToSignals(
+      [
+        {
+          queryid: 'q1',
+          query: 'select * from "orders"',
+          calls: 'not-a-number' as unknown as string,
+          total_exec_time: 0,
+          rows: '0',
+        },
+      ],
+      baselines,
+      '2026-07-03T10:00:00.000Z',
+    )
+    expect(signals).toEqual([])
+  })
+
+  it('drops null pg_stat rows and a non-array body honestly rather than throwing on .queryid', () => {
+    expect(diffPgStatStatementsToSignals([null as unknown as PgStatStatementsRow], new Map(), 'now')).toEqual([])
+    expect(
+      diffPgStatStatementsToSignals(undefined as unknown as PgStatStatementsRow[], new Map(), 'now'),
+    ).toEqual([])
+  })
+})
+
 describe('Supabase connector — target resolution (resolve.ts, docs/connectors/supabase.md §Fusion)', () => {
   it('resolves to the table/RPC InfraNode when a future extractor has already minted one — fusion sharpens automatically, no connector change', () => {
     const graph = newGraph({ projectNode: true, tableNode: true })


### PR DESCRIPTION
Refs #803

The four pull-connectors (Cloudflare, Supabase, Railway, Firebase) each turn a provider's raw API rows into `ObservedSignal`s in a per-provider `map.ts`. Every one of those mappers read its rows assuming they always arrive well-formed. Feeding them realistic shape-drift — a null slot in the array, a field that comes back a number where a string was expected, an out-of-range epoch, or the response's list field coming back as a non-array — throws a `TypeError`/`RangeError` straight out of the mapper.

That matters more than a single dropped row because a thrown poll tick takes *every* good signal in the batch down with it, and the loop never advances its `since` watermark on a failed tick — so one bad record wedges the whole tick and keeps re-fetching the same window every minute. The connectors contract (§4) already says an unresolvable signal drops honestly; a malformed one should too, rather than poisoning the batch.

What changed:
- Each mapper now drops a null/garbage slot or a row missing the fields a signal needs (method, path, timestamp, script name, queryid) and keeps the rest of the batch.
- Cloudflare drops an out-of-range epoch instead of throwing on an Invalid Date's `.toISOString()`, and drops an event whose script name drifts non-string rather than carrying a non-string `targetName` into the graph.
- Supabase stops emitting a `NaN` callCount when `pg_stat_statements.calls` comes back non-numeric against a live baseline, and requires a timestamp so a signal never claims an observation with no time to stand on.
- The shared pull/map/fuse pipeline guards a non-finite `callCount` so a bad count can't tally a phantom edge update (the zero-iteration replay loop otherwise counted an "update" that minted nothing).
- Cloudflare and Firebase also stop crashing when the events/entries collection itself drifts to a non-array shape (Cloudflare reuses its existing loud shape-drift warning; Firebase drops honestly).

Adversarial malformed-payload tests cover all four connectors. Full connector suite + contract audits green; lint clean.

Verified against tests + code, not live provider accounts — this sandbox has no Supabase/Railway/Firebase/Cloudflare credentials, so the map/resolve layers were exercised against the recorded fixtures and adversarial synthetic inputs. The live-account end-to-end poll and the placeholder rate-limit buckets (3 of 4 still unconfirmed) remain open, tracked separately in the launch docket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)