### PR TITLE
Read the stable OpenTelemetry code attributes (semconv 1.33)

### DIFF
--- a/docs/contracts/file-awareness.md
+++ b/docs/contracts/file-awareness.md
@@ -47,6 +47,8 @@ NEAT controls the instrumentation surface end-to-end — the bundled installer w
 
 3. **Facade wrappers for off-stack patterns.** For instrumentations whose span creation is detached from the caller's stack — Node's built-in `fetch` / `undici` (`diagnostics_channel`-based) and `@prisma/instrumentation` (post-hoc backdated dispatch) today — the instrumentation wraps the user-visible library facade and pushes the exact call-site frame into context for the inner call. The registry enumerates the set; it grows as the ecosystem evolves.
 
+Ingest reads the call site through both OpenTelemetry attribute generations — the stable names `code.file.path` / `code.line.number` / `code.function.name` (semconv ≥1.33) and the prior `code.filepath` / `code.lineno` / `code.function`, stable-name first — so a span carrying either generation file-grains identically, whether it comes from NEAT's own emit or from third-party instrumentation that has moved to the stable names. The dual read lives in one shared helper so every code.* reader (edge attribution and incident localization) stays on one definition and the names can't drift across sites.
+
 Ingest joins the runtime path against the service root, resolving `dist/...js` through the file's source map to the original `src/...ts` where applicable, to land the edge on a `FileNode`. The raw dist path is preserved as `code.original_filepath` for diagnostic. The injected template is version-stamped so a re-run upgrades an existing install onto the current layered mechanism.
 
 A NEAT-emitted span without `code.*` is a capture-mechanism bug; ingest surfaces it via a loud audit for diagnostic.

--- a/packages/core/src/ingest.ts
+++ b/packages/core/src/ingest.ts
@@ -42,7 +42,7 @@ import {
 } from '@neat.is/types'
 import type { NeatGraph } from './graph.js'
 import { DEFAULT_PROJECT } from './graph.js'
-import type { ParsedSpan } from './otel.js'
+import type { AttributeValue, ParsedSpan } from './otel.js'
 import { emitNeatEvent } from './events.js'
 
 // Maps OTel spans to graph signal:
