### PR TITLE
Fix Cloudflare connector validate: account-scoped token-verify (CF-1)

### DIFF
--- a/packages/core/src/connectors/registry.ts
+++ b/packages/core/src/connectors/registry.ts
@@ -304,15 +304,21 @@ export const PROVIDER_DISPATCH: Record<string, ProviderDispatch> = {
         resolveTarget: createCloudflareResolveTarget(config, graph),
       }
     },
-    // GET /user/tokens/verify — Cloudflare's own purpose-built "is this API
-    // token live" endpoint. 200 on a valid token, 401 on an invalid one.
+    // GET /accounts/{accountId}/tokens/verify — the *account-scoped* token-verify
+    // endpoint. A Workers connector token is scoped to the account, and the
+    // user-level `GET /user/tokens/verify` returns 401 "Invalid API Token" for
+    // such a token even though it authenticates fine against the account's own
+    // resources (confirmed live). Probing the account-scoped verify endpoint —
+    // `accountId` is already required for this provider — returns 200
+    // `{status:"active"}` for a working token and 401 for a bad one, so a valid
+    // Workers token is no longer falsely rejected at `neat connector add`.
     validate({ credentials, options, fetchImpl }) {
       const cfg = options as Partial<CloudflareConnectorConfig>
       const baseUrl = cfg.baseUrl ?? CLOUDFLARE_API_BASE_URL
       return authProbe({
         provider: 'cloudflare',
         accountKey: cfg.accountId ?? 'validate',
-        url: `${baseUrl}/user/tokens/verify`,
+        url: `${baseUrl}/accounts/${cfg.accountId ?? ''}/tokens/verify`,
         token: String(credentials.apiToken ?? ''),
         ...(fetchImpl ? { fetchImpl } : {}),
       })

--- a/packages/core/test/connectors-registry.test.ts
+++ b/packages/core/test/connectors-registry.test.ts
@@ -111,6 +111,26 @@ describe('PROVIDER_DISPATCH table', () => {
     expect(getProviderDispatch('supabase')?.provider).toBe('supabase')
     expect(getProviderDispatch('vercel')).toBeUndefined()
   })
+
+  // CF-1 (live-verified): a Workers connector token is account-scoped, and
+  // `GET /user/tokens/verify` returns 401 for it while
+  // `GET /accounts/{id}/tokens/verify` returns 200. Validate must probe the
+  // account-scoped endpoint or it falsely rejects working tokens on `add`.
+  it('cloudflare validate probes the account-scoped token-verify endpoint, not /user', async () => {
+    const urls: string[] = []
+    const fetchImpl = (async (url: string | URL) => {
+      urls.push(String(url))
+      return { ok: true, status: 200, statusText: 'OK', json: async () => ({ success: true }) } as Response
+    }) as unknown as typeof fetch
+    const result = await PROVIDER_DISPATCH.cloudflare!.validate({
+      credentials: { apiToken: 'cf-token' },
+      options: { accountId: 'acc123' },
+      fetchImpl,
+    })
+    expect(result).toEqual({ ok: true })
+    expect(urls[0]).toContain('/accounts/acc123/tokens/verify')
+    expect(urls[0]).not.toContain('/user/tokens/verify')
+  })
 })
 
 describe('buildRegistration normalizes each provider into one registration shape', () => {


### PR DESCRIPTION
The shipped validate uses `GET /user/tokens/verify`, which returns 401 for an account-scoped Workers token — so `neat connector add cloudflare` falsely rejects working tokens. Switched to `GET /accounts/{accountId}/tokens/verify` (accountId already required). **Verified live** against a real account: user-scoped → 401, account-scoped → 200 `active`. Regression test pins it.

Found by the connector live-validation hardening pass (the `needs-endpoint-testing` debt coming due). Refs #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)