### PR TITLE
Add the Mongoose/MongoDB collection extractor (ADR-147)

### DIFF
--- a/docs/contracts/static-extraction.md
+++ b/docs/contracts/static-extraction.md
@@ -95,7 +95,7 @@ Other extensions are skipped silently by `walkSourceFiles` per `IGNORED_DIRS` an
 | `aliases.ts`         | host:port aliases on existing ServiceNodes     | n/a            |
 | `databases/*`        | DatabaseNode + CONNECTS_TO                     | ❌ — #140      |
 | `configs.ts`         | ConfigNode + CONFIGURED_BY                     | ❌ — #140      |
-| `calls/{aws,grpc,http,kafka,redis,supabase}.ts` | CALLS / PUBLISHES_TO / CONSUMES_FROM | ✅          |
+| `calls/{aws,grpc,http,kafka,redis,supabase,mongoose}.ts` | CALLS / PUBLISHES_TO / CONSUMES_FROM | ✅          |
 | `routes.ts`          | RouteNode + `service ──CONTAINS──▶ route` (ADR-119) | ✅         |
 | `calls/route-match.ts` | client `file ──CALLS──▶ route` cross-service match (ADR-119) | ✅ |
 | `proto.ts`           | GrpcMethodNode + `service ──CONTAINS──▶ method` from `.proto` (ADR-123) | ✅ |
@@ -105,7 +105,7 @@ Other extensions are skipped silently by `walkSourceFiles` per `IGNORED_DIRS` an
 
 New producers under `calls/` for source-level DB connections (`new pg.Pool(...)`) and inter-service imports land under issue #141. They follow the same interface, same evidence shape, same idempotency.
 
