### PR TITLE
Point Windows users at the neat command, not npx neat.is

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ npx neat.is
 
 Run it from inside your project (or `npx neat.is <path>`). It discovers your services, extracts the static graph, wires in OpenTelemetry, starts the daemon, and opens the dashboard — no config. Then run your app and watch the live edges populate.
 
+> **On Windows, use the `neat` command, not `npx neat.is`.** npm generates a shim literally named `neat.is`, and Windows won't execute a `.is` file — it hands it to a file association instead. Install once and run the dotless binary: `npm i -g neat.is`, then `neat` (or `neat <path>`). Without a global install: `npx -p neat.is neat`. Every `npx neat.is <verb>` below becomes `neat <verb>` this way.
+
 ## A more in-depth explanation:
 
 At the center of NEAT is **one live graph** of your system, fused from two streams into a single model you can query many ways:

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -33,6 +33,27 @@ You ran `npx neat.is` from inside your project expecting it to go zero-to-graph,
 npx neat.is@latest
 ```
 
+## `npx neat.is` fails on Windows (tries to open a `.is` file)
+
+You ran `npx neat.is` on Windows and it errored instead of starting — the shell tried to *open* a `neat.is` file rather than run it.
+
+**Cause:** the package publishes a `neat.is` bin, so npm writes a launcher shim named `neat.is`. On Windows `.is` isn't in `PATHEXT`, so the shell treats `neat.is` as a data file and passes it to a file association instead of executing the `.cmd` shim next to it. It's a limitation of the dotted command name, not your setup — and it only hits the `neat.is` alias, never the dotless `neat`.
+
+**Fix:** use `neat`, which npm shims correctly on every platform. Install once:
+
+```bash
+npm i -g neat.is
+neat                 # or: neat <path>
+```
+
+or run it without a global install:
+
+```bash
+npx -p neat.is neat            # same verbs follow, e.g. npx -p neat.is neat divergences
+```
+
+Everything the guides write as `npx neat.is <verb>` is `neat <verb>` after a global install.
+
 ## Daemon won't start / port in use
 
 The daemon needs three ports: `:8080` (REST API), `:4318` (OTLP receiver), and `:6328` (dashboard). If one's already held, the daemon can't bind it, and `neat <path>` exits with code 3.


### PR DESCRIPTION
`npx neat.is` doesn't run on Windows. npm generates a launcher shim named `neat.is`, and because `.is` isn't in `PATHEXT`, the shell treats it as a data file and passes it to a file association instead of executing the `.cmd` shim next to it — so it "tries to run an executable `.is`."

The dotted bin can't simply be removed: `npx neat.is` needs a bin named exactly `neat.is` to resolve (the umbrella package ships four bins — `neat`, `neat.is`, `neatd`, `neat-mcp` — so npx requires a name match, and the only name that matches the package spec is the dotted one). Making the pretty command work on Windows would mean collapsing to a single `neat` bin — a breaking change against `docs/contracts/one-command-cli.md`.

So this points users at the path that already works on every platform: the dotless `neat` binary, via `npm i -g neat.is` or `npx -p neat.is neat`. Two doc surfaces:

- **README** quickstart gets a Windows callout right under `npx neat.is`.
- **Troubleshooting** gets a dedicated "`npx neat.is` fails on Windows" entry with cause + fix.

The CLI's own runtime hint is already safe — it only prints the `npx neat.is` prefix when it detects an npx invocation, which can't happen on Windows.

Follow-up (not here): the marketing site shows `npx neat.is …` on the hero and every connector page; that copy needs the same substitution.

Refs the Windows `npx neat.is` report.