### PR TITLE
Nudge an agent to reach for NEAT's graph before grepping

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ The `neat-mcp` binary above assumes a global install. Without one, run `neat ski
 
 In any Claude Code session, ask: *"Why is checkout-svc failing?"* NEAT walks the graph and answers with a traversal path, edge provenances, a confidence score, and a recommended fix.
 
+### Reach for the graph before grepping
+
+```bash
+neat hooks --apply
+```
+
+This installs two nudges so your agent queries the graph before it falls back to raw text search:
+
+- **A Claude Code search-nudge hook** — a `PreToolUse` hook that, when the agent reaches for `Grep`/`Glob` or a Bash `grep`/`rg`/`find`, injects a note pointing it at `semantic_search`, `get_dependencies`, and `get_divergences` first. It is a gentle, non-blocking nudge: the search still runs. It merges into `~/.claude/settings.json` without touching your other hooks, and re-running is idempotent.
+- **Agent-agnostic graph-first guidance** — a markdown block (`GRAPH_FIRST.md`, also written to `~/.neat/neat-graph-first.md`) to paste into `CLAUDE.md` / `AGENTS.md` / `.cursorrules`, so agents on any harness get the same steer.
+
+The hook is specific to Claude Code; other harnesses (Codex, Gemini, Cursor) rely on the guidance block instead. `neat hooks --print-hook`, `--print-guide`, and `--print-settings` show each piece without installing.
+
 ## Repository layout
 
 ```

--- a/packages/claude-skill/GRAPH_FIRST.md
+++ b/packages/claude-skill/GRAPH_FIRST.md
@@ -1,0 +1,35 @@
+<!-- NEAT graph-first guidance. Paste this block into your agent's project
+     instructions — CLAUDE.md, AGENTS.md, .cursorrules, or the equivalent —
+     so the agent reaches for NEAT's graph before scanning files by hand.
+     Agent-agnostic: it is plain guidance, no Claude Code features required. -->
+
+## Reach for NEAT's graph before grepping
+
+This project has NEAT wired in. NEAT keeps a live semantic graph of the system —
+code, infrastructure, and runtime behaviour fused into one model — reachable over
+MCP (and a REST API). Every edge carries provenance: `EXTRACTED` from source,
+`OBSERVED` from OpenTelemetry, `INFERRED` where the trace stitcher bridges a gap,
+`STALE` when runtime goes quiet — so you know how much to trust each answer.
+
+When you need to understand this codebase, query the graph first. It is usually
+faster and more accurate than `grep`/`glob`/`find`, and it can tell you what the
+system *actually does at runtime*, not only what the source declares.
+
+Reach for these MCP tools before raw text search:
+
+- `semantic_search` — find code/nodes by a natural-language description.
+- `get_dependencies` — a node's transitive outgoing dependencies (declared, `EXTRACTED`).
+- `get_observed_dependencies` — only what a node calls *in production* (`OBSERVED` via OTel).
+- `get_divergences` — where the code (`EXTRACTED`) and production (`OBSERVED`) disagree.
+  The most NEAT-shaped query; reach for it on "is anything weird here?"
+- `get_root_cause` — trace a failing node up its dependency graph to the culprit.
+- `get_blast_radius` — everything downstream of a node: what breaks if it changes or fails.
+- `get_incident_history` — recent OTel error events recorded against a node.
+- `check_policies` — the project's `policy.json` violations, actual or hypothetical.
+
+Text search is still a fine fallback. If the graph does not have what you need —
+comments, string literals, config minutiae, a file NEAT does not model — go ahead
+and `grep`. The point is order: ask the graph first, then fall back to scanning.
+
+If the tools are not available, the NEAT daemon may not be running (`neatd status`)
+or the MCP server may not be wired in (`neat skill --apply`).

--- a/packages/claude-skill/README.md
+++ b/packages/claude-skill/README.md
@@ -6,9 +6,13 @@ See [SKILL.md](./SKILL.md) for the tool list, install steps, and prerequisites.
 
 The shipped artifact is `claude_code_config.json` — a single object you merge into your `~/.claude.json` under `mcpServers.neat`. The `neat skill` CLI verb (in `@neat.is/core`) handles the merge for you.
 