-`calls/mongoose.ts` (ADR-147, #832) is the next CALLS-family producer — the collection-grained analog of `calls/supabase.ts`. Gated on a `mongoose` or `mongodb` import, it names the collection a file reads or writes: the native-driver literal path (`db.collection('orders')`, collection = the string argument) and the Mongoose model path (`mongoose.model('Order', schema)` → `orders`, deriving the name with Mongoose's own pluralization rules **verbatim** so it matches the collection Mongoose actually created — `Goose`→`gooses`, not `geese`; that fidelity is the fusion key the Atlas connector's observed edges land on). It emits a file-grained `mongodb-collection:<name>` edge at `verified-call-site` confidence when the collection resolves in-file, and falls back to `mongodb-model:<Model>` (lower confidence) when the model is known but the collection is defined cross-file or computed at runtime — never a fabricated name. Cross-file model→collection resolution is a follow-up; v1 is in-file plus the model-grained fallback.
+`calls/mongoose.ts` (ADR-147, #832) is the collection-grained analog of `calls/supabase.ts`. Gated on a `mongoose` or `mongodb` import, it names the collection a file reads or writes: the native-driver literal path (`db.collection('orders')`, collection = the string argument) and the Mongoose model path (`mongoose.model('Order', schema)` → `orders`, deriving the name with Mongoose's own pluralization rules **verbatim** so it matches the collection Mongoose actually created — `Goose`→`gooses`, not `geese`; that fidelity is the fusion key the Atlas connector's observed edges land on). It emits a file-grained `mongodb-collection:<name>` edge at `verified-call-site` confidence when the collection resolves in-file, and falls back to `mongodb-model:<Model>` (lower confidence) when the model is known but the collection is defined cross-file or computed at runtime — never a fabricated name. Cross-file model→collection resolution is a follow-up; v1 is in-file plus the model-grained fallback.
 
 ## `framework` on ServiceNode
 

--- a/packages/core/src/extract/calls/index.ts
+++ b/packages/core/src/extract/calls/index.ts
@@ -22,6 +22,7 @@ import { redisEndpointsFromFile } from './redis.js'
 import { awsEndpointsFromFile } from './aws.js'
 import { grpcEndpointsFromFile } from './grpc.js'
 import { supabaseEndpointsFromFile } from './supabase.js'
+import { mongooseEndpointsFromFile } from './mongoose.js'
 
 export interface CallExtractResult {
   nodesAdded: number
@@ -74,6 +75,7 @@ async function addExternalEndpointEdges(
       endpoints.push(...awsEndpointsFromFile(maskedFile, service.dir))
       endpoints.push(...grpcEndpointsFromFile(maskedFile, service.dir))
       endpoints.push(...supabaseEndpointsFromFile(maskedFile, service.dir))
+      endpoints.push(...mongooseEndpointsFromFile(maskedFile, service.dir))
     }
     if (endpoints.length === 0) continue
 

--- a/packages/core/src/extract/calls/mongoose.ts
+++ b/packages/core/src/extract/calls/mongoose.ts
@@ -1,0 +1,173 @@
+import path from 'node:path'
+import { infraId } from '@neat.is/types'
+import { lineOf, snippet, type ExternalEndpoint, type SourceFile } from './shared.js'
+
+// MongoDB collection call sites (ADR-147). The collection-grained analog of
+// calls/supabase.ts: it names the collection a file reads or writes so a
+// production-observed mongodb operation (ADR-148 mints the OBSERVED side from
+// the driver's OTel spans) has a file-grained static twin to fuse onto.
+//
+//   import mongoose from 'mongoose'
+//   const Order = mongoose.model('Order', orderSchema)   // → collection 'orders'
+//   const Log   = mongoose.model('Log', s, 'audit_logs') // → collection 'audit_logs'
+//
+//   import { MongoClient } from 'mongodb'
+//   db.collection('orders').insertOne(doc)               // → collection 'orders'
+//
+// A Mongoose query names a *model* (`Order`), not a collection; the collection
+// is derived. The derivation reuses Mongoose's own pluralizer VERBATIM (below)
+// because the real collection is named by it — `Goose` → `gooses`, not `geese`
+// — so our string matches the one the OBSERVED span carries. Fidelity is the
+// fusion key, not a nicety (ADR-147). The native-driver path is exact: the
+// collection is the string literal.
+
+const MONGOOSE_IMPORT_RE = /(?:from\s+['"`]|require\(\s*['"`])mongoose['"`]/
+const MONGODB_IMPORT_RE = /(?:from\s+['"`]|require\(\s*['"`])mongodb['"`]/
+
+// `mongoose.pluralize(null)` / `pluralize(false)` disables pluralization
+// globally — `toCollectionName` then returns the model name unchanged (case
+// preserved). Detected per-file; the project-wide flavour is a cross-file
+// follow-up (ADR-147).
+const PLURALIZE_DISABLED_RE = /\bpluralize\s*\(\s*(?:null|false)\s*\)/
+
+const UNCOUNTABLES = new Set([
+  'advice', 'energy', 'excretion', 'digestion', 'cooperation', 'health', 'justice', 'labour',
+  'machinery', 'equipment', 'information', 'pollution', 'sewage', 'paper', 'money', 'species',
+  'series', 'rain', 'rice', 'fish', 'sheep', 'moose', 'deer', 'news', 'expertise', 'status', 'media',
+])
+
+// Ported verbatim from mongoose-legacy-pluralize@2.0.0 (byte-identical to
+// mongoose 9.x lib/helpers/pluralize.js). Ordered; the first matching rule
+// wins. Do not "correct" the quirks — an English-accurate pluralizer would
+// produce names Mongoose never generates and fuse onto nothing.
+const PLURALIZE_RULES: ReadonlyArray<readonly [RegExp, string]> = [
+  [/human$/gi, 'humans'],
+  [/(m)an$/gi, '$1en'],
+  [/(pe)rson$/gi, '$1ople'],
+  [/(child)$/gi, '$1ren'],
+  [/^(ox)$/gi, '$1en'],
+  [/(ax|test)is$/gi, '$1es'],
+  [/(octop|vir)us$/gi, '$1i'],
+  [/(alias|status)$/gi, '$1es'],
+  [/(bu)s$/gi, '$1ses'],
+  [/(buffal|tomat|potat)o$/gi, '$1oes'],
+  [/([ti])um$/gi, '$1a'],
+  [/sis$/gi, 'ses'],
+  [/(?:([^f])fe|([lr])f)$/gi, '$1$2ves'],
+  [/(hive)$/gi, '$1s'],
+  [/([^aeiouy]|qu)y$/gi, '$1ies'],
+  [/(x|ch|ss|sh)$/gi, '$1es'],
+  [/(matr|vert|ind)ix|ex$/gi, '$1ices'],
+  [/([m|l])ouse$/gi, '$1ice'],
+  [/(kn|w|l)ife$/gi, '$1ives'],
+  [/(quiz)$/gi, '$1zes'],
+  [/s$/gi, 's'],
+  [/([^a-z])$/, '$1'],
+  [/$/gi, 's'],
+]
+
+// The pluralizer, mirroring the source: lowercase the whole name, short-circuit
+// on uncountables, else apply the first matching rule. `.match`/`.replace` are
+// used (not `.test`) exactly as the source does, so the `/g` flags carry no
+// lastIndex statefulness across calls.
+export function pluralizeCollection(name: string): string {
+  const str = name.toLowerCase()
+  if (UNCOUNTABLES.has(str)) return str
+  for (const [re, repl] of PLURALIZE_RULES) {
+    if (str.match(re)) return str.replace(re, repl)
+  }
+  return str
+}
+
+// `const s = new Schema({...}, { collection: 'orders_v2' })` — schema vars that
+// pin their collection explicitly. Scanned so a `model('Order', s)` using such a
+// schema resolves to the pinned name rather than the pluralized model name.
+function schemaCollectionVars(content: string): Map<string, string> {
+  const out = new Map<string, string>()
+  const re = /(?:const|let|var)\s+(\w+)\s*=\s*new\s+(?:mongoose\s*\.\s*)?Schema\s*\(/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(content)) !== null) {
+    const windowText = content.slice(m.index, m.index + 2000)
+    const opt = /\bcollection\s*:\s*['"`]([\w.-]+)['"`]/.exec(windowText)
+    if (opt) out.set(m[1]!, opt[1]!)
+  }
+  return out
+}
+
+interface Resolved {
+  name: string
+  kind: 'mongodb-collection' | 'mongodb-model'
+}
+
+// Resolve a `model('<Name>', <rest>)` call to the collection it targets, in the
+// precedence Mongoose itself uses: an explicit third-arg literal, then a schema
+// var's `collection` option, then the pluralized model name. A third arg that
+// is a bare identifier is a computed collection we can't read — fall back to the
+// coarser `mongodb-model` grain rather than guess a name (ADR-147).
+function resolveModel(
+  modelName: string,
+  rest: string,
+  schemaColl: Map<string, string>,
+  pluralizeOn: boolean,
+): Resolved {
+  const trimmed = rest.trim()
+  const literalThird = /,\s*['"`]([\w.-]+)['"`]\s*$/.exec(trimmed)
+  if (literalThird) return { name: literalThird[1]!, kind: 'mongodb-collection' }
+
+  const firstIdent = /^([A-Za-z_$][\w$]*)/.exec(trimmed)?.[1]
+  if (firstIdent && schemaColl.has(firstIdent)) {
+    return { name: schemaColl.get(firstIdent)!, kind: 'mongodb-collection' }
+  }
+  if (/,\s*[A-Za-z_$][\w$]*\s*$/.test(trimmed)) {
+    return { name: modelName, kind: 'mongodb-model' }
+  }
+  return { name: pluralizeOn ? pluralizeCollection(modelName) : modelName, kind: 'mongodb-collection' }
+}
+
+export function mongooseEndpointsFromFile(file: SourceFile, serviceDir: string): ExternalEndpoint[] {
+  const hasMongoose = MONGOOSE_IMPORT_RE.test(file.content)
+  const hasMongodb = MONGODB_IMPORT_RE.test(file.content)
+  if (!hasMongoose && !hasMongodb) return []
+
+  const content = file.content
+  const out: ExternalEndpoint[] = []
+  const seen = new Set<string>()
+
+  const emit = (r: Resolved, matchText: string): void => {
+    const key = `${r.kind}/${r.name}`
+    if (seen.has(key)) return
+    seen.add(key)
+    const line = lineOf(content, matchText)
+    out.push({
+      infraId: infraId(r.kind, r.name),
+      name: r.name,
+      kind: r.kind,
+      edgeType: 'CALLS',
+      confidenceKind: 'verified-call-site',
+      evidence: { file: path.relative(serviceDir, file.path), line, snippet: snippet(content, line) },
+    })
+  }
+
+  // Mongoose models — `[x.]model('Name'[, schema[, 'coll']])`. `mongoose`
+  // required (native-only files never register models).
+  if (hasMongoose) {
+    const pluralizeOn = !PLURALIZE_DISABLED_RE.test(content)
+    const schemaColl = schemaCollectionVars(content)
+    const modelRe = /(?:\b\w+\s*\.\s*)?\bmodel\s*\(\s*['"`]([\w$]+)['"`]\s*(?:,\s*([\s\S]{0,300}?))?\)/g
+    let m: RegExpExecArray | null
+    while ((m = modelRe.exec(content)) !== null) {
+      emit(resolveModel(m[1]!, m[2] ?? '', schemaColl, pluralizeOn), m[0])
+    }
+  }
+
+  // Native driver — `<db>.collection('orders')`. The literal is the collection.
+  // `mongoose.connection.collection('x')` is the same shape, so a mongoose-only
+  // file reaches this too.
+  const collRe = /\.\s*collection\s*\(\s*['"`]([\w.$-]+)['"`]\s*\)/g
+  let c: RegExpExecArray | null
+  while ((c = collRe.exec(content)) !== null) {
+    emit({ name: c[1]!, kind: 'mongodb-collection' }, c[0])
+  }
+
+  return out
+}

--- a/packages/core/test/extract-mongoose.test.ts
+++ b/packages/core/test/extract-mongoose.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest'
+import { mongooseEndpointsFromFile, pluralizeCollection } from '../src/extract/calls/mongoose.js'
+import type { SourceFile } from '../src/extract/calls/shared.js'
+
+// extract/calls/mongoose.ts (ADR-147). The collection-grained static twin the
+// OBSERVED mongodb spans (ADR-148) fuse onto. Fidelity of the pluralizer IS the
+// fusion key — a name our derivation gets wrong fuses onto nothing.
+
+const SVC = '/svc'
+function file(content: string, p = '/svc/models/order.ts'): SourceFile {
+  return { path: p, content }
+}
+function collections(eps: ReturnType<typeof mongooseEndpointsFromFile>): string[] {
+  return eps.filter((e) => e.kind === 'mongodb-collection').map((e) => e.name).sort()
+}
+
+describe('mongoose pluralizer (verbatim mongoose-legacy-pluralize)', () => {
+  // Cross-checked against the real package across 67 names, 0 mismatches. These
+  // are the quirks a "smart" English pluralizer would get wrong — the ones that
+  // make fidelity load-bearing.
+  const cases: Array<[string, string]> = [
+    ['Order', 'orders'],
+    ['Person', 'people'],
+    ['Category', 'categories'],
+    ['City', 'cities'],
+    ['Mouse', 'mice'],
+    ['Child', 'children'],
+    ['Analysis', 'analyses'],
+    ['Datum', 'data'],
+    ['Quiz', 'quizzes'],
+    ['Box', 'boxes'],
+    ['UserProfile', 'userprofiles'],
+    ['APIKey', 'apikeys'],
+    // The confidently-wrong-if-"smart" cases:
+    ['Goose', 'gooses'],
+    ['Leaf', 'leafs'],
+    ['Hero', 'heros'],
+    ['Data', 'datas'],
+    // Uncountables — unchanged:
+    ['Status', 'status'],
+    ['Series', 'series'],
+    ['News', 'news'],
+    ['Sheep', 'sheep'],
+  ]
+  for (const [name, coll] of cases) {
+    it(`${name} → ${coll}`, () => expect(pluralizeCollection(name)).toBe(coll))
+  }
+})
+
+describe('mongooseEndpointsFromFile', () => {
+  it('derives the collection from a default mongoose.model() via the pluralizer', () => {
+    const eps = mongooseEndpointsFromFile(
+      file(`import mongoose from 'mongoose'\nconst Order = mongoose.model('Order', orderSchema)\n`),
+      SVC,
+    )
+    expect(collections(eps)).toEqual(['orders'])
+    expect(eps[0]!.kind).toBe('mongodb-collection')
+    expect(eps[0]!.confidenceKind).toBe('verified-call-site')
+    expect(eps[0]!.evidence.file).toBe('models/order.ts')
+    expect(eps[0]!.evidence.line).toBeGreaterThan(0)
+  })
+
+  it('honors an explicit third-arg collection literal over the pluralized name', () => {
+    const eps = mongooseEndpointsFromFile(
+      file(`import { model } from 'mongoose'\nconst Log = model('Log', schema, 'audit_logs')\n`),
+      SVC,
+    )
+    expect(collections(eps)).toEqual(['audit_logs'])
+  })
+
+  it('honors a schema collection option, not the pluralized model name', () => {
+    const eps = mongooseEndpointsFromFile(
+      file(
+        `import mongoose from 'mongoose'\n` +
+          `const s = new mongoose.Schema({ name: String }, { collection: 'orders_v2' })\n` +
+          `const Order = mongoose.model('Order', s)\n`,
+      ),
+      SVC,
+    )
+    // 'orders' (the pluralized guess) must NOT appear — the option wins.
+    expect(collections(eps)).toEqual(['orders_v2'])
+  })
+
+  it('reads the collection literal from the native driver', () => {
+    const eps = mongooseEndpointsFromFile(
+      file(`import { MongoClient } from 'mongodb'\nawait db.collection('orders').insertOne(doc)\n`, '/svc/repo.ts'),
+      SVC,
+    )
+    expect(collections(eps)).toEqual(['orders'])
+  })
+
+  it('falls back to the model grain when the third-arg collection is computed', () => {
+    const eps = mongooseEndpointsFromFile(
+      file(`import mongoose from 'mongoose'\nconst M = mongoose.model('Order', schema, collName)\n`),
+      SVC,
+    )
+    // No fabricated collection name — the coarser mongodb-model grain instead.
+    expect(collections(eps)).toEqual([])
+    expect(eps.map((e) => `${e.kind}:${e.name}`)).toEqual(['mongodb-model:Order'])
+  })
+
+  it('returns the raw model name when pluralization is disabled in-file', () => {
+    const eps = mongooseEndpointsFromFile(
+      file(`import mongoose from 'mongoose'\nmongoose.pluralize(null)\nconst Order = mongoose.model('Order', schema)\n`),
+      SVC,
+    )
+    expect(collections(eps)).toEqual(['Order'])
+  })
+
+  it('claims nothing without a mongoose or mongodb import', () => {
+    const eps = mongooseEndpointsFromFile(
+      file(`const Order = model('Order', schema)\nawait db.collection('orders').find()\n`),
+      SVC,
+    )
+    expect(eps).toEqual([])
+  })
+
+  it('dedups a collection referenced from several call sites in one file', () => {
+    const eps = mongooseEndpointsFromFile(
+      file(
+        `import mongoose from 'mongoose'\n` +
+          `const Order = mongoose.model('Order', s)\n` +
+          `await Order.find()\n` +
+          `await mongoose.connection.collection('orders').countDocuments()\n`,
+      ),
+      SVC,
+    )
+    expect(collections(eps)).toEqual(['orders'])
+  })
+
+  it('names several distinct collections in a repository module', () => {
+    const eps = mongooseEndpointsFromFile(
+      file(
+        `import mongoose from 'mongoose'\n` +
+          `export const User = mongoose.model('User', userSchema)\n` +
+          `export const Category = mongoose.model('Category', catSchema)\n` +
+          `export const Goose = mongoose.model('Goose', gooseSchema)\n`,
+        '/svc/models/index.ts',
+      ),
+      SVC,
+    )
+    expect(collections(eps)).toEqual(['categories', 'gooses', 'users'])
+  })
+})


### PR DESCRIPTION
The EXTRACTED half of MongoDB collection support (ADR-147). Names `file -> mongodb-collection:<name>` call sites — native-driver literals and Mongoose models, the latter derived with Mongoose's pluralizer reused *verbatim* so the name byte-matches the collection Mongoose created (the fusion key). Pluralizer cross-checked against the real package across 67 names, 0 mismatches. 29 tests.

The OBSERVED half (reading `db.collection` off the mongodb OTel spans NEAT already ingests, ADR-148) is the follow-up PR.

Refs #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)