### PR TITLE
Stop claiming instrumentation is live when the dep install failed

### DIFF
--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -1133,7 +1133,7 @@ export async function runOrchestrator(opts: OrchestratorOptions): Promise<Orches
   return result
 }
 
-function printSummary(
+export function printSummary(
   result: OrchestratorResult,
   graph: ReturnType<typeof getGraph>,
   dashboardUrl: string,
@@ -1175,9 +1175,35 @@ function printSummary(
   // suite: the graph fills its OBSERVED layer as their code executes, and
   // divergences surface where code and runtime disagree. Never suggest
   // synthetic traffic — the point is what their real system does.
+  //
+  // Issue #831 — but only when the dependency install actually completed. If a
+  // `<pm> install` exited non-zero the OTel SDK never landed, so the manifests
+  // are patched but instrumentation is inert: telling the operator to "run your
+  // app, OBSERVED edges fill in" would be a lie, because nothing would fill in.
+  // In that case we say so plainly and hand back the exact install command to
+  // finish, and we withhold the clean next-step line until deps are in place.
+  const failedInstalls = (result.steps.apply.packageManagerInstalls ?? []).filter(
+    (i) => i.exitCode !== 0,
+  )
+
   if (daemonLog !== null) {
     console.log('')
     console.log(`daemon running in the background (logs: ${daemonLog})`)
+  }
+
+  if (failedInstalls.length > 0) {
+    if (daemonLog === null) console.log('')
+    console.log(
+      'instrumentation is wired into your manifests, but it is NOT yet active:',
+    )
+    console.log(
+      'the dependency install did not complete, so the OTel SDK never landed and',
+    )
+    console.log('OBSERVED edges will stay empty until you finish the install. Fix it:')
+    for (const i of failedInstalls) {
+      console.log(`      run \`${i.pm} install\` in ${i.cwd}`)
+    }
+  } else if (daemonLog !== null) {
     console.log(
       'next: run your app or your test suite — OBSERVED edges fill in as it executes,',
     )

--- a/packages/core/test/orchestrator-summary-install-failure.test.ts
+++ b/packages/core/test/orchestrator-summary-install-failure.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest'
+import { printSummary, type OrchestratorResult } from '../src/orchestrator.js'
+import { getGraph, resetGraph } from '../src/graph.js'
+
+// Issue #831 — the one-command summary used to tell the operator "run your app,
+// OBSERVED edges fill in" even when the dependency install had failed. When the
+// `<pm> install` exits non-zero the OTel SDK never lands, so instrumentation is
+// wired into the manifests but inert: nothing would fill in. The summary has to
+// be honest about that and hand back the exact command to finish the install.
+
+function baseResult(
+  packageManagerInstalls: OrchestratorResult['steps']['apply']['packageManagerInstalls'],
+): OrchestratorResult {
+  return {
+    exitCode: packageManagerInstalls?.some((i) => i.exitCode !== 0) ? 1 : 0,
+    steps: {
+      discovery: { services: 1, languages: ['javascript'] },
+      extraction: { nodesAdded: 0, edgesAdded: 0 },
+      gitignore: 'unchanged',
+      apply: {
+        instrumented: 1,
+        alreadyInstrumented: 0,
+        libOnly: 0,
+        skipped: false,
+        packageManagerInstalls,
+      },
+      daemon: 'spawned',
+      browser: 'skipped',
+    },
+  }
+}
+
+function captureSummary(result: OrchestratorResult, daemonLog: string | null): string[] {
+  const key = `test-summary-${Math.random().toString(36).slice(2)}`
+  resetGraph(key)
+  const graph = getGraph(key)
+  const lines: string[] = []
+  const spy = vi.spyOn(console, 'log').mockImplementation((msg?: unknown) => {
+    lines.push(String(msg ?? ''))
+  })
+  try {
+    printSummary(result, graph, 'http://localhost:6328', daemonLog)
+  } finally {
+    spy.mockRestore()
+  }
+  return lines
+}
+
+const CLEAN_LINE = 'OBSERVED edges fill in as it executes'
+
+describe('printSummary is honest when a dependency install failed (#831)', () => {
+  it('emits the "not yet active / run <pm> install" summary and omits the clean line', () => {
+    const lines = captureSummary(
+      baseResult([
+        { pm: 'npm', cwd: '/proj/app', args: ['install'], exitCode: 1, stderr: 'boom' },
+      ]),
+      'neat-out/daemon.log',
+    )
+    const text = lines.join('\n')
+
+    // Honest: instrumentation wired but inert until deps land.
+    expect(text).toContain('NOT yet active')
+    expect(text).toMatch(/OBSERVED edges will stay empty/)
+    // The exact fix command, per failed install, with its cwd.
+    expect(text).toContain('run `npm install` in /proj/app')
+
+    // The clean "run your app, OBSERVED edges fill in" wording must be gone.
+    expect(text).not.toContain(CLEAN_LINE)
+    expect(text).not.toContain('divergences surface where code and runtime disagree')
+  })
+
+  it('lists a fix command for each failed install and uses that install\'s pm/cwd', () => {
+    const lines = captureSummary(
+      baseResult([
+        { pm: 'npm', cwd: '/proj/api', args: ['install'], exitCode: 0, stderr: '' },
+        { pm: 'pnpm', cwd: '/proj/web', args: ['install'], exitCode: 1, stderr: 'x' },
+        { pm: 'yarn', cwd: '/proj/worker', args: ['install'], exitCode: 127, stderr: 'y' },
+      ]),
+      'neat-out/daemon.log',
+    )
+    const text = lines.join('\n')
+
+    // Only the two failed installs are surfaced, each with its own pm + cwd.
+    expect(text).toContain('run `pnpm install` in /proj/web')
+    expect(text).toContain('run `yarn install` in /proj/worker')
+    // The install that succeeded is not listed as needing a fix.
+    expect(text).not.toContain('run `npm install` in /proj/api')
+    expect(text).not.toContain(CLEAN_LINE)
+  })
+
+  it('keeps the clean next-step line when every install succeeded', () => {
+    const lines = captureSummary(
+      baseResult([
+        { pm: 'npm', cwd: '/proj/app', args: ['install'], exitCode: 0, stderr: '' },
+      ]),
+      'neat-out/daemon.log',
+    )
+    const text = lines.join('\n')
+
+    expect(text).toContain(CLEAN_LINE)
+    expect(text).not.toContain('NOT yet active')
+  })
+
+  it('keeps the clean next-step line when there were no installs at all', () => {
+    const lines = captureSummary(baseResult(undefined), 'neat-out/daemon.log')
+    const text = lines.join('\n')
+
+    expect(text).toContain(CLEAN_LINE)
+    expect(text).not.toContain('NOT yet active')
+  })
+
+  it('surfaces the failure even when the daemon is not running (no daemon log)', () => {
+    const lines = captureSummary(
+      baseResult([
+        { pm: 'npm', cwd: '/proj/app', args: ['install'], exitCode: 1, stderr: 'boom' },
+      ]),
+      null,
+    )
+    const text = lines.join('\n')
+
+    expect(text).toContain('NOT yet active')
+    expect(text).toContain('run `npm install` in /proj/app')
+    expect(text).not.toContain(CLEAN_LINE)
+  })
+})


### PR DESCRIPTION
Fixes the false "run your app, OBSERVED edges fill in" sign-off on a run where the dependency install didn't finish.

When `neat <path>` patches a project's manifests but the follow-up `<pm> install` exits non-zero, the OTel SDK never actually lands. The summary would still tell the operator to run their app and watch OBSERVED edges fill in — but they never would, because instrumentation is wired into the manifests and inert. The operator is left waiting for spans that can't arrive.

`printSummary` now looks at `result.steps.apply.packageManagerInstalls`. If any install failed it says so plainly: instrumentation is wired but not yet active, OBSERVED stays empty until the install finishes, and here's the exact `<pm> install` to run in each directory that failed. The clean next-step line only prints when every install succeeded (or there were none). The failure notice shows even when the daemon didn't come up, since it's true regardless.

New test in `packages/core/test/orchestrator-summary-install-failure.test.ts` drives `printSummary` with a failed install and asserts the honest "not yet active / run <pm> install" wording appears and the clean line is gone, plus the success and no-install paths still print the clean line.

Verified: `@neat.is/core` builds clean, full core vitest run is green (1642 passed, 6 skipped, 5 todo), eslint clean on the changed files.

Refs #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)