@@ -416,16 +416,44 @@ function isLoopbackHost(host: string): boolean {
 // ──────────────────────────────────────────────────────────────────────────
 // Call-site capture (file-awareness.md §4)
 //
-// The injected SpanProcessor sets `code.filepath` / `code.lineno` /
-// `code.function` on CLIENT/PRODUCER spans — the exact OTel attribute names,
-// written by the emit template (installers/templates.ts) and read here. The
-// two sites are cross-referenced so the names can't drift. When present, an
-// OBSERVED relationship originates from the file rather than the service.
-// SERVER spans and the callee side carry no call site and stay service-level;
+// The call-site processor stamps the source location on CLIENT/PRODUCER spans.
+// OpenTelemetry stabilized the code attributes at semconv v1.33 —
+// `code.file.path` / `code.line.number` / `code.function.name` — renaming the
+// prior `code.filepath` / `code.lineno` / `code.function`. NEAT's own emit
+// templates (installers/templates.ts, and the Python processor, ADR-151) and any
+// third-party instrumentation may carry either generation, so the read accepts
+// BOTH, stable-name first. When present, an OBSERVED relationship originates from
+// the file rather than the service; a span with neither stays service-level, and
 // evidence is never fabricated (§6).
-const CODE_FILEPATH_ATTR = 'code.filepath'
+const CODE_FILE_PATH_ATTR = 'code.file.path' // semconv ≥1.33 (stable)
+const CODE_FILEPATH_ATTR = 'code.filepath' // prior convention
+const CODE_LINE_NUMBER_ATTR = 'code.line.number'
 const CODE_LINENO_ATTR = 'code.lineno'
+const CODE_FUNCTION_NAME_ATTR = 'code.function.name'
 const CODE_FUNCTION_ATTR = 'code.function'
+
+// Read the source call site off an attribute bag, accepting the stable
+// (semconv ≥1.33) and prior attribute names. Exported so every code.* reader —
+// edge attribution here, incident localization in traverse.ts — shares one
+// definition and the names can't drift across sites.
+export function codeFilepathOf(attrs: Record<string, AttributeValue>): string | undefined {
+  const stable = attrs[CODE_FILE_PATH_ATTR]
+  if (typeof stable === 'string' && stable.length > 0) return stable
+  const prior = attrs[CODE_FILEPATH_ATTR]
+  return typeof prior === 'string' && prior.length > 0 ? prior : undefined
+}
+export function codeLinenoOf(attrs: Record<string, AttributeValue>): number | undefined {
+  const stable = attrs[CODE_LINE_NUMBER_ATTR]
+  if (typeof stable === 'number' && Number.isFinite(stable)) return stable
+  const prior = attrs[CODE_LINENO_ATTR]
+  return typeof prior === 'number' && Number.isFinite(prior) ? prior : undefined
+}
+export function codeFunctionOf(attrs: Record<string, AttributeValue>): string | undefined {
+  const stable = attrs[CODE_FUNCTION_NAME_ATTR]
+  if (typeof stable === 'string' && stable.length > 0) return stable
+  const prior = attrs[CODE_FUNCTION_ATTR]
+  return typeof prior === 'string' && prior.length > 0 ? prior : undefined
+}
 
 function toPosix(p: string): string {
   return p.split('\\').join('/')
@@ -564,11 +592,9 @@ function callSiteFromSpan(
   serviceNode?: ServiceNode,
   scanPath?: string,
 ): CallSite | null {
-  const filepath = span.attributes[CODE_FILEPATH_ATTR]
-  if (typeof filepath !== 'string' || filepath.length === 0) return null
-  const linenoRaw = span.attributes[CODE_LINENO_ATTR]
-  let line =
-    typeof linenoRaw === 'number' && Number.isFinite(linenoRaw) ? linenoRaw : undefined
+  const filepath = codeFilepathOf(span.attributes)
+  if (filepath === undefined) return null
+  let line = codeLinenoOf(span.attributes)
   // Resolve a compiled dist frame to its source before computing the service-
   // relative path, so the FileNode lands on the original `src/...ts`.
   const abs = toPosix(filepath).replace(/^file:\/\//, '')
@@ -589,8 +615,7 @@ function callSiteFromSpan(
   if (!resolved && abs.endsWith('.js') && relPath.startsWith('dist/') && serviceNode?.name) {
     warnNoSourceMaps(serviceNode.name)
   }
-  const fnRaw = span.attributes[CODE_FUNCTION_ATTR]
-  const fn = typeof fnRaw === 'string' && fnRaw.length > 0 ? fnRaw : undefined
+  const fn = codeFunctionOf(span.attributes)
   return {
     relPath,
     ...(line !== undefined ? { line } : {}),

--- a/packages/core/src/traverse.ts
+++ b/packages/core/src/traverse.ts
@@ -11,6 +11,7 @@ import type {
   TransitiveDependenciesResult,
   TransitiveDependency,
 } from '@neat.is/types'
+import { codeFilepathOf, codeLinenoOf } from './ingest.js'
 import {
   BlastRadiusResultSchema,
   EdgeType,
@@ -475,8 +476,10 @@ function localizeFromIncidents(
   // Most recent incident is the representative; ISO timestamps sort lexically.
   const latest = [...relevant].sort((a, b) => b.timestamp.localeCompare(a.timestamp))[0]!
   const attrs = latest.attributes ?? {}
-  const filepath = typeof attrs['code.filepath'] === 'string' ? attrs['code.filepath'] : undefined
-  const lineno = typeof attrs['code.lineno'] === 'number' ? attrs['code.lineno'] : undefined
+  // Read the call site through the shared dual-name helper (semconv ≥1.33 stable
+  // names + the prior ones), so incident localization survives either generation.
+  const filepath = codeFilepathOf(attrs)
+  const lineno = codeLinenoOf(attrs)
   const route = typeof attrs['http.route'] === 'string' ? attrs['http.route'] : undefined
   const location = filepath ? `${filepath}${lineno !== undefined ? `:${lineno}` : ''}` : undefined
 

--- a/packages/core/test/ingest.test.ts
+++ b/packages/core/test/ingest.test.ts
@@ -26,6 +26,9 @@ import {
 import { ensureFileNode } from '../src/extract/calls/shared.js'
 import {
   buildErrorEventForReceiver,
+  codeFilepathOf,
+  codeFunctionOf,
+  codeLinenoOf,
   handleSpan,
   markStaleEdges,
   mergeSnapshot,
@@ -141,6 +144,44 @@ function dbSpan(overrides: Partial<ParsedSpan> = {}): ParsedSpan {
   }
 }
 
+describe('code.* attribute dual-name read (semconv 1.33 stabilization)', () => {
+  it('reads the prior attribute names', () => {
+    const attrs = { 'code.filepath': 'src/a.py', 'code.lineno': 12, 'code.function': 'handler' }
+    expect(codeFilepathOf(attrs)).toBe('src/a.py')
+    expect(codeLinenoOf(attrs)).toBe(12)
+    expect(codeFunctionOf(attrs)).toBe('handler')
+  })
+
+  it('reads the stable (semconv ≥1.33) attribute names', () => {
+    const attrs = {
+      'code.file.path': 'src/b.py',
+      'code.line.number': 34,
+      'code.function.name': 'Mod.handler',
+    }
+    expect(codeFilepathOf(attrs)).toBe('src/b.py')
+    expect(codeLinenoOf(attrs)).toBe(34)
+    expect(codeFunctionOf(attrs)).toBe('Mod.handler')
+  })
+
+  it('prefers the stable name when both generations are present', () => {
+    const attrs = {
+      'code.file.path': 'stable.py',
+      'code.filepath': 'prior.py',
+      'code.line.number': 2,
+      'code.lineno': 1,
+    }
+    expect(codeFilepathOf(attrs)).toBe('stable.py')
+    expect(codeLinenoOf(attrs)).toBe(2)
+  })
+
+  it('returns undefined for an absent, empty, or wrong-typed value', () => {
+    expect(codeFilepathOf({})).toBeUndefined()
+    expect(codeFilepathOf({ 'code.filepath': '' })).toBeUndefined()
+    expect(codeLinenoOf({ 'code.lineno': 'x' })).toBeUndefined()
+    expect(codeFunctionOf({})).toBeUndefined()
+  })
+})
+
 describe('handleSpan', () => {
   let tmpDir: string
   let ctx: IngestContext
@@ -195,6 +236,34 @@ describe('handleSpan', () => {
       ts,
     )
     expect(file?.edge.grain).toBe('file')
+  })
+
+  it('file-grains identically whether the span carries the stable or prior code.* names', async () => {
+    const priorSpan = dbSpan({
+      spanId: 'code-prior',
+      attributes: {
+        'server.address': 'payments-db',
+        'code.filepath': 'src/db.py',
+        'code.lineno': 7,
+      },
+    })
+    const stableSpan = dbSpan({
+      spanId: 'code-stable',
+      attributes: {
+        'server.address': 'payments-db',
+        'code.file.path': 'src/db.py',
+        'code.line.number': 7,
+      },
+    })
+    await handleSpan(ctx, priorSpan)
+    await handleSpan(ctx, stableSpan)
+    // Both call sites resolve to the same source file, so both land on one
+    // file-grained edge — the stable-name span is not dropped to service grain.
+    const id = `${EdgeType.CONNECTS_TO}:OBSERVED:${fileId('service-b', 'src/db.py')}->database:payments-db`
+    expect(ctx.graph.hasEdge(id)).toBe(true)
+    const edge = ctx.graph.getEdgeAttributes(id) as GraphEdge
+    expect(edge.grain).toBe('file')
+    expect(edge.callCount).toBe(2)
   })
 
   it('populates edge.signal with span and error counts', async () => {


### PR DESCRIPTION
OpenTelemetry stabilized the source-location attributes at semconv 1.33 — `code.file.path` / `code.line.number` / `code.function.name`, renaming the earlier `code.filepath` / `code.lineno` / `code.function`. Ingest now reads **both** generations, stable-name first, through one shared helper used for edge attribution (`callSiteFromSpan`) and incident localization (`traverse.ts`) alike.

A span from instrumentation that has moved to the stable names now file-grains onto its source file the same as one still using the prior names, instead of quietly falling back to service grain. This is the language-neutral groundwork the Python file-grain rungs (ADR-151) build on — the new Python call-site processor will emit the stable names — and it keeps the JS path correct as the ecosystem migrates.

## Verification
`npx turbo build test lint` green (17/17). New tests: the dual-name helper reads prior and stable names, prefers stable when both are present, and rejects empty/wrong-typed values; a handleSpan integration proves a `code.file.path` span lands on the same file-grained edge as a `code.filepath` one.

Refs #576, #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5a8xfpbRXTjnRDE3mcZE5