### PR TITLE
Fix MongoDB OBSERVED: accept db.system: mongoose spans (ADR-150)

### DIFF
--- a/packages/core/src/otel.ts
+++ b/packages/core/src/otel.ts
@@ -288,6 +288,20 @@ function pickEnv(
   return ENV_FALLBACK
 }
 
+// The datastore engine a `db.system` span names, normalized at the parse
+// boundary. The mongoose OTel instrumentation — the one that actually emits
+// per-operation collection spans on real apps — tags its spans
+// `db.system: 'mongoose'`, but mongoose is an ORM over mongodb: the datastore
+// IS mongodb, and `mongoose` on the span is an instrumentation detail. Rewrite
+// it to `mongodb` here so every downstream reader (the collection edge, the
+// database-node engine, ADR-141 fusion) sees one engine and none of them has to
+// know the ORM label. See ADR-150.
+function normalizeDbSystem(attrs: Record<string, AttributeValue>): string | undefined {
+  const raw = attrs['db.system']
+  if (typeof raw !== 'string') return undefined
+  return raw === 'mongoose' ? 'mongodb' : raw
+}
+
 // The messaging destination (topic / queue / stream) a producer or consumer
 // span names. `messaging.destination.name` is the canonical semconv key
 // (SC v1.24+); `messaging.destination` is the older form some instrumentations
@@ -379,7 +393,7 @@ export function parseOtlpRequest(body: OtlpTracesRequest): ParsedSpan[] {
           durationNanos: durationNanos(span.startTimeUnixNano, span.endTimeUnixNano),
           env: pickEnv(attrs, resourceAttrs),
           attributes: attrs,
-          dbSystem: typeof attrs['db.system'] === 'string' ? (attrs['db.system'] as string) : undefined,
+          dbSystem: normalizeDbSystem(attrs),
           dbName: typeof attrs['db.name'] === 'string' ? (attrs['db.name'] as string) : undefined,
           dbCollection:
             typeof attrs['db.collection.name'] === 'string'

--- a/packages/core/test/observed-mongodb-collection.test.ts
+++ b/packages/core/test/observed-mongodb-collection.test.ts
@@ -5,8 +5,15 @@ import path from 'node:path'
 import { resetGraph, getGraph } from '../src/graph.js'
 import { extractFromDirectory } from '../src/extract.js'
 import { handleSpan, type IngestContext } from '../src/ingest.js'
-import { EdgeType, Provenance, infraId, type GraphEdge } from '@neat.is/types'
-import type { ParsedSpan } from '../src/otel.js'
+import {
+  EdgeType,
+  Provenance,
+  infraId,
+  databaseId,
+  type GraphEdge,
+  type DatabaseNode,
+} from '@neat.is/types'
+import { parseOtlpRequest, type OtlpTracesRequest, type ParsedSpan } from '../src/otel.js'
 
 // ADR-148 — the MongoDB per-collection OBSERVED signal is the `db.collection`
 // attribute on the mongodb spans NEAT already ingests, read into a
@@ -108,5 +115,86 @@ describe('MongoDB collection OBSERVED from driver spans (ADR-148)', () => {
     await handleSpan(ctx, mongoSpan())
     expect(collectionNodes()).toEqual([ORDERS_COLLECTION])
     expect(observedCallTargets(ctx)).toContain(ORDERS_COLLECTION)
+  })
+})
+
+// ADR-150 — the @opentelemetry/instrumentation-mongoose (the one that actually
+// fires on a real mongoose app, NEAT's primary Mongo target) tags its
+// per-operation spans `db.system: 'mongoose'`, not `'mongodb'`. otel.ts
+// normalizes that at the parse boundary, so exercising the fix means driving the
+// span through parseOtlpRequest rather than hand-building a ParsedSpan.
+
+// A mongoose span as it arrives on the wire: db.system === 'mongoose', the
+// collection under the older db.mongodb.collection key, CLIENT kind. Carries a
+// peer host when one is asked for so the database-node engine can be asserted.
+function mongooseOtlpBody(opts: { host?: string } = {}): OtlpTracesRequest {
+  const attributes = [
+    { key: 'db.system', value: { stringValue: 'mongoose' } },
+    { key: 'db.mongodb.collection', value: { stringValue: 'orders' } },
+    { key: 'db.operation', value: { stringValue: 'find' } },
+  ]
+  if (opts.host) {
+    attributes.push({ key: 'server.address', value: { stringValue: opts.host } })
+  }
+  return {
+    resourceSpans: [
+      {
+        resource: { attributes: [{ key: 'service.name', value: { stringValue: 'orders' } }] },
+        scopeSpans: [
+          {
+            spans: [
+              {
+                traceId: 'aabbccddeeff00112233445566778899',
+                spanId: '1111111111111111',
+                name: 'mongoose.Order.find',
+                kind: 3, // CLIENT
+                startTimeUnixNano: '1000000000000000000',
+                endTimeUnixNano: '1000000000010000000',
+                attributes,
+                status: { code: 0 },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+}
+
+describe('MongoDB collection OBSERVED reads mongoose-system spans (ADR-150)', () => {
+  let dir: string
+  let ctx: IngestContext
+
+  beforeEach(async () => {
+    resetGraph()
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'neat-mongoose-observed-'))
+    ctx = { graph: getGraph(), errorsPath: path.join(dir, 'errors.ndjson'), scanPath: dir }
+  })
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('normalizes db.system: mongoose to mongodb at the parse boundary', () => {
+    const [span] = parseOtlpRequest(mongooseOtlpBody())
+    expect(span.dbSystem).toBe('mongodb')
+    // The collection read is untouched — still the older db.mongodb.collection key.
+    expect(span.dbCollection).toBe('orders')
+  })
+
+  it('mints the OBSERVED CALLS edge to the collection node from a mongoose span', async () => {
+    const [span] = parseOtlpRequest(mongooseOtlpBody())
+    await handleSpan(ctx, span)
+    expect(collectionNodes()).toEqual([ORDERS_COLLECTION])
+    expect(observedCallTargets(ctx)).toContain(ORDERS_COLLECTION)
+  })
+
+  it('gives the peer-host database node engine mongodb, not mongoose', async () => {
+    const host = 'cluster0.abcde.mongodb.net'
+    const [span] = parseOtlpRequest(mongooseOtlpBody({ host }))
+    await handleSpan(ctx, span)
+    const dbId = databaseId(host)
+    expect(ctx.graph.hasNode(dbId)).toBe(true)
+    const node = ctx.graph.getNodeAttributes(dbId) as DatabaseNode
+    expect(node.engine).toBe('mongodb')
   })
 })


### PR DESCRIPTION
Implements ADR-150. Normalizes `db.system: 'mongoose'` → `'mongodb'` at the OTLP parse boundary (`otel.ts`), so the collection-edge gate, the database-node engine, and ADR-141 fusion all see `mongodb`. The mongoose OTel instrumentation is the one that actually emits per-operation collection spans on real apps (the raw mongodb-driver instrumentation emits none on modern drivers) — proven against live Atlas — and it tags them `db.system: 'mongoose'`, which NEAT was silently dropping.

Boundary normalization verified sufficient: every `db.system` reader consumes the normalized `ParsedSpan.dbSystem`; `otel-grpc.ts` reuses the same parse. 3 new tests drive a mongoose-system OTLP span through the parse → assert `dbSystem` normalizes, the `mongodb-collection` edge mints, and the database node's engine is `mongodb`. Full core suite green.

Refs #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)