### PR TITLE
Read db.collection off mongodb spans into a collection-grained OBSERVED edge (ADR-148)

### DIFF
--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -1708,6 +1708,29 @@ export async function handleSpan(ctx: IngestContext, span: ParsedSpan): Promise<
         callSiteEvidence,
       )
       if (result) affectedNode = targetId
+
+      // ADR-148 — a mongodb span also names the collection it operated on, one
+      // grain finer than the database node above. Mint an additive OBSERVED
+      // CALLS edge to `infra:mongodb-collection:<name>` — the same node id the
+      // mongoose extractor emits (ensureInfraNode + infraId match calls/index.ts
+      // exactly) — so the declared and observed collection edges fuse instead of
+      // twinning. The collection is read straight off the span (dbCollection:
+      // db.collection.name / db.mongodb.collection), so it is ground truth where
+      // the extractor's Mongoose-pluralized derivation is quirk-wrong. Additive:
+      // a mongodb span with no collection still mints only the db-grain edge
+      // above.
+      if (span.dbSystem === 'mongodb' && span.dbCollection) {
+        const collectionId = ensureInfraNode(ctx.graph, 'mongodb-collection', span.dbCollection, 'self')
+        upsertObservedEdge(
+          ctx.graph,
+          EdgeType.CALLS,
+          observedSource(),
+          collectionId,
+          ts,
+          isError,
+          callSiteEvidence,
+        )
+      }
     }
   } else if (
     span.messagingSystem &&

--- a/packages/core/src/otel.ts
+++ b/packages/core/src/otel.ts
@@ -49,6 +49,11 @@ export interface ParsedSpan {
   // Convenience accessors for the attributes #8 cares about.
   dbSystem?: string
   dbName?: string
+  // The collection a `db.system: mongodb` span operated on (ADR-148). The
+  // mongodb / mongoose instrumentation sets `db.collection.name` in the stable
+  // convention, `db.mongodb.collection` in the older one — read the first, fall
+  // back to the second.
+  dbCollection?: string
   // Messaging semconv (OTel). `messaging.system` names the broker family
   // (kafka, rabbitmq, redis, …); the destination is the topic/queue the span
   // produced to or consumed from — the canonical `messaging.destination.name`
@@ -376,6 +381,12 @@ export function parseOtlpRequest(body: OtlpTracesRequest): ParsedSpan[] {
           attributes: attrs,
           dbSystem: typeof attrs['db.system'] === 'string' ? (attrs['db.system'] as string) : undefined,
           dbName: typeof attrs['db.name'] === 'string' ? (attrs['db.name'] as string) : undefined,
+          dbCollection:
+            typeof attrs['db.collection.name'] === 'string'
+              ? (attrs['db.collection.name'] as string)
+              : typeof attrs['db.mongodb.collection'] === 'string'
+                ? (attrs['db.mongodb.collection'] as string)
+                : undefined,
           messagingSystem:
             typeof attrs['messaging.system'] === 'string'
               ? (attrs['messaging.system'] as string)

--- a/packages/core/test/observed-mongodb-collection.test.ts
+++ b/packages/core/test/observed-mongodb-collection.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { resetGraph, getGraph } from '../src/graph.js'
+import { extractFromDirectory } from '../src/extract.js'
+import { handleSpan, type IngestContext } from '../src/ingest.js'
+import { EdgeType, Provenance, infraId, type GraphEdge } from '@neat.is/types'
+import type { ParsedSpan } from '../src/otel.js'
+
+// ADR-148 — the MongoDB per-collection OBSERVED signal is the `db.collection`
+// attribute on the mongodb spans NEAT already ingests, read into a
+// collection-grained edge that fuses onto the extractor's static twin (ADR-147).
+
+const ORDERS_COLLECTION = infraId('mongodb-collection', 'orders')
+
+function mongoSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
+  return {
+    service: 'orders',
+    traceId: 't1',
+    spanId: 's1',
+    name: 'mongodb.find',
+    kind: 3, // CLIENT
+    startTimeUnixNano: '0',
+    endTimeUnixNano: '0',
+    durationNanos: 0n,
+    env: 'unknown',
+    attributes: { 'db.system': 'mongodb', 'db.collection.name': 'orders' },
+    dbSystem: 'mongodb',
+    dbCollection: 'orders',
+    statusCode: 0,
+    ...overrides,
+  }
+}
+
+async function writeMongooseService(dir: string): Promise<void> {
+  const svc = path.join(dir, 'api')
+  await fs.mkdir(svc, { recursive: true })
+  await fs.writeFile(
+    path.join(svc, 'package.json'),
+    JSON.stringify({ name: 'orders', version: '1.0.0', dependencies: { mongoose: '^8.0.0' } }),
+  )
+  await fs.writeFile(
+    path.join(svc, 'models.js'),
+    `const mongoose = require('mongoose')\n` +
+      `const Order = mongoose.model('Order', new mongoose.Schema({ name: String }))\n` +
+      `module.exports = { Order }\n`,
+  )
+}
+
+function collectionNodes(g = getGraph()): string[] {
+  return g.filterNodes((id) => id.startsWith('infra:mongodb-collection:'))
+}
+function observedCallTargets(ctx: IngestContext): string[] {
+  return ctx.graph
+    .filterEdges((_id, e: GraphEdge) => e.provenance === Provenance.OBSERVED && e.type === EdgeType.CALLS)
+    .map((id) => (ctx.graph.getEdgeAttributes(id) as GraphEdge).target)
+}
+
+describe('MongoDB collection OBSERVED from driver spans (ADR-148)', () => {
+  let dir: string
+  let ctx: IngestContext
+
+  beforeEach(async () => {
+    resetGraph()
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-mongo-observed-'))
+    ctx = { graph: getGraph(), errorsPath: path.join(dir, 'errors.ndjson'), scanPath: dir }
+  })
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('mints an OBSERVED CALLS edge to the collection node from a mongodb span', async () => {
+    await handleSpan(ctx, mongoSpan())
+    expect(collectionNodes()).toEqual([ORDERS_COLLECTION])
+    expect(observedCallTargets(ctx)).toContain(ORDERS_COLLECTION)
+  })
+
+  it('reads the collection from the older db.mongodb.collection key too', async () => {
+    // (The attribute-key fallback lives in otel.ts; here the ParsedSpan is built
+    // directly, so we assert the ingest still mints from dbCollection whatever
+    // key populated it.)
+    await handleSpan(ctx, mongoSpan({ attributes: { 'db.system': 'mongodb', 'db.mongodb.collection': 'orders' } }))
+    expect(observedCallTargets(ctx)).toContain(ORDERS_COLLECTION)
+  })
+
+  it('is additive — a mongodb span with no collection mints no collection node', async () => {
+    await handleSpan(ctx, mongoSpan({ attributes: { 'db.system': 'mongodb' }, dbCollection: undefined }))
+    expect(collectionNodes()).toEqual([])
+  })
+
+  it('does not mint a collection edge for a non-mongodb db span', async () => {
+    await handleSpan(ctx, mongoSpan({ dbSystem: 'postgresql', dbCollection: undefined, attributes: { 'db.system': 'postgresql' } }))
+    expect(collectionNodes()).toEqual([])
+  })
+
+  it('fuses onto the extractor’s static twin — one collection node, both provenances land on it', async () => {
+    await writeMongooseService(dir)
+    await extractFromDirectory(ctx.graph, dir)
+
+    // The extractor named the collection statically (Order → orders).
+    expect(collectionNodes()).toEqual([ORDERS_COLLECTION])
+    const extractedToColl = ctx.graph
+      .filterEdges((_id, e: GraphEdge) => e.provenance === Provenance.EXTRACTED && e.target === ORDERS_COLLECTION)
+    expect(extractedToColl.length).toBeGreaterThan(0)
+
+    // The observed span lands on the SAME node — no twin, no phantom.
+    await handleSpan(ctx, mongoSpan())
+    expect(collectionNodes()).toEqual([ORDERS_COLLECTION])
+    expect(observedCallTargets(ctx)).toContain(ORDERS_COLLECTION)
+  })
+})


### PR DESCRIPTION
The OBSERVED half of MongoDB collection support (ADR-148). The mongodb/mongoose OTel instrumentation already ships in the `auto-instrumentations-node` NEAT installs, so per-operation spans carrying the collection already arrive — the daemon just dropped the attribute. It now reads `db.collection.name` (fallback `db.mongodb.collection`) and mints an additive OBSERVED `CALLS` edge to `infra:mongodb-collection:<name>` — the same node the extractor emits — so declared and observed **fuse**, with the span's collection as ground truth where the static pluralization is quirk-wrong.

Tier-independent and local-first: it's the app's driver spans over the daemon's own OTLP endpoint — no Atlas creds, no M10+, no tunnel. 5 tests incl. the end-to-end extractor↔span fusion.

Pairs with the extractor (#848). Refs #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)