+Alongside the MCP config, this package ships the affordances that make an agent reach for the graph before it grep-scans a repo: a Claude Code search-nudge `PreToolUse` hook (`hooks/neat-search-nudge.mjs`) and agent-agnostic graph-first guidance (`GRAPH_FIRST.md`). `neat hooks --apply` installs both. See [SKILL.md](./SKILL.md#reach-for-the-graph-first).
+
 ## Files
 
 - `claude_code_config.json` — the MCP server snippet
+- `hooks/neat-search-nudge.mjs` — the Claude Code search-nudge PreToolUse hook
+- `GRAPH_FIRST.md` — agent-agnostic graph-first guidance to paste into project instructions
 - `SKILL.md` — what the skill exposes and how to install
 - `package.json` — workspace metadata; this package ships no compiled code
 

--- a/packages/claude-skill/SKILL.md
+++ b/packages/claude-skill/SKILL.md
@@ -69,6 +69,42 @@ neat skill --apply
 
 This merges the `neat` server into `~/.claude.json` without touching other entries.
 
+## Reach for the graph first
+
+Wiring the tools in is half the job; the other half is getting your agent to
+*use* them instead of falling straight to text search. NEAT ships two nudges:
+
+```bash
+neat hooks --apply
+```
+
+That installs both:
+
+1. **A Claude Code search-nudge hook.** A `PreToolUse` hook (materialised to
+   `~/.neat/hooks/neat-search-nudge.mjs`, wired into `~/.claude/settings.json`)
+   that fires when the agent reaches for `Grep`, `Glob`, or a Bash
+   `grep`/`rg`/`find`. It injects a short note steering the agent to
+   `semantic_search` / `get_dependencies` / `get_divergences` first. It is a
+   **gentle, non-blocking nudge** — the search still runs; the agent just sees
+   the graph as the better first move. Your existing hooks are left in place,
+   and re-running is idempotent.
+
+2. **Agent-agnostic graph-first guidance** (`GRAPH_FIRST.md`, also written to
+   `~/.neat/neat-graph-first.md`). A markdown block you paste into your project
+   instructions — `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, whatever your agent
+   reads — so the same "ask the graph before grepping" steer reaches agents on
+   any harness.
+
+The hook is Claude-Code-specific; agents on other harnesses (Codex, Gemini,
+Cursor, …) don't get the `PreToolUse` interception, but the guidance block
+gives them the same instruction. Preview either without installing:
+
+```bash
+neat hooks --print-hook       # the hook script
+neat hooks --print-guide      # the graph-first guidance
+neat hooks --print-settings   # the settings.json block --apply merges
+```
+
 ## Prerequisites
 
 - `neat init <repo>` has registered at least one project.

--- a/packages/claude-skill/hooks/neat-search-nudge.mjs
+++ b/packages/claude-skill/hooks/neat-search-nudge.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// NEAT search-nudge — a Claude Code PreToolUse hook.
+//
+// When the agent reaches for raw text search — the Grep or Glob tools, or a
+// Bash command that shells out to grep / rg / ag / ack / find / fd — this hook
+// injects a short note suggesting NEAT's graph tools first. NEAT already holds
+// this project's structure, dependencies, and runtime behaviour, so a graph
+// query is usually faster and more accurate than scanning files by hand.
+//
+// It is a NUDGE, not a gate. The hook only ever adds context; it never denies
+// the call and always exits 0, so the search runs regardless. Anything that is
+// not a text search is a silent no-op.
+//
+// Wired by `neat hooks --apply`, which copies this script under ~/.neat/hooks/
+// and adds a PreToolUse entry to ~/.claude/settings.json. The hook itself is
+// Claude-Code-specific; agents on other harnesses get the same steer from the
+// graph-first guidance NEAT ships instead (see `neat hooks --print-guide`).
+//
+// This file is a documentation copy. The source of truth is NEAT_SEARCH_HOOK
+// in @neat.is/core (packages/core/src/hooks-cli.ts); a contract test keeps the
+// two byte-aligned.
+
+import process from 'node:process'
+
+// grep-family and file-finder binaries. Matched at a word boundary so a path
+// like agent.ts does not trip it, and after a shell separator so the binary in
+// a pipe (... | grep foo) still counts.
+const SEARCH_BINARY = /(?:^|[\s|;&(){}])(?:grep|egrep|fgrep|rg|ripgrep|ag|ack|find|fd)(?=\s|$)/
+
+function bashLooksLikeSearch(command) {
+  return typeof command === 'string' && SEARCH_BINARY.test(command)
+}
+
+function nudge(toolName) {
+  return [
+    'NEAT is wired into this project — its live graph already knows this codebase',
+    'structure, dependencies, and runtime behaviour. Before leaning on ' + toolName + ', consider',
+    'asking the graph over MCP; it answers with structured, provenance-tagged results',
+    'rather than line matches:',
+    '',
+    '  - semantic_search — find code/nodes by a natural-language description',
+    '  - get_dependencies / get_observed_dependencies — what a thing calls, as declared',
+    '    in code (EXTRACTED) vs. what it actually calls in production (OBSERVED)',
+    '  - get_divergences — where the code and production disagree',
+    '  - get_root_cause / get_blast_radius — trace a failure, or a change reach',
+    '',
+    'Text search is still a fine fallback — go ahead and run it if the graph does not',
+    'have what you need.',
+  ].join('\n')
+}
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = ''
+    process.stdin.setEncoding('utf8')
+    process.stdin.on('data', (chunk) => {
+      data += chunk
+    })
+    process.stdin.on('end', () => resolve(data))
+    process.stdin.on('error', () => resolve(data))
+  })
+}
+
+const raw = await readStdin()
+
+let payload
+try {
+  payload = JSON.parse(raw)
+} catch {
+  // No parseable payload — nothing to nudge about. Let the call proceed.
+  process.exit(0)
+}
+
+const toolName = typeof payload?.tool_name === 'string' ? payload.tool_name : ''
+const toolInput = payload?.tool_input ?? {}
+
+let isSearch = false
+if (toolName === 'Grep' || toolName === 'Glob') isSearch = true
+else if (toolName === 'Bash') isSearch = bashLooksLikeSearch(toolInput.command)
+
+if (!isSearch) process.exit(0)
+
+process.stdout.write(
+  JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      additionalContext: nudge(toolName),
+    },
+  }),
+)
+process.exit(0)

--- a/packages/claude-skill/package.json
+++ b/packages/claude-skill/package.json
@@ -18,7 +18,9 @@
   "files": [
     "README.md",
     "SKILL.md",
-    "claude_code_config.json"
+    "GRAPH_FIRST.md",
+    "claude_code_config.json",
+    "hooks/neat-search-nudge.mjs"
   ],
   "scripts": {
     "test": "vitest run --passWithNoTests",

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -42,6 +42,7 @@ import {
 } from './installers/index.js'
 import { runOrchestrator } from './orchestrator.js'
 import { runConnectorCommand } from './connector-cli.js'
+import { runHooksCommand } from './hooks-cli.js'
 import { runSync } from './cli-verbs.js'
 import { DivergenceTypeSchema, type DivergenceType } from '@neat.is/types'
 import {
@@ -155,6 +156,14 @@ export function usage(): void {
   console.log('                 Flags:')
   console.log('                   --print-config   print the JSON snippet to stdout')
   console.log('                   --apply          merge mcpServers.neat into ~/.claude.json')
+  console.log('  hooks          Wire NEAT into your agent so it queries the graph before')
+  console.log('                 grepping. Installs a gentle Claude Code search-nudge hook and')
+  console.log('                 writes agent-agnostic graph-first guidance for other harnesses.')
+  console.log('                 Flags:')
+  console.log('                   --apply          install the hook + guidance')
+  console.log('                   --print-hook     print the hook script')
+  console.log('                   --print-guide    print the graph-first guidance')
+  console.log('                   --print-settings print the settings.json block --apply adds')
   console.log('  deploy         Detect the deploy substrate, generate NEAT_AUTH_TOKEN,')
   console.log('                 emit a docker-compose / systemd / docker run artifact, and')
   console.log('                 print the OTel env-vars block to paste into your platform.')
@@ -689,6 +698,9 @@ export async function runSkill(opts: SkillOptions): Promise<{ exitCode: number }
     await fs.writeFile(target, JSON.stringify(merged, null, 2) + '\n', 'utf8')
     console.log(`neat skill: wrote mcpServers.neat to ${target}`)
     console.log('restart Claude Code to pick up the new MCP server.')
+    console.log('')
+    console.log('Tip: run `neat hooks --apply` to also install the search-nudge hook, so')
+    console.log('your agent reaches for the graph before it grep-scans the repo.')
     return { exitCode: 0 }
   }
 
@@ -702,6 +714,9 @@ export async function runSkill(opts: SkillOptions): Promise<{ exitCode: number }
   console.log('')
   console.log('The MCP server reads NEAT_CORE_URL for the daemon URL — point it at a')
   console.log('non-default daemon by editing that value in the generated config.')
+  console.log('')
+  console.log('See also `neat hooks --apply` — the search-nudge hook + graph-first guidance')
+  console.log('that steer an agent to query the graph before falling back to text search.')
   return { exitCode: 0 }
 }
 
@@ -730,6 +745,15 @@ export async function main(): Promise<void> {
   // its own argv rather than routing through the shared query-flag table.
   if (cmd0 === 'connector') {
     const code = await runConnectorCommand(argv.slice(1))
+    if (code !== 0) process.exit(code)
+    return
+  }
+
+  // `neat hooks <--apply|--print-*>` — the Claude Code affordances that make an
+  // agent reach for NEAT's graph before it grep-scans. A config command family
+  // alongside `neat skill`, not a query verb, so it parses its own argv.
+  if (cmd0 === 'hooks') {
+    const code = await runHooksCommand(argv.slice(1))
     if (code !== 0) process.exit(code)
     return
   }

--- a/packages/core/src/hooks-cli.ts
+++ b/packages/core/src/hooks-cli.ts
@@ -1,0 +1,261 @@
+// `neat hooks` — install the Claude Code affordances that make an agent reach
+// for NEAT's graph before it grep-scans a repo.
+//
+// Two things ship here, and they cover different audiences:
+//
+//   1. A PreToolUse search-nudge hook. When the agent calls Grep/Glob (or a
+//      Bash grep|rg|find), Claude Code runs the hook, which injects a note
+//      steering the agent to NEAT's MCP tools first. It is a gentle nudge —
+//      the search still runs. This is a Claude-Code-specific affordance.
+//
+//   2. Agent-agnostic graph-first guidance (GRAPH_FIRST.md). A markdown block
+//      a user pastes into CLAUDE.md / AGENTS.md / .cursorrules so an agent on
+//      any harness — not just Claude Code — knows to query the graph first.
+//
+// Both artifacts live in @neat.is/claude-skill and are read from there at run
+// time. `--apply` copies the hook script to a stable ~/.neat/hooks/ path and
+// merges a PreToolUse entry into ~/.claude/settings.json without disturbing a
+// user's existing hooks. It is idempotent — re-running refreshes the path and
+// never double-registers.
+//
+// This is a config command family (like `neat connector`), not a query verb,
+// so it stays off the ADR-050 locked allowlist and parses its own argv.
+
+import path from 'node:path'
+import os from 'node:os'
+import { promises as fs } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+export const HOOK_FILENAME = 'neat-search-nudge.mjs'
+export const GUIDE_FILENAME = 'GRAPH_FIRST.md'
+// The materialised guide gets a lowercased name so it sits tidily beside the
+// other ~/.neat state; the package copy keeps the SCREAMING doc name.
+export const GUIDE_INSTALL_NAME = 'neat-graph-first.md'
+// One matcher covers both dedicated search tools and Bash; the hook self-filters
+// Bash down to grep-family commands, so a broad Bash match is a cheap no-op.
+export const HOOK_MATCHER = 'Grep|Glob|Bash'
+
+// Same dual-format base-dir idiom banner.ts uses: __dirname in the CJS build,
+// import.meta.url in the ESM one (tsup emits both).
+function moduleDir(): string {
+  return typeof __dirname !== 'undefined'
+    ? __dirname
+    : path.dirname(fileURLToPath(import.meta.url))
+}
+
+// Locate a file shipped in @neat.is/claude-skill. The @neat.is/ scope directory
+// mirrors the packages/ layout, so a fixed `../../claude-skill` walk lands in
+// both the published install (node_modules/@neat.is/{core,claude-skill}/…) and
+// the monorepo (packages/{core,claude-skill}/…). The extra candidates are
+// belt-and-suspenders for unusual dist depths.
+async function readSkillAsset(rel: string): Promise<string> {
+  const here = moduleDir()
+  const candidates = [
+    path.resolve(here, '../../claude-skill', rel),
+    path.resolve(here, '../../../claude-skill', rel),
+    path.resolve(here, '../claude-skill', rel),
+  ]
+  for (const candidate of candidates) {
+    try {
+      return await fs.readFile(candidate, 'utf8')
+    } catch {
+      // try the next candidate
+    }
+  }
+  throw new Error(
+    `neat hooks: could not find @neat.is/claude-skill/${rel} — is the package installed?`,
+  )
+}
+
+// ~/.neat, overridable via NEAT_HOME for tests (matches registry.ts).
+function neatHome(): string {
+  const override = process.env.NEAT_HOME
+  if (override && override.length > 0) return path.resolve(override)
+  return path.join(os.homedir(), '.neat')
+}
+
+// Claude Code's user-level settings file — where hooks live (distinct from
+// ~/.claude.json, which holds MCP servers; `neat skill` owns that one).
+// Overridable via NEAT_CLAUDE_SETTINGS so tests never touch the real file.
+function claudeSettingsPath(): string {
+  const override = process.env.NEAT_CLAUDE_SETTINGS
+  if (override && override.length > 0) return path.resolve(override)
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? os.homedir()
+  return path.join(home, '.claude', 'settings.json')
+}
+
+function installedHookPath(): string {
+  return path.join(neatHome(), 'hooks', HOOK_FILENAME)
+}
+
+interface PreToolUseEntry {
+  matcher?: string
+  hooks?: Array<{ type?: string; command?: string }>
+}
+
+// True when this settings entry is our search-nudge — keyed on the script
+// filename in the command, so a user who moved the file still gets refreshed
+// rather than duplicated.
+function isNeatSearchEntry(entry: PreToolUseEntry): boolean {
+  return (entry.hooks ?? []).some(
+    (h) => typeof h.command === 'string' && h.command.includes(HOOK_FILENAME),
+  )
+}
+
+function neatHookEntry(command: string): PreToolUseEntry {
+  return { matcher: HOOK_MATCHER, hooks: [{ type: 'command', command }] }
+}
+
+// The shell command Claude Code runs. Quoted so a home dir with spaces works.
+function hookCommand(scriptPath: string): string {
+  return `node "${scriptPath}"`
+}
+
+export interface HooksOptions {
+  apply: boolean
+  printHook: boolean
+  printGuide: boolean
+  printSettings: boolean
+}
+
+export async function runHooks(opts: HooksOptions): Promise<{ exitCode: number }> {
+  if (opts.printHook) {
+    process.stdout.write(await readSkillAsset(`hooks/${HOOK_FILENAME}`))
+    return { exitCode: 0 }
+  }
+
+  if (opts.printGuide) {
+    process.stdout.write(await readSkillAsset(GUIDE_FILENAME))
+    return { exitCode: 0 }
+  }
+
+  if (opts.printSettings) {
+    // Show the block a manual installer would paste, pointing at the path
+    // `--apply` would materialise.
+    const block = {
+      hooks: { PreToolUse: [neatHookEntry(hookCommand(installedHookPath()))] },
+    }
+    process.stdout.write(JSON.stringify(block, null, 2) + '\n')
+    return { exitCode: 0 }
+  }
+
+  if (opts.apply) {
+    const hookScript = await readSkillAsset(`hooks/${HOOK_FILENAME}`)
+    const guide = await readSkillAsset(GUIDE_FILENAME)
+
+    // 1. Materialise the hook script to a stable, upgrade-surviving path.
+    const scriptPath = installedHookPath()
+    await fs.mkdir(path.dirname(scriptPath), { recursive: true })
+    await fs.writeFile(scriptPath, hookScript, { mode: 0o755 })
+
+    // 2. Drop the agent-agnostic guidance beside it for easy reference.
+    const guidePath = path.join(neatHome(), GUIDE_INSTALL_NAME)
+    await fs.writeFile(guidePath, guide, 'utf8')
+
+    // 3. Merge the PreToolUse entry into ~/.claude/settings.json, leaving any
+    //    hooks the user wired by hand in place.
+    const settingsFile = claudeSettingsPath()
+    let settings: Record<string, unknown> = {}
+    try {
+      settings = JSON.parse(await fs.readFile(settingsFile, 'utf8'))
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.error(
+          `neat hooks: failed to read ${settingsFile} — ${(err as Error).message}`,
+        )
+        return { exitCode: 1 }
+      }
+    }
+
+    const hooks = (settings.hooks ?? {}) as Record<string, unknown>
+    const preToolUse = Array.isArray(hooks.PreToolUse)
+      ? [...(hooks.PreToolUse as PreToolUseEntry[])]
+      : []
+
+    const command = hookCommand(scriptPath)
+    const existingIdx = preToolUse.findIndex(isNeatSearchEntry)
+    if (existingIdx >= 0) {
+      preToolUse[existingIdx] = neatHookEntry(command)
+    } else {
+      preToolUse.push(neatHookEntry(command))
+    }
+
+    const merged = {
+      ...settings,
+      hooks: { ...hooks, PreToolUse: preToolUse },
+    }
+    await fs.mkdir(path.dirname(settingsFile), { recursive: true })
+    await fs.writeFile(settingsFile, JSON.stringify(merged, null, 2) + '\n', 'utf8')
+
+    console.log(`neat hooks: installed the search-nudge hook`)
+    console.log(`  script:   ${scriptPath}`)
+    console.log(`  settings: ${settingsFile} (PreToolUse → ${HOOK_MATCHER})`)
+    console.log(`  guidance: ${guidePath}`)
+    console.log('')
+    console.log('restart Claude Code to load the hook. On a Grep/Glob or a Bash grep,')
+    console.log('your agent will now be nudged to query NEAT first.')
+    console.log('')
+    console.log('The hook is Claude-Code-specific. For agents on other harnesses, paste')
+    console.log(`the guidance above into your project instructions (CLAUDE.md / AGENTS.md).`)
+    return { exitCode: 0 }
+  }
+
+  usage()
+  return { exitCode: 0 }
+}
+
+function usage(): void {
+  console.log('neat hooks — wire NEAT into your agent so it queries the graph before grepping')
+  console.log('')
+  console.log('  --apply          install the Claude Code search-nudge hook and write the')
+  console.log('                   graph-first guidance to ~/.neat/, merging into')
+  console.log('                   ~/.claude/settings.json without touching your other hooks')
+  console.log('  --print-hook     print the hook script to stdout')
+  console.log('  --print-guide    print the agent-agnostic graph-first guidance to stdout')
+  console.log('  --print-settings print the settings.json PreToolUse block --apply would add')
+  console.log('')
+  console.log('The hook is a gentle, non-blocking nudge — searches still run. It is')
+  console.log('Claude-Code-specific; other harnesses get the same steer from the guidance.')
+}
+
+// Parse this command family's own argv and dispatch. Mirrors runConnectorCommand
+// — a config command, not a locked query verb.
+export async function runHooksCommand(args: string[]): Promise<number> {
+  const opts: HooksOptions = {
+    apply: false,
+    printHook: false,
+    printGuide: false,
+    printSettings: false,
+  }
+  for (const arg of args) {
+    switch (arg) {
+      case '--apply':
+        opts.apply = true
+        break
+      case '--print-hook':
+        opts.printHook = true
+        break
+      case '--print-guide':
+        opts.printGuide = true
+        break
+      case '--print-settings':
+        opts.printSettings = true
+        break
+      case '-h':
+      case '--help':
+        usage()
+        return 0
+      default:
+        console.error(`neat hooks: unknown flag "${arg}"`)
+        usage()
+        return 2
+    }
+  }
+  try {
+    const { exitCode } = await runHooks(opts)
+    return exitCode
+  } catch (err) {
+    console.error((err as Error).message)
+    return 1
+  }
+}

--- a/packages/core/test/hooks-cli.test.ts
+++ b/packages/core/test/hooks-cli.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import os from 'node:os'
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import { execFile } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { runHooks, runHooksCommand, HOOK_MATCHER } from '../src/hooks-cli.js'
+
+// The affordances that make an agent reach for NEAT's graph before it
+// grep-scans: a Claude Code PreToolUse search-nudge hook, and agent-agnostic
+// graph-first guidance. Everything runs against a temp NEAT_HOME + a temp
+// settings file, never the real ones.
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const SKILL_DIR = path.resolve(here, '../../claude-skill')
+const SHIPPED_HOOK = path.join(SKILL_DIR, 'hooks/neat-search-nudge.mjs')
+const SHIPPED_GUIDE = path.join(SKILL_DIR, 'GRAPH_FIRST.md')
+
+const tmpDirs: string[] = []
+
+async function makeTmp(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-hooks-cli-'))
+  const real = await fs.realpath(dir)
+  tmpDirs.push(real)
+  return real
+}
+
+// Run runHooks with a temp home + settings file, capturing stdout/stderr.
+async function withTmpEnv<T>(
+  fn: (env: { home: string; settings: string }) => Promise<T>,
+): Promise<T> {
+  const root = await makeTmp()
+  const home = path.join(root, 'neat')
+  const settings = path.join(root, 'claude', 'settings.json')
+  const prevHome = process.env.NEAT_HOME
+  const prevSettings = process.env.NEAT_CLAUDE_SETTINGS
+  const prevLog = console.log
+  const prevErr = console.error
+  process.env.NEAT_HOME = home
+  process.env.NEAT_CLAUDE_SETTINGS = settings
+  console.log = () => {}
+  console.error = () => {}
+  try {
+    return await fn({ home, settings })
+  } finally {
+    console.log = prevLog
+    console.error = prevErr
+    if (prevHome === undefined) delete process.env.NEAT_HOME
+    else process.env.NEAT_HOME = prevHome
+    if (prevSettings === undefined) delete process.env.NEAT_CLAUDE_SETTINGS
+    else process.env.NEAT_CLAUDE_SETTINGS = prevSettings
+  }
+}
+
+// Feed a PreToolUse payload to the shipped hook script as a real child process
+// and return the parsed stdout (or null when it stayed a silent no-op).
+function runHookScript(
+  payload: unknown,
+): Promise<{ stdout: string; parsed: unknown | null }> {
+  return new Promise((resolve, reject) => {
+    const child = execFile('node', [SHIPPED_HOOK], (err, stdout) => {
+      if (err) return reject(err)
+      const trimmed = stdout.trim()
+      resolve({ stdout, parsed: trimmed ? JSON.parse(trimmed) : null })
+    })
+    child.stdin!.end(JSON.stringify(payload))
+  })
+}
+
+afterEach(async () => {
+  while (tmpDirs.length > 0) {
+    await fs.rm(tmpDirs.pop()!, { recursive: true, force: true }).catch(() => {})
+  }
+})
+
+describe('neat hooks — search-nudge hook (the shipped affordance)', () => {
+  it('fires on a Grep tool call with a non-blocking PreToolUse nudge', async () => {
+    const { parsed } = await runHookScript({
+      tool_name: 'Grep',
+      tool_input: { pattern: 'foo' },
+    })
+    expect(parsed).not.toBeNull()
+    const out = parsed as {
+      hookSpecificOutput: { hookEventName: string; additionalContext: string }
+    }
+    expect(out.hookSpecificOutput.hookEventName).toBe('PreToolUse')
+    // It nudges toward the graph tools — and never denies the call.
+    expect(out.hookSpecificOutput.additionalContext).toMatch(/semantic_search/)
+    expect(out.hookSpecificOutput.additionalContext).toMatch(/get_divergences/)
+    expect(JSON.stringify(out)).not.toMatch(/permissionDecision/)
+  })
+
+  it('fires on Glob and on a Bash grep/find, but not on other Bash', async () => {
+    expect((await runHookScript({ tool_name: 'Glob', tool_input: { pattern: '**/*.ts' } })).parsed).not.toBeNull()
+    expect((await runHookScript({ tool_name: 'Bash', tool_input: { command: 'grep -r foo src/' } })).parsed).not.toBeNull()
+    expect((await runHookScript({ tool_name: 'Bash', tool_input: { command: 'rg foo' } })).parsed).not.toBeNull()
+    expect((await runHookScript({ tool_name: 'Bash', tool_input: { command: 'find . -name x' } })).parsed).not.toBeNull()
+    // A Bash command that isn't a search stays a silent no-op.
+    expect((await runHookScript({ tool_name: 'Bash', tool_input: { command: 'ls -la' } })).parsed).toBeNull()
+    // A path that merely contains "find"/"grep" as a substring doesn't trip it.
+    expect((await runHookScript({ tool_name: 'Bash', tool_input: { command: 'node ./scripts/finder.js' } })).parsed).toBeNull()
+  })
+
+  it('is a silent no-op on non-search tools (Read/Write/Edit)', async () => {
+    for (const tool_name of ['Read', 'Write', 'Edit']) {
+      const { stdout, parsed } = await runHookScript({ tool_name, tool_input: { file_path: '/x' } })
+      expect(parsed).toBeNull()
+      expect(stdout.trim()).toBe('')
+    }
+  })
+})
+
+describe('neat hooks --apply', () => {
+  it('materialises the hook script + guidance and wires a PreToolUse entry', async () => {
+    await withTmpEnv(async ({ home, settings }) => {
+      const { exitCode } = await runHooks({ apply: true, printHook: false, printGuide: false, printSettings: false })
+      expect(exitCode).toBe(0)
+
+      const scriptPath = path.join(home, 'hooks', 'neat-search-nudge.mjs')
+      const installed = await fs.readFile(scriptPath, 'utf8')
+      const shipped = await fs.readFile(SHIPPED_HOOK, 'utf8')
+      expect(installed).toBe(shipped)
+
+      const guide = await fs.readFile(path.join(home, 'neat-graph-first.md'), 'utf8')
+      expect(guide).toBe(await fs.readFile(SHIPPED_GUIDE, 'utf8'))
+
+      const parsed = JSON.parse(await fs.readFile(settings, 'utf8'))
+      const entries = parsed.hooks.PreToolUse
+      expect(Array.isArray(entries)).toBe(true)
+      const neat = entries.find((e: { matcher?: string }) => e.matcher === HOOK_MATCHER)
+      expect(neat).toBeDefined()
+      expect(neat.hooks[0].type).toBe('command')
+      expect(neat.hooks[0].command).toContain('neat-search-nudge.mjs')
+    })
+  })
+
+  it('leaves a user\'s existing hooks and settings untouched', async () => {
+    await withTmpEnv(async ({ settings }) => {
+      await fs.mkdir(path.dirname(settings), { recursive: true })
+      await fs.writeFile(
+        settings,
+        JSON.stringify({
+          hooks: { PreToolUse: [{ matcher: 'Write', hooks: [{ type: 'command', command: 'echo mine' }] }] },
+          model: 'opus',
+        }),
+      )
+      await runHooks({ apply: true, printHook: false, printGuide: false, printSettings: false })
+      const parsed = JSON.parse(await fs.readFile(settings, 'utf8'))
+      expect(parsed.model).toBe('opus')
+      const mine = parsed.hooks.PreToolUse.find((e: { matcher?: string }) => e.matcher === 'Write')
+      expect(mine.hooks[0].command).toBe('echo mine')
+      // Both the user's entry and ours are present.
+      expect(parsed.hooks.PreToolUse.length).toBe(2)
+    })
+  })
+
+  it('is idempotent — re-applying refreshes rather than duplicating', async () => {
+    await withTmpEnv(async ({ settings }) => {
+      await runHooks({ apply: true, printHook: false, printGuide: false, printSettings: false })
+      await runHooks({ apply: true, printHook: false, printGuide: false, printSettings: false })
+      const parsed = JSON.parse(await fs.readFile(settings, 'utf8'))
+      const neatEntries = parsed.hooks.PreToolUse.filter((e: { matcher?: string }) => e.matcher === HOOK_MATCHER)
+      expect(neatEntries.length).toBe(1)
+    })
+  })
+})
+
+describe('neat hooks — print flags & argv', () => {
+  it('--print-hook and --print-guide emit the shipped files verbatim', async () => {
+    const out: string[] = []
+    const prev = process.stdout.write.bind(process.stdout)
+    ;(process.stdout.write as unknown) = (chunk: string) => {
+      out.push(chunk)
+      return true
+    }
+    try {
+      await runHooks({ apply: false, printHook: true, printGuide: false, printSettings: false })
+      await runHooks({ apply: false, printHook: false, printGuide: true, printSettings: false })
+    } finally {
+      ;(process.stdout.write as unknown) = prev
+    }
+    expect(out[0]).toBe(await fs.readFile(SHIPPED_HOOK, 'utf8'))
+    expect(out[1]).toBe(await fs.readFile(SHIPPED_GUIDE, 'utf8'))
+  })
+
+  it('rejects an unknown flag with exit code 2', async () => {
+    const prevErr = console.error
+    const prevLog = console.log
+    console.error = () => {}
+    console.log = () => {}
+    try {
+      expect(await runHooksCommand(['--bogus'])).toBe(2)
+    } finally {
+      console.error = prevErr
+      console.log = prevLog
+    }
+  })
+})


### PR DESCRIPTION
The pitch is that an agent with NEAT's graph as its eyes works better than one grepping and guessing — but wiring the MCP tools in doesn't make the agent *use* them. Left alone, it reaches straight for `Grep`/`Glob`/`find`. This ships the affordances that flip that default.

`neat hooks --apply` installs two nudges:

- **A Claude Code `PreToolUse` search-nudge hook.** When the agent calls `Grep`, `Glob`, or a Bash `grep`/`rg`/`find`, the hook injects a short note steering it toward `semantic_search`, `get_dependencies`, and `get_divergences` first. It's a **gentle, non-blocking nudge** — the search still runs. The entry merges into `~/.claude/settings.json` without disturbing a user's existing hooks, and re-applying is idempotent.
- **Agent-agnostic graph-first guidance** (`GRAPH_FIRST.md`, also written to `~/.neat/neat-graph-first.md`). A markdown block a user pastes into `CLAUDE.md` / `AGENTS.md` / `.cursorrules` so agents on any harness get the same steer.

Both artifacts ship in `@neat.is/claude-skill` and are read from there at apply time. `neat skill` now points at `neat hooks`, so a user setting NEAT up finds both. `--print-hook` / `--print-guide` / `--print-settings` show each piece without installing.

**Honest limit:** the hook is Claude-Code-specific — it depends on Claude Code's `PreToolUse` mechanism. Agents on Codex / Gemini / Cursor get the guidance block, not the interception.

### How this was verified
- Fed sample `PreToolUse` payloads to the shipped hook script as a real child process: it fires on `Grep`, `Glob`, and a Bash `grep`/`rg`/`find` (emitting a non-blocking `additionalContext` nudge, exit 0), and stays a silent no-op on `Read`/`Write`/other Bash. A path that merely contains "find" as a substring doesn't trip it.
- `neat hooks --apply` end-to-end against temp dirs: materializes the script (0755) + guidance, merges the `PreToolUse` entry while leaving an existing user hook and unrelated settings intact, and is idempotent across repeated applies.
- `--print-hook` / `--print-guide` emit the shipped files byte-for-byte.
- New suite `packages/core/test/hooks-cli.test.ts` (8 tests) covers all of the above; `turbo build` + `turbo lint` clean on core and claude-skill.
- Confirmed the schema against the current Claude Code hooks docs: non-blocking context injection via `hookSpecificOutput.additionalContext` + exit 0, user-level hooks live in `~/.claude/settings.json` (distinct from `~/.claude.json` where MCP config lives).

Pre-existing `test/otlp-port-step.test.ts` timeouts are unrelated — they reproduce identically on base with `cli.ts` reverted; this branch touches none of the watch/OTLP/daemon code.

Refs #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)