### PR TITLE
Stop the otlp-port-step daemon-spawn tests from flaking under load

### DIFF
--- a/packages/core/test/otlp-port-step.test.ts
+++ b/packages/core/test/otlp-port-step.test.ts
@@ -43,6 +43,33 @@ function makeGraph(): NeatGraph {
   return new MultiDirectedGraph({ allowSelfLoops: false }) as unknown as NeatGraph
 }
 
+// Spawning a real daemon/watch here means a Fastify listen plus a default-
+// project extraction pass, which legitimately takes seconds — and on a loaded
+// machine one spawn has been seen to take ~23s. Vitest's default 5s per-test
+// budget is far too tight for that, so these tests time out locally while
+// passing on a clean CI runner (refs #818). Give the spawn a comfortable cap.
+const SPAWN_TIMEOUT_MS = 60_000
+
+// A freshly-bound OTLP receiver can take a beat to start answering, so poll
+// /health until it reports 200 rather than betting the first request lands.
+// The cap is generous so a busy machine still gets there; if it never does,
+// re-throw the last failure so the assertion points at the real problem.
+async function waitForHealthy(url: string, capMs = 30_000): Promise<Response> {
+  const deadline = Date.now() + capMs
+  let lastErr: unknown
+  for (;;) {
+    try {
+      const res = await fetch(url)
+      if (res.status === 200) return res
+      lastErr = new Error(`health check ${url} returned ${res.status}`)
+    } catch (err) {
+      lastErr = err
+    }
+    if (Date.now() >= deadline) throw lastErr
+    await new Promise((r) => setTimeout(r, 100))
+  }
+}
+
 describe('OTLP port stepping + watch daemon.json (refs #621)', () => {
   const pending: Array<() => Promise<void> | void> = []
   const savedEnv = new Map<string, string | undefined>()
@@ -102,13 +129,13 @@ describe('OTLP port stepping + watch daemon.json (refs #621)', () => {
     expect(boundOtlp).toBeGreaterThan(held)
 
     // The receiver is live on the stepped port, and daemon.json points there.
-    const res = await fetch(`${daemon.otlpAddress}/health`)
+    const res = await waitForHealthy(`${daemon.otlpAddress}/health`)
     expect(res.status).toBe(200)
     expect(daemon.otlpAddress).toBe(`http://127.0.0.1:${boundOtlp}`)
 
     const record = await readDaemonRecord(projPath)
     expect(record!.ports.otlp).toBe(boundOtlp)
-  })
+  }, SPAWN_TIMEOUT_MS)
 
   it('neat watch writes daemon.json carrying the real (non-default) bound OTLP port', async () => {
     const projPath = await projectDir('watch-svc')
@@ -137,9 +164,9 @@ describe('OTLP port stepping + watch daemon.json (refs #621)', () => {
     expect(record!.ports.otlp).toBe(otelPort)
 
     // And the receiver is genuinely listening on the recorded port.
-    const res = await fetch(`http://127.0.0.1:${record!.ports.otlp}/health`)
+    const res = await waitForHealthy(`http://127.0.0.1:${record!.ports.otlp}/health`)
     expect(res.status).toBe(200)
-  })
+  }, SPAWN_TIMEOUT_MS)
 
   it('neat watch steps its OTLP bind off a held port and records the stepped one', async () => {
     const projPath = await projectDir('watch-step-svc')
@@ -163,9 +190,9 @@ describe('OTLP port stepping + watch daemon.json (refs #621)', () => {
     const record = await readDaemonRecord(projPath)
     expect(record!.ports.otlp).not.toBe(held)
     expect(record!.ports.otlp).toBeGreaterThan(held)
-    const res = await fetch(`http://127.0.0.1:${record!.ports.otlp}/health`)
+    const res = await waitForHealthy(`http://127.0.0.1:${record!.ports.otlp}/health`)
     expect(res.status).toBe(200)
-  })
+  }, SPAWN_TIMEOUT_MS)
 
   it('watch clears its daemon.json record to stopped on shutdown', async () => {
     const projPath = await projectDir('watch-stop-svc')
@@ -183,5 +210,5 @@ describe('OTLP port stepping + watch daemon.json (refs #621)', () => {
     expect((await readDaemonRecord(projPath))!.status).toBe('running')
     await handle.stop()
     expect((await readDaemonRecord(projPath))!.status).toBe('stopped')
-  })
+  }, SPAWN_TIMEOUT_MS)
 })


### PR DESCRIPTION
The three daemon-spawning tests in `packages/core/test/otlp-port-step.test.ts` start a real neatd/watch — a Fastify listen plus a default-project extraction pass — and then assert against it. They ran under vitest's default 5s per-test timeout, which is fine on a clean CI runner but far too tight once the machine is under load. On a busy dev machine all three time out at 5s; the exact same tests pass with a wider timeout, one spawn taking north of 20 seconds. The code is correct and CI is green — this is purely test robustness, and the red locally sends anyone debugging down the wrong path.

The fix:

- Raise the per-test timeout on the spawning tests to a comfortable 60s (via a shared `SPAWN_TIMEOUT_MS` constant), so an inherently multi-second daemon boot isn't racing a stopwatch meant for millisecond unit tests.
- Replace the one-shot `/health` fetch with a short poll (`waitForHealthy`) that waits until the freshly bound receiver actually answers, with a generous cap, rather than betting the first request lands the instant the port binds.

Same intent, same assertions — just no longer flaky.

Verified: `npm run build --workspace @neat.is/core` clean, full `packages/core` vitest suite green (1637 passed, 6 skipped, 5 todo), eslint clean on the changed file, and the target file passes reliably — including under a saturated-CPU load run where two of the tests legitimately took 5.4s and 6.7s (both would have failed the old 5s budget) and all still passed.

Refs #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)